### PR TITLE
fix(live-preview): accept legacy component loader import

### DIFF
--- a/projects/live-preview/esbuild-component-loader.mjs
+++ b/projects/live-preview/esbuild-component-loader.mjs
@@ -4,7 +4,7 @@ import { globIterate } from 'glob';
 const livePreviewComponentLoader = {
   name: 'live-preview-component-loader',
   setup: build => {
-    build.onResolve({ filter: /@siemens\/live-preview\/component-loader.*/ }, args => {
+    build.onResolve({ filter: /(@siemens|@simpl)\/live-preview\/component-loader.*/ }, args => {
       const [data] = args.path.split('!');
       const url = new URL('fake:' + data);
       const root = url.searchParams.get('root');
@@ -24,7 +24,7 @@ const livePreviewComponentLoader = {
 
     build.onLoad(
       {
-        filter: /@siemens\/live-preview\/component-loader.*/,
+        filter: /(@siemens|@simpl)\/live-preview\/component-loader.*/,
         namespace: 'live-preview-component-loader'
       },
       async ({ pluginData: { root, webcomponents, examples } }) => {


### PR DESCRIPTION
To avoid breaking changes when re-exporting, we need to accept the old `@simpl/live-preview` package name.
Otherwise, we cannot re-export without a breaking change.


> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the
      [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
