### PR TITLE
docs(code-of-conduct): correct project name

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Code of Conduct - Siemens Lint
+# Code of Conduct - Siemens Element
 
 ## Our Pledge
 


### PR DESCRIPTION
Addressed a small oversight in the `CODE_OF_CONDUCT.md`, using a copied project name.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
