### PR TITLE
build(semantic-release): add custom configuration

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,3 +1,6 @@
+import writerOpts from './tools/semantic-release/writer-opts.js';
+import { commitTypes, releaseRules } from './tools/semantic-release/config.js';
+
 export default {
   branches: [
     {
@@ -12,8 +15,29 @@ export default {
     }
   ],
   plugins: [
-    '@semantic-release/commit-analyzer',
-    '@semantic-release/release-notes-generator',
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'angular',
+        releaseRules,
+        parserOpts: {
+          noteKeywords: ['BREAKING CHANGE']
+        },
+        presetConfig: {
+          types: commitTypes
+        }
+      }
+    ],
+    [
+      '@semantic-release/release-notes-generator',
+      {
+        preset: 'angular',
+        parserOpts: {
+          noteKeywords: ['BREAKING CHANGE', 'NOTE', 'DEPRECATED']
+        },
+        writerOpts
+      }
+    ],
     '@semantic-release/changelog',
     // Packages to be pushed
     [

--- a/tools/semantic-release/config.js
+++ b/tools/semantic-release/config.js
@@ -1,0 +1,32 @@
+// To reorder the types, simply change the order of the items
+export const commitTypes = [
+  { type: 'feat', section: 'Features' },
+  { type: 'fix', section: 'Bug Fixes' },
+  { type: 'perf', section: 'Performance Improvements' },
+  { type: 'revert', section: 'Reverts' },
+  { type: 'fixup', hidden: true },
+  { type: 'docs', hidden: true },
+  { type: 'style', hidden: true },
+  { type: 'refactor', hidden: true },
+  { type: 'test', hidden: true },
+  { type: 'build', hidden: true },
+  { type: 'ci', hidden: true },
+  { type: 'chore', hidden: true }
+];
+
+export const releaseRules = [
+  { breaking: true, release: 'major' },
+  { revert: true, release: 'patch' },
+  { type: 'feat', release: 'minor' },
+  { type: 'fix', release: 'patch' },
+  { type: 'perf', release: 'patch' }
+];
+
+// To reorder the notes, simply change the order of the items
+export const noteTitleMap = {
+  'NOTE': 'NOTES',
+  'BREAKING CHANGE': 'BREAKING CHANGES',
+  'DEPRECATED': 'DEPRECATIONS'
+};
+
+export const noteTitles = Object.values(noteTitleMap);

--- a/tools/semantic-release/writer-opts.js
+++ b/tools/semantic-release/writer-opts.js
@@ -1,0 +1,83 @@
+import { noteTitleMap, noteTitles, commitTypes } from './config.js';
+
+const COMMIT_HASH_LENGTH = 7;
+
+const commitGroups = commitTypes.map(t => t.section).filter(Boolean);
+const hiddenTypeCommitNotes = [];
+
+const hiddenTypes = new Set();
+const visibleTypes = {};
+
+commitTypes.forEach(({ type, section, hidden }) => {
+  if (hidden) {
+    hiddenTypes.add(type);
+  } else if (section) {
+    visibleTypes[type] = section;
+  }
+});
+
+function transform(commit) {
+  const hasNotes = Array.isArray(commit.notes) && commit.notes.length > 0;
+
+  const normalizedNotes = hasNotes
+    ? commit.notes.map(note => ({
+        title: noteTitleMap[note.title],
+        text: note.text.replace(/\n/g, '\n  ')
+      }))
+    : [];
+
+  if (hiddenTypes.has(commit.type)) {
+    if (normalizedNotes.length > 0) {
+      normalizedNotes.map(note => ({
+        text: `${commit.scope ? `**${commit.scope}:** ` : ''}${note.text}`
+      }));
+      // Add to the hiddenTypeCommitNotes if there are notes and the type is hidden
+      // The notes will be added to the context in finalizeContext
+      hiddenTypeCommitNotes.push(...normalizedNotes);
+    }
+    return;
+  }
+
+  const shortHash =
+    typeof commit.hash === 'string'
+      ? commit.hash.substring(0, COMMIT_HASH_LENGTH)
+      : commit.shortHash;
+
+  return {
+    ...commit,
+    notes: normalizedNotes,
+    type: visibleTypes[commit.type],
+    shortHash
+  };
+}
+
+/**
+ *  Append collected notes that have a hidden type to the matching noteGroups
+ */
+function finalizeContext(context) {
+  for (const note of hiddenTypeCommitNotes) {
+    let group = context.noteGroups.find(g => g.title === note.title);
+    if (!group) {
+      group = { title: note.title, notes: [] };
+      const insertIndex = noteTitles.findIndex(t => t === note.title);
+      context.noteGroups.splice(insertIndex, 0, group);
+    }
+    group.notes.push(note);
+  }
+  return context;
+}
+
+export default {
+  transform,
+  finalizeContext,
+  commitGroupsSort(a, b) {
+    return commitGroups.indexOf(a.title) - commitGroups.indexOf(b.title);
+  },
+  commitsSort: ['scope', 'subject'],
+  noteGroupsSort(a, b) {
+    return noteTitles.indexOf(a.title) - noteTitles.indexOf(b.title);
+  },
+  notesSort(a, b) {
+    return a.title.localeCompare(b.title);
+  }
+};


### PR DESCRIPTION
### Purpose

This pull request introduces a custom semantic-release configuration based on the default preset, tailored to elements project's specific commit conventions and release logic.

### Changes

- Custom commit analysis logic in `tools/semantic-release/config.js`
  - Defines `commitTypes` used in CHANGELOG and the corresponding section titles.
  - Controls which types are included or hidden from the CHANGELOG.
  - The sorting of the CHANGELOG sections can be done by rearranging the arrays `commitTypes` and `noteTitleMap`

- Automatic version bump logic - determine whether a release is major, minor, or patch based on the commits.
  - **major** is triggered by a commit that includes a note with `BREAKING CHANGE` (configurable through [releaserc.js](https://github.com/siemens/element/blob/9f4cc66e5f76ebe1cf7a9e3ffbda28579d5fb93e/.releaserc.js#L24))
  - **minor** is triggered by a commit with the type `feat` (configurable through [config.js](https://github.com/siemens/element/blob/9f4cc66e5f76ebe1cf7a9e3ffbda28579d5fb93e/tools/semantic-release/config.js#L17-L23))
  - **patch** is triggered by commits with the types `fix`, `perf` or `revert` (configurable through [config.js](https://github.com/siemens/element/blob/9f4cc66e5f76ebe1cf7a9e3ffbda28579d5fb93e/tools/semantic-release/config.js#L17-L23))

### Writer enhancements

Custom release note formatting in `tools/semantic-release/writer-opts.js`

- Indent multi-line notes e.g. for `BREAKING CHANGES`
- Create new sections `NOTES` and `DEPRECATIONS` in the CHANGELOG if commits with notes `DEPRECATED:` or `NOTE:` are found.
- Ensure that notes like `BREAKING CHANGE`, `DEPRECATED`, and `NOTE` are included in the CHANGELOG, even when they originate from commits of hidden types (e.g., `docs`, `refactor`, `chore`, etc.).
- Prevent hidden commit types (e.g. `docs`, `refactor`, `chore`, ...) from appearing in the CHANGELOG if they contain notes. Only the notes themselves should be shown in their appropriate sections (e.g., under **BREAKING CHANGES**), without revealing the hidden commit type or adding a section for it.
  - **Example:** With the default preset, a **hidden** commit like `build(semantic-release): add custom configuration` that includes a `BREAKING CHANGE` would generate a new section with an entry like:
    ```markdown
    ### Build
    * **semantic-release:** add custom configuration
    ```
    With this setup, the `Build` section is suppressed, and only the `BREAKING CHANGE` note is shown, keeping the hidden type (`build`) excluded from the CHANGELOG output.

### Testing

The configuration can be tested locally by using the following command that simulates a release without publishing artifacts or pushing tags:

```bash
npx semantic-release --dry-run --no-ci --loglevel debug
```

Because I have not setup any tokens on my environment I commented out the sections that include `'@semantic-release/npm',` and `'@semantic-release/github'` in the [releaserc.js](https://github.com/siemens/element/blob/9f4cc66e5f76ebe1cf7a9e3ffbda28579d5fb93e/.releaserc.js#L43-L102).

You can create commits using various types and note footers (e.g., fix: ..., feat: ..., with `BREAKING CHANGE:`,`NOTE:`, `DEPRECATED:`) and observe:

- Which type of release would be triggered
- How the CHANGELOG is structured
- How notes appear in the generated CHANGELOG

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).