### PR TITLE
docs(index): correct link to demo playground

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ which implement the Element design system. The components are developed in the
 
 ## Playground
 
-Open our [demo playground](https://element.siemens.io/demo/#/overview)
+Open our [demo playground](https://element.siemens.io/element-examples/#/overview)
 to see examples for all our components.
 
 ## Figma design assets


### PR DESCRIPTION
This PR corrects the link to the demo playground page within the startpage.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the
      [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
