### PR TITLE
refactor(filtered-search): split single and multi select

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search-value.component.html
+++ b/projects/element-ng/filtered-search/si-filtered-search-value.component.html
@@ -60,6 +60,28 @@
         (submitValue)="submitCriterion.emit($event)"
       />
     }
+    @case ('multi-select') {
+      <si-filtered-search-multi-select
+        [definition]="definition()"
+        [disabled]="disabled()"
+        [searchLabel]="searchLabel()"
+        [searchDebounceTime]="searchDebounceTime()"
+        [onlySelectValue]="onlySelectValue()"
+        [optionsInScrollableView]="optionsInScrollableView()"
+        [maxCriteriaOptions]="maxCriteriaOptions()"
+        [lazyValueProvider]="lazyValueProvider()"
+        [itemCountText]="itemCountText()"
+        [isStrictOrOnlySelectValue]="isStrictOrOnlySelectValue()"
+        [disableSelectionByColonAndSemicolon]="disableSelectionByColonAndSemicolon()"
+        [items]="items()"
+        [readonly]="readonly()"
+        [(active)]="active"
+        [(criterionValue)]="value"
+        (backspaceOverflow)="backspaceOverflow()"
+        (editValue)="edit('value')"
+        (submitValue)="submitCriterion.emit($event)"
+      />
+    }
     @case ('typeahead') {
       <si-filtered-search-typeahead
         [definition]="definition()"

--- a/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
@@ -23,6 +23,7 @@ import { Observable } from 'rxjs';
 
 import { CriterionDefinition, CriterionValue, OptionType } from './si-filtered-search.model';
 import { SiFilteredSearchDateValueComponent } from './values/date-value/si-filtered-search-date-value.component';
+import { SiFilteredSearchMultiSelectComponent } from './values/multi-select/si-filtered-search-multi-select.component';
 import { SiFilteredSearchValueBase } from './values/si-filtered-search-value.base';
 import { SiFilteredSearchTypeaheadComponent } from './values/typeahead/si-filtered-search-typeahead.component';
 
@@ -35,7 +36,8 @@ import { SiFilteredSearchTypeaheadComponent } from './values/typeahead/si-filter
     SiTranslateModule,
     SiFilteredSearchDateValueComponent,
     SiFilteredSearchTypeaheadComponent,
-    SiIconNextComponent
+    SiIconNextComponent,
+    SiFilteredSearchMultiSelectComponent
   ],
   templateUrl: './si-filtered-search-value.component.html',
   styleUrl: './si-filtered-search-value.component.scss',
