### PR TITLE
build(e2e): introduce e2e setup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+playwright/snapshots/**/*.png filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -56,6 +56,7 @@ jobs:
       - run: npm ci --prefer-offline --no-audit
       - run: npm run lint:format
       - run: npm run lint:ng
+      - run: npm run lint:playwright:eslint
       - run: npm run translate:test -- --watch=false --progress=false --code-coverage
       - run: npm run lib:test -- --watch=false --progress=false --code-coverage
       # TODO: Upload coverage reports
@@ -80,6 +81,70 @@ jobs:
       - run: npm ci --prefer-offline --no-audit --include=optional
       - run: npm run prepare-brand
       - run: npm run build:examples:aot
+
+  e2e:
+    runs-on: ubuntu-22.04
+    container: mcr.microsoft.com/playwright:v1.52.0-noble
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2]
+        shardTotal: [2]
+    steps:
+      # We cannot use built-in LFS functionality due to the missing support of custom LFS endpoints.
+      # See: https://github.com/actions/checkout/issues/365
+      # As we are in another container, we even need to install LFS manually.
+      - name: Install LFS
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+          apt install git-lfs
+      - uses: actions/checkout@v4
+      - run: git lfs pull
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/jod
+          cache: 'npm'
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      # Not injecting the token will exclude the brand packages, but this is fine for e2e tests.
+      - run: npm ci --prefer-offline --no-audit --include=optional
+      - run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: blob-report
+          retention-days: 1
+
+  e2e-merge-reports:
+    # Merge reports after playwright-tests, even if some shards have failed
+    if: ${{ !cancelled() }}
+    container: mcr.microsoft.com/playwright:v1.52.0-noble
+    needs: [e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+          node-version: lts/jod
+      - run: npm ci --prefer-offline --no-audit --include=optional
+      - uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+      - run: npx playwright merge-reports --reporter html ./all-blob-reports
+      - uses: actions/upload-artifact@v4
+        with:
+          name: html-report--attempt-${{ github.run_attempt }}
+          path: playwright-report
+          retention-days: 2
 
   documentation:
     runs-on: ubuntu-22.04

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,3 @@
+[lfs]
+	url = https://github.com/siemens-research/element-snapshots.git/info/lfs
+	pushurl = https://github.com/siemens-research/element-snapshots.git/info/lfs

--- a/e2e-local.sh
+++ b/e2e-local.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+
+# Copyright Siemens 2016 - 2025.
+# SPDX-License-Identifier: MIT
+
+cd $(dirname $0)
+
+# this is to stop MSys (Git bash on Windows) from messing with the paths
+export MSYS_NO_PATHCONV=1
+
+# Keep image version in sync with the image used in .github/workflows/build-and-test.yaml
+PLAYWRIGHT_IMAGE="mcr.microsoft.com/playwright:v1.52.0-noble"
+OS=$(uname -s)
+CWD=$(pwd)
+
+if [ x"$DOCKER" = "x" ]; then
+  DOCKER=docker
+fi
+
+case "$DOCKER" in
+  *podman*)
+    BRIDGE_ADDRESS=host.containers.internal
+    ;;
+  *)
+    BRIDGE_ADDRESS=host.docker.internal
+    ;;
+esac
+
+if command -v getenforce &> /dev/null && [ "$(getenforce)" = "Enforcing" ]; then
+  MOUNT_FLAGS=",Z"
+fi
+
+LOCAL_ADDRESS=$BRIDGE_ADDRESS
+NETWORK_MODE=bridge
+DISPLAY=$LOCAL_ADDRESS:0
+
+case "$OS" in
+  Linux*)
+    LOCAL_ADDRESS=localhost
+    NETWORK_MODE=host
+    DISPLAY=$DISPLAY
+    ;;
+  MINGW*)
+    CWD=$(cygpath -w $CWD)
+    ;;
+esac
+
+if [ x$PORT = "x" ]; then
+  PORT=4200
+fi
+
+echo "Using '$DOCKER' in '$NETWORK_MODE' mode, connecting to '$LOCAL_ADDRESS:$PORT'"
+
+if [ x$1 = "xshell" ]; then
+  shift
+  $DOCKER run -it --rm \
+    -e DISPLAY=$DISPLAY \
+    -e LOCAL_ADDRESS=$LOCAL_ADDRESS \
+    -e PORT=$PORT \
+    -e PLAYWRIGHT_CONTAINER=true \
+    -e PLAYWRIGHT_isvrt=true \
+    -e PLAYWRIGHT_staticTest=$PLAYWRIGHT_staticTest \
+    -v $CWD:/e2e:rw$MOUNT_FLAGS \
+    -w /e2e \
+    --net=$NETWORK_MODE \
+    --ipc=host \
+    --entrypoint bash \
+    $PLAYWRIGHT_IMAGE \
+    "$@"
+
+else
+  if [ x$1 = "xrun" ]; then
+    shift
+  fi
+  if [ x$1 = "xvrt" ]; then
+    shift
+    PLAYWRIGHT_isvrt=true
+  fi
+  if [ x$1 = "xa11y" ]; then
+    shift
+    PLAYWRIGHT_isa11y=true
+  fi
+  if [ x$1 = "xupdate" ]; then
+    shift
+    # using env var so the user can pass a --env
+    UPDATE_ARGS="--update-snapshots=changed"
+    PLAYWRIGHT_isvrt=true
+    echo "Updating snapshots.."
+  fi
+  if [ x$1 = "xupdate-all" ]; then
+    shift
+    # using env var so the user can pass a --env
+    UPDATE_ARGS="--update-snapshots=all"
+    PLAYWRIGHT_isvrt=true
+    echo "Updating all snapshots.."
+  fi
+  $DOCKER run -it --rm \
+    -e LOCAL_ADDRESS=$LOCAL_ADDRESS \
+    -e PORT=$PORT \
+    -e PLAYWRIGHT_CONTAINER=true \
+    -e PLAYWRIGHT_isa11y=$PLAYWRIGHT_isa11y \
+    -e PLAYWRIGHT_isvrt=$PLAYWRIGHT_isvrt \
+    -e PLAYWRIGHT_staticTest=$PLAYWRIGHT_staticTest \
+    -v $CWD:/e2e:rw$MOUNT_FLAGS \
+    -w /e2e \
+    --net=$NETWORK_MODE \
+    --ipc=host \
+    $PLAYWRIGHT_IMAGE \
+    npx \
+    playwright \
+    test \
+    $UPDATE_ARGS \
+    "$@" \
+  || npx playwright show-report playwright/results/preview
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,11 @@
         "@angular/compiler-cli": "19.0.6",
         "@angular/language-service": "19.0.6",
         "@angular/localize": "19.0.6",
