### PR TITLE
build(deps): add renovate bot

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "group:allNonMajor",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":prHourlyLimitNone",
+    ":prConcurrentLimitNone"
+  ],
+  "addLabels": ["dep-bump"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["e2e-local.sh"],
+      "matchStrings": [
+        "PLAYWRIGHT_IMAGE=\"(?<packageName>mcr\\.microsoft\\.com/playwright):(?<currentValue>[^\\s]+)\""
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": [
+        "Prevent Angular related major and minor updates. Those should be manually done"
+      ],
+      "matchPackageNames": [
+        "@angular/**",
+        "@angular-devkit/**",
+        "@angular-eslint/**",
+        "@angular-architects/**",
+        "@angular-builders/**",
+        "ng-packagr",
+        "rxjs",
+        "typescript",
+        "zone.js",
+        "tslib"
+      ],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
+      "groupName": "Angular dependencies",
+      "description": ["Update Angular packages"],
+      "matchPackageNames": [
+        "@angular/**",
+        "@angular-devkit/**",
+        "@angular-eslint/**",
+        "@angular-architects/**",
+        "@angular-builders/**",
+        "ng-packagr",
+        "rxjs",
+        "typescript",
+        "zone.js",
+        "tslib"
+      ],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true
+    },
+    {
+      "groupName": "ECharts",
+      "description": [
+        "Update ECharts packages separately as they appeared to be less stable in the past."
+      ],
+      "matchPackageNames": ["echarts"]
+    },
+    {
+      "groupName": "Map dependencies",
+      "description": [
+        "Update map dependencies separately as they appeared to be less stable in the past."
+      ],
+      "matchPackageNames": ["ol", "ol-ext", "ol-mapbox-style", "@types/geojson"]
+    },
+    {
+      "groupName": "E2E dependencies",
+      "description": ["Update E2E packages"],
+      "matchPackageNames": [
+        "@playwright/**",
+        "@axe-core/**",
+        "axe-html-reporter",
+        "mcr.microsoft.com/playwright"
+      ]
+    },
+    {
+      "description": ["Node LTS gitlab-ci update"],
+      "matchPackageNames": ["node"],
+      "matchDatasources": ["docker"],
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
Enables the renovate bot. This is basically the same config as we use internally.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
