### PR TITLE
feat(translate): use provider function to create service instances

### DIFF
--- a/projects/element-translate-ng/translate/si-translate.module.ts
+++ b/projects/element-translate-ng/translate/si-translate.module.ts
@@ -17,7 +17,7 @@ import { SiTranslateServiceBuilder } from './si-translate.service-builder';
  * @internal
  */
 @NgModule({
-  declarations: [SiTranslatePipe],
+  imports: [SiTranslatePipe],
   exports: [SiTranslatePipe],
   providers: [
     /* This is needed for ngx-translate when using the isolated mode for lazy child routes.

--- a/projects/element-translate-ng/translate/si-translate.pipe.ts
+++ b/projects/element-translate-ng/translate/si-translate.pipe.ts
@@ -5,7 +5,7 @@
 import { ChangeDetectorRef, inject, OnDestroy, Pipe, PipeTransform } from '@angular/core';
 import { Subscription } from 'rxjs';
 
-import { SiTranslateService } from './si-translate.service';
+import { injectSiTranslateService, SiTranslateService } from './si-translate.service';
 
 /**
  * Translates keys by using the {@link SiTranslateService}.
@@ -18,15 +18,13 @@ import { SiTranslateService } from './si-translate.service';
 @Pipe({
   name: 'translate',
   // eslint-disable-next-line @angular-eslint/no-pipe-impure
-  pure: false,
-  // eslint-disable-next-line @angular-eslint/prefer-standalone
-  standalone: false
+  pure: false
 })
 export class SiTranslatePipe implements PipeTransform, OnDestroy {
   private lastKeyParams?: string;
   private value = '';
   private subscription?: Subscription;
-  private siTranslateService = inject(SiTranslateService);
+  private siTranslateService = injectSiTranslateService();
   private cdRef = inject(ChangeDetectorRef);
 
   /**

--- a/projects/element-translate-ng/translate/si-translate.service.ts
+++ b/projects/element-translate-ng/translate/si-translate.service.ts
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 import { DOCUMENT } from '@angular/common';
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, Injector } from '@angular/core';
 import { NEVER, Observable } from 'rxjs';
+
+import { SiNoTranslateServiceBuilder } from './si-no-translate.service-builder';
+import { SiTranslateServiceBuilder } from './si-translate.service-builder';
 
 export type TranslationResult<T> = T extends string ? string : Record<string, string>;
 
@@ -20,9 +23,23 @@ export const getBrowserCultureLanguage = (): string | undefined =>
 export const getBrowserLanguage = (): string | undefined =>
   getBrowserCultureLanguage()?.split(/-|_/)[0];
 
+/** Injects a {@link SiTranslateService} based on the global configuration. */
+export const injectSiTranslateService = (): SiTranslateService =>
+  /* This is needed for ngx-translate when using the isolated mode for lazy child routes.
+   * In that case, a new TranslateService is created by ngx-translate which also needs to be used
+   * by Element components within that route.
+   * The Builder can be used to check if a new service is available
+   * and then provide a corresponding SiTranslateService.
+   */
+  (
+    inject(SiTranslateServiceBuilder, { optional: true }) ?? inject(SiNoTranslateServiceBuilder)
+  ).buildService(inject(Injector));
+
 /**
  * Wrapper around an actual translation framework which is meant to be used internally by Element.
  * Applications must not use this service.
+ *
+ * Use {@link injectSiTranslateService} to get an instance of the translation service.
  *
  * @internal
  */


### PR DESCRIPTION
In order to achieve 100% standalone, we need to get rid of all modules. Until now, we used a module to ensure
that a correct service instances is created.
This change adds an alternative `injectSiTranslateService`, which shall replace the `SiTranslateModule`.

Having a specialized inject function follows a pattern seen in other libraries like [angular query](https://tanstack.com/query/v5/docs/framework/angular/guides/queries).

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