+        "@axe-core/playwright": "4.10.1",
         "@commitlint/cli": "19.8.0",
         "@commitlint/config-conventional": "19.8.0",
         "@eslint/js": "9.25.1",
+        "@playwright/test": "1.52.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@siemens/commitlint-config": "2.1.1",
@@ -49,12 +51,14 @@
         "@types/jasmine": "5.1.7",
         "@types/node": "~22.14.0",
         "angular-eslint": "19.3.0",
+        "axe-html-reporter": "2.2.11",
         "cpy-cli": "5.0.0",
         "eslint": "9.25.1",
         "eslint-plugin-headers": "1.2.1",
         "eslint-plugin-perfectionist": "4.12.2",
         "eslint-plugin-prefer-arrow": "1.2.3",
         "eslint-plugin-tsdoc": "0.4.0",
+        "http-server": "14.1.1",
         "husky": "9.1.7",
         "jasmine-core": "5.6.0",
         "karma": "6.4.4",
@@ -82,9 +86,11 @@
         "yarn": "Please use NPM to install dependencies"
       },
       "optionalDependencies": {
-        "@playwright/test": "1.52.0",
+        "@axe-core/playwright": "4.10.1",
         "@simpl/brand": "^0.2.0",
-        "@simpl/element-icons": "^1.28.0"
+        "@simpl/element-icons": "^1.28.0",
+        "axe-html-reporter": "2.2.11",
+        "http-server": "14.1.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1846,6 +1852,19 @@
         "@angular/core": "19.0.6",
         "@angular/platform-browser": "19.0.6",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.1.tgz",
+      "integrity": "sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.2"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6535,8 +6554,8 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
       "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "playwright": "1.52.0"
       },
@@ -9265,6 +9284,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -9301,6 +9327,32 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axe-html-reporter": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/axe-html-reporter/-/axe-html-reporter-2.2.11.tgz",
+      "integrity": "sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mustache": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      },
+      "peerDependencies": {
+        "axe-core": ">=3"
       }
     },
     "node_modules/axobject-query": {
@@ -9419,6 +9471,26 @@
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -10821,6 +10893,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/cosmiconfig": {
@@ -13617,6 +13699,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -13711,6 +13803,19 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/html-entities": {
@@ -13877,6 +13982,87 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-server/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/http-server/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/http-server/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/http-server/node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -16498,6 +16684,16 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
       }
     },
     "node_modules/mute-stream": {
@@ -20059,6 +20255,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -20867,8 +21073,8 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
       "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "playwright-core": "1.52.0"
       },
@@ -20886,8 +21092,8 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
       "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -20899,6 +21105,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -20907,6 +21114,20 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.37.tgz",
+      "integrity": "sha512-yuGIEjDAYnnOex9ddMnKZEMFE0CcGo6zbfzDklkmT1m5z734ss6JMzN9rNB3+RR7iS+F10D4/BVIaXOyh8PQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
       }
     },
     "node_modules/postcss": {
@@ -22012,6 +22233,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -24726,6 +24954,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/unique-filename": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
@@ -25901,6 +26141,32 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint:format": "prettier --check .",
     "lint:commit": "commitlint --from=origin/main",
     "lint:ng": "ng lint",
+    "lint:playwright:eslint": "eslint playwright",
     "build:examples": "ng build",
     "build:examples:prod": "ng build --configuration production",
     "build:examples:aot": "ng build --configuration aot",
@@ -75,9 +76,11 @@
     "@angular/compiler-cli": "19.0.6",
     "@angular/language-service": "19.0.6",
     "@angular/localize": "19.0.6",
+    "@axe-core/playwright": "4.10.1",
     "@commitlint/cli": "19.8.0",
     "@commitlint/config-conventional": "19.8.0",
     "@eslint/js": "9.25.1",
+    "@playwright/test": "1.52.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@siemens/commitlint-config": "2.1.1",
@@ -88,12 +91,14 @@
     "@types/jasmine": "5.1.7",
     "@types/node": "~22.14.0",
     "angular-eslint": "19.3.0",
+    "axe-html-reporter": "2.2.11",
     "cpy-cli": "5.0.0",
     "eslint": "9.25.1",
     "eslint-plugin-headers": "1.2.1",
     "eslint-plugin-perfectionist": "4.12.2",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-tsdoc": "0.4.0",
+    "http-server": "14.1.1",
     "husky": "9.1.7",
     "jasmine-core": "5.6.0",
     "karma": "6.4.4",
@@ -116,7 +121,6 @@
     "typescript-eslint": "8.31.0"
   },
   "optionalDependencies": {
-    "@playwright/test": "1.52.0",
     "@simpl/brand": "^0.2.0",
     "@simpl/element-icons": "^1.28.0"
   }

