### PR TITLE
Fix/live preview overview dark

### DIFF
--- a/projects/live-preview/components/si-example-overview/si-example-overview.component.scss
+++ b/projects/live-preview/components/si-example-overview/si-example-overview.component.scss
@@ -1,5 +1,6 @@
 @use '../../styles/variables';
 @use '../../styles/components/links';
+@use '../../styles/components/focus';
 
 :host {
   display: flex;

--- a/projects/live-preview/components/si-example-overview/si-example-overview.component.ts
+++ b/projects/live-preview/components/si-example-overview/si-example-overview.component.ts
@@ -2,7 +2,7 @@
  * Copyright Siemens 2016 - 2025.
  * SPDX-License-Identifier: MIT
  */
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -27,13 +27,15 @@ interface TreeItem {
   templateUrl: './si-example-overview.component.html',
   styleUrl: './si-example-overview.component.scss'
 })
-export class SiExampleOverviewComponent implements OnInit {
+export class SiExampleOverviewComponent implements OnInit, OnDestroy {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private title = inject(Title);
   private config = inject(SI_LIVE_PREVIEW_CONFIG);
   private internalConfig = inject(SI_LIVE_PREVIEW_INTERNALS);
   private componentList: string[] = [];
+  private darkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  private mediaQueryListener = (): void => this.toggleDark(this.darkMediaQuery.matches);
 
   protected activeExampleRoute!: Observable<string>;
   protected tree: TreeItem[] = [];
@@ -73,6 +75,18 @@ export class SiExampleOverviewComponent implements OnInit {
           queryParamsHandling: 'merge'
         });
       });
