### PR TITLE
refactor: align module names

### DIFF
--- a/projects/charts-ng/src/public-api.module.ts
+++ b/projects/charts-ng/src/public-api.module.ts
@@ -43,3 +43,5 @@ import { SiCustomLegendComponent } from './components/si-custom-legend/si-custom
   ]
 })
 export class SiChartsNgModule {}
+
+export { SiChartsNgModule as SimplChartsNgModule };

--- a/projects/live-preview/live-preview-routes.ts
+++ b/projects/live-preview/live-preview-routes.ts
@@ -55,4 +55,6 @@ export const livePreviewRoutes: Routes = [
   imports: [RouterModule.forRoot(livePreviewRoutes, { useHash: true })],
   exports: [RouterModule]
 })
-export class SimplLivePreviewRoutingModule {}
+export class SiLivePreviewRoutingModule {}
+
+export { SiLivePreviewRoutingModule as SimplLivePreviewRoutingModule };

--- a/projects/live-preview/public-api.module.ts
+++ b/projects/live-preview/public-api.module.ts
@@ -35,13 +35,13 @@ import {
   exports: [SiExampleOverviewComponent, SiExampleViewerComponent],
   providers: [{ provide: REMOVE_STYLES_ON_COMPONENT_DESTROY, useValue: true }]
 })
-export class SimplLivePreviewModule {
+export class SiLivePreviewModule {
   static forRoot(
     config: SiLivePreviewConfig,
     isMobile = false
-  ): ModuleWithProviders<SimplLivePreviewModule> {
+  ): ModuleWithProviders<SiLivePreviewModule> {
     return {
-      ngModule: SimplLivePreviewModule,
+      ngModule: SiLivePreviewModule,
       providers: [
         { provide: SI_LIVE_PREVIEW_CONFIG, useValue: config },
         {
@@ -52,3 +52,5 @@ export class SimplLivePreviewModule {
     };
   }
 }
+
+export { SiLivePreviewModule as SimplLivePreviewModule };

--- a/projects/native-charts-ng/src/public-api.module.ts
+++ b/projects/native-charts-ng/src/public-api.module.ts
@@ -10,4 +10,6 @@ import { SiNChartGaugeComponent } from './components/si-nchart-gauge/si-nchart-g
   imports: [SiNChartGaugeComponent],
   exports: [SiNChartGaugeComponent]
 })
-export class ElementNativeChartsNgModule {}
+export class SiNativeChartsNgModule {}
+
+export { SiNativeChartsNgModule as SimplNativeChartsNgModule };

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -31,8 +31,8 @@ import { provideNgxTranslateForElement } from '@siemens/element-translate-ng/ngx
 import {
   SiLivePreviewLocaleApi,
   SiLivePreviewThemeApi,
-  SimplLivePreviewModule,
-  SimplLivePreviewRoutingModule
+  SiLivePreviewModule,
+  SiLivePreviewRoutingModule
 } from '@siemens/live-preview';
 import { lastValueFrom, Observable, take } from 'rxjs';
 
@@ -114,9 +114,9 @@ export const APP_CONFIG: ApplicationConfig = {
           useClass: WebpackTranslateLoader
         }
       }),
-      SimplLivePreviewRoutingModule,
+      SiLivePreviewRoutingModule,
       // App internal
-      SimplLivePreviewModule.forRoot(
+      SiLivePreviewModule.forRoot(
         {
           modules: [
             SiFormlyModule.forRoot({


### PR DESCRIPTION
We previously exported all main modules as `SimplPackageName`. With the open source migration, this got changed partially.

This change now brings back alignment.
The new pattern is `SiPackageName` plus adding a re-export with the old name to avoid breaking changes.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
