### PR TITLE
build: split workflows into multiple files

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,11 +1,13 @@
-name: Build
+name: Build and Test
 on:
-  push:
-    branches:
-      - main
-      - maintenance/*
-      - next
+  workflow_call:
+    secrets:
+      SIEMENS_NPM_TOKEN:
+        required: true
+      SIEMENS_NPM_USER:
+        required: true
   pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -98,25 +100,6 @@ jobs:
         with:
           name: pages
           path: dist/design
-
-  publish-documentation:
-    if: github.ref_name == github.event.repository.default_branch
-    runs-on: ubuntu-22.04
-    permissions:
-      pages: write
-      id-token: write
-    needs:
-      - documentation
-    steps:
-      - uses: actions/configure-pages@v5
-      - uses: actions/download-artifact@v4
-        with:
-          name: pages
-          path: dist/design
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: 'dist/design'
-      - uses: actions/deploy-pages@v4
 # TODO: add release job
 # TODO: build PR previews
 # TODO: e2e test

--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -1,0 +1,30 @@
+name: Publish Documentation
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yaml
+    secrets:
+      SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
+      SIEMENS_NPM_USER: ${{ secrets.SIEMENS_NPM_USER }}
+
+  publish-documentation:
+    runs-on: ubuntu-22.04
+    permissions:
+      pages: write
+      id-token: write
+    needs:
+      - build-and-test
+    steps:
+      - uses: actions/configure-pages@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: pages
+          path: dist/design
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'dist/design'
+      - uses: actions/deploy-pages@v4


### PR DESCRIPTION
Splits up the workflow in two parts:
- one workflow for testing and building (build-and-test.yaml)
- one for publishing the documentation (publish-documentation.yaml)
- (there will be a 3rd one for releasing) (release.yaml)

What we need to achieve is running jobs conditional.
While github allows checking for branch name there is no way to trigger a job manually. But we need this to release.
Workflows can be triggered manually and they can be reused.

We have 3 triggers we care about that should to lead slightly different output:
- PR: just run checks
- Push to main: run checks and deploy pages
- Manual release trigger: run checks and publish npm packages

So the publish-documentation and release workflow are reusing the build-and-test workflow.


A working a example of the main job is visible here: https://github.com/spike-rabbit/element/

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the
      [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