+
+    this.mediaQueryListener();
+    this.darkMediaQuery.addEventListener('change', this.mediaQueryListener);
+  }
+
+  ngOnDestroy(): void {
+    this.darkMediaQuery.removeEventListener('change', this.mediaQueryListener);
+  }
+
+  private toggleDark(dark: boolean): void {
+    document.documentElement.classList.toggle('app--dark', dark);
+    document.documentElement.classList.toggle('app--light', !dark);
   }
 
   private makeTree(filterValue?: string): void {

--- a/projects/live-preview/components/si-example-viewer/si-example-viewer.component.scss
+++ b/projects/live-preview/components/si-example-viewer/si-example-viewer.component.scss
@@ -1,5 +1,6 @@
 @use '../../styles/variables';
 @use '../../styles/components/tabs';
+@use '../../styles/components/focus';
 
 .wrapper {
   background-color: variables.$live-preview-background-color;

--- a/projects/live-preview/components/si-live-preview-iframe/si-live-preview-iframe.component.scss
+++ b/projects/live-preview/components/si-live-preview-iframe/si-live-preview-iframe.component.scss
@@ -1,5 +1,6 @@
 @use '../../styles/variables';
 @use '../../styles/components/links';
+@use '../../styles/components/focus';
 @use 'ios';
 @use 'ios-with-notch';
 @use 'md';
@@ -120,10 +121,6 @@ iframe {
   margin-block: 0;
   display: flex;
   flex: 1;
-
-  &:focus {
-    box-shadow: 0 0 0 2px variables.$live-preview-focus-shadow-color;
-  }
 }
 
 .device {

--- a/projects/live-preview/components/si-live-preview-qr/si-live-preview-qr.component.scss
+++ b/projects/live-preview/components/si-live-preview-qr/si-live-preview-qr.component.scss
@@ -1,4 +1,5 @@
 @use '../../styles/components/links';
+@use '../../styles/components/focus';
 @use '../../styles/variables';
 
 :host {

--- a/projects/live-preview/components/si-live-preview/si-live-preview-codeflask.scss
+++ b/projects/live-preview/components/si-live-preview/si-live-preview-codeflask.scss
@@ -7,8 +7,8 @@
 // stylelint-disable selector-class-pattern
 
 $default: #000;
-$background: #fff;
-$background-readonly: #f9f9f9;
+$background: variables.$live-preview-editor-background-color;
+$background-readonly: variables.$live-preview-editor-background-color;
 $purple: #a626a4;
 $yellow: #986801;
 $yellow2: #c18401;
@@ -22,8 +22,8 @@ $lines-background: #eee;
 
 // join the dark side, we have cookies!
 $default-dark: #bcbcbc;
-$background-dark: #222;
-$background-readonly-dark: #333;
+$background-dark: variables.$live-preview-editor-background-color;
+$background-readonly-dark: variables.$live-preview-editor-background-color;
 $lines-color-dark: #eee;
 $lines-background-dark: #666;
 

--- a/projects/live-preview/components/si-live-preview/si-live-preview-codeflask.scss
+++ b/projects/live-preview/components/si-live-preview/si-live-preview-codeflask.scss
@@ -245,21 +245,10 @@ $lines-background-dark: #666;
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  :host ::ng-deep {
-    @include code-dark;
-  }
+:host ::ng-deep {
+  @include code-light;
 }
 
 :host-context(.app--dark) :host ::ng-deep {
   @include code-dark;
-}
-
-:host-context(.app--light) {
-  // For higher specificity
-  @media (min-width: 0) {
-    :host ::ng-deep {
-      @include code-light;
-    }
-  }
 }

--- a/projects/live-preview/components/si-live-preview/si-live-preview.component.scss
+++ b/projects/live-preview/components/si-live-preview/si-live-preview.component.scss
@@ -1,5 +1,6 @@
 @use '../../styles/variables';
 @use '../../styles/components/tabs';
+@use '../../styles/components/focus';
 
 $padding-base-horizontal: 14px;
 $font-size-small: 11px;

--- a/projects/live-preview/styles/_variables.scss
+++ b/projects/live-preview/styles/_variables.scss
@@ -15,7 +15,9 @@ $live-preview-button-background-color: variables.$element-action-secondary;
 
 $live-preview-control-fill-color: variables.$element-text-primary;
 
-$live-preview-focus-shadow-color: variables.$focus-style-outline;
+$live-preview-focus-outline: variables.$focus-style-outline;
+$live-preview-focus-outline-offset: variables.$focus-style-outline-offset;
+$live-preview-focus-outline-inside-offset: variables.$focus-style-outline-inside-offset;
 $live-preview-font-color: variables.$element-text-primary;
 
 $live-preview-link-color: variables.$element-action-secondary-text;

--- a/projects/live-preview/styles/_variables.scss
+++ b/projects/live-preview/styles/_variables.scss
@@ -9,6 +9,7 @@ $live-preview-info-color: variables.$element-action-secondary-text;
 $live-preview-info-background-color: variables.$element-action-secondary;
 
 $live-preview-background-color: variables.$element-base-0;
+$live-preview-editor-background-color: variables.$element-base-1;
 $live-preview-bar-background-color: variables.$element-base-0;
 $live-preview-border-color: variables.$element-ui-4;
 $live-preview-button-background-color: variables.$element-action-secondary;

--- a/projects/live-preview/styles/components/_focus.scss
+++ b/projects/live-preview/styles/components/_focus.scss
@@ -1,0 +1,6 @@
+@use '../variables';
+
+*:focus-visible {
+  outline: variables.$live-preview-focus-outline;
+  outline-offset: variables.$live-preview-focus-outline-offset;
+}

--- a/projects/live-preview/styles/components/_tabs.scss
+++ b/projects/live-preview/styles/components/_tabs.scss
@@ -11,6 +11,10 @@
   font-weight: 700;
 
   .tab-item {
+    &:focus-visible {
+      outline-offset: variables.$live-preview-focus-outline-inside-offset;
+    }
+
     &.tab-active {
       &.tab-link {
         color: variables.$live-preview-link-color;


### PR DESCRIPTION
Various fixes for live-preview related to theming. Mainly restores automatic dark-mode in overview

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