--- a/playwright-merge.config.ts
+++ b/playwright-merge.config.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright Siemens 2016 - 2025.
+ * SPDX-License-Identifier: MIT
+ */
+import { PlaywrightTestConfig } from '@playwright/test';
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './playwright/e2e/element',
+  snapshotDir: './playwright/snapshots',
+  outputDir: './playwright/results/tests',
+  reporter: [
+    ['github'],
+    [
+      'html',
+      {
+        open: 'on-failure',
+        outputFolder: './playwright/results/preview'
+      }
+    ],
+    [
+      'junit',
+      {
+        outputFile: `./playwright/results/reports/report-e2e.xml`,
+        includeProjectInTestName: true
+      }
+    ],
+    [
+      './playwright/reporters/playwright-axe-reporter.ts',
+      {
+        outputFile: './playwright/results/a11y/accessibility-report.json',
+        htmlOutputDir: './playwright/results/a11y/tests'
+      }
+    ]
+  ]
+};
+
+export default config;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright Siemens 2016 - 2025.
+ * SPDX-License-Identifier: MIT
+ */
+import { devices, type PlaywrightTestConfig } from '@playwright/test';
+
+const isContainer = !!process.env.PLAYWRIGHT_CONTAINER;
+const port = process.env.PORT ?? '4200';
+const localAddress = process.env.LOCAL_ADDRESS ?? 'localhost';
+const onDifferentLocalAddress = localAddress !== 'localhost';
+const isCI = !!process.env.CI;
+const webServerCommand = 'npx http-server dist/element-examples -s -p 4200 -a 127.0.0.1';
+let isA11y =
+  !!process.env.PLAYWRIGHT_isa11y && process.env.PLAYWRIGHT_isa11y.toLocaleLowerCase() !== 'false';
+let isVrt =
+  !!process.env.PLAYWRIGHT_isvrt && process.env.PLAYWRIGHT_isvrt.toLocaleLowerCase() !== 'false';
+// Per default do both A11y and VRT
+if (!isA11y && !isVrt) {
+  isA11y = true;
+  isVrt = true;
+}
+// List of all projects, which will be used to automatically start the web server if necessary.
+let projectsToRun = [`element-examples/chromium/light`, `element-examples/chromium/dark`];
+
+// Check if only one is run using the command-line arguments. Do not use for any other reason because this won't be set for runner subprocesses.
+const onlySelectProjects = process.argv.find(val => val.startsWith('--project='));
+if (onlySelectProjects) {
+  let projectsGlob = onlySelectProjects.split('=')[1];
+  if (projectsGlob.endsWith('/*')) {
+    projectsGlob = projectsGlob.replace(/(\/\*)+$/, '');
+    projectsToRun = projectsToRun.filter(project => project.startsWith(projectsGlob));
+  } else {
+    projectsToRun = [projectsGlob];
+  }
+}
+
+/* Use the same default viewport as cypress */
+const baseViewport = {
+  width: 1000,
+  height: 660
+};
+
+const chromeLaunchOptions = {
+  args: [
+    '--disable-skia-runtime-opts',
+    '--force-color-profile=srgb',
+    '--disable-low-res-tiling',
+    '--disable-oop-rasterization',
+    '--disable-composited-antialiasing',
+    '--disable-smooth-scrolling'
+  ]
+};
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  snapshotDir: './playwright/snapshots',
+  outputDir: './playwright/results/tests',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000,
+    toHaveScreenshot: { maxDiffPixels: 0, threshold: 0.075 }
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: isCI,
+  /* Retry on CI only */
+  retries: isCI ? 1 : 0,
+  /* Use fixed number of workers. */
+  workers: 4,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: isCI
+    ? [['dot'], ['blob']]
+    : [
+        ['line'],
+        [
+          'html',
+          {
+            open: isContainer ? 'never' : 'on-failure',
+            outputFolder: './playwright/results/preview'
+          }
+        ],
+        [
+          'junit',
+          {
+            outputFile: `./playwright/results/reports/report-${
+              isA11y && isVrt ? 'e2e' : isA11y ? 'a11y' : 'vrt'
+            }.xml`,
+            includeProjectInTestName: true
+          }
+        ],
+        [
+          './playwright/reporters/playwright-axe-reporter.ts',
+          {
+            outputFile: './playwright/results/a11y/accessibility-report.json',
+            htmlOutputDir: './playwright/results/a11y/tests',
+            isA11y
+          }
+        ]
+      ],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    ...devices['Desktop Chrome'],
+    launchOptions: chromeLaunchOptions,
+
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: `http://${localAddress}:${port}`,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: isCI ? 'on-first-retry' : 'retain-on-failure',
+
+    viewport: baseViewport,
+
+    /* Screenshot on failure */
+    screenshot: 'only-on-failure',
+
+    video: isCI ? 'on-first-retry' : 'retain-on-failure'
+  },
+
+  /* Configure projects for major browsers, webkit is currently flaky */
+  projects: [
+    {
+      name: `element-examples/chromium/light`,
+      metadata: { livePreviewer: true, theme: 'light' },
+      testDir: './playwright/e2e/element-examples'
+    },
+    {
+      name: `element-examples/chromium/dark`,
+      metadata: { livePreviewer: true, theme: 'dark', skipAriaSnapshot: true },
+      testDir: './playwright/e2e/element-examples'
+    }
+  ],
+  webServer: !onDifferentLocalAddress
+    ? [
+        ...(projectsToRun.find(project => project.startsWith('element-examples/chromium'))
+          ? [
+              {
+                command: webServerCommand,
+                url: `http://${localAddress}:${port}`,
+                reuseExistingServer: !isCI
+              }
+            ]
+          : [])
+      ]
+    : undefined
+};
+
+export default config;

