### PR TITLE
build: harmonize package versions to 47.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "siemens-element",
-  "version": "47.11.0",
+  "version": "47.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "siemens-element",
-      "version": "47.11.0",
+      "version": "47.0.0",
       "license": "MIT",
       "workspaces": [
         "projects/element-translate-ng",
@@ -26345,12 +26345,12 @@
     },
     "projects/element-theme": {
       "name": "@siemens/element-theme",
-      "version": "47.11.0",
+      "version": "47.0.0",
       "license": "MIT"
     },
     "projects/element-translate-ng": {
       "name": "@siemens/element-translate-ng",
-      "version": "47.11.0",
+      "version": "47.0.0",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^4.5.0"
@@ -26371,7 +26371,7 @@
     },
     "projects/live-preview": {
       "name": "@siemens/live-preview",
-      "version": "47.11.0",
+      "version": "47.0.0",
       "license": "MIT",
       "dependencies": {
         "codeflask": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siemens-element",
-  "version": "47.11.0",
+  "version": "47.0.0",
   "description": "Siemens Element open source theme",
   "license": "MIT",
   "private": true,

--- a/projects/element-ng/package.json
+++ b/projects/element-ng/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siemens/element-ng",
   "description": "Element Angular component library, implementing the Siemens Design Language",
-  "version": "47.11.0",
+  "version": "47.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
     "@angular/core": "19",
     "@angular/forms": "19",
     "@angular/router": "19",
-    "@siemens/element-translate-ng": "47.11.0",
-    "@siemens/element-theme": "47.11.0"
+    "@siemens/element-translate-ng": "47.0.0",
+    "@siemens/element-theme": "47.0.0"
   },
   "peerDependenciesMeta": {
     "@angular/animations": {

--- a/projects/element-theme/package.json
+++ b/projects/element-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siemens/element-theme",
-  "version": "47.11.0",
+  "version": "47.0.0",
   "description": "Element CSS theme.",
   "license": "MIT",
   "repository": {

--- a/projects/element-translate-ng/package.json
+++ b/projects/element-translate-ng/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siemens/element-translate-ng",
   "description": "Element translation abstraction layer.",
-  "version": "47.11.0",
+  "version": "47.0.0",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/projects/live-preview/package.json
+++ b/projects/live-preview/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@siemens/live-preview",
   "description": "Element live preview for web",
-  "version": "47.11.0",
+  "version": "47.0.0",
   "license": "MIT",
   "type": "module",
   "repository": {


### PR DESCRIPTION
Harmonize the package version to 47.0.0

The breaking change notice is need to make semantic-release a new v47.0.0.

In addition I added a v46.0.0 tag before that commit which we should remove later.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the
      [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
