### PR TITLE
docs(brand): use Siemens favicon

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -25,6 +25,7 @@ jobs:
       - run: npm ci --prefer-offline --no-audit --include=optional
       - run: npm run lint:commit
       - run: npm run build:all
+      - run: npm run prepare-brand
       - run: npm run build:examples
       - uses: actions/upload-artifact@v4
         with:
@@ -75,6 +76,7 @@ jobs:
         env:
           SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
       - run: npm ci --prefer-offline --no-audit --include=optional
+      - run: npm run prepare-brand
       - run: npm run build:examples:aot
       - run: npm run build:all:update-translatable-keys
       - run: git diff --exit-code "projects/**/*-translatable-keys.interface.ts"
@@ -90,6 +92,7 @@ jobs:
         with:
           name: dist
           path: dist
+      - run: cp dist/element-examples/favicon.png docs/_src/favicon.png
       - run: uv run mkdocs build
         env:
           UV_INDEX_CODE_DOCS_THEME_USERNAME: ${{ secrets.SIEMENS_NPM_USER }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
       },
       "optionalDependencies": {
         "@playwright/test": "1.52.0",
-        "@simpl/brand": "^0.1.3",
+        "@simpl/brand": "^0.2.0",
         "@simpl/element-icons": "^1.28.0"
       }
     },
@@ -7719,9 +7719,9 @@
       }
     },
     "node_modules/@simpl/brand": {
-      "version": "0.1.3",
-      "resolved": "https://code.siemens.com/api/v4/projects/732/packages/npm/@simpl/brand/-/@simpl/brand-0.1.3.tgz",
-      "integrity": "sha1-/lMA//u2oH9Qw/8HDuIIp9HsYXo=",
+      "version": "0.2.0",
+      "resolved": "https://code.siemens.com/api/v4/projects/732/packages/npm/@simpl/brand/-/@simpl/brand-0.2.0.tgz",
+      "integrity": "sha1-EuRIB0uFavHDaKvaCvGb9t4Z7gE=",
       "optional": true
     },
     "node_modules/@simpl/element-icons": {
@@ -12700,24 +12700,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^1.1.1"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -26390,12 +26372,6 @@
       "name": "@siemens/element-translate-ng",
       "version": "47.0.0",
       "license": "MIT",
-      "dependencies": {
-        "fast-xml-parser": "^4.5.0"
-      },
-      "bin": {
-        "update-translatable-keys": "element-translate-cli/bin/update-translatable-keys.js"
-      },
       "peerDependencies": {
         "@angular/common": "19",
         "@angular/core": "19",

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "lib:test:browser": "cross-env HEADLESS=0 ng test element-ng",
     "translate:test": "ng test element-translate-ng",
     "translate:build": "ng build element-translate-ng && cpy LICENSE.md \"./dist/@siemens/element-translate-ng/\"",
-    "docs:prepare": "poetry install",
-    "docs:build": "poetry run mkdocs build --strict",
-    "docs:serve": "poetry run mkdocs serve",
+    "docs:build": "uv run mkdocs build --strict",
+    "docs:serve": "uv run mkdocs serve",
     "live-preview:build": "ng build live-preview",
     "prepare": "husky; exit 0",
+    "prepare-brand": "cpy --flat node_modules/@simpl/brand/src/favicon/sie-favicon_internet_64px.png docs/_src --rename=favicon.png && cpy --flat node_modules/@simpl/brand/src/favicon/sie-favicon_internet_64px.png src --rename=favicon.png",
     "postversion": "node ./postversion.js && npm run format"
   },
   "workspaces": [
@@ -117,7 +117,7 @@
   },
   "optionalDependencies": {
     "@playwright/test": "1.52.0",
-    "@simpl/brand": "^0.1.3",
+    "@simpl/brand": "^0.2.0",
     "@simpl/element-icons": "^1.28.0"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="app--dark">
   <head>
     <meta charset="utf-8" />
-    <title>Element</title>
+    <title>Siemens Element Live Preview</title>
     <base href="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/png" href="favicon.png" />


### PR DESCRIPTION
The OSS repository has a OSS favicon. When building for official deployment, we load the Siemens favicon from our brand package and replace the default favicon.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the
      [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
