### PR TITLE
docs(tree-view): provide more clarity on usage of enableContextMenuButton

### DIFF
--- a/projects/element-ng/tree-view/si-tree-view.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.ts
@@ -274,7 +274,7 @@ export class SiTreeViewComponent
   readonly enableIcon = input(true, { transform: booleanAttribute });
 
   /**
-   * Shows or hides context menu button.
+   * Shows or hides context menu button and also controls context menu visibility on right click.
    * @defaultValue true
    * @defaultref {@link SiTreeViewService#enableContextMenuButton}
    */


### PR DESCRIPTION
Describes the API more accurately.
Currently the behaviour is such that enableContextMenuButton must be set true to show the context menu irrespective of whether we need the button or not (for right-clicks at least).
I would also like this to be renamed to enableContextMenu if this is the intended design because the name points that it is only to enable the button and not the whole context menu.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