@@ -78,7 +80,11 @@ export class SiFilteredSearchValueComponent implements OnInit {
       case 'date-time':
         return 'date';
       default:
-        return 'typeahead';
+        if (this.definition().multiSelect) {
+          return 'multi-select';
+        } else {
+          return 'typeahead';
+        }
     }
   });
   readonly selectedOperatorIndex = computed(() => {

--- a/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.html
+++ b/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.html
@@ -6,9 +6,14 @@
     (keydown.enter)="editValue.emit()"
     (click)="editValue.emit()"
   >
-    @let optionValue = this.optionValue();
-    @if (optionValue) {
-      {{ optionValue.label ?? optionValue.value | translate }}
+    @if (!!value && hasMultiSelections()) {
+      @if (itemCountText()) {
+        {{ itemCountText() | translate: { itemCount: value.length } }}
+      } @else {
+        {{ value!.length }} {{ items() | translate }}
+      }
+    } @else if (optionValue()[0]) {
+      {{ optionValue()[0].label ?? optionValue()[0].value | translate }}
     } @else {
       {{ value }}
     }
@@ -19,22 +24,17 @@
     typeaheadOptionField="translatedLabel"
     class="px-4 py-0 border-0 focus-inside"
     typeaheadScrollable
+    typeaheadMultiSelect
     [type]="inputType()"
     [step]="step()"
-    [ngModel]="valueLabel()"
     [siTypeahead]="options() ?? []"
-    [typeaheadProcess]="!onlySelectValue()"
     [typeaheadMinLength]="0"
     [typeaheadOptionsLimit]="maxCriteriaOptions()"
-    [typeaheadAutoSelectIndex]="value?.length ? 0 : -1"
-    [readOnly]="readonly() || onlySelectValue() || definition().onlySelectValue"
+    [readOnly]="readonly() || onlySelectValue()"
     [typeaheadOptionsInScrollableView]="optionsInScrollableView()"
     [attr.aria-label]="searchLabel() | translate"
-    (keydown)="valueFilterKeys($event)"
     (keydown.backspace)="valueBackspace()"
     (keydown.enter)="valueEnter()"
-    (ngModelChange)="valueChange($event)"
-    (typeaheadOnFullMatch)="valueTypeaheadFullMatch($event)"
     (typeaheadOnSelect)="valueTypeaheadSelect($event)"
   />
 }

--- a/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.scss
+++ b/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.scss
@@ -1,0 +1,10 @@
+input {
+  background: transparent;
+  -moz-appearance: textfield; // stylelint-disable-line property-no-vendor-prefix
+
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none; // stylelint-disable-line property-no-vendor-prefix
+    margin: 0;
+  }
+}

--- a/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.ts
+++ b/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright Siemens 2016 - 2025.
+ * SPDX-License-Identifier: MIT
+ */
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ElementRef,
+  OnChanges,
+  OnInit,
+  signal,
+  SimpleChanges,
+  viewChild
+} from '@angular/core';
+import { SiTypeaheadDirective, TypeaheadMatch } from '@siemens/element-ng/typeahead';
+import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { BehaviorSubject, Observable, switchMap } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
+
+import { selectOptions, TypeaheadOptionCriterion } from '../../si-filtered-search-helper';
+import { OptionCriterion } from '../../si-filtered-search.model';
+import { SiFilteredSearchOptionValueBase } from '../si-filtered-search-option-value.base';
+import { SiFilteredSearchValueBase } from '../si-filtered-search-value.base';
+
+@Component({
+  selector: 'si-filtered-search-multi-select',
+  imports: [SiTranslateModule, SiTypeaheadDirective],
+  templateUrl: './si-filtered-search-multi-select.component.html',
+  styleUrl: './si-filtered-search-multi-select.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    { provide: SiFilteredSearchValueBase, useExisting: SiFilteredSearchMultiSelectComponent }
+  ]
+})
+export class SiFilteredSearchMultiSelectComponent
+  extends SiFilteredSearchOptionValueBase
+  implements OnChanges, OnInit
+{
+  protected override readonly valueInput = viewChild<ElementRef<HTMLInputElement>>('valueInput');
+  protected readonly optionValue = signal<OptionCriterion[]>([]);
+  protected readonly selectionChange = new BehaviorSubject<string[]>([]);
+
+  readonly hasMultiSelections = computed(
+    () => Array.isArray(this.criterionValue().value) && this.criterionValue().value!.length > 1
+  );
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (
+      changes.criterionValue &&
+      this.criterionValue().value?.length !== this.optionValue().length
+    ) {
+      this.optionValue.set([]);
+      this.selectionChange.next([]);
+    }
+  }
+
+  ngOnInit(): void {
+    this.inputChange.next('');
+    this.selectionChange.next(this.criterionValue().value as string[]);
+    this.buildOptionValue();
+  }
+
+  protected valueTypeaheadSelect(match: TypeaheadMatch): void {
+    const option = match.option as OptionCriterion;
+    if (match.itemSelected) {
+      this.criterionValue.update(v => ({ ...v, value: [...v.value!, option.value] }));
+      this.optionValue.update(v => [...v, option]);
+    } else {
+      const value = this.criterionValue();
+      if (typeof value.value !== 'string') {
+        this.criterionValue.set({
+          ...value,
+          value: value.value?.filter(elem => elem !== option.value)
+        });
+      }
+      this.optionValue.update(v => v.filter(elem => elem.value !== option.value));
+    }
+    this.selectionChange.next(this.criterionValue().value as string[]);
+  }
+
+  protected override buildOptions(): Observable<TypeaheadOptionCriterion[]> | undefined {
+    const translatedOptions = super.buildOptions();
+    if (this.definition().options) {
+      return translatedOptions?.pipe(
+        switchMap(options =>
+          this.selectionChange!.pipe(
+            tap(value => selectOptions(options, value)),
+            map(() => options)
+          )
+        )
+      );
+    } else {
+      return translatedOptions;
+    }
+  }
+
+  protected processTypeaheadOptions(options: TypeaheadOptionCriterion[]): void {
+    const value = this.criterionValue().value as string[];
+    this.optionValue.set(
+      options.filter(
+        option =>
+          value.includes(option.value) ||
+          // TODO: remove this. I don't know why, but it seems like previously FS accepted labels as well
+          value.includes(option.translatedLabel)
+      )
+    );
+    // Sneaky patch the value.
+    // We did not emit a change, as no user interaction happened.
+    // We should consider dropping this, but there is currently a unit test checking this behavior.
+    value.splice(0, value.length, ...this.optionValue().map(option => option.value));
+  }
+
+  protected hasOptionValue(): boolean {
+    return !!this.optionValue().length;
+  }
+}

