### PR TITLE
docs(README): use absolute urls for links

### DIFF
--- a/projects/element-translate-ng/README.md
+++ b/projects/element-translate-ng/README.md
@@ -65,4 +65,4 @@ You can set a seed for running the tests in a specific using an environment vari
 
 Code and documentation copyright 2024 Siemens AG.
 
-See [LICENSE.md](../../LICENSE.md).
+See [LICENSE.md](https://github.com/siemens/element/blob/main/LICENSE.md).

--- a/projects/native-charts-ng/README.md
+++ b/projects/native-charts-ng/README.md
@@ -20,4 +20,4 @@ You can set a seed for running the tests in a specific using an environment vari
 
 Code and documentation copyright 2024 Siemens AG.
 
-See [LICENSE.md](../../LICENSE.md).
+See [LICENSE.md](https://github.com/siemens/element/blob/main/LICENSE.md).


### PR DESCRIPTION
The license links in npmjs.com is invalid since it is relative.
Other libs also have an absolute URL (ngx-datatable, ionic).

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