--- a/playwright/e2e/element-examples/si-application-header.spec.ts
+++ b/playwright/e2e/element-examples/si-application-header.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright Siemens 2016 - 2025.
+ * SPDX-License-Identifier: MIT
+ */
+import { test } from '../../support/test-helpers';
+
+test.describe('application-header', () => {
+  const example = 'si-application-header/si-application-header';
+
+  test('on a large screen', async ({ page, si }) => {
+    await si.visitExample(example);
+    await page.getByRole('button', { name: 'Tenant 1' }).click();
+    await page.getByRole('button', { name: 'Tenant 2', exact: true }).click();
+    await page.getByText('Module 2').click();
+    await si.runVisualAndA11yTests('navigation expanded');
+    await page.getByText('Notifications').click();
+    await si.runVisualAndA11yTests('notifications expanded');
+    await page.getByRole('button', { name: 'Lars Vegas' }).click();
+    await page.getByText('Language').click();
+    await si.runVisualAndA11yTests('account expanded');
+    await page.getByRole('button', { name: 'Lars Vegas' }).click();
+    await si.runVisualAndA11yTests();
+  });
+
+  test('on a small screen', async ({ page, si }) => {
+    await si.visitExample(example);
+    await page.setViewportSize({ width: 500, height: 660 });
+    await page.getByLabel('Toggle navigation').click();
+    await page.getByText('Module 2').click();
+    await si.runVisualAndA11yTests('mobile navigation expanded');
+    await page.getByText('Notifications').click();
+    await si.runVisualAndA11yTests('mobile notifications expanded');
+    await page.getByLabel('Toggle actions').click();
+    await page.getByText('Support').click();
+    await si.runVisualAndA11yTests('mobile collapsible actions expanded');
+    await page.getByRole('button', { name: 'Lars Vegas' }).click();
+    await page.getByText('Language').click();
+    await si.runVisualAndA11yTests('mobile account expanded');
+    // might be fully covered, but clicking it should be fine
+    await page.locator('.modal-backdrop').click({ force: true });
+    await si.runVisualAndA11yTests('mobile');
+  });
+});

