### PR TITLE
feat(translate): resolve error with new application unit test builder

### DIFF
--- a/projects/element-ng/breadcrumb/si-breadcrumb.component.ts
+++ b/projects/element-ng/breadcrumb/si-breadcrumb.component.ts
@@ -24,7 +24,10 @@ import {
 } from '@siemens/element-ng/icon';
 import { SiLinkDirective } from '@siemens/element-ng/link';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-import { SiTranslateModule, SiTranslateService } from '@siemens/element-translate-ng/translate';
+import {
+  injectSiTranslateService,
+  SiTranslateModule
+} from '@siemens/element-translate-ng/translate';
 import { merge, of, Subscription } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
@@ -106,7 +109,7 @@ export class SiBreadcrumbComponent implements OnChanges, OnDestroy {
   private readonly breadcrumbElements = viewChildren<ElementRef>('breadcrumbItem');
 
   private changeDetector = inject(ChangeDetectorRef);
-  private translate = inject(SiTranslateService);
+  private translate = injectSiTranslateService();
 
   ngOnChanges(): void {
     // Reprocess items on every change and on init

--- a/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.ts
+++ b/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.ts
@@ -27,8 +27,8 @@ import {
 import { addIcons, elementCancel, SiIconNextComponent } from '@siemens/element-ng/icon';
 import { ModalRef } from '@siemens/element-ng/modal';
 import {
+  injectSiTranslateService,
   SiTranslateModule,
-  SiTranslateService,
   TranslatableString
 } from '@siemens/element-translate-ng/translate';
 import { first } from 'rxjs/operators';
@@ -178,7 +178,7 @@ export class SiColumnSelectionDialogComponent implements OnInit {
   protected visibleIds: string[] = [];
 
   private readonly liveAnnouncer = inject(LiveAnnouncer);
-  private readonly translateService = inject(SiTranslateService);
+  private readonly translateService = injectSiTranslateService();
 
   ngOnInit(): void {
     this.setupColumnData();

--- a/projects/element-ng/filtered-search/si-filtered-search.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.ts
@@ -31,8 +31,8 @@ import {
 } from '@siemens/element-ng/icon';
 import { SiTypeaheadDirective, TypeaheadOption } from '@siemens/element-ng/typeahead';
 import {
+  injectSiTranslateService,
   SiTranslateModule,
-  SiTranslateService,
   TranslatableString
 } from '@siemens/element-translate-ng/translate';
 import { BehaviorSubject, Observable, of, Subject, switchMap } from 'rxjs';
@@ -361,7 +361,7 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges, OnDestroy {
   private searchEmitQueue = new Subject<SearchCriteria | undefined>();
   private destroySubscriptions = new Subject<boolean>();
   private cdRef = inject(ChangeDetectorRef);
-  private translateService = inject(SiTranslateService);
+  private translateService = injectSiTranslateService();
   private locale = inject(LOCALE_ID).toString();
   /**
    * The cache is used to control when the interceptDisplayedCriteria event needs to be called.

--- a/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
+++ b/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
@@ -20,7 +20,10 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { SiTypeaheadDirective, TypeaheadMatch } from '@siemens/element-ng/typeahead';
-import { SiTranslateModule, SiTranslateService } from '@siemens/element-translate-ng/translate';
+import {
+  injectSiTranslateService,
+  SiTranslateModule
+} from '@siemens/element-translate-ng/translate';
 import { BehaviorSubject, Observable, of, switchMap } from 'rxjs';
 import { debounceTime, first, map, tap } from 'rxjs/operators';
 
@@ -66,7 +69,7 @@ export class SiFilteredSearchTypeaheadComponent
   protected readonly optionValue = signal<OptionCriterion[]>([]);
 
   private readonly destroyRef = inject(DestroyRef);
-  private readonly translateService = inject(SiTranslateService);
+  private readonly translateService = injectSiTranslateService();
 
   readonly inputType = computed(() =>
     this.definition().validationType === 'integer' || this.definition().validationType === 'float'

--- a/projects/element-ng/formly/fields/button/si-formly-button.component.spec.ts
+++ b/projects/element-ng/formly/fields/button/si-formly-button.component.spec.ts
@@ -9,6 +9,7 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 import { SiTranslateService } from '@siemens/element-ng/translate';
+import { provideMockTranslateServiceBuilder } from '@siemens/element-translate-ng/translate';
 
 import { SiFormlyButtonComponent } from './si-formly-button.component';
 
@@ -38,12 +39,9 @@ describe('formly button type', () => {
     TestBed.overrideComponent(SiFormlyButtonComponent, {
       add: {
         providers: [
-          {
-            provide: SiTranslateService,
-            useValue: {
-              translate: translateSpy
-            }
-          }
+          provideMockTranslateServiceBuilder(
+            () => ({ translate: translateSpy }) as unknown as SiTranslateService
+          )
         ]
       }
     });

--- a/projects/element-ng/formly/fields/text/si-formly-text-display.component.spec.ts
+++ b/projects/element-ng/formly/fields/text/si-formly-text-display.component.spec.ts
@@ -8,7 +8,10 @@ import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
-import { SiTranslateService } from '@siemens/element-ng/translate';
+import {
+  provideMockTranslateServiceBuilder,
+  SiTranslateService
+} from '@siemens/element-ng/translate';
 
 import { SiFormlyTextDisplayComponent } from './si-formly-text-display.component';
 
@@ -35,12 +38,9 @@ describe('formly text-display-type', () => {
     TestBed.overrideComponent(SiFormlyTextDisplayComponent, {
       add: {
         providers: [
-          {
-            provide: SiTranslateService,
-            useValue: {
-              translate: translateSpy
-            }
-          }
+          provideMockTranslateServiceBuilder(
+            () => ({ translate: translateSpy }) as unknown as SiTranslateService
+          )
         ]
       }
     });

--- a/projects/element-ng/language-switcher/si-language-switcher.component.ts
+++ b/projects/element-ng/language-switcher/si-language-switcher.component.ts
@@ -2,8 +2,11 @@
  * Copyright Siemens 2016 - 2025.
  * SPDX-License-Identifier: MIT
  */
-import { Component, computed, inject, input } from '@angular/core';
-import { SiTranslateModule, SiTranslateService } from '@siemens/element-translate-ng/translate';
+import { Component, computed, input } from '@angular/core';
+import {
+  injectSiTranslateService,
+  SiTranslateModule
+} from '@siemens/element-translate-ng/translate';
 
 import { IsoLanguageValue } from './iso-language-value';
 
@@ -40,7 +43,7 @@ export class SiLanguageSwitcherComponent {
    */
   readonly availableLanguages = input<(string | IsoLanguageValue)[] | null>(null);
 
-  protected readonly translate = inject(SiTranslateService);
+  protected readonly translate = injectSiTranslateService();
 
   protected readonly availableIsoLanguages = computed(() => {
     let languages = this.availableLanguages() ?? this.translate.availableLanguages;

--- a/projects/element-ng/link/si-link.directive.spec.ts
+++ b/projects/element-ng/link/si-link.directive.spec.ts
@@ -6,7 +6,11 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject } from '@
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
-import { SiTranslateModule, SiTranslateService } from '@siemens/element-translate-ng/translate';
+import {
+  provideMockTranslateServiceBuilder,
+  SiTranslateModule,
+  SiTranslateService
+} from '@siemens/element-translate-ng/translate';
 import { of } from 'rxjs';
 
 import { Link, LinkAction } from './link.model';
@@ -49,12 +53,12 @@ describe('SiLinkDirective', () => {
       providers: [
         SiLinkActionService,
         provideRouter([]),
-        {
-          provide: SiTranslateService,
-          useValue: {
-            translateAsync: (keys, params) => of(`translated=>${keys}-${JSON.stringify(params)}`)
-          } as SiTranslateService
-        }
+        provideMockTranslateServiceBuilder(
+          () =>
+            ({
+              translateAsync: (keys, params) => of(`translated=>${keys}-${JSON.stringify(params)}`)
+            }) as SiTranslateService
+        )
       ]
     }).compileComponents();
   }));

--- a/projects/element-ng/link/si-link.directive.ts
+++ b/projects/element-ng/link/si-link.directive.ts
@@ -19,7 +19,7 @@ import {
   signal
 } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, NavigationExtras, Router, UrlTree } from '@angular/router';
-import { SiTranslateService } from '@siemens/element-translate-ng/translate';
+import { injectSiTranslateService } from '@siemens/element-translate-ng/translate';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
@@ -71,7 +71,7 @@ export class SiLinkDirective implements DoCheck, OnChanges, OnDestroy {
   private router = inject(Router, { optional: true });
   private activatedRoute = inject(ActivatedRoute, { optional: true });
   private locationStrategy = inject(LocationStrategy, { optional: true });
-  private translateService = inject(SiTranslateService);
+  private translateService = injectSiTranslateService();
   private actionService = inject(SiLinkActionService, { optional: true });
   private defaultNavigationExtra = inject(SI_LINK_DEFAULT_NAVIGATION_EXTRA, { optional: true });
 

--- a/projects/element-ng/localization/si-locale.service.ts
+++ b/projects/element-ng/localization/si-locale.service.ts
@@ -7,7 +7,7 @@ import { inject, Injectable, InjectionToken, PLATFORM_ID } from '@angular/core';
 import {
   getBrowserCultureLanguage,
   getBrowserLanguage,
-  SiTranslateService
+  injectSiTranslateService
 } from '@siemens/element-translate-ng/translate';
 import { BehaviorSubject, ReplaySubject } from 'rxjs';
 import { first } from 'rxjs/operators';
@@ -74,7 +74,7 @@ export class SiLocaleService {
 
   private _nextLocale!: string;
   private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
-  private translate = inject(SiTranslateService);
+  private translate = injectSiTranslateService();
   private localeStore =
     inject(SiLocaleStore, { optional: true }) ?? new SiDefaultLocaleStore(this.isBrowser);
   /**

--- a/projects/element-ng/phone-number/si-phone-number-input.component.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.ts
@@ -31,7 +31,10 @@ import {
 import { SI_FORM_ITEM_CONTROL, SiFormItemControl } from '@siemens/element-ng/form';
 import { elementDown2, addIcons, SiIconNextComponent } from '@siemens/element-ng/icon';
 import { SiSelectListHasFilterComponent } from '@siemens/element-ng/select';
-import { SiTranslateModule, SiTranslateService } from '@siemens/element-translate-ng/translate';
+import {
+  injectSiTranslateService,
+  SiTranslateModule
+} from '@siemens/element-translate-ng/translate';
 import { PhoneNumber, PhoneNumberFormat, PhoneNumberUtil } from 'google-libphonenumber';
 
 import { SiPhoneNumberInputSelectDirective } from './si-phone-number-input-select.directive';
@@ -82,7 +85,7 @@ export class SiPhoneNumberInputComponent
   private static idCounter = 0;
 
   private phoneUtil = PhoneNumberUtil.getInstance();
-  private translate = inject(SiTranslateService);
+  private translate = injectSiTranslateService();
   private changeDetectorRef = inject(ChangeDetectorRef);
   private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 

--- a/projects/element-ng/status-bar/si-status-bar.component.ts
+++ b/projects/element-ng/status-bar/si-status-bar.component.ts
@@ -33,7 +33,10 @@ import {
   ResizeObserverService,
   SiResizeObserverDirective
 } from '@siemens/element-ng/resize-observer';
-import { SiTranslateModule, SiTranslateService } from '@siemens/element-translate-ng/translate';
+import {
+  injectSiTranslateService,
+  SiTranslateModule
+} from '@siemens/element-translate-ng/translate';
 import { Observable, Subscription } from 'rxjs';
 import { first } from 'rxjs/operators';
 
@@ -164,7 +167,7 @@ export class SiStatusBarComponent implements DoCheck, OnDestroy, OnChanges {
 
   private readonly element = inject(ElementRef);
   private readonly blinkService = inject(BlinkService);
-  private readonly translateService = inject(SiTranslateService);
+  private readonly translateService = injectSiTranslateService();
   private readonly resizeObserver = inject(ResizeObserverService);
   private readonly measureService = inject(TextMeasureService);
   private readonly destroyRef = inject(DestroyRef);

--- a/projects/element-translate-ng/translate/index.ts
+++ b/projects/element-translate-ng/translate/index.ts
@@ -12,3 +12,4 @@ export * from './si-localize';
 export * from './si-translate.service';
 export * from './testing/si-translate.mock-service-builder.factory';
 export * from '@siemens/element-translate-ng/translate-types';
+export * from './si-translate.inject';

--- a/projects/element-translate-ng/translate/si-localize.spec.ts
+++ b/projects/element-translate-ng/translate/si-localize.spec.ts
@@ -5,7 +5,6 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { initSiLocalize } from './si-localize';
 import { SiTranslatableService } from './si-translatable.service';
 
 describe('siLocalize', () => {
@@ -24,7 +23,6 @@ describe('siLocalize', () => {
         }
       ]
     });
-    initSiLocalize();
   });
 
   it('should resolve $localize calls', () => {

--- a/projects/element-translate-ng/translate/si-localize.ts
+++ b/projects/element-translate-ng/translate/si-localize.ts
@@ -25,18 +25,17 @@ const $localize = (strings: TemplateStringsArray, ...expressions: string[]): Tra
 const siResolveLocalize = (key: string, value: string): TranslatableString =>
   inject(SiTranslatableService).resolveText(key, value);
 
-/**
- * Initializes the Element version of $localize. Can be called multiple times.
- */
-export const initSiLocalize = (): void => {
-  (Zone.current as any)._properties.siResolveLocalize = siResolveLocalize;
-  globalScope.$localize = $localize;
-};
+// Always register in the current zone. This is needed in MFE setups, where $localize is already patched.
+(Zone.current as any)._properties.siResolveLocalize = siResolveLocalize;
 
-// Init $localize in the current zone
+// Patch $localize in the global scope if it was not already patched by ourselves or Angular.
+// The default $localize function by Angular just throws an error.
 try {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   globalScope.$localize`:@@si-localize:This is a test for $localize`;
 } catch {
-  initSiLocalize();
+  globalScope.$localize = $localize;
 }
+
+/** @deprecated $localize is now automatically initialized. Drop all calls of this function. */
+export const initSiLocalize = (): void => {};

--- a/projects/element-translate-ng/translate/si-localize.ts
+++ b/projects/element-translate-ng/translate/si-localize.ts
@@ -32,3 +32,11 @@ export const initSiLocalize = (): void => {
   (Zone.current as any)._properties.siResolveLocalize = siResolveLocalize;
   globalScope.$localize = $localize;
 };
+
+// Init $localize in the current zone
+try {
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  globalScope.$localize`:@@si-localize:This is a test for $localize`;
+} catch {
+  initSiLocalize();
+}

--- a/projects/element-translate-ng/translate/si-translate.inject.ts
+++ b/projects/element-translate-ng/translate/si-translate.inject.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright Siemens 2016 - 2025.
+ * SPDX-License-Identifier: MIT
+ */
+import { inject, Injector } from '@angular/core';
+
+import { SiNoTranslateServiceBuilder } from './si-no-translate.service-builder';
+import { SiTranslateService } from './si-translate.service';
+import { SiTranslateServiceBuilder } from './si-translate.service-builder';
+
+export const injectSiTranslateService = (): SiTranslateService =>
+  /* This is needed for ngx-translate when using the isolated mode for lazy child routes.
+   * In that case, a new TranslateService is created by ngx-translate which also needs to be used
+   * by Element components within that route.
+   * The Builder can be used to check if a new service is available
+   * and then provide a corresponding SiTranslateService.
+   */
+  (
+    inject(SiTranslateServiceBuilder, { optional: true }) ?? inject(SiNoTranslateServiceBuilder)
+  ).buildService(inject(Injector));

--- a/projects/element-translate-ng/translate/si-translate.module.ts
+++ b/projects/element-translate-ng/translate/si-translate.module.ts
@@ -2,12 +2,11 @@
  * Copyright Siemens 2016 - 2025.
  * SPDX-License-Identifier: MIT
  */
-import { Injector, NgModule } from '@angular/core';
+import { NgModule } from '@angular/core';
 
-import { SiNoTranslateServiceBuilder } from './si-no-translate.service-builder';
+import { injectSiTranslateService } from './si-translate.inject';
 import { SiTranslatePipe } from './si-translate.pipe';
 import { SiTranslateService } from './si-translate.service';
-import { SiTranslateServiceBuilder } from './si-translate.service-builder';
 
 /**
  * This provides declares SiTranslatePipe and provides a respective SiTranslateService.
@@ -16,7 +15,7 @@ import { SiTranslateServiceBuilder } from './si-translate.service-builder';
  * @internal
  */
 @NgModule({
-  declarations: [SiTranslatePipe],
+  imports: [SiTranslatePipe],
   exports: [SiTranslatePipe],
   providers: [
     /* This is needed for ngx-translate when using the isolated mode for lazy child routes.
@@ -27,9 +26,7 @@ import { SiTranslateServiceBuilder } from './si-translate.service-builder';
      */
     {
       provide: SiTranslateService,
-      useFactory: (injector: Injector, noTranslateBuilder: SiNoTranslateServiceBuilder) =>
-        injector.get(SiTranslateServiceBuilder, noTranslateBuilder).buildService(injector),
-      deps: [Injector, SiNoTranslateServiceBuilder]
+      useFactory: () => injectSiTranslateService()
     }
   ]
 })

--- a/projects/element-translate-ng/translate/si-translate.module.ts
+++ b/projects/element-translate-ng/translate/si-translate.module.ts
@@ -2,9 +2,8 @@
  * Copyright Siemens 2016 - 2025.
  * SPDX-License-Identifier: MIT
  */
-import { inject, Injector, NgModule } from '@angular/core';
+import { Injector, NgModule } from '@angular/core';
 
-import { initSiLocalize } from './si-localize';
 import { SiNoTranslateServiceBuilder } from './si-no-translate.service-builder';
 import { SiTranslatePipe } from './si-translate.pipe';
 import { SiTranslateService } from './si-translate.service';
@@ -34,11 +33,4 @@ import { SiTranslateServiceBuilder } from './si-translate.service-builder';
     }
   ]
 })
-export class SiTranslateModule {
-  constructor() {
-    const translateService = inject(SiTranslateService);
-    if (!translateService.prevent$LocalizeInit) {
-      initSiLocalize();
-    }
-  }
-}
+export class SiTranslateModule {}

--- a/projects/element-translate-ng/translate/si-translate.pipe.ts
+++ b/projects/element-translate-ng/translate/si-translate.pipe.ts
@@ -5,6 +5,7 @@
 import { ChangeDetectorRef, inject, OnDestroy, Pipe, PipeTransform } from '@angular/core';
 import { Subscription } from 'rxjs';
 
+import { injectSiTranslateService } from './si-translate.inject';
 import { SiTranslateService } from './si-translate.service';
 
 /**
@@ -18,15 +19,13 @@ import { SiTranslateService } from './si-translate.service';
 @Pipe({
   name: 'translate',
   // eslint-disable-next-line @angular-eslint/no-pipe-impure
-  pure: false,
-  // eslint-disable-next-line @angular-eslint/prefer-standalone
-  standalone: false
+  pure: false
 })
 export class SiTranslatePipe implements PipeTransform, OnDestroy {
   private lastKeyParams?: string;
   private value = '';
   private subscription?: Subscription;
-  private siTranslateService = inject(SiTranslateService);
+  private siTranslateService = injectSiTranslateService();
   private cdRef = inject(ChangeDetectorRef);
 
   /**

--- a/projects/element-translate-ng/translate/si-translate.service.ts
+++ b/projects/element-translate-ng/translate/si-translate.service.ts
@@ -24,6 +24,8 @@ export const getBrowserLanguage = (): string | undefined =>
  * Wrapper around an actual translation framework which is meant to be used internally by Element.
  * Applications must not use this service.
  *
+ * Use {@link injectSiTranslateService} to get an instance of the translation service.
+ *
  * @internal
  */
 @Injectable()


### PR DESCRIPTION
This PR fixes the issues with the new angular application unit test builder.
Both are needed as Angular fails with modules in certain cases.
Yet it also helps to fully go standalone.

A follow-up will drop all other usages of the module.
This PR only contains the necessary changes.

We need to keep the module for compatibility.


## fix(translate): prevent missing $localize errors
Moves the initialization out of the module constructor
as the constructor is not reliably called.
The new version ensures that `$localize` is patched
early enough before any other angular initializations.

## feat(use) provider function to create service instances
In order to achieve 100% standalone, we need to get rid of all modules.
Until now, we used a module to ensure
that a correct service instances is created.
This change adds an alternative `injectSiTranslateService`,
which shall replace the `SiTranslateModule`.

Having a specialized inject function follows a pattern seen
in other libraries like [angular query](https://tanstack.com/query/v5/docs/framework/angular/guides/queries).

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
