### PR TITLE
build(github): remove gitlab markup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,6 @@
-%{first_multiline_commit}
-
 > Describe in detail what your merge request does and why. Add relevant
 > screenshots and reference related issues via `Closes #XY` or `Related to #XY`.
 
 ---
 
-- [ ] I confirm that this MR follows the
-      [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
+- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
GitHub automatically includes the commit message body. No need for a marker.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the
      [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