--- a/playwright/reporters/playwright-axe-reporter.ts
+++ b/playwright/reporters/playwright-axe-reporter.ts
@@ -1,0 +1,228 @@
+/**
+ * Copyright Siemens 2016 - 2025.
+ * SPDX-License-Identifier: MIT
+ */
+import { expect, type FullConfig, type TestInfo } from '@playwright/test';
+import { type Reporter, Suite, TestCase } from '@playwright/test/reporter';
+import * as axe from 'axe-core';
+import { createHtmlReport } from 'axe-html-reporter';
+import { mkdir, writeFile } from 'fs/promises';
+
+const A11Y_VIOLATIONS_ID = 'a11yViolations';
+
+const A11Y_TEST_NAME_ID = 'a11yTestName';
+
+export const expectNoA11yViolations = async (
+  testInfo: TestInfo,
+  violations: axe.Result[],
+  testName: string
+): Promise<void> => {
+  testInfo.annotations.push({ type: A11Y_TEST_NAME_ID, description: testName });
+  await testInfo.attach(A11Y_VIOLATIONS_ID, { body: JSON.stringify(violations, null, 2) });
+  const errorMessages = generateErrorMessages(testInfo, violations, testName);
+  expect(errorMessages).toEqual('');
+};
+
+const generateHTMLFileName = (reportFileName: string): string => `${reportFileName}.html`;
+
+const generateHTMLFilePath = (directory: string, reportTestName: string): string =>
+  `${directory}/${generateHTMLFileName(reportTestName)}`;
+
+const getReporterConfig = (testInfo: TestInfo): any | undefined => {
+  const reporters = testInfo.config.reporter;
+
+  if (reporters && typeof reporters !== 'string') {
+    return reporters.find(reporter => reporter[0].includes('playwright-axe-reporter'));
+  }
+
+  return undefined;
+};
+
+const generateErrorMessages = (
+  testInfo: TestInfo,
+  violations: axe.Result[],
+  testName: string
+): string => {
+  if (violations.length) {
+    let html: string | undefined;
+
+    const reporterConfig = getReporterConfig(testInfo);
+
+    const htmlOutputDir = reporterConfig?.[1] ? reporterConfig[1].htmlOutputDir : undefined;
+
+    if (htmlOutputDir) {
+      html = generateHTMLFilePath(htmlOutputDir, testName);
+    }
+
+    let message = `${violations.length} a11y violation(s) detected\n`;
+    violations.forEach(v => {
+      message += `      - ${v.nodes.length} ${v.id} (${v.impact}): ${v.description}\n`;
+    });
+    if (html) {
+      message += `      => report: ${html}`;
+    }
+    return message;
+  }
+  return '';
+};
+
+class PlaywrightAxeReporter implements Reporter {
+  private isA11y = true;
+  private outputFile?: string;
+  private htmlOutputDir?: string;
+
+  private tests?: TestCase[];
+
+  constructor(
+    options: { outputFile?: string; htmlOutputDir?: string; isA11y?: boolean | string } = {}
+  ) {
+    this.outputFile = options.outputFile;
+    this.htmlOutputDir = options.htmlOutputDir;
+    if (options.isA11y === false) {
+      this.isA11y = false;
+    } else if (options.isA11y && options.isA11y !== true) {
+      const env = process.env[options.isA11y];
+      this.isA11y = !!env && env.toLocaleLowerCase() !== 'false';
+    }
+  }
+
+  private generateGitLabReportItem(item: axe.Result): any {
+    return {
+      code: item.id,
+      type: 'error',
+      typeCode: 1,
+      message: `${item.help} (${item.helpUrl})`,
+      context: item.nodes.map((node: axe.NodeResult) => node.html).join(' | '),
+      selector: item.nodes.map((node: axe.NodeResult) => node.target).join(' | '),
+      runner: 'axe',
+      runnerExtras: {
+        description: item.description,
+        impact: item.impact,
+        help: item.help,
+        helpUrl: item.helpUrl,
+        tags: item.tags
+      }
+    };
+  }
+
+  private generateGitLabReport(items: axe.Result[]): any[] {
+    return items.map(item => this.generateGitLabReportItem(item));
+  }
+
+  private getTestName(test: TestCase): string {
+    return (
+      test.annotations.find(result => result.type === A11Y_TEST_NAME_ID)?.description ?? test.title
+    );
+  }
+
+  // Get all attachments of the latest test result (if there are multiple there were retries).
+  private getViolations(test: TestCase): axe.Result[] {
+    for (let index = test.results.length - 1; index >= 0; index--) {
+      const result = test.results[index];
+
+      let violations: axe.Result[] | undefined;
+
+      result.attachments.forEach(attachment => {
+        if (attachment.name !== A11Y_VIOLATIONS_ID) {
+          return;
+        }
+
+        const attachmentString = attachment.body?.toString('utf8');
+
+        if (!attachmentString) {
+          return;
+        }
+
+        const foundViolations = JSON.parse(attachmentString) as axe.Result[];
+
+        if (!violations) {
+          violations = [...foundViolations];
+        } else {
+          violations.push(...foundViolations);
+        }
+      });
+
+      if (violations) {
+        return violations;
+      }
+    }
+
+    return [];
+  }
+
+  private generateHTMLReport(
+    testTitle: string,
+    reportTestName: string,
+    violations: axe.Result[]
+  ): void {
+    if (this.htmlOutputDir) {
+      /* eslint-disable no-console */
+      // createHtmlReport contains a hardcoded console.info() that generates noise
+      const origConsoleInfo = console.info;
+      (console.info as any) = () => {};
+
+      createHtmlReport({
+        results: { violations },
+        options: {
+          projectKey: testTitle,
+          outputDir: this.htmlOutputDir,
+          reportFileName: generateHTMLFileName(reportTestName)
+        }
+      });
+
+      console.info = origConsoleInfo;
+      /* eslint-enable no-console */
+    }
+  }
+
+  onBegin(_: FullConfig, suite: Suite): void {
+    if (this.isA11y && this.outputFile) {
+      this.tests = suite.allTests();
+    }
+  }
+
+  async onEnd(): Promise<void> {
+    if (this.isA11y && this.outputFile && this.tests) {
+      const a11yReport: Record<
+        string,
+        ReturnType<PlaywrightAxeReporter['generateGitLabReportItem']>[]
+      > = {};
+
+      this.tests.forEach(test => {
+        const violations = this.getViolations(test);
+
+        if (violations.length) {
+          const testName = this.getTestName(test);
+
+          this.generateHTMLReport(test.title, testName, violations);
+
+          a11yReport[testName] = this.generateGitLabReport(violations);
+        }
+      });
+
+      const jsonReport = {
+        total: this.tests.length,
+        passes: this.tests.reduce(
+          (count, test) =>
+            test.outcome() === 'expected' || test.outcome() === 'flaky' ? count + 1 : count,
+          0
+        ),
+        errors: this.tests.reduce(
+          (count, test) => (test.outcome() === 'unexpected' ? count + 1 : count),
+          0
+        ),
+        results: a11yReport
+      };
+
+      await mkdir(this.outputFile.substring(0, this.outputFile.lastIndexOf('/')), {
+        recursive: true
+      });
+      await writeFile(this.outputFile, JSON.stringify(jsonReport, null, 2), 'utf8');
+    }
+  }
+
+  printsToStdio(): boolean {
+    return false;
+  }
+}
+export default PlaywrightAxeReporter;

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--account-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--account-expanded-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:032395c1bb6590e4eb4b8efaf5d7ee259583606812233948eea17267dc8c45bb
+size 23334

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--account-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--account-expanded-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49eeef45dfdea2840461e8bfa73c95834420940fc79890c357d02f7e309b3ea7
+size 23111

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--account-expanded.yaml
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--account-expanded.yaml
@@ -1,0 +1,22 @@
+- banner:
+  - link "Siemens logo":
+    - /url: "#/"
+  - text: My application
+  - navigation "Main navigation":
+    - link "Module 1":
+      - /url: "#/viewer/viewer/m1"
+    - button "Module 2"
+  - button "Tenant 2"
+  - button "Notifications"
+  - button /\+\d+ Support/
+  - button "Settings"
+  - button "Lars Vegas" [expanded]
+  - group "Lars Vegas":
+    - text: Lars Vegas lars.vegas@siemens.com Siemens AG Admin
+    - button "Language" [expanded]
+    - group "Language":
+      - text: Selection has no effect!
+      - button "German"
+      - button "English"
+    - button "Design"
+    - button "Profile"

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-account-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-account-expanded-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:380516657576e841ceea6ed870859701fe9bc39e02ac6e69aa24e533a11e013b
+size 17819

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-account-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-account-expanded-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:751c137eaf69f9c3916269a8f3a2440a8c487de64189866c81bd3906e38662e0
+size 16869

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-account-expanded.yaml
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-account-expanded.yaml
@@ -1,0 +1,15 @@
+- banner:
+  - button "Toggle navigation"
+  - text: My application
+  - button "Notifications"
+  - button "Toggle actions"
+  - button "Lars Vegas" [expanded]
+  - group "Lars Vegas":
+    - text: Lars Vegas lars.vegas@siemens.com Siemens AG Admin
+    - button "Language" [expanded]
+    - group "Language":
+      - text: Selection has no effect!
+      - button "German"
+      - button "English"
+    - button "Design"
+    - button "Profile"

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-collapsible-actions-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-collapsible-actions-expanded-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ed82f6131a31c5442b242e2074a9f4c2d42bc513aa6ef528b5d261ca799ac90
+size 12517

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-collapsible-actions-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-collapsible-actions-expanded-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90c5e1bff88d0b449322b8a1c7938da1a227bc163d80a4cb10676161fd892253
+size 12021

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-collapsible-actions-expanded.yaml
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-collapsible-actions-expanded.yaml
@@ -1,0 +1,12 @@
+- banner:
+  - button "Toggle navigation"
+  - text: My application
+  - button "Notifications"
+  - button "Toggle actions" [expanded]
+  - button "Tenant 1"
+  - button /\+\d+ Support/ [expanded]
+  - group /\+\d+ Support/:
+    - button "Help"
+    - button "Contact"
+  - button "Settings"
+  - button "Lars Vegas"

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8400a31fe73ed9acef74d353213d95a7beaeb6da8cb78af1bee88152eba58194
+size 5944

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d3381a3d98f24375bbe2df541176e7a41639e4f9c1930fc7fe8bfb93a8afccd
+size 5617

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-navigation-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-navigation-expanded-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e34c82cc4a51346e12dca1b80d8515947a181da544b20aba407fbdd87a7e0df4
+size 9607

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-navigation-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-navigation-expanded-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4be8a52f9e4d6a4c7d8bc02bc8c6558ba498c93b0683fcf5ad338cbbab3a242c
+size 9155

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-navigation-expanded.yaml
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-navigation-expanded.yaml
@@ -1,0 +1,15 @@
+- banner:
+  - button "Toggle navigation" [expanded]
+  - text: My application
+  - navigation "Main navigation":
+    - link "Module 1":
+      - /url: "#/viewer/viewer/m1"
+    - button "Module 2" [expanded]
+    - group "Module 2":
+      - link "M2.1":
+        - /url: "#/viewer/viewer/m2/1"
+      - link "M2.2":
+        - /url: "#/viewer/viewer/m2/2"
+  - button "Notifications"
+  - button "Toggle actions"
+  - button "Lars Vegas"

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-notifications-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-notifications-expanded-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c7f0de3f5f984d3ee63fbd3a78fdda62e8213a45b8576a4aaa42dca8c23c1a5
+size 8168

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-notifications-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-notifications-expanded-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:703669c52b22cb35da4f8c0ad50ad7a6430b62e912bfffe2419eb2bc2d90c85c
+size 7656

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-notifications-expanded.yaml
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-notifications-expanded.yaml
@@ -1,0 +1,9 @@
+- banner:
+  - button "Toggle navigation"
+  - text: My application
+  - button "Notifications" [expanded]
+  - group "Notifications":
+    - button "Message 1"
+    - button "Message 2"
+  - button "Toggle actions"
+  - button "Lars Vegas"

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile.yaml
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile.yaml
@@ -1,0 +1,6 @@
+- banner:
+  - button "Toggle navigation"
+  - text: My application
+  - button "Notifications"
+  - button "Toggle actions"
+  - button "Lars Vegas"

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--navigation-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--navigation-expanded-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfe2cf6b62c6aea5ac0a5d4447d83366a3ce3a767b9236698ef1d3e35c2a16e0
+size 16244

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--navigation-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--navigation-expanded-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:244716e63ebcbc3be97ffcaf2b03f091730d512c25e2a7ce3834739b35b55b57
+size 16040

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--navigation-expanded.yaml
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--navigation-expanded.yaml
@@ -1,0 +1,18 @@
+- banner:
+  - link "Siemens logo":
+    - /url: "#/"
+  - text: My application
+  - navigation "Main navigation":
+    - link "Module 1":
+      - /url: "#/viewer/viewer/m1"
+    - button "Module 2" [expanded]
+    - group "Module 2":
+      - link "M2.1":
+        - /url: "#/viewer/viewer/m2/1"
+      - link "M2.2":
+        - /url: "#/viewer/viewer/m2/2"
+  - button "Tenant 2"
+  - button "Notifications"
+  - button /\+\d+ Support/
+  - button "Settings"
+  - button "Lars Vegas"

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--notifications-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--notifications-expanded-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd4d048f60cd1792d294fe7fe11e3185f378676dca02f922828eb308d3e5e098
+size 16463

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--notifications-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--notifications-expanded-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:197d3a5ab1e3f6d28b42c328170a90aefdb362a5b1bdbdd00a068353c5d3c15c
+size 16217

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--notifications-expanded.yaml
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--notifications-expanded.yaml
@@ -1,0 +1,16 @@
+- banner:
+  - link "Siemens logo":
+    - /url: "#/"
+  - text: My application
+  - navigation "Main navigation":
+    - link "Module 1":
+      - /url: "#/viewer/viewer/m1"
+    - button "Module 2"
+  - button "Tenant 2"
+  - button "Notifications" [expanded]
+  - group "Notifications":
+    - button "Message 1"
+    - button "Message 2"
+  - button /\+\d+ Support/
+  - button "Settings"
+  - button "Lars Vegas"

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fe34ce16338adae1ff64c79b6d795ae999540a03df799ca35743071a2e07658
+size 13276

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f96cc58ffc6d05ae033fbe39841ba912312c0b244b743fe9cac0d8f8d49254d
+size 12226

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header.yaml
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header.yaml
@@ -1,0 +1,13 @@
+- banner:
+  - link "Siemens logo":
+    - /url: "#/"
+  - text: My application
+  - navigation "Main navigation":
+    - link "Module 1":
+      - /url: "#/viewer/viewer/m1"
+    - button "Module 2"
+  - button "Tenant 2"
+  - button "Notifications"
+  - button /\+\d+ Support/
+  - button "Settings"
+  - button "Lars Vegas"