--- a/projects/element-ng/filtered-search/values/si-filtered-search-option-value.base.ts
+++ b/projects/element-ng/filtered-search/values/si-filtered-search-option-value.base.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright Siemens 2016 - 2025.
+ * SPDX-License-Identifier: MIT
+ */
+import { computed, DestroyRef, Directive, inject, input } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { SiTranslateService } from '@siemens/element-translate-ng/translate';
+import { BehaviorSubject, Observable, of, switchMap } from 'rxjs';
+import { debounceTime, first, map, tap } from 'rxjs/operators';
+
+import {
+  InternalCriterionDefinition,
+  toOptionCriteria,
+  TypeaheadOptionCriterion
+} from '../si-filtered-search-helper';
+import { OptionCriterion, OptionType } from '../si-filtered-search.model';
+import { SiFilteredSearchValueBase } from './si-filtered-search-value.base';
+
+@Directive()
+export abstract class SiFilteredSearchOptionValueBase extends SiFilteredSearchValueBase {
+  readonly lazyValueProvider =
+    input<(criterionName: string, typed: string | string[]) => Observable<OptionType[]>>();
+  readonly searchDebounceTime = input.required<number>();
+  readonly itemCountText = input.required<string>();
+  readonly items = input.required<string>();
+  readonly onlySelectValue = input.required<boolean>();
+  readonly maxCriteriaOptions = input.required<number>();
+  readonly optionsInScrollableView = input.required<number>();
+  readonly readonly = input.required<boolean>();
+  readonly disableSelectionByColonAndSemicolon = input.required<boolean>();
+  readonly isStrictOrOnlySelectValue = input.required<boolean>();
+
+  protected readonly inputChange = new BehaviorSubject('');
+
+  private readonly destroyRef = inject(DestroyRef);
+  protected readonly translateService = inject(SiTranslateService);
+
+  readonly inputType = computed(() =>
+    this.definition().validationType === 'integer' || this.definition().validationType === 'float'
+      ? 'number'
+      : 'text'
+  );
+  readonly step = computed(() => (this.definition().validationType === 'integer' ? '1' : 'any'));
+  readonly options = computed(() => this.buildOptions());
+  override readonly validValue = computed(() => {
+    const config = this.definition();
+    if (!this.isStrictOrOnlySelectValue() && !config.strictValue && !config.onlySelectValue) {
+      return true;
+    }
+
+    // TODO: this never worked with lazy options. We should fix that.
+    // TODO: checking if options are empty is also questionable. Should be changed v47.
+    return (
+      (config.options?.length && this.hasOptionValue()) ||
+      (!config.options?.length && !!this.criterionValue().value)
+    );
+  });
+
+  protected buildOptions(): Observable<TypeaheadOptionCriterion[]> | undefined {
+    let optionsStream: Observable<OptionCriterion[]> | undefined;
+    if (this.lazyValueProvider()) {
+      optionsStream = this.inputChange.pipe(
+        debounceTime(this.searchDebounceTime()),
+        takeUntilDestroyed(this.destroyRef),
+        switchMap(value => {
+          return this.lazyValueProvider()!(
+            this.definition().name,
+            // TODO: fix lazy loading for multi-select. Seems to be not needed, but it should work.
+            this.definition().multiSelect ? '' : (value ?? '')
+          ).pipe(
+            map(options => toOptionCriteria(options)),
+            tap(
+              options =>
+                ((this.definition() ?? ({} as InternalCriterionDefinition)).options = options)
+            )
+          );
+        })
+      );
+    } else if (this.definition()) {
+      optionsStream = of(toOptionCriteria(this.definition().options));
+    }
+
+    return optionsStream?.pipe(
+      switchMap(options => {
+        const keys: string[] = options.map(option => option.label!).filter(label => !!label);
+        return this.translateService.translateAsync(keys).pipe(
+          map(translations =>
+            options.map(option => ({
+              ...option,
+              translatedLabel: translations[option.label!] ?? option.label ?? option.value
+            }))
+          )
+        );
+      })
+    );
+  }
+
+  protected buildOptionValue(): void {
+    if (this.criterionValue().value?.length) {
+      // resolve options for initial values
+      this.options()!
+        .pipe(first())
+        .subscribe(options => this.processTypeaheadOptions(options));
+    }
+  }
+
+  protected abstract processTypeaheadOptions(value: TypeaheadOptionCriterion[]): void;
+  protected abstract hasOptionValue(): boolean;
+}

