### PR TITLE
test(e2e): optional screenshot delay after hiding .e2e-ignore

### DIFF
--- a/playwright/support/vrt-styles.css
+++ b/playwright/support/vrt-styles.css
@@ -1,3 +1,0 @@
-.e2e-ignore {
-  display: none;
-}


### PR DESCRIPTION
When an example uses full height, hiding the e2e control panel will cause a change in layout that can result in calculated changes that are not immediately rendered. E.g. the vertical wizard.


---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
