### PR TITLE
fix(tabs-next): calculate scroll container width correctly on load

### DIFF
--- a/playwright/snapshots/tabs-next.spec.ts-snapshots/si-tabs--si-tabs-next--tabs-menu-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/tabs-next.spec.ts-snapshots/si-tabs--si-tabs-next--tabs-menu-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e33dea2ade1842f783cdcf2c0d4379dc6390367b63f55205b1bddc9060cd8e4
-size 14456
+oid sha256:706e5e54843489c80821eff48d06069517e14d17cd32c80637c18c3d35758c03
+size 14487

--- a/playwright/snapshots/tabs-next.spec.ts-snapshots/si-tabs--si-tabs-next--tabs-menu-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/tabs-next.spec.ts-snapshots/si-tabs--si-tabs-next--tabs-menu-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c92c36a30ca470404003e977a6b5a9e4f6102cfc933054934046e6c84520bf9c
-size 15060
+oid sha256:e8c733046280b69589f21d58398a6cece11452fae4a1f7fd6c6a1079ee7e350a
+size 15079

--- a/playwright/snapshots/tabs-next.spec.ts-snapshots/si-tabs--si-tabs-next--tabs-mobile-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/tabs-next.spec.ts-snapshots/si-tabs--si-tabs-next--tabs-mobile-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4950162845d7f53cd100cf54f56abc64c84b5e764acc330c2019ca9d8f7d66d4
-size 6313
+oid sha256:d289722797222e5850122d80e15d4373981f88c555e75bd7cb26b99aa6cfc393
+size 6311

--- a/playwright/snapshots/tabs-next.spec.ts-snapshots/si-tabs--si-tabs-next--tabs-mobile-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/tabs-next.spec.ts-snapshots/si-tabs--si-tabs-next--tabs-mobile-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99ddcac3219f81a1e7a7d57cbe030a7e30d26699be7c356f970f92ffb80e637f
-size 6575
+oid sha256:321239a2f018ee2c7c8f85cd089f9039c2572efc3d3491ba967d18b750089ccc
+size 6572

--- a/projects/element-ng/tabs-next/si-tabset-next.component.html
+++ b/projects/element-ng/tabs-next/si-tabset-next.component.html
@@ -2,6 +2,7 @@
   <div
     #tabContainer
     class="tab-container-buttonbar-list nav nav-tabs"
+    [emitInitial]="false"
     (siResizeObserver)="resize($event)"
   >
     <div


### PR DESCRIPTION
this also fixes the flaky e2e.

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
