### PR TITLE
feat(resize-observer): add emitInitial input to control initial resize emit

### DIFF
--- a/projects/element-ng/resize-observer/si-resize-observer.directive.spec.ts
+++ b/projects/element-ng/resize-observer/si-resize-observer.directive.spec.ts
@@ -21,6 +21,7 @@ import { SiResizeObserverDirective } from './si-resize-observer.directive';
       style="width: 100px; height: 100px;"
       [style.width.px]="width"
       [style.height.px]="height"
+      [emitInitial]="emitInitial"
       (siResizeObserver)="resizeHandler($event)"
     >
       Testli
@@ -31,6 +32,7 @@ import { SiResizeObserverDirective } from './si-resize-observer.directive';
 class TestHostComponent {
   width = 100;
   height = 100;
+  emitInitial = true;
 
   resizeHandler(dim: ElementDimensions): void {}
 }
@@ -93,5 +95,31 @@ describe('SiResizeObserverDirective', () => {
 
     flush();
     expect(component.resizeHandler).toHaveBeenCalledWith({ width: 100, height: 200 });
+  }));
+});
+
+describe('SiResizeObserverDirective with emitInitial=false', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+  let spy: jasmine.Spy<(dim: ElementDimensions) => void>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: []
+    }).compileComponents();
+  }));
+
+  beforeEach(fakeAsync(() => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    component.emitInitial = false;
+    spy = spyOn(component, 'resizeHandler');
+    fixture.detectChanges();
+    tick();
+  }));
+
+  it('does not emit initial size event', fakeAsync(() => {
+    expect(spy).not.toHaveBeenCalled();
   }));
 });

--- a/projects/element-ng/resize-observer/si-resize-observer.directive.ts
+++ b/projects/element-ng/resize-observer/si-resize-observer.directive.ts
@@ -2,7 +2,16 @@
  * Copyright Siemens 2016 - 2025.
  * SPDX-License-Identifier: MIT
  */
-import { Directive, ElementRef, inject, input, OnDestroy, OnInit, output } from '@angular/core';
+import {
+  booleanAttribute,
+  Directive,
+  ElementRef,
+  inject,
+  input,
+  OnDestroy,
+  OnInit,
+  output
+} from '@angular/core';
 import { Subscription } from 'rxjs';
 
 import { ElementDimensions, ResizeObserverService } from './resize-observer.service';
@@ -23,6 +32,9 @@ import { ElementDimensions, ResizeObserverService } from './resize-observer.serv
 export class SiResizeObserverDirective implements OnInit, OnDestroy {
   /** @defaultValue 100 */
   readonly resizeThrottle = input(100);
+  /** @defaultValue true */
+  // TODO: switch default to false in v48.0.0
+  readonly emitInitial = input(true, { transform: booleanAttribute });
   readonly siResizeObserver = output<ElementDimensions>();
 
   private subs?: Subscription;
@@ -31,7 +43,7 @@ export class SiResizeObserverDirective implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.subs = this.service
-      .observe(this.element.nativeElement, this.resizeThrottle(), true)
+      .observe(this.element.nativeElement, this.resizeThrottle(), this.emitInitial())
       .subscribe(value => this.siResizeObserver.emit(value));
   }
 


### PR DESCRIPTION

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
