### PR TITLE
fix(application-header): announce logo text in Safari / VoiceOver

### DIFF
--- a/projects/element-ng/application-header/si-header-logo.directive.ts
+++ b/projects/element-ng/application-header/si-header-logo.directive.ts
@@ -2,13 +2,48 @@
  * Copyright Siemens 2016 - 2025.
  * SPDX-License-Identifier: MIT
  */
-import { Directive } from '@angular/core';
+import {
+  afterNextRender,
+  Directive,
+  ElementRef,
+  HostListener,
+  inject,
+  Injector,
+  OnInit,
+  signal
+} from '@angular/core';
 
 /** The siemens logo. Should be located inside `.header-brand`. */
 @Directive({
   selector: 'si-header-logo, [siHeaderLogo]',
   host: {
-    class: 'header-logo px-6 focus-inside'
+    class: 'header-logo px-6 focus-inside',
+    '[attr.aria-label]': 'logoText()'
   }
 })
-export class SiHeaderLogoDirective {}
+export class SiHeaderLogoDirective implements OnInit {
+  protected readonly logoText = signal<string | undefined>(undefined);
+
+  private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private injector = inject(Injector);
+
+  ngOnInit(): void {
+    this.updateLogoText();
+  }
+
+  @HostListener('window:theme-switch')
+  protected updateLogoText(): void {
+    afterNextRender(
+      {
+        read: () =>
+          this.logoText.set(
+            window
+              .getComputedStyle(this.elementRef.nativeElement)
+              .getPropertyValue('--element-brand-logo-text')
+              .replace(/^["']|["']$/g, '')
+          )
+      },
+      { injector: this.injector }
+    );
+  }
+}

--- a/projects/element-ng/application-header/si-header-siemens-logo.component.ts
+++ b/projects/element-ng/application-header/si-header-siemens-logo.component.ts
@@ -4,6 +4,8 @@
  */
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
+import { SiHeaderLogoDirective } from './si-header-logo.directive';
+
 /**
  * The siemens logo.
  * Should be located inside `.header-brand`.
@@ -22,9 +24,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 @Component({
   selector: 'si-header-siemens-logo, [si-header-siemens-logo]',
   template: '',
-  host: {
-    class: 'header-logo px-6 focus-inside'
-  },
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SiHeaderSiemensLogoComponent {}
+export class SiHeaderSiemensLogoComponent extends SiHeaderLogoDirective {}

--- a/projects/element-ng/icon/index.ts
+++ b/projects/element-ng/icon/index.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 export * from './si-icon.module';
+export * from './icon-status';
 export { addIcons } from './si-icons';
 export * from './si-icon-next.component';
-export * from './icon-status';
 export * from './si-icon.component';
+export * from './si-status-icon.component';
 export * from './element-icons';

--- a/projects/element-ng/icon/si-status-icon.component.ts
+++ b/projects/element-ng/icon/si-status-icon.component.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright Siemens 2016 - 2025.
+ * SPDX-License-Identifier: MIT
+ */
+import { NgClass } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { EntityStatusType } from '@siemens/element-ng/common';
+
+import { STATUS_ICON_CONFIG } from './icon-status';
+import { SiIconNextComponent } from './si-icon-next.component';
+
+@Component({
+  selector: 'si-status-icon',
+  template: `
+    @let iconValue = statusIcon();
+    @if (iconValue) {
+      <si-icon-next [ngClass]="iconValue.color" [icon]="iconValue.icon" />
+      <si-icon-next [ngClass]="iconValue.stackedColor" [icon]="iconValue.stacked" />
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgClass, SiIconNextComponent],
+  host: {
+    class: 'icon-stack'
+  }
+})
+export class SiStatusIconComponent {
+  private readonly statusIcons = inject(STATUS_ICON_CONFIG);
+
+  readonly status = input.required<EntityStatusType>();
+
+  protected readonly statusIcon = computed(() => this.statusIcons[this.status()]);
+}


### PR DESCRIPTION
Voice over currently not understands CSS content alt text. So we add it manually.

Add pending commits from internal repo

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the
      [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