--- a/playwright/support/test-helpers.ts
+++ b/playwright/support/test-helpers.ts
@@ -1,0 +1,302 @@
+/**
+ * Copyright Siemens 2016 - 2025.
+ * SPDX-License-Identifier: MIT
+ */
+import AxeBuilder from '@axe-core/playwright';
+import {
+  test as baseTest,
+  type ElementHandle,
+  expect,
+  type Page,
+  type TestInfo,
+  Locator
+} from '@playwright/test';
+import axe from 'axe-core';
+
+import { expectNoA11yViolations } from '../reporters/playwright-axe-reporter';
+
+export { expect } from '@playwright/test';
+
+const SI_EXAMPLE_NAME_ID = 'siExampleName';
+
+const detectTestTypes = (): { isA11y: boolean; isVrt: boolean } => {
+  let isA11y =
+    !!process.env.PLAYWRIGHT_isa11y &&
+    process.env.PLAYWRIGHT_isa11y.toLocaleLowerCase() !== 'false';
+
+  let isVrt =
+    !!process.env.PLAYWRIGHT_isvrt && process.env.PLAYWRIGHT_isvrt.toLocaleLowerCase() !== 'false';
+
+  // Per default do both A11y and VRT
+  if (!isA11y && !isVrt) {
+    isA11y = true;
+    isVrt = true;
+  }
+
+  return { isA11y, isVrt };
+};
+
+const { isA11y, isVrt } = detectTestTypes();
+
+const staticTest = process.env.PLAYWRIGHT_staticTest
+  ? new Set(process.env.PLAYWRIGHT_staticTest.split(':'))
+  : undefined;
+
+export const VIEWPORTS = [
+  { name: 'default', width: 0, height: 0 }, // Default, 0 will skip resizing and use the default value
+  { name: 'tablet-portrait', width: 768, height: 1024 },
+  { name: 'tablet-landscape', width: 1024, height: 768 }
+];
+export type Viewport = (typeof VIEWPORTS)[number];
+
+export type StaticTestOptions = {
+  delay?: number;
+  maxDiffPixels?: number;
+  disabledA11yRules?: string[];
+  viewports?: (Viewport | string)[];
+  waitCallback?: (page: Page) => Promise<void>;
+  skipAutoScaleViewport?: boolean;
+  skipAriaSnapshot?: boolean;
+};
+
+// Playwright since 1.48 has the mouse cursor at 0/0 causing any element at this coordinate to be
+// in hover state. This leads to unexpected state in snapshots. To work around this, simply
+// move the mouse outside the viewport. Since this is executed before any test code runs,
+// tests using the mouse are not affected.
+const hoverFix = async (page: Page): Promise<void> => page.mouse.move(-10, -10);
+
+class SiTestHelpers {
+  private disableAnimationsTag: ElementHandle<Node> | undefined;
+
+  constructor(
+    private page: Page,
+    private testInfo: TestInfo
+  ) {}
+
+  /**
+   * Gets example name from test name and statically runs visual and a11y tests.
+   */
+  public async static(options?: StaticTestOptions): Promise<void> {
+    const exampleName = this.testInfo.title;
+    if (!staticTest || staticTest.has(exampleName)) {
+      const viewports = (options?.viewports?.length ? options.viewports : ['default'])
+        .map(viewport =>
+          typeof viewport !== 'string' ? viewport : VIEWPORTS.find(v => v.name === viewport)
+        )
+        .filter(viewport => !!viewport)
+        .sort((a, b) => a.width * a.height - a.height * b.height); // This ensures the default viewport is first.
+
+      for (const viewport of viewports) {
+        const isDefaultViewport = viewport.height === 0 && viewport.width === 0;
+        const specifyViewport = !isDefaultViewport || viewports.length > 1;
+        const step = specifyViewport ? viewport.name : undefined;
+        if (!isDefaultViewport) {
+          await this.page.setViewportSize({ width: viewport.width, height: viewport.height });
+        }
+        await this.visitExample(exampleName, !options?.skipAutoScaleViewport);
+        if (options?.waitCallback) {
+          await options?.waitCallback(this.page);
+        }
+        if (options?.delay) {
+          await this.page.waitForTimeout(options?.delay);
+        }
+        await this.runVisualAndA11yTests(step, {
+          axeRulesSet: options?.disabledA11yRules?.map(item => ({ id: item, enabled: false })),
+          maxDiffPixels: options?.maxDiffPixels,
+          skipAriaSnapshot: options?.skipAriaSnapshot
+        });
+      }
+    }
+  }
+
+  public async visitExample(name: string, autoScaleViewport = true): Promise<void> {
+    await test.step(
+      'visitExample: ' + name,
+      async () => {
+        this.testInfo.annotations.push({ type: SI_EXAMPLE_NAME_ID, description: name });
+        const livePreviewer = !!this.testInfo.project.metadata.livePreviewer;
+        const theme = this.testInfo.project.metadata.theme;
+        const mode = this.testInfo.project.metadata.mode;
+        const urlParams = [];
+        if (theme) {
+          urlParams.push(`theme=${theme}`);
+        }
+        if (mode) {
+          urlParams.push(`mode=${mode}`);
+        }
+        if (livePreviewer) {
+          urlParams.push(`e=${encodeURIComponent(name)}`);
+        }
+        const urlParamsString = urlParams.length ? '?' + urlParams.join('&') : '';
+        const newHash = livePreviewer
+          ? `#/viewer/viewer${urlParamsString}`
+          : `#/${name}${urlParamsString}`;
+        await this.page.goto(newHash);
+
+        await this.page.evaluate(() => document.fonts.ready);
+
+        if (livePreviewer) {
+          await expect(
+            this.page.locator(`si-live-preview-renderer[data-example*="${name}"]`)
+          ).toBeVisible();
+          await expect(this.page.locator('.live-preview-done')).toBeVisible();
+        }
+
+        if (autoScaleViewport) {
+          const height = await this.page.evaluate(() => document.body.scrollHeight);
+          const width = await this.page.evaluate(() => document.body.scrollWidth);
+          const viewportSize = this.page.viewportSize();
+          if (!viewportSize || viewportSize.height < height || viewportSize.width < width) {
+            await this.page.setViewportSize({
+              height: Math.max(height, viewportSize?.height ?? 0),
+              width: Math.max(width, viewportSize?.width ?? 0)
+            });
+          }
+        }
+      },
+      { box: true }
+    );
+  }
+
+  public async runVisualAndA11yTests(
+    step?: string,
+    options?: {
+      axeRulesSet?: (string | { id: string; enabled: boolean })[];
+      skipAriaSnapshot?: boolean;
+      maxDiffPixels?: number;
+    }
+  ): Promise<void> {
+    const example = this.getExampleName() ?? this.testInfo.title;
+    const testName = this.makeTestName(example, step);
+    let axeRulesSet = options?.axeRulesSet ?? [];
+    await test.step(
+      'runVisualAndA11yTests: ' + testName,
+      async () => {
+        if (isA11y) {
+          await this.enableDisableAnimations(this.page, false);
+          const rules = (options?.axeRulesSet ?? [])
+            .filter(
+              item =>
+                typeof item === 'string' || (typeof item === 'object' && item?.enabled === true)
+            )
+            .map(item => (typeof item === 'object' ? item.id : item));
+
+          if (
+            !!process.env.PLAYWRIGHT_a11y_all &&
+            process.env.PLAYWRIGHT_a11y_all.toLocaleLowerCase() !== 'false'
+          ) {
+            // Only use global disabled rules.
+            axeRulesSet = [];
+          }
+
+          const disabledRules = [
+            'landmark-one-main',
+            'page-has-heading-one',
+            'region',
+            ...axeRulesSet
+              .filter(item => typeof item === 'object' && item?.enabled === false)
+              .map(item => (typeof item === 'object' ? item.id : item))
+          ];
+          let axeResults: axe.AxeResults;
+          try {
+            if (rules.length) {
+              axeResults = (await new AxeBuilder({ page: this.page })
+                // Excluding .header-logo is a temporary workaround as axe does not accept alt text in content style
+                .exclude(
+                  '.e2e-ignore-a11y, .cdk-focus-trap-anchor, .header-logo, .landing-page-logo'
+                )
+                .withRules(rules)
+                .disableRules(disabledRules)
+                .analyze()) as axe.AxeResults;
+            } else {
+              axeResults = (await new AxeBuilder({ page: this.page })
+                // Excluding .header-logo is a temporary workaround as axe does not accept alt text in content style
+                .exclude(
+                  '.e2e-ignore-a11y, .cdk-focus-trap-anchor, .header-logo, .landing-page-logo'
+                )
+                .disableRules(disabledRules)
+                .analyze()) as axe.AxeResults;
+            }
+          } finally {
+            await this.enableDisableAnimations(this.page, true);
+          }
+          await expectNoA11yViolations(this.testInfo, axeResults.violations, testName);
+        }
+        if (isVrt) {
+          await expect(this.page).toHaveScreenshot(testName + '.png', {
+            maxDiffPixels: options?.maxDiffPixels,
+            stylePath: './playwright/support/vrt-styles.css'
+          });
+
+          if (!options?.skipAriaSnapshot && !this.testInfo.project.metadata.skipAriaSnapshot) {
+            await expect(this.page.locator('body')).toMatchAriaSnapshot({
+              name: testName + '.yaml'
+            });
+          }
+        }
+      },
+      { box: true }
+    );
+  }
+
+  public async waitForAllAnimationsToComplete(threshold = 0): Promise<void> {
+    await this.page.waitForFunction(
+      count => window.document.getAnimations().length <= count,
+      threshold
+    );
+  }
+  /**
+   * Get the example name set by `visitExample`.
+   */
+  public getExampleName(): string | undefined {
+    return this.testInfo.annotations.find(result => result.type === SI_EXAMPLE_NAME_ID)
+      ?.description;
+  }
+
+  public async getDescription(locator: Locator): Promise<Locator> {
+    const describedBy = await locator.getAttribute('aria-describedby');
+    return this.page.locator(`#${describedBy}`);
+  }
+
+  private async enableDisableAnimations(page: Page, show: boolean): Promise<void> {
+    if (!show) {
+      await this.disableAnimationsTag?.evaluate(element =>
+        element.parentNode?.removeChild(element)
+      );
+      await this.disableAnimationsTag?.dispose();
+      this.disableAnimationsTag = await page.addStyleTag({
+        content: `*, *:before, *:after {
+  transition-property: none !important;
+  animation: none !important;
+}`
+      });
+    } else {
+      await this.disableAnimationsTag?.evaluate(element =>
+        element.parentNode?.removeChild(element)
+      );
+      await this.disableAnimationsTag?.dispose();
+      this.disableAnimationsTag = undefined;
+    }
+  }
+
+  private makeTestName(example: string, step?: string): string {
+    // this is so that we have filenames that make sense
+    let testName = example.replace(/\//g, '--');
+    if (step) {
+      testName += `--${step}`;
+    }
+    return testName;
+  }
+}
+
+export const test = baseTest.extend<{
+  si: SiTestHelpers;
+}>({
+  si: [
+    async ({ page }, use, testInfo) => {
+      await hoverFix(page);
+      await use(new SiTestHelpers(page, testInfo));
+    },
+    { box: true }
+  ]
+});

--- a/playwright/support/vrt-styles.css
+++ b/playwright/support/vrt-styles.css
@@ -1,0 +1,3 @@
+.e2e-ignore {
+  display: none;
+}

--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "target": "es2022",
+    "lib": ["dom", "es2022"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
Introducing the e2e test setup based on playwright. It is based mainly on our internal with some modifications.

Since GitHub is still not able to set up our lfs billing, we have to use the alternative repository in siemens-research. This is hopefully fixed soon.

A remark: we have sharding and stuff in place because there will be many more vrts as we move on with migration.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
