### PR TITLE
build: deploy examples to GitHub pages on main runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,25 @@ jobs:
         with:
           name: pages
           path: dist/design
-# TODO: build design system
+
+  publish-documentation:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-22.04
+    permissions:
+      pages: write
+      id-token: write
+    needs:
+      - documentation
+    steps:
+      - uses: actions/configure-pages@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: pages
+          path: dist/design
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'dist/design'
+      - uses: actions/deploy-pages@v4
 # TODO: add release job
 # TODO: build PR previews
 # TODO: e2e test


### PR DESCRIPTION
Publish the documentation on main runs.

See for a working version: https://spike-rabbit.github.io/element/components/
Examples are broken because of absolute link, but they should be working with element.siemens.io.

Code is on the main branch.


> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the
      [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