--- a/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
+++ b/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
@@ -6,31 +6,19 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  DestroyRef,
   ElementRef,
-  inject,
-  input,
-  OnChanges,
   OnInit,
   signal,
-  SimpleChanges,
   untracked,
   viewChild
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { SiTypeaheadDirective, TypeaheadMatch } from '@siemens/element-ng/typeahead';
-import { SiTranslateModule, SiTranslateService } from '@siemens/element-translate-ng/translate';
-import { BehaviorSubject, Observable, of, switchMap } from 'rxjs';
-import { debounceTime, first, map, tap } from 'rxjs/operators';
+import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
-import {
-  InternalCriterionDefinition,
-  selectOptions,
-  toOptionCriteria,
-  TypeaheadOptionCriterion
-} from '../../si-filtered-search-helper';
-import { OptionCriterion, OptionType } from '../../si-filtered-search.model';
+import { TypeaheadOptionCriterion } from '../../si-filtered-search-helper';
+import { OptionCriterion } from '../../si-filtered-search.model';
+import { SiFilteredSearchOptionValueBase } from '../si-filtered-search-option-value.base';
 import { SiFilteredSearchValueBase } from '../si-filtered-search-value.base';
 
 @Component({
@@ -44,92 +32,63 @@ import { SiFilteredSearchValueBase } from '../si-filtered-search-value.base';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SiFilteredSearchTypeaheadComponent
-  extends SiFilteredSearchValueBase
-  implements OnChanges, OnInit
+  extends SiFilteredSearchOptionValueBase
+  implements OnInit
 {
-  readonly lazyValueProvider =
-    input<(criterionName: string, typed: string | string[]) => Observable<OptionType[]>>();
-  readonly searchDebounceTime = input.required<number>();
-  readonly itemCountText = input.required<string>();
-  readonly items = input.required<string>();
-  readonly onlySelectValue = input.required<boolean>();
-  readonly maxCriteriaOptions = input.required<number>();
-  readonly optionsInScrollableView = input.required<number>();
-  readonly readonly = input.required<boolean>();
-  readonly disableSelectionByColonAndSemicolon = input.required<boolean>();
-  readonly isStrictOrOnlySelectValue = input.required<boolean>();
-
-  private readonly inputChange = new BehaviorSubject('');
-  private readonly selectionChange = new BehaviorSubject<string[]>([]);
-
   protected override readonly valueInput = viewChild<ElementRef<HTMLInputElement>>('valueInput');
-  protected readonly optionValue = signal<OptionCriterion[]>([]);
+  protected readonly optionValue = signal<OptionCriterion | undefined>(undefined);
 
-  private readonly destroyRef = inject(DestroyRef);
-  private readonly translateService = inject(SiTranslateService);
-
-  readonly inputType = computed(() =>
-    this.definition().validationType === 'integer' || this.definition().validationType === 'float'
-      ? 'number'
-      : 'text'
-  );
-  readonly step = computed(() => (this.definition().validationType === 'integer' ? '1' : 'any'));
-  readonly options = computed(() => this.buildOptions());
-  readonly hasMultiSelections = computed(
-    () =>
-      this.definition().multiSelect &&
-      Array.isArray(this.criterionValue().value) &&
-      this.criterionValue().value!.length > 1
-  );
-  override readonly validValue = computed(() => {
-    const config = this.definition();
-    if (!this.isStrictOrOnlySelectValue() && !config.strictValue && !config.onlySelectValue) {
-      return true;
-    }
-
-    // TODO: this never worked with lazy options. We should fix that.
-    // TODO: checking if options are empty is also questionable. Should be changed v47.
-    return !!(
-      (config.options?.length && this.optionValue().length) ||
-      (!config.options?.length && !!this.criterionValue().value)
-    );
-  });
   // This MUST only be updated if the active state changes.
   // Otherwise, user values might be overridden.
   // It is only used to pass the initial input value if the user starts editing the input.
   readonly valueLabel = computed(() => {
     if (this.active()) {
-      const optionValue = untracked(() => this.optionValue());
-      const definition = untracked(() => this.definition());
-      if (optionValue.length && !definition.multiSelect) {
-        const [option] = optionValue;
+      const option = untracked(() => this.optionValue());
+      if (option) {
         return option.label ? this.translateService.translateSync(option.label) : option.value;
-      } else if (!definition.multiSelect) {
+      } else {
         return untracked(() => this.criterionValue().value) as string;
       }
     }
     return '';
   });
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (
-      this.definition().multiSelect &&
-      changes.criterionValue &&
-      this.criterionValue().value?.length !== this.optionValue().length
-    ) {
-      this.optionValue.set([]);
-      this.selectionChange.next([]);
+  ngOnInit(): void {
+    this.inputChange.next((this.criterionValue().value as string) ?? '');
+    this.buildOptionValue();
+  }
+
+  protected valueChange(newValue: string | string[]): void {
+    if (typeof newValue === 'string') {
+      const match = newValue.match(/(.+?);(.*)$/);
+      let value: string;
+      if (!this.disableSelectionByColonAndSemicolon() && match) {
+        value = match[1];
+        this.submitValue.emit({ freeText: match[2] });
+      } else {
+        value = newValue;
+      }
+      this.optionValue.set(undefined);
+      this.criterionValue.update(v => ({ ...v, value }));
+      this.inputChange.next(newValue);
     }
   }
 
-  ngOnInit(): void {
-    this.inputChange.next(
-      this.definition().multiSelect ? '' : ((this.criterionValue().value as string) ?? '')
-    );
-    if (this.definition().multiSelect) {
-      this.selectionChange.next(this.criterionValue().value as string[]);
+  protected valueTypeaheadFullMatch(match: TypeaheadMatch): void {
+    const option = match.option as TypeaheadOptionCriterion;
+    this.optionValue.set(option);
+    // Usually, we already emitted a change in onCriterionValueInputChange using the text entered by the user.
+    // In case of a fullMatch, we should check if the value is different from label.
+    // If it is different, we must emit another event using the value instead of the label.
+    // TODO: prevent the emit of the label matching the option. This is currently not possible due to the order events.
+    if (option.value !== option.translatedLabel) {
+      this.criterionValue.update(v => ({ ...v, value: option.value }));
     }
-    this.buildOptionValue();
+  }
+
+  protected valueTypeaheadSelect(match: TypeaheadMatch): void {
+    this.valueTypeaheadFullMatch(match);
+    this.submitValue.emit();
   }
 
   protected valueFilterKeys(event: KeyboardEvent): void {
@@ -141,154 +100,26 @@ export class SiFilteredSearchTypeaheadComponent
     }
   }
 
-  protected valueChange(newValue: string | string[]): void {
-    if (!this.definition().multiSelect && typeof newValue === 'string') {
-      const match = newValue.match(/(.+?);(.*)$/);
-      let value: string;
-      if (!this.disableSelectionByColonAndSemicolon() && match) {
-        value = match[1];
-        this.submitValue.emit({ freeText: match[2] });
-      } else {
-        value = newValue;
-      }
-      this.optionValue.set([]);
-      this.criterionValue.update(v => ({ ...v, value }));
-      this.inputChange.next(newValue);
-    }
-  }
-
-  protected valueTypeaheadFullMatch(match: TypeaheadMatch): void {
-    if (this.definition().multiSelect) {
-      return;
-    }
-    const option = match.option as TypeaheadOptionCriterion;
-    this.optionValue.set([option]);
-    // Usually, we already emitted a change in onCriterionValueInputChange using the text entered by the user.
-    // In case of a fullMatch, we should check if the value is different from label.
-    // If it is different, we must emit another event using the value instead of the label.
-    // TODO: prevent the emit of the label matching the option. This is currently not possible due to the order events.
-    if (option.value !== option.translatedLabel) {
-      this.criterionValue.update(v => ({ ...v, value: option.value }));
-    }
-  }
-
-  protected valueTypeaheadSelect(match: TypeaheadMatch): void {
-    if (!this.definition().multiSelect) {
-      this.valueTypeaheadFullMatch(match);
-      this.submitValue.emit();
-    } else {
-      // In multi-select scenarios, the internal model value is always of type array
-      const option = match.option as OptionCriterion;
-      if (match.itemSelected) {
-        this.criterionValue.update(v => ({ ...v, value: [...v.value!, option.value] }));
-        this.optionValue.update(v => [...v, option]);
-      } else {
-        const value = this.criterionValue();
-        if (typeof value.value !== 'string') {
-          this.criterionValue.set({
-            ...value,
-            value: value.value?.filter(elem => elem !== option.value)
-          });
-        }
-        this.optionValue.update(v => v.filter(elem => elem.value !== option.value));
-      }
-      this.selectionChange.next(this.criterionValue().value as string[]);
-    }
-  }
-
-  private buildOptions(): Observable<TypeaheadOptionCriterion[]> | undefined {
-    let optionsStream: Observable<OptionCriterion[]> | undefined;
-    if (this.lazyValueProvider()) {
-      optionsStream = this.inputChange.pipe(
-        debounceTime(this.searchDebounceTime()),
-        takeUntilDestroyed(this.destroyRef),
-        switchMap(value => {
-          return this.lazyValueProvider()!(
-            this.definition().name,
-            // TODO: fix lazy loading for multi-select. Seems to be not needed, but it should work.
-            this.definition().multiSelect ? '' : (value ?? '')
-          ).pipe(
-            map(options => toOptionCriteria(options)),
-            tap(
-              options =>
-                ((this.definition() ?? ({} as InternalCriterionDefinition)).options = options)
-            )
-          );
-        })
-      );
-    } else if (this.definition()) {
-      optionsStream = of(toOptionCriteria(this.definition().options));
-    }
-
-    let translatedOptionsStream = optionsStream?.pipe(
-      switchMap(options => {
-        const keys: string[] = options.map(option => option.label!).filter(label => !!label);
-        return this.translateService.translateAsync(keys).pipe(
-          map(translations =>
-            options.map(option => ({
-              ...option,
-              translatedLabel: translations[option.label!] ?? option.label ?? option.value
-            }))
-          )
-        );
-      })
+  protected processTypeaheadOptions(options: TypeaheadOptionCriterion[]): void {
+    this.optionValue.set(
+      options.find(
+        option =>
+          option.value === this.criterionValue().value ||
+          // TODO: remove this. I don't know why, but it seems like previously FS accepted labels as well
+          option.translatedLabel === this.criterionValue().value
+      )
     );
-
-    if (this.definition().multiSelect && this.definition().options) {
-      translatedOptionsStream = translatedOptionsStream?.pipe(
-        switchMap(options =>
-          this.selectionChange!.pipe(
-            tap(value => selectOptions(options, value)),
-            map(() => options)
-          )
-        )
-      );
+    // Sneaky patch the value.
+    // We did not emit a change, as no user interaction happened.
+    // We should consider dropping this, but there is currently a unit test checking this behavior.
+    const optionValue = this.optionValue();
+    if (optionValue) {
+      // TODO: The last ?? optionValue.label is non-sense, but we have a unit test checking this behavior.
+      this.criterionValue().value = optionValue.value ?? optionValue.label;
     }
-
-    return translatedOptionsStream;
   }
 
-  private buildOptionValue(): void {
-    if (!this.criterionValue().value?.length) {
-      this.optionValue.set([]);
-    } else {
-      // resolve options for initial values
-      this.options()!
-        .pipe(first())
-        .subscribe(options => {
-          if (this.definition().multiSelect) {
-            const value = this.criterionValue().value as string[];
-            this.optionValue.set(
-              options.filter(
-                option =>
-                  value.includes(option.value) ||
-                  // TODO: remove this. I don't know why, but it seems like previously FS accepted labels as well
-                  value.includes(option.translatedLabel)
-              )
-            );
-            // Sneaky patch the value.
-            // We did not emit a change, as no user interaction happened.
-            // We should consider dropping this, but there is currently a unit test checking this behavior.
-            value.splice(0, value.length, ...this.optionValue().map(option => option.value));
-          } else {
-            this.optionValue.set(
-              options.filter(
-                option =>
-                  option.value === this.criterionValue().value ||
-                  // TODO: remove this. I don't know why, but it seems like previously FS accepted labels as well
-                  option.translatedLabel === this.criterionValue().value
-              )
-            );
-            // Sneaky patch the value.
-            // We did not emit a change, as no user interaction happened.
-            // We should consider dropping this, but there is currently a unit test checking this behavior.
-            const [optionValue] = this.optionValue();
-            if (optionValue) {
-              // TODO: The last ?? optionValue.label is non-sense, but we have a unit test checking this behavior.
-              this.criterionValue().value = optionValue.value ?? optionValue.label;
-            }
-          }
-        });
-    }
+  protected hasOptionValue(): boolean {
+    return !!this.optionValue();
   }
 }


### PR DESCRIPTION
This PR serves two goals:
1. Decouple logic of different criteria types. It helps to prevent unwanted sideeffect of changes and makes the code more readable.
2. Preparing the move of multi select logic from the typeahead to the filtered-search. As discussed internally, the typeahead should have never gotten multi-select support which anyway only works in the filtered-search.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
