### PR TITLE
feat(theme): add a .text-link class for link in text

### DIFF
--- a/docs/components/buttons-menus/links.md
+++ b/docs/components/buttons-menus/links.md
@@ -14,6 +14,8 @@ If the action taken by the user will change or manipulate data, use a [button](b
 - Text should be consistent with the title of the intended destination.
 - Use caution with links that are several words long. It is recommended that links are long enough to be understood by the user, but short enough to prevent text wrapping.
 - Avoid the term “click here,” other links to “here,” or the web address itself. Instead, use a meaningful descriptive label for the link, and match the destination site name.
+- Links in paragraphs should always be underlined to ensure they’re easily recognized.
+  As standalone elements (e.g., in cards or lists), underlines aren’t needed and an arrow icon (>) can be used to clarify function.
 - If a link needs to trigger an action instead of navigating (e.g., opening a modal or expanding content),
   use a button link instead.
 
@@ -21,7 +23,7 @@ If the action taken by the user will change or manipulate data, use a [button](b
 
 ### States
 
-Links support the different styles: default/visited, hover, pressed, focused and disabled
+Links support the different styles: default/visited, hover, pressed, focused and disabled.
 
 ![Links](images/link-usage-construction.png)
 
@@ -42,6 +44,7 @@ This ensures correct semantics, accessibility, and behavior.
 
 ## Code ---
 
-The link styling is applied to the standard HTML `a` element.
+The link styling is applied to the standard HTML `a` element. For links inside a paragraph,
+add the class `.link-text` to add the underline.
 
-<si-docs-component example="links/links" height="50"></si-docs-component>
+<si-docs-component example="links/links" height="75"></si-docs-component>

--- a/projects/element-theme/src/styles/components/_links.scss
+++ b/projects/element-theme/src/styles/components/_links.scss
@@ -17,6 +17,11 @@ a:active {
   @extend a;
 }
 
+.link-text {
+  @extend a;
+  text-decoration: underline;
+}
+
 .link-icon {
   font-size: $si-link-icon-size !important; // stylelint-disable-line declaration-no-important
   line-height: $si-link-icon-line-height !important; // stylelint-disable-line declaration-no-important

--- a/src/app/examples/links/links.html
+++ b/src/app/examples/links/links.html
@@ -1,0 +1,42 @@
+<a href="#">Default Link</a><br />
+<a href="#" target="_blank">Link in new Window</a><br />
+
+<a href="#"><i class="link-icon link-start element-right-2 flip-rtl"></i>Default Icon Link</a><br />
+<a href="#" target="_blank"
+  ><i class="link-icon link-start element-right-2 flip-rtl"></i>Icon Link in new Window</a
+><br />
+
+<a href="#">Default Icon Link<i class="link-icon link-end element-right-2 flip-rtl"></i></a><br />
+<a href="#" target="_blank"
+  >Icon Link in new Window<i class="link-icon link-end element-right-2 flip-rtl"></i></a
+><br />
+
+<a href="#"><b>Default Link</b></a
+><br />
+<a href="#" target="_blank"><b>Link in new Window</b></a
+><br />
+
+<a href="#"
+  ><b><i class="link-icon link-start element-right-2 flip-rtl"></i>Default Icon Link</b></a
+><br />
+<a href="#" target="_blank"
+  ><b><i class="link-icon link-start element-right-2 flip-rtl"></i>Icon Link in new Window</b></a
+><br />
+
+<a href="#"
+  ><b>Default Icon Link<i class="link-icon link-end element-right-2 flip-rtl"></i></b></a
+><br />
+<a href="#" target="_blank"
+  ><b>Icon Link in new Window<i class="link-icon link-end element-right-2 flip-rtl"></i></b></a
+><br />
+
+<button type="button" class="btn btn-link">Button Link</button>
+<br />
+<button type="button" class="btn btn-link">
+  <span>Button Link with icon<i class="link-icon link-end element-right-2 flip-rtl"></i></span>
+</button>
+
+<p>
+  This is a paragraph of text with an <a href="#" class="link-text">embedded link</a> that needs the
+  class <code>.link-text</code> to be accessible.
+</p>

--- a/src/app/examples/links/links.ts
+++ b/src/app/examples/links/links.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright Siemens 2016 - 2025.
+ * SPDX-License-Identifier: MIT
+ */
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-sample',
+  templateUrl: './links.html',
+  host: { class: 'p-5' }
+})
+export class SampleComponent {}


### PR DESCRIPTION
When a link is used in a paragraph of text, it needs to be distinguishable from normal text. Either a contrast of at least 3:1 regarding the text color or by other means. Since colors don't always work, make it underline.

See https://dequeuniversity.com/rules/axe/4.10/link-in-text-block

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
