### PR TITLE
feat(element-translation-ng): move key extraction CLI into a separate package

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -19,6 +19,8 @@ plugins:
     - pkgRoot: dist/@siemens/live-preview
   - - '@semantic-release/npm'
     - pkgRoot: projects/element-theme
+  - - '@semantic-release/npm'
+    - pkgRoot: projects/element-translate-cli
   # Only update remaining package.json that are not directly published
   - - '@semantic-release/npm'
     - pkgRoot: projects/element-ng

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "47.0.0",
       "license": "MIT",
       "workspaces": [
+        "projects/element-translate-cli",
         "projects/element-translate-ng",
         "projects/element-theme",
         "projects/live-preview"
@@ -7575,6 +7576,10 @@
     },
     "node_modules/@siemens/element-theme": {
       "resolved": "projects/element-theme",
+      "link": true
+    },
+    "node_modules/@siemens/element-translate-cli": {
+      "resolved": "projects/element-translate-cli",
       "link": true
     },
     "node_modules/@siemens/element-translate-ng": {
@@ -26348,6 +26353,39 @@
       "version": "47.0.0",
       "license": "MIT"
     },
+    "projects/element-translate-cli": {
+      "name": "@siemens/element-translate-cli",
+      "version": "47.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "4.5.0"
+      },
+      "bin": {
+        "update-translatable-keys": "bin/update-translatable-keys.js"
+      }
+    },
+    "projects/element-translate-cli/node_modules/fast-xml-parser": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
+      "integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "projects/element-translate-ng": {
       "name": "@siemens/element-translate-ng",
       "version": "47.0.0",
@@ -26356,7 +26394,7 @@
         "fast-xml-parser": "^4.5.0"
       },
       "bin": {
-        "update-translatable-keys": "bin/update-translatable-keys.js"
+        "update-translatable-keys": "element-translate-cli/bin/update-translatable-keys.js"
       },
       "peerDependencies": {
         "@angular/common": "19",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "postversion": "node ./postversion.js && npm run format"
   },
   "workspaces": [
+    "projects/element-translate-cli",
     "projects/element-translate-ng",
     "projects/element-theme",
     "projects/live-preview"

--- a/projects/element-translate-cli/bin/update-translatable-keys.js
+++ b/projects/element-translate-cli/bin/update-translatable-keys.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-/* eslint-disable prefer-arrow/prefer-arrow-functions */
 import { spawn } from 'child_process';
 import * as fs from 'fs';
 import { dirname } from 'path';

--- a/projects/element-translate-cli/package.json
+++ b/projects/element-translate-cli/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@siemens/element-translate-ng",
-  "description": "Element translation abstraction layer.",
+  "name": "@siemens/element-translate-cli",
+  "description": "Element translation abstraction layer CLI.",
   "version": "47.0.0",
   "license": "MIT",
   "type": "module",
@@ -17,19 +17,10 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
-    "@angular/common": "19",
-    "@angular/core": "19",
-    "@ngx-translate/core": "15 - 16"
+  "bin": {
+    "update-translatable-keys": "bin/update-translatable-keys.js"
   },
-  "peerDependenciesMeta": {
-    "@ngx-translate/core": {
-      "optional": true
-    }
-  },
-  "exports": {
-    "./docs.json": {
-      "default": "./docs.json"
-    }
+  "dependencies": {
+    "fast-xml-parser": "4.5.0"
   }
 }


### PR DESCRIPTION
The key extraction must be separated for internal dependency clearing. As the key extraction is not included in an app bundle, its dependencies must not be cleared.
Moving it into its own package allows apps to install it as a dev dependency and therefore exclude it from clearing.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the
      [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
