### PR TITLE
refactor(status-icon): use visually hidden text instead of aria-label

### DIFF
--- a/projects/element-ng/icon/si-status-icon.component.ts
+++ b/projects/element-ng/icon/si-status-icon.component.ts
@@ -3,19 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgClass } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  DestroyRef,
-  inject,
-  input,
-  OnChanges,
-  signal
-} from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { EntityStatusType } from '@siemens/element-ng/common';
-import { SiTranslateService } from '@siemens/element-translate-ng/translate';
+import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { STATUS_ICON_CONFIG } from './icon-status';
 import { SiIconNextComponent } from './si-icon-next.component';
@@ -27,33 +17,17 @@ import { SiIconNextComponent } from './si-icon-next.component';
     @if (iconValue) {
       <si-icon-next [ngClass]="iconValue.color" [icon]="iconValue.icon" />
       <si-icon-next [ngClass]="iconValue.stackedColor" [icon]="iconValue.stacked" />
+      <span class="visually-hidden">{{ iconValue.ariaLabel | translate }}</span>
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgClass, SiIconNextComponent],
-  host: {
-    class: 'icon-stack',
-    '[attr.aria-label]': 'ariaLabel()'
-  }
+  imports: [NgClass, SiIconNextComponent, SiTranslateModule],
+  host: { class: 'icon-stack' }
 })
-export class SiStatusIconComponent implements OnChanges {
+export class SiStatusIconComponent {
   private readonly statusIcons = inject(STATUS_ICON_CONFIG);
-  private readonly translate = inject(SiTranslateService);
-  private readonly destroyRef = inject(DestroyRef);
 
   readonly status = input.required<EntityStatusType>();
 
   protected readonly statusIcon = computed(() => this.statusIcons[this.status()]);
-
-  protected readonly ariaLabel = signal<string | null>(null);
-
-  ngOnChanges(): void {
-    const ariaLabel = this.statusIcon()?.ariaLabel;
-    if (ariaLabel) {
-      this.translate
-        .translateAsync(ariaLabel)
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe(label => this.ariaLabel.set(label));
-    }
-  }
 }


### PR DESCRIPTION
The use of an aria-label is prohibited on
this element, see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label#associated_roles .

@panch1739 This is our inline notification example:

![image](https://github.com/user-attachments/assets/b7e29069-0f90-4c76-892b-4fc54469ac39)

This change adds a hidden label for the status, so the announced screen reader text is:
`Information Information: Better description of what happened.` (information is doubled).

Is our example "wrong" and the heading would normally not contain the status?
If not we would need to hide the status for inline-notifications.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
