### PR TITLE
build: add release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: Release
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yaml
+    secrets:
+      SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
+      SIEMENS_NPM_USER: ${{ secrets.SIEMENS_NPM_USER }}
+
+  publish:
+    runs-on: ubuntu-22.04
+    needs:
+      - build-and-test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # semantic-release needs this
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/jod
+          cache: 'npm'
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - run: npm ci --prefer-offline --no-audit
+      - run: npx semantic-release
+        env:
+          GIT_AUTHOR_NAME: 'Siemens Element Bot'
+          GIT_AUTHOR_EMAIL: 'simpl.si@siemens.com'
+          GIT_COMMITTER_NAME: 'Siemens Element Bot'
+          GIT_COMMITTER_EMAIL: 'simpl.si@siemens.com'
+          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -37,5 +37,7 @@ plugins:
     - assets:
         - CHANGELOG.md
         - package.json
+        - package-lock.json
         - projects/*/package.json
       message: 'chore(release): ${nextRelease.version}'
+  - '@semantic-release/github'

--- a/projects/element-ng/package.json
+++ b/projects/element-ng/package.json
@@ -13,6 +13,9 @@
   },
   "homepage": "https://github.com/siemens/element",
   "bugs": "https://github.com/siemens/element/issues/new",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "peerDependencies": {
     "@angular/animations": "19",

--- a/projects/element-theme/package.json
+++ b/projects/element-theme/package.json
@@ -13,6 +13,9 @@
   },
   "homepage": "https://github.com/siemens/element",
   "bugs": "https://github.com/siemens/element/issues/new",
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "siemens",
     "theme",

--- a/projects/element-translate-ng/package.json
+++ b/projects/element-translate-ng/package.json
@@ -14,6 +14,9 @@
   },
   "homepage": "https://github.com/siemens/element",
   "bugs": "https://github.com/siemens/element/issues/new",
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "update-translatable-keys": "bin/update-translatable-keys.js"
   },

--- a/projects/live-preview/package.json
+++ b/projects/live-preview/package.json
@@ -14,6 +14,9 @@
   },
   "homepage": "https://github.com/siemens/element",
   "bugs": "https://github.com/siemens/element/issues/new",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "codeflask": "^1.4.1",
     "qrcode-generator": "^1.4.4",


### PR DESCRIPTION
Enables releasing of `@siemens/element-*` packages using a manual triggered workflow.
Also corrects issues with the pre-existing configuration.

Variables are added to the repo.
A working example can be found here: https://github.com/spike-rabbit/element/

Please note that the variables were adjusted accordingly.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the
      [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
