### PR TITLE
refactor(translate): drop SiTranslateModule usages

### DIFF
--- a/projects/element-ng/about/si-about.component.ts
+++ b/projects/element-ng/about/si-about.component.ts
@@ -16,9 +16,9 @@ import {
 import { DomSanitizer } from '@angular/platform-browser';
 import { SiCollapsiblePanelComponent } from '@siemens/element-ng/accordion';
 import { CopyrightDetails, SiCopyrightNoticeComponent } from '@siemens/element-ng/copyright-notice';
-import { addIcons, SiIconNextComponent, elementDocument } from '@siemens/element-ng/icon';
+import { addIcons, elementDocument, SiIconNextComponent } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { ApiInfo, LicenseInfo } from './si-about-data.model';
 
@@ -30,7 +30,7 @@ import { ApiInfo, LicenseInfo } from './si-about-data.model';
     SiCopyrightNoticeComponent,
     SiIconNextComponent,
     SiLinkDirective,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-about.component.html',
   styleUrl: './si-about.component.scss',

--- a/projects/element-ng/accordion/si-accordion.component.spec.ts
+++ b/projects/element-ng/accordion/si-accordion.component.spec.ts
@@ -5,13 +5,12 @@
 import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiAccordionComponent } from './si-accordion.component';
 import { SiCollapsiblePanelComponent } from './si-collapsible-panel.component';
 
 @Component({
-  imports: [SiTranslateModule, SiAccordionComponent, SiCollapsiblePanelComponent],
+  imports: [SiAccordionComponent, SiCollapsiblePanelComponent],
   template: `
     <si-accordion [expandFirstPanel]="expandFirstPanel()">
       <si-collapsible-panel heading="one"><div>content</div></si-collapsible-panel>
@@ -33,7 +32,7 @@ describe('SiAccordion', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, NoopAnimationsModule, TestHostComponent]
+      imports: [NoopAnimationsModule, TestHostComponent]
     }).compileComponents();
   }));
 

--- a/projects/element-ng/accordion/si-collapsible-panel.component.spec.ts
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.spec.ts
@@ -6,12 +6,11 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiCollapsiblePanelComponent } from './index';
 
 @Component({
-  imports: [SiTranslateModule, SiCollapsiblePanelComponent],
+  imports: [SiCollapsiblePanelComponent],
   template: `
     <si-collapsible-panel [heading]="heading">
       <div style="height: 100px;">This is the content</div>
@@ -39,12 +38,7 @@ describe('SiCollapsiblePanel', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        SiTranslateModule,
-        NoopAnimationsModule,
-        SiCollapsiblePanelComponent,
-        TestHostComponent
-      ]
+      imports: [NoopAnimationsModule, SiCollapsiblePanelComponent, TestHostComponent]
     }).compileComponents();
   }));
 

--- a/projects/element-ng/accordion/si-collapsible-panel.component.ts
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.ts
@@ -19,8 +19,8 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { areAnimationsDisabled, BackgroundColorVariant } from '@siemens/element-ng/common';
-import { addIcons, SiIconNextComponent, elementDown2 } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { addIcons, elementDown2, SiIconNextComponent } from '@siemens/element-ng/icon';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { filter } from 'rxjs';
 
 import { SiAccordionHCollapseService } from './si-accordion-hcollapse.service';
@@ -30,7 +30,7 @@ let controlIdCounter = 1;
 
 @Component({
   selector: 'si-collapsible-panel',
-  imports: [NgClass, SiIconNextComponent, SiTranslateModule],
+  imports: [NgClass, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-collapsible-panel.component.html',
   styleUrl: './si-collapsible-panel.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiAlertDialogComponent } from './si-alert-dialog.component';
 
@@ -16,7 +15,7 @@ describe('SiAlertDialogComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, SiAlertDialogComponent],
+      imports: [SiAlertDialogComponent],
       providers: [ModalRef]
     }).compileComponents();
     modalRef = TestBed.inject(ModalRef);

--- a/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.ts
@@ -7,14 +7,14 @@ import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
 import { SiLoadingButtonComponent } from '@siemens/element-ng/loading-spinner';
 import { ModalRef } from '@siemens/element-ng/modal';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { take } from 'rxjs';
 
 import { AlertDialogResult } from '../si-action-dialog.types';
 
 @Component({
   selector: 'si-alert-dialog',
-  imports: [AsyncPipe, SiIconNextComponent, SiTranslateModule, SiLoadingButtonComponent],
+  imports: [AsyncPipe, SiIconNextComponent, SiTranslatePipe, SiLoadingButtonComponent],
   templateUrl: './si-alert-dialog.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiConfirmationDialogComponent } from './si-confirmation-dialog.component';
 
@@ -16,7 +15,7 @@ describe('SiConfirmationDialogComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, SiConfirmationDialogComponent],
+      imports: [SiConfirmationDialogComponent],
       providers: [ModalRef]
     }).compileComponents();
     modalRef = TestBed.inject(ModalRef);

--- a/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.ts
@@ -7,14 +7,14 @@ import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
 import { SiLoadingButtonComponent } from '@siemens/element-ng/loading-spinner';
 import { ModalRef } from '@siemens/element-ng/modal';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { take } from 'rxjs';
 
 import { ConfirmationDialogResult } from '../si-action-dialog.types';
 
 @Component({
   selector: 'si-confirmation-dialog',
-  imports: [AsyncPipe, SiIconNextComponent, SiTranslateModule, SiLoadingButtonComponent],
+  imports: [AsyncPipe, SiIconNextComponent, SiTranslatePipe, SiLoadingButtonComponent],
   templateUrl: './si-confirmation-dialog.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiDeleteConfirmationDialogComponent } from './si-delete-confirmation-dialog.component';
 
@@ -16,7 +15,7 @@ describe('SiDeleteConfirmationDialogComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, SiDeleteConfirmationDialogComponent],
+      imports: [SiDeleteConfirmationDialogComponent],
       providers: [ModalRef]
     });
     modalRef = TestBed.inject(ModalRef);

--- a/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.ts
@@ -7,14 +7,14 @@ import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
 import { SiLoadingButtonComponent } from '@siemens/element-ng/loading-spinner';
 import { ModalRef } from '@siemens/element-ng/modal';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { take } from 'rxjs';
 
 import { DeleteConfirmationDialogResult } from '../si-action-dialog.types';
 
 @Component({
   selector: 'si-delete-confirmation-dialog',
-  imports: [AsyncPipe, SiIconNextComponent, SiTranslateModule, SiLoadingButtonComponent],
+  imports: [AsyncPipe, SiIconNextComponent, SiTranslatePipe, SiLoadingButtonComponent],
   templateUrl: './si-delete-confirmation-dialog.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiEditDiscardDialogComponent } from './si-edit-discard-dialog.component';
 
@@ -16,7 +15,7 @@ describe('SiEditDiscardDialogComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, SiEditDiscardDialogComponent],
+      imports: [SiEditDiscardDialogComponent],
       providers: [ModalRef]
     }).compileComponents();
     modalRef = TestBed.inject(ModalRef);

--- a/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.ts
@@ -7,14 +7,14 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input } f
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
 import { SiLoadingButtonComponent } from '@siemens/element-ng/loading-spinner';
 import { ModalRef } from '@siemens/element-ng/modal';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { take } from 'rxjs';
 
 import { EditDiscardDialogResult } from '../si-action-dialog.types';
 
 @Component({
   selector: 'si-edit-discard-dialog',
-  imports: [AsyncPipe, SiIconNextComponent, SiTranslateModule, SiLoadingButtonComponent],
+  imports: [AsyncPipe, SiIconNextComponent, SiTranslatePipe, SiLoadingButtonComponent],
   templateUrl: './si-edit-discard-dialog.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
@@ -20,7 +20,7 @@ import {
   SiIconNextComponent
 } from '@siemens/element-ng/icon';
 import { SiLinkModule } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiApplicationHeaderComponent } from '../si-application-header.component';
 import { SiLaunchpadAppComponent } from './si-launchpad-app.component';
@@ -37,7 +37,7 @@ export interface FavoriteChangeEvent {
     A11yModule,
     CommonModule,
     SiLinkModule,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiLaunchpadAppComponent,
     SiIconNextComponent
   ],

--- a/projects/element-ng/application-header/si-application-header.component.ts
+++ b/projects/element-ng/application-header/si-application-header.component.ts
@@ -29,14 +29,14 @@ import {
   SiIconNextComponent
 } from '@siemens/element-ng/icon';
 import { BOOTSTRAP_BREAKPOINTS, Breakpoints } from '@siemens/element-ng/resize-observer';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { defer, of, Subject } from 'rxjs';
 import { map, skip, takeUntil } from 'rxjs/operators';
 
 /** Root component for the application header. */
 @Component({
   selector: 'si-application-header',
-  imports: [SiTranslateModule, NgClass, A11yModule, NgTemplateOutlet, SiIconNextComponent],
+  imports: [SiTranslatePipe, NgClass, A11yModule, NgTemplateOutlet, SiIconNextComponent],
   templateUrl: './si-application-header.component.html',
   styleUrl: './si-application-header.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/application-header/si-header-collapsible-actions.component.ts
+++ b/projects/element-ng/application-header/si-header-collapsible-actions.component.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import { SI_HEADER_DROPDOWN_OPTIONS } from '@siemens/element-ng/header-dropdown';
 import { addIcons, elementOptionsVertical, SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Subscription } from 'rxjs';
 import { skip, takeUntil } from 'rxjs/operators';
 
@@ -24,7 +24,7 @@ import { SiApplicationHeaderComponent } from './si-application-header.component'
 /** Container for actions that should be collapsed in mobile mode. */
 @Component({
   selector: 'si-header-collapsible-actions',
-  imports: [SiTranslateModule, A11yModule, SiIconNextComponent],
+  imports: [SiTranslatePipe, A11yModule, SiIconNextComponent],
   templateUrl: './si-header-collapsible-actions.component.html',
   styles: '.badge-dot::after { inset-inline-end: 4px; }',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/application-header/si-header-navigation.component.ts
+++ b/projects/element-ng/application-header/si-header-navigation.component.ts
@@ -5,13 +5,13 @@
 import { NgClass } from '@angular/common';
 import { Component, inject, OnDestroy } from '@angular/core';
 import { addIcons, elementThumbnails, SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiApplicationHeaderComponent } from './si-application-header.component';
 
 @Component({
   selector: 'si-header-navigation',
-  imports: [NgClass, SiTranslateModule, SiIconNextComponent],
+  imports: [NgClass, SiTranslatePipe, SiIconNextComponent],
   template: `
     @if (header.launchpad()) {
       <button

--- a/projects/element-ng/avatar/si-avatar.component.spec.ts
+++ b/projects/element-ng/avatar/si-avatar.component.spec.ts
@@ -5,7 +5,6 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { EntityStatusType } from '@siemens/element-ng/common';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiAvatarComponent } from './index';
 
@@ -39,7 +38,7 @@ describe('SiAvatarComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiAvatarComponent, TestHostComponent, SiTranslateModule]
+      imports: [SiAvatarComponent, TestHostComponent]
     }).compileComponents()
   );
 

--- a/projects/element-ng/breadcrumb/si-breadcrumb.component.ts
+++ b/projects/element-ng/breadcrumb/si-breadcrumb.component.ts
@@ -24,10 +24,7 @@ import {
 } from '@siemens/element-ng/icon';
 import { SiLinkDirective } from '@siemens/element-ng/link';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-import {
-  injectSiTranslateService,
-  SiTranslateModule
-} from '@siemens/element-translate-ng/translate';
+import { injectSiTranslateService, SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { merge, of, Subscription } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
@@ -66,7 +63,7 @@ let controlIdCounter = 1;
     SiIconNextComponent,
     SiLinkDirective,
     SiResizeObserverDirective,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiBreadcrumbItemTemplateDirective
   ],
   templateUrl: './si-breadcrumb.component.html',

--- a/projects/element-ng/card/si-card.component.ts
+++ b/projects/element-ng/card/si-card.component.ts
@@ -10,11 +10,11 @@ import {
   ViewType
 } from '@siemens/element-ng/content-action-bar';
 import { MenuItem } from '@siemens/element-ng/menu';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-card',
-  imports: [SiContentActionBarComponent, SiTranslateModule],
+  imports: [SiContentActionBarComponent, SiTranslatePipe],
   templateUrl: './si-card.component.html',
   styleUrl: './si-card.component.scss',
   host: {

--- a/projects/element-ng/circle-status/si-circle-status.component.ts
+++ b/projects/element-ng/circle-status/si-circle-status.component.ts
@@ -24,12 +24,12 @@ import {
   SiIconNextComponent,
   STATUS_ICON_CONFIG
 } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Observable, Subscription } from 'rxjs';
 
 @Component({
   selector: 'si-circle-status',
-  imports: [NgClass, SiIconNextComponent, SiTranslateModule],
+  imports: [NgClass, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-circle-status.component.html',
   styleUrl: './si-circle-status.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/color-picker/si-color-picker.component.ts
+++ b/projects/element-ng/color-picker/si-color-picker.component.ts
@@ -17,7 +17,7 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { isRTL } from '@siemens/element-ng/common';
 import { addIcons, elementOk, SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 /**
  * The Element data color palette is used as default.
@@ -43,7 +43,7 @@ const defaultDataColors: string[] = [
 ];
 @Component({
   selector: 'si-color-picker',
-  imports: [SiIconNextComponent, SiTranslateModule, CdkConnectedOverlay, CdkOverlayOrigin],
+  imports: [SiIconNextComponent, SiTranslatePipe, CdkConnectedOverlay, CdkOverlayOrigin],
   templateUrl: './si-color-picker.component.html',
   styleUrl: './si-color-picker.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.ts
+++ b/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.ts
@@ -28,7 +28,7 @@ import { addIcons, elementCancel, SiIconNextComponent } from '@siemens/element-n
 import { ModalRef } from '@siemens/element-ng/modal';
 import {
   injectSiTranslateService,
-  SiTranslateModule,
+  SiTranslatePipe,
   TranslatableString
 } from '@siemens/element-translate-ng/translate';
 import { first } from 'rxjs/operators';
@@ -51,7 +51,7 @@ const dragConfig = {
     CdkOption,
     CdkScrollableModule,
     SiIconNextComponent,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiColumnSelectionEditorComponent
   ],
   templateUrl: './si-column-selection-dialog.component.html',

--- a/projects/element-ng/content-action-bar/si-content-action-bar.component.ts
+++ b/projects/element-ng/content-action-bar/si-content-action-bar.component.ts
@@ -21,14 +21,14 @@ import { MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
 import { addIcons, elementCancel, elementOptionsVertical } from '@siemens/element-ng/icon';
 import { SiLinkModule } from '@siemens/element-ng/link';
 import {
+  MenuItem,
   MenuItemAction,
   MenuItemCheckbox,
-  MenuItem,
   MenuItemRadio,
   SiMenuActionService,
   SiMenuModule
 } from '@siemens/element-ng/menu';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiContentActionBarToggleComponent } from './si-content-action-bar-toggle.component';
 import { ContentActionBarMainItem, ViewType } from './si-content-action-bar.model';
@@ -39,7 +39,7 @@ import { ContentActionBarMainItem, ViewType } from './si-content-action-bar.mode
     SiMenuModule,
     CdkMenuModule,
     SiAutoCollapsableListModule,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiLinkModule,
     SiContentActionBarToggleComponent,
     RouterLink

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
@@ -6,7 +6,7 @@ import { CdkTrapFocus } from '@angular/cdk/a11y';
 import { MediaMatcher } from '@angular/cdk/layout';
 import { CdkListbox, CdkOption } from '@angular/cdk/listbox';
 import { OverlayModule } from '@angular/cdk/overlay';
-import { DatePipe, NgClass, NgTemplateOutlet } from '@angular/common';
+import { DatePipe, NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
   ChangeDetectionStrategy,
@@ -34,7 +34,7 @@ import {
 import { addIcons, elementDown2, SiIconNextComponent } from '@siemens/element-ng/icon';
 import { BOOTSTRAP_BREAKPOINTS } from '@siemens/element-ng/resize-observer';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiDateRangeCalculationService } from './si-date-range-calculation.service';
 import {
@@ -60,7 +60,6 @@ export class PresetMatchFilterPipe implements PipeTransform {
     CdkTrapFocus,
     DatePipe,
     FormsModule,
-    NgClass,
     NgTemplateOutlet,
     OverlayModule,
     PresetMatchFilterPipe,
@@ -70,7 +69,7 @@ export class PresetMatchFilterPipe implements PipeTransform {
     SiIconNextComponent,
     SiRelativeDateComponent,
     SiSearchBarComponent,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-date-range-filter.component.html',
   styleUrl: './si-date-range-filter.component.scss',

--- a/projects/element-ng/datepicker/components/si-day-selection.component.ts
+++ b/projects/element-ng/datepicker/components/si-day-selection.component.ts
@@ -15,7 +15,7 @@ import {
   output
 } from '@angular/core';
 import { isRTL } from '@siemens/element-ng/common';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import {
   addDaysInRange,
@@ -46,12 +46,7 @@ import { SiInitialFocusComponent } from './si-initial-focus.component';
  */
 @Component({
   selector: 'si-day-selection',
-  imports: [
-    DatePipe,
-    SiCalendarBodyComponent,
-    SiCalendarDirectionButtonComponent,
-    SiTranslateModule
-  ],
+  imports: [DatePipe, SiCalendarBodyComponent, SiCalendarDirectionButtonComponent, SiTranslatePipe],
   templateUrl: './si-day-selection.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/projects/element-ng/datepicker/si-calendar-button.component.ts
+++ b/projects/element-ng/datepicker/si-calendar-button.component.ts
@@ -20,7 +20,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgControl } from '@angular/forms';
 import { addIcons, elementCalendar, SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiDatepickerOverlayDirective } from './si-datepicker-overlay.directive';
 import { SiDatepickerDirective } from './si-datepicker.directive';
@@ -42,7 +42,7 @@ import { SiDatepickerDirective } from './si-datepicker.directive';
  */
 @Component({
   selector: 'si-calendar-button',
-  imports: [SiIconNextComponent, SiTranslateModule],
+  imports: [SiIconNextComponent, SiTranslatePipe],
   template: `<ng-content />
     <button
       #calendarButton

--- a/projects/element-ng/datepicker/si-date-range.component.ts
+++ b/projects/element-ng/datepicker/si-date-range.component.ts
@@ -45,7 +45,7 @@ import {
 } from '@siemens/element-ng/common';
 import { SI_FORM_ITEM_CONTROL, SiFormItemControl } from '@siemens/element-ng/form';
 import { addIcons, elementCalendar, SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { getMaxDate, getMinDate } from './date-time-helper';
 import { SiDateInputDirective } from './si-date-input.directive';
@@ -55,7 +55,7 @@ import { DatepickerInputConfig, DateRange } from './si-datepicker.model';
 
 @Component({
   selector: 'si-date-range',
-  imports: [FormsModule, SiDateInputDirective, SiIconNextComponent, SiTranslateModule, A11yModule],
+  imports: [FormsModule, SiDateInputDirective, SiIconNextComponent, SiTranslatePipe, A11yModule],
   templateUrl: './si-date-range.component.html',
   styleUrl: './si-date-range.component.scss',
   host: {

--- a/projects/element-ng/datepicker/si-datepicker.component.ts
+++ b/projects/element-ng/datepicker/si-datepicker.component.ts
@@ -21,7 +21,7 @@ import {
   viewChild
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { Cell } from './components/si-calendar-body.component';
 import { SiDaySelectionComponent } from './components/si-day-selection.component';
@@ -60,7 +60,7 @@ export type RangeType = 'START' | 'END' | undefined;
     SiDaySelectionComponent,
     SiTimepickerComponent,
     FormsModule,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-datepicker.component.html',
   styleUrl: './si-datepicker.component.scss'

--- a/projects/element-ng/datepicker/si-timepicker.component.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.ts
@@ -28,7 +28,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { SI_FORM_ITEM_CONTROL, SiFormItemControl } from '@siemens/element-ng/form';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { createDate } from './date-time-helper';
 
@@ -45,7 +45,7 @@ interface TimeComponents {
 
 @Component({
   selector: 'si-timepicker',
-  imports: [NgTemplateOutlet, FormsModule, SiTranslateModule, A11yModule],
+  imports: [NgTemplateOutlet, FormsModule, SiTranslatePipe, A11yModule],
   templateUrl: './si-timepicker.component.html',
   styleUrl: './si-timepicker.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/electron-titlebar/si-electron-titlebar.component.spec.ts
+++ b/projects/element-ng/electron-titlebar/si-electron-titlebar.component.spec.ts
@@ -5,12 +5,11 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MenuItem } from '@siemens/element-ng/menu';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiElectrontitlebarComponent } from './si-electron-titlebar.component';
 
 @Component({
-  imports: [SiElectrontitlebarComponent, SiTranslateModule],
+  imports: [SiElectrontitlebarComponent],
   template: `
     <si-electron-titlebar
       [appTitle]="appTitle"
@@ -46,7 +45,7 @@ describe('SiElectrontitlebarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiTranslateModule, TestHostComponent]
+      imports: [TestHostComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/electron-titlebar/si-electron-titlebar.component.ts
+++ b/projects/element-ng/electron-titlebar/si-electron-titlebar.component.ts
@@ -13,11 +13,11 @@ import {
   SiIconNextComponent
 } from '@siemens/element-ng/icon';
 import { MenuItem, SiMenuFactoryComponent } from '@siemens/element-ng/menu';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-electron-titlebar',
-  imports: [CdkMenuTrigger, SiMenuFactoryComponent, SiIconNextComponent, SiTranslateModule],
+  imports: [CdkMenuTrigger, SiMenuFactoryComponent, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-electron-titlebar.component.html',
   styleUrl: './si-electron-titlebar.component.scss'
 })

--- a/projects/element-ng/empty-state/si-empty-state.component.ts
+++ b/projects/element-ng/empty-state/si-empty-state.component.ts
@@ -4,11 +4,11 @@
  */
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-empty-state',
-  imports: [SiIconNextComponent, SiTranslateModule],
+  imports: [SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-empty-state.component.html',
   styleUrl: './si-empty-state.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/file-uploader/si-file-dropzone.component.ts
+++ b/projects/element-ng/file-uploader/si-file-dropzone.component.ts
@@ -15,13 +15,13 @@ import {
   viewChild
 } from '@angular/core';
 import { addIcons, elementUpload, SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { UploadFile } from './si-file-uploader.model';
 
 @Component({
   selector: 'si-file-dropzone',
-  imports: [SiIconNextComponent, SiTranslateModule],
+  imports: [SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-file-dropzone.component.html',
   styleUrl: './si-file-dropzone.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/file-uploader/si-file-uploader.component.ts
+++ b/projects/element-ng/file-uploader/si-file-uploader.component.ts
@@ -35,7 +35,7 @@ import {
 } from '@siemens/element-ng/icon';
 import { SiInlineNotificationComponent } from '@siemens/element-ng/inline-notification';
 import { SiProgressbarComponent } from '@siemens/element-ng/progressbar';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Observable, Subscription } from 'rxjs';
 import { retry } from 'rxjs/operators';
 
@@ -95,7 +95,7 @@ interface ExtUploadFile extends UploadFile {
     SiIconNextComponent,
     SiInlineNotificationComponent,
     SiProgressbarComponent,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-file-uploader.component.html',
   styleUrl: './si-file-uploader.component.scss'

--- a/projects/element-ng/filter-bar/si-filter-bar.component.ts
+++ b/projects/element-ng/filter-bar/si-filter-bar.component.ts
@@ -10,7 +10,7 @@ import {
   SiAutoCollapsableListOverflowItemDirective
 } from '@siemens/element-ng/auto-collapsable-list';
 import { BackgroundColorVariant } from '@siemens/element-ng/common';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { Filter } from './filter';
 import { SiFilterPillComponent } from './si-filter-pill.component';
@@ -23,7 +23,7 @@ import { SiFilterPillComponent } from './si-filter-pill.component';
     SiAutoCollapsableListOverflowItemDirective,
     SiAutoCollapsableListAdditionalContentDirective,
     SiFilterPillComponent,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-filter-bar.component.html',
   styleUrl: './si-filter-bar.component.scss',

--- a/projects/element-ng/filter-bar/si-filter-pill.component.ts
+++ b/projects/element-ng/filter-bar/si-filter-pill.component.ts
@@ -4,13 +4,13 @@
  */
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { booleanAttribute, Component, input, output } from '@angular/core';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { Filter } from './filter';
 
 @Component({
   selector: 'si-filter-pill',
-  imports: [NgClass, NgTemplateOutlet, SiTranslateModule],
+  imports: [NgClass, NgTemplateOutlet, SiTranslatePipe],
   templateUrl: './si-filter-pill.component.html',
   styleUrl: './si-filter-pill.component.scss'
 })

--- a/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
@@ -16,9 +16,9 @@ import {
   viewChild
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { addIcons, SiIconNextComponent, elementCancel } from '@siemens/element-ng/icon';
+import { addIcons, elementCancel, SiIconNextComponent } from '@siemens/element-ng/icon';
 import { SiTypeaheadDirective } from '@siemens/element-ng/typeahead';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Observable } from 'rxjs';
 
 import { CriterionDefinition, CriterionValue, OptionType } from './si-filtered-search.model';
@@ -32,7 +32,7 @@ import { SiFilteredSearchTypeaheadComponent } from './values/typeahead/si-filter
     CdkMonitorFocus,
     SiTypeaheadDirective,
     FormsModule,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiFilteredSearchDateValueComponent,
     SiFilteredSearchTypeaheadComponent,
     SiIconNextComponent

--- a/projects/element-ng/filtered-search/si-filtered-search.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.ts
@@ -25,14 +25,14 @@ import { FormsModule } from '@angular/forms';
 import { BackgroundColorVariant, isRTL } from '@siemens/element-ng/common';
 import {
   addIcons,
-  SiIconNextComponent,
   elementCancel,
-  elementSearch
+  elementSearch,
+  SiIconNextComponent
 } from '@siemens/element-ng/icon';
 import { SiTypeaheadDirective, TypeaheadOption } from '@siemens/element-ng/typeahead';
 import {
   injectSiTranslateService,
-  SiTranslateModule,
+  SiTranslatePipe,
   TranslatableString
 } from '@siemens/element-translate-ng/translate';
 import { BehaviorSubject, Observable, of, Subject, switchMap } from 'rxjs';
@@ -60,7 +60,7 @@ import {
     FormsModule,
     SiIconNextComponent,
     SiTypeaheadDirective,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiFilteredSearchValueComponent
   ],
   templateUrl: './si-filtered-search.component.html',

--- a/projects/element-ng/filtered-search/values/date-value/si-filtered-search-date-value.component.ts
+++ b/projects/element-ng/filtered-search/values/date-value/si-filtered-search-date-value.component.ts
@@ -21,14 +21,14 @@ import {
   SiDatepickerDirective,
   SiDatepickerOverlayDirective
 } from '@siemens/element-ng/datepicker';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { getISODateString } from '../../si-filtered-search-helper';
 import { SiFilteredSearchValueBase } from '../si-filtered-search-value.base';
 
 @Component({
   selector: 'si-filtered-search-date-value',
-  imports: [DatePipe, FormsModule, SiDatepickerDirective, SiTranslateModule],
+  imports: [DatePipe, FormsModule, SiDatepickerDirective, SiTranslatePipe],
   templateUrl: './si-filtered-search-date-value.component.html',
   styleUrl: './si-filtered-search-date-value.component.scss',
   providers: [

--- a/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
+++ b/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
@@ -20,10 +20,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { SiTypeaheadDirective, TypeaheadMatch } from '@siemens/element-ng/typeahead';
-import {
-  injectSiTranslateService,
-  SiTranslateModule
-} from '@siemens/element-translate-ng/translate';
+import { injectSiTranslateService, SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { BehaviorSubject, Observable, of, switchMap } from 'rxjs';
 import { debounceTime, first, map, tap } from 'rxjs/operators';
 
@@ -38,7 +35,7 @@ import { SiFilteredSearchValueBase } from '../si-filtered-search-value.base';
 
 @Component({
   selector: 'si-filtered-search-typeahead',
-  imports: [SiTypeaheadDirective, FormsModule, SiTranslateModule],
+  imports: [SiTypeaheadDirective, FormsModule, SiTranslatePipe],
   templateUrl: './si-filtered-search-typeahead.component.html',
   styleUrl: './si-filtered-search-typeahead.component.scss',
   providers: [

--- a/projects/element-ng/footer/si-footer.component.ts
+++ b/projects/element-ng/footer/si-footer.component.ts
@@ -4,11 +4,11 @@
  */
 import { Component, input } from '@angular/core';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-footer',
-  imports: [SiLinkDirective, SiTranslateModule],
+  imports: [SiLinkDirective, SiTranslatePipe],
   templateUrl: './si-footer.component.html',
   styleUrl: './si-footer.component.scss'
 })

--- a/projects/element-ng/form/form-fieldset/si-form-fieldset.component.ts
+++ b/projects/element-ng/form/form-fieldset/si-form-fieldset.component.ts
@@ -12,13 +12,13 @@ import {
   input,
   signal
 } from '@angular/core';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiFormItemComponent } from '../si-form-item/si-form-item.component';
 
 @Component({
   selector: 'si-form-fieldset',
-  imports: [SiTranslateModule],
+  imports: [SiTranslatePipe],
   templateUrl: './si-form-fieldset.component.html',
   styleUrl: '../si-form.shared.scss',
   host: {

--- a/projects/element-ng/form/si-form-container/si-form-container.component.ts
+++ b/projects/element-ng/form/si-form-container/si-form-container.component.ts
@@ -6,7 +6,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import { booleanAttribute, Component, computed, inject, input } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
 import { Breakpoints, SiResponsiveContainerDirective } from '@siemens/element-ng/resize-observer';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiFormValidationErrorMapper } from '../si-form-validation-error.model';
 import { SiFormValidationErrorService } from '../si-form-validation-error.service';
@@ -21,7 +20,7 @@ export interface SiFormValidationError {
 
 @Component({
   selector: 'si-form-container',
-  imports: [NgTemplateOutlet, SiResponsiveContainerDirective, SiTranslateModule],
+  imports: [NgTemplateOutlet, SiResponsiveContainerDirective],
   templateUrl: './si-form-container.component.html',
   styleUrl: './si-form-container.component.scss',
   host: {

--- a/projects/element-ng/form/si-form-item/si-form-item.component.spec.ts
+++ b/projects/element-ng/form/si-form-item/si-form-item.component.spec.ts
@@ -4,12 +4,11 @@
  */
 import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiFormItemComponent } from './si-form-item.component';
 
 @Component({
-  imports: [SiTranslateModule, SiFormItemComponent],
+  imports: [SiFormItemComponent],
   template: `
     <si-form-item [label]="label()">
       <input type="text" id="name" class="form-control" />
@@ -32,7 +31,7 @@ describe('SiFormItemComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, TestHostComponent]
+      imports: [TestHostComponent]
     }).compileComponents();
   }));
 

--- a/projects/element-ng/form/si-form-item/si-form-item.component.ts
+++ b/projects/element-ng/form/si-form-item/si-form-item.component.ts
@@ -30,7 +30,7 @@ import {
   ValidationErrors,
   ValidatorFn
 } from '@angular/forms';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiFormFieldsetComponent } from '../form-fieldset/si-form-fieldset.component';
 import { SiFormContainerComponent } from '../si-form-container/si-form-container.component';
@@ -48,7 +48,7 @@ export interface SiFormError {
 
 @Component({
   selector: 'si-form-item',
-  imports: [SiTranslateModule, NgTemplateOutlet],
+  imports: [SiTranslatePipe, NgTemplateOutlet],
   templateUrl: './si-form-item.component.html',
   styleUrl: '../si-form.shared.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.component.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component, inject, InjectionToken, Signal } from '@angular/core';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiFormError } from '../si-form-item/si-form-item.component';
 
@@ -13,7 +13,7 @@ export const SI_FORM_VALIDATION_TOOLTIP_DATA = new InjectionToken<Signal<SiFormE
 
 @Component({
   selector: 'si-form-validation-tooltip',
-  imports: [SiTranslateModule],
+  imports: [SiTranslatePipe],
   template: `
     @for (error of errors(); track error.key) {
       <div>{{ error.message | translate: error.params }}</div>

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
@@ -6,18 +6,13 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiFormValidationTooltipHarness } from '../testing/si-form-validation-tooltip.harness';
 import { SiFormValidationTooltipDirective } from './si-form-validation-tooltip.directive';
 
 describe('SiFormValidationTooltipDirective', () => {
   @Component({
-    // We need the SiTranslateModule here,
-    // as the directive depends on the validation error resolver service which itself may calls $localize.
-    // TODO: this is a potential bug, yet it won't have any impact.
-    // Fix requires refactoring of the translation layer.
-    imports: [SiFormValidationTooltipDirective, ReactiveFormsModule, SiTranslateModule],
+    imports: [SiFormValidationTooltipDirective, ReactiveFormsModule],
     template: `<input siFormValidationTooltip required [formControl]="control" />`
   })
   class TestHostComponent {

--- a/projects/element-ng/formly/fields/button/si-formly-button.component.ts
+++ b/projects/element-ng/formly/fields/button/si-formly-button.component.ts
@@ -5,11 +5,11 @@
 import { NgClass } from '@angular/common';
 import { Component } from '@angular/core';
 import { FieldType, FormlyModule } from '@ngx-formly/core';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-formly-button',
-  imports: [NgClass, SiTranslateModule, FormlyModule],
+  imports: [NgClass, SiTranslatePipe, FormlyModule],
   templateUrl: './si-formly-button.component.html'
 })
 export class SiFormlyButtonComponent extends FieldType {

--- a/projects/element-ng/formly/fields/text/si-formly-text-display.component.ts
+++ b/projects/element-ng/formly/fields/text/si-formly-text-display.component.ts
@@ -5,13 +5,13 @@
 import { Component } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FieldType, FieldTypeConfig, FormlyModule } from '@ngx-formly/core';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { getFieldValue, getKeyPath } from '../../utils';
 
 @Component({
   selector: 'si-formly-text-display',
-  imports: [FormlyModule, ReactiveFormsModule, SiTranslateModule],
+  imports: [FormlyModule, ReactiveFormsModule, SiTranslatePipe],
   templateUrl: './si-formly-text-display.component.html'
 })
 export class SiFormlyTextDisplayComponent extends FieldType<FieldTypeConfig> {

--- a/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.spec.ts
@@ -9,11 +9,10 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { SiFormlyModule } from '@siemens/element-ng/formly';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-formly-test',
-  imports: [SiTranslateModule, SiFormlyModule],
+  imports: [SiFormlyModule],
   template: `
     <si-formly
       class="si-layout-fixed-height"
@@ -97,7 +96,7 @@ describe('formly accordion type', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SiTranslateModule, SiFormlyModule, FormlyTestComponent]
+      imports: [NoopAnimationsModule, SiFormlyModule, FormlyTestComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/structural/si-formly-array/si-formly-array.component.ts
+++ b/projects/element-ng/formly/structural/si-formly-array/si-formly-array.component.ts
@@ -4,11 +4,11 @@
  */
 import { Component } from '@angular/core';
 import { FieldArrayType, FormlyModule } from '@ngx-formly/core';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-formly-array',
-  imports: [FormlyModule, SiTranslateModule],
+  imports: [FormlyModule, SiTranslatePipe],
   templateUrl: './si-formly-array.component.html'
 })
 export class SiFormlyArrayComponent extends FieldArrayType {}

--- a/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.spec.ts
@@ -9,19 +9,12 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 import { SiTabComponent, SiTabsetComponent } from '@siemens/element-ng/tabs';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiFormlyObjectTabsetComponent } from './si-formly-object-tabset.component';
 
 @Component({
   selector: 'si-formly-test',
-  imports: [
-    ReactiveFormsModule,
-    SiTabComponent,
-    SiTabsetComponent,
-    SiTranslateModule,
-    FormlyModule
-  ],
+  imports: [ReactiveFormsModule, FormlyModule],
   template: ` <formly-form [form]="form" [fields]="fields" [model]="model" [options]="options" /> `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -42,7 +35,7 @@ describe('formly tabset type', () => {
         ReactiveFormsModule,
         SiTabComponent,
         SiTabsetComponent,
-        SiTranslateModule,
+
         FormlyModule.forRoot({
           types: [
             {

--- a/projects/element-ng/formly/wrapper/si-formly-icon-wrapper.component.ts
+++ b/projects/element-ng/formly/wrapper/si-formly-icon-wrapper.component.ts
@@ -5,11 +5,11 @@
 import { Component } from '@angular/core';
 import { FieldWrapper } from '@ngx-formly/core';
 import { SiTooltipDirective } from '@siemens/element-ng/tooltip';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-formly-icon-wrapper',
-  imports: [SiTooltipDirective, SiTranslateModule],
+  imports: [SiTooltipDirective, SiTranslatePipe],
   templateUrl: './si-formly-icon-wrapper.component.html',
   styleUrl: './si-formly-icon-wrapper.component.scss'
 })

--- a/projects/element-ng/header-dropdown/si-header-dropdown-items-factory.component.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown-items-factory.component.ts
@@ -5,7 +5,7 @@
 import { Component, input, output } from '@angular/core';
 import { MenuItem } from '@siemens/element-ng/common';
 import { SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiHeaderDropdownItemComponent } from './si-header-dropdown-item.component';
 import { SiHeaderDropdownTriggerDirective } from './si-header-dropdown-trigger.directive';
@@ -22,7 +22,7 @@ import { SiHeaderDropdownComponent } from './si-header-dropdown.component';
   imports: [
     SiHeaderDropdownComponent,
     SiHeaderDropdownItemComponent,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiLinkDirective,
     SiHeaderDropdownTriggerDirective
   ],

--- a/projects/element-ng/icon-status/si-icon-status.component.spec.ts
+++ b/projects/element-ng/icon-status/si-icon-status.component.spec.ts
@@ -5,7 +5,6 @@
 import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SiIconModule } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiIconStatusComponent as TestComponent } from './si-icon-status.component';
 
@@ -21,7 +20,7 @@ describe('SiIconStatusComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiIconModule, SiTranslateModule, TestComponent]
+      imports: [SiIconModule, TestComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/icon/si-icon.component.spec.ts
+++ b/projects/element-ng/icon/si-icon.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiIconComponent as TestComponent } from './si-icon.component';
 
@@ -14,7 +13,7 @@ describe('SiIconComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, TestComponent]
+      imports: [TestComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/icon/si-icon.component.ts
+++ b/projects/element-ng/icon/si-icon.component.ts
@@ -4,11 +4,11 @@
  */
 import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-icon',
-  imports: [NgClass, SiTranslateModule],
+  imports: [NgClass, SiTranslatePipe],
   templateUrl: './si-icon.component.html',
   styles: ':host, span { line-height: 1; }',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/icon/si-status-icon.component.ts
+++ b/projects/element-ng/icon/si-status-icon.component.ts
@@ -5,14 +5,14 @@
 import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { EntityStatusType } from '@siemens/element-ng/common';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { STATUS_ICON_CONFIG } from './icon-status';
 import { SiIconNextComponent } from './si-icon-next.component';
 
 @Component({
   selector: 'si-status-icon',
-  imports: [NgClass, SiIconNextComponent, SiTranslateModule],
+  imports: [NgClass, SiIconNextComponent, SiTranslatePipe],
   template: `
     @let iconValue = statusIcon();
     @if (iconValue) {

--- a/projects/element-ng/info-page/si-info-page.component.ts
+++ b/projects/element-ng/info-page/si-info-page.component.ts
@@ -6,7 +6,7 @@ import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 /**
  * The component displays application info messages. A message uses an icon and a title, optionally a copy text,
@@ -16,7 +16,7 @@ import { SiTranslateModule, TranslatableString } from '@siemens/element-translat
  */
 @Component({
   selector: 'si-info-page',
-  imports: [NgClass, SiLinkDirective, SiIconNextComponent, SiTranslateModule],
+  imports: [NgClass, SiLinkDirective, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-info-page.component.html',
   styleUrl: './si-info-page.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/inline-notification/si-inline-notification.component.ts
+++ b/projects/element-ng/inline-notification/si-inline-notification.component.ts
@@ -7,11 +7,11 @@ import { booleanAttribute, Component, input } from '@angular/core';
 import { StatusType } from '@siemens/element-ng/common';
 import { SiStatusIconComponent } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-inline-notification',
-  imports: [NgClass, SiLinkDirective, SiTranslateModule, SiStatusIconComponent],
+  imports: [NgClass, SiLinkDirective, SiTranslatePipe, SiStatusIconComponent],
   templateUrl: './si-inline-notification.component.html',
   styleUrl: './si-inline-notification.component.scss'
 })

--- a/projects/element-ng/language-switcher/si-language-switcher.component.ts
+++ b/projects/element-ng/language-switcher/si-language-switcher.component.ts
@@ -3,16 +3,13 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component, computed, input } from '@angular/core';
-import {
-  injectSiTranslateService,
-  SiTranslateModule
-} from '@siemens/element-translate-ng/translate';
+import { injectSiTranslateService, SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { IsoLanguageValue } from './iso-language-value';
 
 @Component({
   selector: 'si-language-switcher',
-  imports: [SiTranslateModule],
+  imports: [SiTranslatePipe],
   templateUrl: './si-language-switcher.component.html',
   styleUrl: './si-language-switcher.component.scss'
 })

--- a/projects/element-ng/link/si-link.directive.spec.ts
+++ b/projects/element-ng/link/si-link.directive.spec.ts
@@ -8,7 +8,6 @@ import { provideRouter, Router } from '@angular/router';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
 import {
   provideMockTranslateServiceBuilder,
-  SiTranslateModule,
   SiTranslateService
 } from '@siemens/element-translate-ng/translate';
 import { of } from 'rxjs';
@@ -49,7 +48,7 @@ describe('SiLinkDirective', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, SiLinkDirective, TestHostComponent],
+      imports: [SiLinkDirective, TestHostComponent],
       providers: [
         SiLinkActionService,
         provideRouter([]),
@@ -219,7 +218,7 @@ describe('SiLinkDirective', () => {
       beforeEach(() => {
         TestBed.resetTestingModule();
         TestBed.configureTestingModule({
-          imports: [SiTranslateModule, SiLinkDirective, TestHostComponent],
+          imports: [SiLinkDirective, TestHostComponent],
           providers: [
             SiLinkActionService,
             provideRouter([]),

--- a/projects/element-ng/list-details/si-details-pane-header/si-details-pane-header.component.ts
+++ b/projects/element-ng/list-details/si-details-pane-header/si-details-pane-header.component.ts
@@ -13,7 +13,7 @@ import {
   viewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiListDetailsComponent } from '../si-list-details.component';
 
@@ -23,7 +23,7 @@ import { SiListDetailsComponent } from '../si-list-details.component';
   host: {
     class: 'nav nav-tabs' // To allow nav-link styling.
   },
-  imports: [SiTranslateModule],
+  imports: [SiTranslatePipe],
   templateUrl: './si-details-pane-header.component.html',
   styleUrl: './si-details-pane-header.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/list-details/si-list-details.component.ts
+++ b/projects/element-ng/list-details/si-list-details.component.ts
@@ -27,13 +27,12 @@ import {
   ResizeObserverService
 } from '@siemens/element-ng/resize-observer';
 import { SiSplitComponent, SiSplitPartComponent } from '@siemens/element-ng/split';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 
 /** @experimental */
 @Component({
   selector: 'si-list-details',
-  imports: [NgTemplateOutlet, SiSplitComponent, SiSplitPartComponent, SiTranslateModule],
+  imports: [NgTemplateOutlet, SiSplitComponent, SiSplitPartComponent],
   templateUrl: './si-list-details.component.html',
   styleUrl: './si-list-details.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/loading-spinner/si-loading-button.component.ts
+++ b/projects/element-ng/loading-spinner/si-loading-button.component.ts
@@ -4,13 +4,13 @@
  */
 import { NgClass } from '@angular/common';
 import { booleanAttribute, ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiLoadingSpinnerComponent } from './si-loading-spinner.component';
 
 @Component({
   selector: 'si-loading-button',
-  imports: [SiLoadingSpinnerComponent, NgClass, SiTranslateModule],
+  imports: [SiLoadingSpinnerComponent, NgClass, SiTranslatePipe],
   templateUrl: './si-loading-button.component.html',
   styleUrl: './si-loading-button.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/loading-spinner/si-loading-spinner.component.ts
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.component.ts
@@ -11,13 +11,14 @@ import {
   InjectionToken,
   input
 } from '@angular/core';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
+
 export const LOADING_SPINNER_BLOCKING = new InjectionToken<boolean>('isBlockingSpinner');
 export const LOADING_SPINNER_OVERLAY = new InjectionToken<boolean>('isSpinnerOverlay');
 
 @Component({
   selector: 'si-loading-spinner',
-  imports: [SiTranslateModule],
+  imports: [SiTranslatePipe],
   templateUrl: './si-loading-spinner.component.html',
   styleUrl: './si-loading-spinner.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
@@ -26,12 +26,12 @@ import {
   ResizeObserverService
 } from '@siemens/element-ng/resize-observer';
 import { SiSplitComponent, SiSplitPartComponent } from '@siemens/element-ng/split';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'si-main-detail-container',
-  imports: [NgClass, NgTemplateOutlet, SiSplitComponent, SiSplitPartComponent, SiTranslateModule],
+  imports: [NgClass, NgTemplateOutlet, SiSplitComponent, SiSplitPartComponent, SiTranslatePipe],
   templateUrl: './si-main-detail-container.component.html',
   styleUrl: './si-main-detail-container.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/menu/si-menu-factory.component.ts
+++ b/projects/element-ng/menu/si-menu-factory.component.ts
@@ -8,7 +8,7 @@ import { Component, inject, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
 import { SiLinkActionService, SiLinkModule } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiMenuActionService } from './si-menu-action.service';
 import { SiMenuDividerDirective } from './si-menu-divider.directive';
@@ -17,7 +17,7 @@ import { SiMenuHeaderDirective } from './si-menu-header.directive';
 import { SiMenuItemCheckboxComponent } from './si-menu-item-checkbox.component';
 import { SiMenuItemRadioComponent } from './si-menu-item-radio.component';
 import { SiMenuItemComponent } from './si-menu-item.component';
-import { MenuItemAction, MenuItemCheckbox, MenuItem, MenuItemRadio } from './si-menu-model';
+import { MenuItem, MenuItemAction, MenuItemCheckbox, MenuItemRadio } from './si-menu-model';
 import { SiMenuDirective } from './si-menu.directive';
 
 @Component({
@@ -31,7 +31,7 @@ import { SiMenuDirective } from './si-menu.directive';
     SiMenuDividerDirective,
     SiLinkModule,
     CdkMenuTrigger,
-    SiTranslateModule,
+    SiTranslatePipe,
     CdkMenuGroup,
     NgTemplateOutlet,
     RouterLink,

--- a/projects/element-ng/menu/si-menu.spec.ts
+++ b/projects/element-ng/menu/si-menu.spec.ts
@@ -9,7 +9,6 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MenuItem } from '@siemens/element-ng/common';
 import { SiLinkActionService } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiMenuModule } from './si-menu.module';
 import { SiMenuItemHarness } from './testing/si-menu.harness';
@@ -22,7 +21,7 @@ class ButtonHarness extends ComponentHarness {
 }
 
 @Component({
-  imports: [SiMenuModule, SiTranslateModule, CdkMenuTrigger],
+  imports: [SiMenuModule, CdkMenuTrigger],
   template: `
     <button class="btn" type="button" [cdkMenuTriggerFor]="menu">Toggle Menu</button>
     <ng-template #menu>

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical-item-legacy.component.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical-item-legacy.component.ts
@@ -5,7 +5,7 @@
 import { Component, computed, inject, input, model, viewChildren } from '@angular/core';
 import { MenuItem } from '@siemens/element-ng/common';
 import { SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiNavbarVerticalGroupTriggerDirective } from './si-navbar-vertical-group-trigger.directive';
 import { SiNavbarVerticalGroupComponent } from './si-navbar-vertical-group.component';
@@ -17,7 +17,7 @@ import { SI_NAVBAR_VERTICAL } from './si-navbar-vertical.provider';
   selector: 'si-navbar-vertical-item-legacy',
   imports: [
     SiLinkDirective,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiNavbarVerticalItemComponent,
     SiNavbarVerticalGroupTriggerDirective,
     SiNavbarVerticalGroupComponent,

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical.component.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical.component.ts
@@ -38,7 +38,7 @@ import { MenuItem, SI_UI_STATE_SERVICE } from '@siemens/element-ng/common';
 import { BOOTSTRAP_BREAKPOINTS } from '@siemens/element-ng/resize-observer';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
 import { SiSkipLinkTargetDirective } from '@siemens/element-ng/skip-links';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -73,7 +73,7 @@ export class SiNavbarVerticalItemGuardDirective {
     SiNavbarVerticalItemLegacyComponent,
     SiSearchBarComponent,
     SiSkipLinkTargetDirective,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiNavbarVerticalItemComponent,
     RouterLink,
     SiNavbarVerticalItemGuardDirective,

--- a/projects/element-ng/navbar/si-navbar-item/si-navbar-item.component.ts
+++ b/projects/element-ng/navbar/si-navbar-item/si-navbar-item.component.ts
@@ -20,7 +20,7 @@ import {
   SiHeaderDropdownTriggerDirective
 } from '@siemens/element-ng/header-dropdown';
 import { SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiNavbarPrimaryComponent } from '../si-navbar-primary/si-navbar-primary.component';
 
@@ -29,7 +29,7 @@ import { SiNavbarPrimaryComponent } from '../si-navbar-primary/si-navbar-primary
   selector: 'si-navbar-item',
   imports: [
     SiLinkDirective,
-    SiTranslateModule,
+    SiTranslatePipe,
     NgClass,
     NgTemplateOutlet,
     SiHeaderDropdownComponent,

--- a/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.ts
+++ b/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.ts
@@ -37,7 +37,7 @@ import {
   SiHeaderDropdownTriggerDirective
 } from '@siemens/element-ng/header-dropdown';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { defer } from 'rxjs';
 
 import { AccountItem } from '../account.model';
@@ -50,7 +50,7 @@ import { AppItem, AppItemCategory } from './si-navbar-primary.model';
     A11yModule,
     NgTemplateOutlet,
     SiLinkDirective,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiApplicationHeaderComponent,
     SiLaunchpadFactoryComponent,
     SiHeaderAccountItemComponent,

--- a/projects/element-ng/number-input/si-number-input.component.ts
+++ b/projects/element-ng/number-input/si-number-input.component.ts
@@ -29,13 +29,13 @@ import {
   Validators
 } from '@angular/forms';
 import { SI_FORM_ITEM_CONTROL, SiFormItemControl } from '@siemens/element-ng/form';
-import { elementMinus, elementPlus, addIcons, SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { addIcons, elementMinus, elementPlus, SiIconNextComponent } from '@siemens/element-ng/icon';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { Subscription, timer } from 'rxjs';
 
 @Component({
   selector: 'si-number-input',
-  imports: [SiIconNextComponent, SiTranslateModule],
+  imports: [SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-number-input.component.html',
   styleUrl: './si-number-input.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/pagination/si-pagination.component.spec.ts
+++ b/projects/element-ng/pagination/si-pagination.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiPaginationComponent as TestComponent } from '.';
 
@@ -23,7 +22,7 @@ describe('SiPaginationComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [CommonModule, SiTranslateModule, TestComponent]
+      imports: [CommonModule, TestComponent]
     }).compileComponents();
   }));
 

--- a/projects/element-ng/pagination/si-pagination.component.ts
+++ b/projects/element-ng/pagination/si-pagination.component.ts
@@ -5,15 +5,15 @@
 import { ChangeDetectionStrategy, Component, computed, input, model } from '@angular/core';
 import {
   addIcons,
-  SiIconNextComponent,
   elementLeft3,
-  elementRight3
+  elementRight3,
+  SiIconNextComponent
 } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-pagination',
-  imports: [SiIconNextComponent, SiTranslateModule],
+  imports: [SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-pagination.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/projects/element-ng/password-strength/si-password-strength.component.spec.ts
+++ b/projects/element-ng/password-strength/si-password-strength.component.spec.ts
@@ -5,12 +5,11 @@
 import { ChangeDetectionStrategy, Component, ElementRef, viewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import {
   PasswordPolicy,
-  SiPasswordStrengthModule,
-  SiPasswordStrengthComponent as TestComponent
+  SiPasswordStrengthComponent as TestComponent,
+  SiPasswordStrengthModule
 } from '.';
 
 const passwordStrengthValue: PasswordPolicy = {
@@ -22,7 +21,7 @@ const passwordStrengthValue: PasswordPolicy = {
 };
 
 @Component({
-  imports: [SiPasswordStrengthModule, FormsModule, SiTranslateModule],
+  imports: [SiPasswordStrengthModule, FormsModule],
   template: `
     <si-password-strength>
       <input
@@ -65,7 +64,7 @@ describe('SiPasswordStrengthDirective', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiPasswordStrengthModule, FormsModule, SiTranslateModule, WrapperComponent]
+      imports: [SiPasswordStrengthModule, FormsModule, WrapperComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/password-toggle/si-password-toggle.component.spec.ts
+++ b/projects/element-ng/password-toggle/si-password-toggle.component.spec.ts
@@ -5,12 +5,11 @@
 import { Component, input } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiPasswordToggleModule } from './si-password-toggle.module';
 
 @Component({
-  imports: [FormsModule, SiPasswordToggleModule, SiTranslateModule],
+  imports: [FormsModule, SiPasswordToggleModule],
   template: `
     <si-password-toggle #toggle [showVisibilityIcon]="showVisibilityIcon()">
       <input [attr.type]="toggle.inputType" />
@@ -27,7 +26,7 @@ describe('SiPasswordToggleComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule, SiPasswordToggleModule, SiTranslateModule, TestHostComponent]
+      imports: [FormsModule, SiPasswordToggleModule, TestHostComponent]
     });
   });
 

--- a/projects/element-ng/password-toggle/si-password-toggle.component.ts
+++ b/projects/element-ng/password-toggle/si-password-toggle.component.ts
@@ -4,11 +4,11 @@
  */
 import { Component, input, output, signal } from '@angular/core';
 import { addIcons, elementHide, elementShow, SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-password-toggle',
-  imports: [SiIconNextComponent, SiTranslateModule],
+  imports: [SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-password-toggle.component.html',
   styleUrl: './si-password-toggle.component.scss',
   host: {

--- a/projects/element-ng/phone-number/si-phone-number-input.component.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.ts
@@ -29,12 +29,9 @@ import {
   Validator
 } from '@angular/forms';
 import { SI_FORM_ITEM_CONTROL, SiFormItemControl } from '@siemens/element-ng/form';
-import { elementDown2, addIcons, SiIconNextComponent } from '@siemens/element-ng/icon';
+import { addIcons, elementDown2, SiIconNextComponent } from '@siemens/element-ng/icon';
 import { SiSelectListHasFilterComponent } from '@siemens/element-ng/select';
-import {
-  injectSiTranslateService,
-  SiTranslateModule
-} from '@siemens/element-translate-ng/translate';
+import { injectSiTranslateService, SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { PhoneNumber, PhoneNumberFormat, PhoneNumberUtil } from 'google-libphonenumber';
 
 import { SiPhoneNumberInputSelectDirective } from './si-phone-number-input-select.directive';
@@ -49,7 +46,7 @@ import { CountryInfo, PhoneDetails } from './si-phone-number-input.models';
     SiIconNextComponent,
     SiPhoneNumberInputSelectDirective,
     SiSelectListHasFilterComponent,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-phone-number-input.component.html',
   styleUrl: './si-phone-number-input.component.scss',

--- a/projects/element-ng/photo-upload/si-photo-upload.component.ts
+++ b/projects/element-ng/photo-upload/si-photo-upload.component.ts
@@ -26,11 +26,10 @@ import {
   elementCancel,
   elementCircleFilled,
   elementStateExclamationMark,
-  SiIconComponent,
   SiIconNextComponent
 } from '@siemens/element-ng/icon';
 import { ModalRef, SiModalService } from '@siemens/element-ng/modal';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { CropperPosition, ImageCroppedEvent, ImageCropperComponent } from 'ngx-image-cropper';
 
 import { SiImageCropperStyleComponent } from './si-image-cropper-style.component';
@@ -47,10 +46,9 @@ import { SiImageCropperStyleComponent } from './si-image-cropper-style.component
   imports: [
     NgTemplateOutlet,
     ImageCropperComponent,
-    SiIconComponent,
     SiIconNextComponent,
     SiImageCropperStyleComponent,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-photo-upload.component.html',
   styleUrl: './si-photo-upload.component.scss',

--- a/projects/element-ng/pills-input/si-pills-input.component.ts
+++ b/projects/element-ng/pills-input/si-pills-input.component.ts
@@ -18,7 +18,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { SI_FORM_ITEM_CONTROL, SiFormItemControl } from '@siemens/element-ng/form';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiInputPillComponent } from './si-input-pill.component';
 import {
@@ -28,7 +28,7 @@ import {
 
 @Component({
   selector: 'si-pills-input',
-  imports: [SiInputPillComponent, SiTranslateModule],
+  imports: [SiInputPillComponent, SiTranslatePipe],
   templateUrl: './si-pills-input.component.html',
   styleUrl: './si-pills-input.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/progressbar/si-progressbar.component.spec.ts
+++ b/projects/element-ng/progressbar/si-progressbar.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiProgressbarComponent as TestComponent } from './si-progressbar.component';
 
@@ -15,7 +14,7 @@ describe('SiProgressbarComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, TestComponent]
+      imports: [TestComponent]
     })
   );
 

--- a/projects/element-ng/progressbar/si-progressbar.component.ts
+++ b/projects/element-ng/progressbar/si-progressbar.component.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-progressbar',
-  imports: [SiTranslateModule],
+  imports: [SiTranslatePipe],
   templateUrl: './si-progressbar.component.html',
   styleUrl: './si-progressbar.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/result-details-list/si-result-details-list.component.spec.ts
+++ b/projects/element-ng/result-details-list/si-result-details-list.component.spec.ts
@@ -4,12 +4,11 @@
  */
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { ResultDetailStep, SiResultDetailsListComponent } from '.';
 
 @Component({
-  imports: [SiResultDetailsListComponent, SiTranslateModule],
+  imports: [SiResultDetailsListComponent],
   template: `<si-result-details-list [steps]="steps" /> `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -24,7 +23,7 @@ describe('SiResultDetailsListComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, TestHostComponent]
+      imports: [TestHostComponent]
     })
   );
 

--- a/projects/element-ng/result-details-list/si-result-details-list.component.ts
+++ b/projects/element-ng/result-details-list/si-result-details-list.component.ts
@@ -4,22 +4,22 @@
  */
 import { Component, computed, input } from '@angular/core';
 import {
+  addIcons,
   elementCircleFilled,
-  elementOutOfService,
   elementNotChecked,
+  elementOutOfService,
   elementStateExclamationMark,
   elementStateTick,
-  addIcons,
   SiIconNextComponent
 } from '@siemens/element-ng/icon';
 import { SiLoadingSpinnerComponent } from '@siemens/element-ng/loading-spinner';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { ResultDetailStep } from './si-result-details-list.datamodel';
 
 @Component({
   selector: 'si-result-details-list',
-  imports: [SiLoadingSpinnerComponent, SiIconNextComponent, SiTranslateModule],
+  imports: [SiLoadingSpinnerComponent, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-result-details-list.component.html',
   styleUrl: './si-result-details-list.component.scss'
 })

--- a/projects/element-ng/select/select-input/si-select-input.component.ts
+++ b/projects/element-ng/select/select-input/si-select-input.component.ts
@@ -14,8 +14,8 @@ import {
   TemplateRef
 } from '@angular/core';
 import { SiAutoCollapsableListModule } from '@siemens/element-ng/auto-collapsable-list';
-import { elementDown2, addIcons, SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { addIcons, elementDown2, SiIconNextComponent } from '@siemens/element-ng/icon';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import {
   SI_SELECT_OPTIONS_STRATEGY,
@@ -31,7 +31,7 @@ import { SelectOption } from '../si-select.types';
     SiAutoCollapsableListModule,
     SiIconNextComponent,
     SiSelectOptionComponent,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-select-input.component.html',
   styleUrl: './si-select-input.component.scss',

--- a/projects/element-ng/select/select-list/si-select-list-has-filter.component.ts
+++ b/projects/element-ng/select/select-list/si-select-list-has-filter.component.ts
@@ -15,9 +15,9 @@ import {
   viewChild
 } from '@angular/core';
 import { SiAutocompleteDirective, SiAutocompleteModule } from '@siemens/element-ng/autocomplete';
-import { elementSearch, addIcons, SiIconNextComponent } from '@siemens/element-ng/icon';
+import { addIcons, elementSearch, SiIconNextComponent } from '@siemens/element-ng/icon';
 import { SiLoadingSpinnerComponent } from '@siemens/element-ng/loading-spinner';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiSelectOptionRowComponent } from '../select-option/si-select-option-row.component';
 import { SiSelectGroupTemplateDirective } from '../si-select-group-template.directive';
@@ -33,7 +33,7 @@ import { SiSelectListBase } from './si-select-list.base';
     SiSelectGroupTemplateDirective,
     SiSelectOptionRowComponent,
     SiSelectOptionRowTemplateDirective,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiAutocompleteModule,
     SiLoadingSpinnerComponent
   ],

--- a/projects/element-ng/select/select-list/si-select-list.component.ts
+++ b/projects/element-ng/select/select-list/si-select-list.component.ts
@@ -5,7 +5,7 @@
 import { CdkListbox, CdkOption, ListboxValueChangeEvent } from '@angular/cdk/listbox';
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ElementRef, OnInit, viewChild } from '@angular/core';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiSelectOptionRowComponent } from '../select-option/si-select-option-row.component';
 import { SiSelectGroupTemplateDirective } from '../si-select-group-template.directive';
@@ -17,7 +17,7 @@ import { SiSelectListBase } from './si-select-list.base';
   imports: [
     CommonModule,
     CdkListbox,
-    SiTranslateModule,
+    SiTranslatePipe,
     CdkOption,
     SiSelectOptionRowTemplateDirective,
     SiSelectGroupTemplateDirective,

--- a/projects/element-ng/select/select-option/si-select-option.component.ts
+++ b/projects/element-ng/select/select-option/si-select-option.component.ts
@@ -5,7 +5,7 @@
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, input, TemplateRef } from '@angular/core';
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiSelectOptionTemplateDirective } from '../si-select-option-template.directive';
 import { SelectOption } from '../si-select.types';
@@ -16,7 +16,7 @@ import { SelectOption } from '../si-select.types';
     NgClass,
     NgTemplateOutlet,
     SiIconNextComponent,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiSelectOptionTemplateDirective
   ],
   templateUrl: './si-select-option.component.html',

--- a/projects/element-ng/side-panel/si-side-panel-content.component.ts
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.ts
@@ -22,16 +22,16 @@ import {
   SiContentActionBarComponent
 } from '@siemens/element-ng/content-action-bar';
 import {
+  addIcons,
   elementDoubleLeft,
   elementDoubleRight,
-  addIcons,
   SiIconNextComponent
 } from '@siemens/element-ng/icon';
 import { SiLinkDirective } from '@siemens/element-ng/link';
 import { MenuItem } from '@siemens/element-ng/menu';
 import { BOOTSTRAP_BREAKPOINTS } from '@siemens/element-ng/resize-observer';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiSidePanelService } from './si-side-panel.service';
 
@@ -49,7 +49,7 @@ export interface StatusItem extends MenuItemLegacy {
     SiIconNextComponent,
     SiLinkDirective,
     SiSearchBarComponent,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-side-panel-content.component.html',
   styleUrl: './si-side-panel-content.component.scss',

--- a/projects/element-ng/skip-links/si-skip-links.component.ts
+++ b/projects/element-ng/skip-links/si-skip-links.component.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: MIT
  */
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiSkipLinkTargetDirective } from './si-skip-link-target.directive';
 
 @Component({
   selector: 'si-skip-links',
-  imports: [SiTranslateModule],
+  imports: [SiTranslatePipe],
   templateUrl: './si-skip-links.component.html',
   styleUrl: './si-skip-links.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/slider/si-slider.component.spec.ts
+++ b/projects/element-ng/slider/si-slider.component.spec.ts
@@ -5,12 +5,11 @@
 import { Component, inject, signal } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiSliderComponent } from './si-slider.component';
 
 @Component({
-  imports: [FormsModule, ReactiveFormsModule, SiTranslateModule, SiSliderComponent],
+  imports: [FormsModule, ReactiveFormsModule, SiSliderComponent],
   template: `<si-slider
     [min]="min"
     [max]="max"
@@ -34,7 +33,7 @@ class HostComponent {
 }
 
 @Component({
-  imports: [FormsModule, ReactiveFormsModule, SiTranslateModule, SiSliderComponent],
+  imports: [FormsModule, ReactiveFormsModule, SiSliderComponent],
   template: `<form [formGroup]="form">
     <si-slider formControlName="slider" />
   </form>`
@@ -69,7 +68,7 @@ describe('SiSliderComponent', () => {
       imports: [
         FormsModule,
         ReactiveFormsModule,
-        SiTranslateModule,
+
         SiSliderComponent,
         FormHostComponent,
         HostComponent

--- a/projects/element-ng/slider/si-slider.component.ts
+++ b/projects/element-ng/slider/si-slider.component.ts
@@ -21,13 +21,13 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { correctKeyRTL, isRTL, listenGlobal } from '@siemens/element-ng/common';
 import { SI_FORM_ITEM_CONTROL, SiFormItemControl } from '@siemens/element-ng/form';
-import { elementMinus, elementPlus, addIcons, SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { addIcons, elementMinus, elementPlus, SiIconNextComponent } from '@siemens/element-ng/icon';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Subscription, timer } from 'rxjs';
 
 @Component({
   selector: 'si-slider',
-  imports: [SiIconNextComponent, SiTranslateModule],
+  imports: [SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-slider.component.html',
   styleUrl: './si-slider.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/sort-bar/si-sort-bar.component.ts
+++ b/projects/element-ng/sort-bar/si-sort-bar.component.ts
@@ -10,7 +10,7 @@ import {
   elementSortUp,
   SiIconNextComponent
 } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 export interface SortCriteria {
   name: string;
@@ -19,7 +19,7 @@ export interface SortCriteria {
 
 @Component({
   selector: 'si-sort-bar',
-  imports: [SiIconNextComponent, SiTranslateModule],
+  imports: [SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-sort-bar.component.html',
   styleUrl: './si-sort-bar.component.scss'
 })

--- a/projects/element-ng/split/si-split-part.component.ts
+++ b/projects/element-ng/split/si-split-part.component.ts
@@ -19,13 +19,13 @@ import {
   TemplateRef
 } from '@angular/core';
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { Action, CollapseTo, PartState, Scale, SplitOrientation } from './si-split.interfaces';
 
 @Component({
   selector: 'si-split-part',
-  imports: [NgTemplateOutlet, SiIconNextComponent, SiTranslateModule],
+  imports: [NgTemplateOutlet, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-split-part.component.html',
   styleUrl: './si-split-part.component.scss',
   // Signals cannot be used directly with @HostBinding. See: https://github.com/angular/angular/issues/53888#issuecomment-1888935225

--- a/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.spec.ts
+++ b/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.spec.ts
@@ -5,12 +5,11 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SiIconModule } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiStatusBarItemComponent } from './si-status-bar-item.component';
 
 @Component({
-  imports: [SiIconModule, SiTranslateModule, SiStatusBarItemComponent],
+  imports: [SiIconModule, SiStatusBarItemComponent],
   template: `
     <si-status-bar-item
       #item
@@ -37,7 +36,7 @@ describe('SiStatusBarItemComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiIconModule, SiTranslateModule, SiStatusBarItemComponent, TestHostComponent]
+      imports: [SiIconModule, SiStatusBarItemComponent, TestHostComponent]
     }).compileComponents()
   );
 

--- a/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.ts
+++ b/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.ts
@@ -14,11 +14,11 @@ import {
 } from '@angular/core';
 import { ExtendedStatusType } from '@siemens/element-ng/common';
 import { SiIconNextComponent, STATUS_ICON_CONFIG } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-status-bar-item',
-  imports: [NgClass, SiIconNextComponent, SiTranslateModule],
+  imports: [NgClass, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-status-bar-item.component.html',
   styleUrl: './si-status-bar-item.component.scss',
   host: {

--- a/projects/element-ng/status-bar/si-status-bar.component.ts
+++ b/projects/element-ng/status-bar/si-status-bar.component.ts
@@ -23,20 +23,17 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BlinkService, STATUS_ICON, TextMeasureService } from '@siemens/element-ng/common';
 import {
+  addIcons,
   elementDown2,
   elementSoundMute,
   elementSoundOn,
-  addIcons,
   SiIconNextComponent
 } from '@siemens/element-ng/icon';
 import {
   ResizeObserverService,
   SiResizeObserverDirective
 } from '@siemens/element-ng/resize-observer';
-import {
-  injectSiTranslateService,
-  SiTranslateModule
-} from '@siemens/element-translate-ng/translate';
+import { injectSiTranslateService, SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Observable, Subscription } from 'rxjs';
 import { first } from 'rxjs/operators';
 
@@ -68,7 +65,7 @@ let idCounter = 1;
     SiIconNextComponent,
     SiStatusBarItemComponent,
     SiResizeObserverDirective,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-status-bar.component.html',
   styleUrl: './si-status-bar.component.scss',

--- a/projects/element-ng/status-toggle/si-status-toggle.component.ts
+++ b/projects/element-ng/status-toggle/si-status-toggle.component.ts
@@ -22,13 +22,13 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { isRTL, listenGlobal } from '@siemens/element-ng/common';
 import { SiIconComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { StatusToggleItem } from './status-toggle.model';
 
 @Component({
   selector: 'si-status-toggle',
-  imports: [NgClass, SiIconComponent, SiTranslateModule],
+  imports: [NgClass, SiIconComponent, SiTranslatePipe],
   templateUrl: './si-status-toggle.component.html',
   styleUrl: './si-status-toggle.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/summary-chip/si-summary-chip.component.ts
+++ b/projects/element-ng/summary-chip/si-summary-chip.component.ts
@@ -14,11 +14,11 @@ import {
 } from '@angular/core';
 import { ExtendedStatusType } from '@siemens/element-ng/common';
 import { SiIconNextComponent, STATUS_ICON_CONFIG } from '@siemens/element-ng/icon';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-summary-chip',
-  imports: [NgClass, SiIconNextComponent, SiTranslateModule],
+  imports: [NgClass, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-summary-chip.component.html',
   styleUrl: './si-summary-chip.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/summary-widget/si-summary-widget.component.ts
+++ b/projects/element-ng/summary-widget/si-summary-widget.component.ts
@@ -12,11 +12,11 @@ import {
 } from '@angular/core';
 import { ExtendedStatusType, STATUS_ICON } from '@siemens/element-ng/common';
 import { SiIconComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-summary-widget',
-  imports: [SiIconComponent, SiTranslateModule],
+  imports: [SiIconComponent, SiTranslatePipe],
   templateUrl: './si-summary-widget.component.html',
   styleUrl: './si-summary-widget.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/system-banner/system-banner.component.spec.ts
+++ b/projects/element-ng/system-banner/system-banner.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { NgClass } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 import { SiSystemBannerComponent } from './system-banner.component';
 
@@ -14,7 +13,7 @@ describe('SiSystemBannerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiSystemBannerComponent, NgClass, SiTranslateModule]
+      imports: [SiSystemBannerComponent, NgClass]
     }).compileComponents();
   });
 

--- a/projects/element-ng/system-banner/system-banner.component.ts
+++ b/projects/element-ng/system-banner/system-banner.component.ts
@@ -4,7 +4,7 @@
  */
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { ExtendedStatusType } from '@siemens/element-ng/common';
-import { TranslatableString, SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 /**
  * The system banner component displays a message with specific status as background.
@@ -12,7 +12,7 @@ import { TranslatableString, SiTranslateModule } from '@siemens/element-translat
  */
 @Component({
   selector: 'si-system-banner',
-  imports: [SiTranslateModule],
+  imports: [SiTranslatePipe],
   templateUrl: './system-banner.component.html',
   styleUrl: './system-banner.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/tabs-next/si-tab-next-link.component.ts
+++ b/projects/element-ng/tabs-next/si-tab-next-link.component.ts
@@ -7,7 +7,7 @@ import { ChangeDetectionStrategy, Component, effect, inject, signal } from '@ang
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiTabNextBaseDirective } from './si-tab-next-base.directive';
 
@@ -15,7 +15,7 @@ import { SiTabNextBaseDirective } from './si-tab-next-base.directive';
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'a[si-tab-next][routerLink]',
-  imports: [NgClass, SiIconNextComponent, SiTranslateModule],
+  imports: [NgClass, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-tab-next.component.html',
   styleUrl: './si-tab-next.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/tabs-next/si-tab-next.component.ts
+++ b/projects/element-ng/tabs-next/si-tab-next.component.ts
@@ -5,14 +5,14 @@
 import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, model, OnDestroy } from '@angular/core';
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiTabNextBaseDirective } from './si-tab-next-base.directive';
 
 /** @experimental */
 @Component({
   selector: 'si-tab-next',
-  imports: [NgClass, SiIconNextComponent, SiTranslateModule],
+  imports: [NgClass, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-tab-next.component.html',
   styleUrl: './si-tab-next.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/tabs-next/si-tabset-next.component.ts
+++ b/projects/element-ng/tabs-next/si-tabset-next.component.ts
@@ -20,7 +20,7 @@ import {
 import { RouterLink } from '@angular/router';
 import { SiMenuDirective, SiMenuItemComponent } from '@siemens/element-ng/menu';
 import { SiResizeObserverModule } from '@siemens/element-ng/resize-observer';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiTabNextLinkComponent } from './si-tab-next-link.component';
 import { SiTabNextComponent } from './si-tab-next.component';
@@ -46,7 +46,7 @@ export interface SiTabNextDeselectionEvent {
 @Component({
   selector: 'si-tabset-next',
   imports: [
-    SiTranslateModule,
+    SiTranslatePipe,
     SiMenuDirective,
     SiMenuItemComponent,
     CdkMenuTrigger,

--- a/projects/element-ng/tabs/si-tabset/si-tabset.component.ts
+++ b/projects/element-ng/tabs/si-tabset/si-tabset.component.ts
@@ -17,20 +17,19 @@ import {
   OnDestroy,
   Output,
   QueryList,
-  viewChildren,
-  viewChild
+  viewChild,
+  viewChildren
 } from '@angular/core';
 import { isRTL, WebComponentContentChildren } from '@siemens/element-ng/common';
 import {
+  addIcons,
   elementCancel,
   elementLeft3,
   elementRight3,
-  addIcons,
-  SiIconComponent,
   SiIconNextComponent
 } from '@siemens/element-ng/icon';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { asyncScheduler, Subscription } from 'rxjs';
 import { first, observeOn } from 'rxjs/operators';
 
@@ -55,13 +54,7 @@ const SCROLL_INCREMENT = 55;
 
 @Component({
   selector: 'si-tabset',
-  imports: [
-    NgClass,
-    SiIconNextComponent,
-    SiIconComponent,
-    SiResizeObserverDirective,
-    SiTranslateModule
-  ],
+  imports: [NgClass, SiIconNextComponent, SiResizeObserverDirective, SiTranslatePipe],
   templateUrl: './si-tabset.component.html',
   styleUrl: './si-tabset.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/threshold/si-readonly-threshold-option.component.ts
+++ b/projects/element-ng/threshold/si-readonly-threshold-option.component.ts
@@ -6,11 +6,11 @@ import { NgClass } from '@angular/common';
 import { Component, computed, input } from '@angular/core';
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
 import { SelectOption, SelectOptionLegacy } from '@siemens/element-ng/select';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-readonly-threshold-option',
-  imports: [NgClass, SiTranslateModule, SiIconNextComponent],
+  imports: [NgClass, SiTranslatePipe, SiIconNextComponent],
   template: `@let opt = option();
     @if (opt && opt.icon) {
       <i class="icon-stack">

--- a/projects/element-ng/threshold/si-threshold.component.ts
+++ b/projects/element-ng/threshold/si-threshold.component.ts
@@ -24,7 +24,7 @@ import {
   SiSelectSimpleOptionsDirective,
   SiSelectSingleValueDirective
 } from '@siemens/element-ng/select';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiReadonlyThresholdOptionComponent } from './si-readonly-threshold-option.component';
 
@@ -51,7 +51,7 @@ export interface ThresholdStep {
     SiSelectComponent,
     SiSelectSingleValueDirective,
     SiSelectSimpleOptionsDirective,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiReadonlyThresholdOptionComponent
   ],
   templateUrl: './si-threshold.component.html',

--- a/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.spec.ts
@@ -5,7 +5,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 import { Observable, Subject } from 'rxjs';
 
 import { SiToast } from '../si-toast.model';
@@ -27,7 +26,7 @@ describe('SiToastNotificationDrawerComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, NoopAnimationsModule, TestHostComponent]
+      imports: [NoopAnimationsModule, TestHostComponent]
     }).compileComponents();
   }));
 

--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.ts
@@ -22,13 +22,13 @@ import {
   STATUS_ICON_CONFIG
 } from '@siemens/element-ng/icon';
 import { SiLinkModule } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiToast } from '../si-toast.model';
 
 @Component({
   selector: 'si-toast-notification',
-  imports: [NgClass, SiLinkModule, SiIconNextComponent, SiStatusIconComponent, SiTranslateModule],
+  imports: [NgClass, SiLinkModule, SiIconNextComponent, SiStatusIconComponent, SiTranslatePipe],
   templateUrl: './si-toast-notification.component.html',
   styleUrl: './si-toast-notification.component.scss'
 })

--- a/projects/element-ng/tooltip/si-tooltip.component.ts
+++ b/projects/element-ng/tooltip/si-tooltip.component.ts
@@ -15,11 +15,11 @@ import {
   Type
 } from '@angular/core';
 import { calculateOverlayArrowPosition, OverlayArrowPosition } from '@siemens/element-ng/common';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-tooltip',
-  imports: [NgClass, NgTemplateOutlet, SiTranslateModule, NgComponentOutlet],
+  imports: [NgClass, NgTemplateOutlet, SiTranslatePipe, NgComponentOutlet],
   templateUrl: './si-tooltip.component.html'
 })
 export class TooltipComponent {

--- a/projects/element-ng/tour/si-tour.component.ts
+++ b/projects/element-ng/tour/si-tour.component.ts
@@ -20,14 +20,14 @@ import {
   OverlayArrowPosition
 } from '@siemens/element-ng/common';
 import { addIcons, elementCancel, SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Subscription } from 'rxjs';
 
 import { PositionChange, SI_TOUR_TOKEN, TourAction, TourStepInternal } from './si-tour-token.model';
 
 @Component({
   selector: 'si-tour',
-  imports: [A11yModule, NgClass, SiIconNextComponent, SiTranslateModule],
+  imports: [A11yModule, NgClass, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-tour.component.html',
   styleUrl: './si-tour.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
@@ -22,10 +22,9 @@ import {
   transferTreeItem,
   TreeItem
 } from '@siemens/element-ng/tree-view';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 
 @Component({
-  imports: [SiTranslateModule, SiTreeViewModule, DragDropModule],
+  imports: [SiTreeViewModule, DragDropModule],
   template: `<div class="d-flex" style="height: 300px">
     <si-tree-view
       #treeOne
@@ -129,7 +128,7 @@ describe('SiTreeViewComponentWithDragDrop', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
-      imports: [SiTranslateModule, SiTreeViewModule, DragDropModule, WrapperComponent]
+      imports: [SiTreeViewModule, DragDropModule, WrapperComponent]
     });
   });
 

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
@@ -25,7 +25,7 @@ import {
 import { correctKeyRTL, MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
 import { SiLoadingSpinnerComponent } from '@siemens/element-ng/loading-spinner';
 import { MenuItem, SiMenuFactoryComponent } from '@siemens/element-ng/menu';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { asyncScheduler, Subject, Subscription } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 
@@ -54,7 +54,7 @@ import {
     NgTemplateOutlet,
     SiLoadingSpinnerComponent,
     SiMenuFactoryComponent,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-tree-view-item.component.html',
   styleUrl: './si-tree-view-item.component.scss',

--- a/projects/element-ng/tree-view/si-tree-view.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.spec.ts
@@ -17,7 +17,6 @@ import { SiLoadingSpinnerModule } from '@siemens/element-ng/loading-spinner';
 import { MenuItem } from '@siemens/element-ng/menu';
 import { ResizeObserverService } from '@siemens/element-ng/resize-observer';
 import { MenuItemsProvider, SiTreeViewModule } from '@siemens/element-ng/tree-view';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 import { BehaviorSubject } from 'rxjs';
 
 import { runOnPushChangeDetection } from '../test-helpers';
@@ -26,7 +25,7 @@ import { SiTreeViewComponent } from './si-tree-view.component';
 import { LoadChildrenEventArgs, TreeItem } from './si-tree-view.model';
 
 @Component({
-  imports: [SiLoadingSpinnerModule, SiTranslateModule, SiTreeViewModule],
+  imports: [SiLoadingSpinnerModule, SiTreeViewModule],
   template: `<si-tree-view
     class="vh-100"
     [style]="style"
@@ -130,13 +129,7 @@ describe('SiTreeViewComponent', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
-      imports: [
-        SiLoadingSpinnerModule,
-        NoopAnimationsModule,
-        SiTranslateModule,
-        SiTreeViewModule,
-        WrapperComponent
-      ]
+      imports: [SiLoadingSpinnerModule, NoopAnimationsModule, SiTreeViewModule, WrapperComponent]
     });
   });
 

--- a/projects/element-ng/tree-view/si-tree-view.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.ts
@@ -36,7 +36,7 @@ import {
 import { buildTrackByIdentity, MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
 import { MenuItem } from '@siemens/element-ng/menu';
 import { ElementDimensions, ResizeObserverService } from '@siemens/element-ng/resize-observer';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { asyncScheduler, defer, fromEvent, merge, Observable, Subject, Subscription } from 'rxjs';
 import { map, withLatestFrom } from 'rxjs/operators';
 
@@ -105,7 +105,7 @@ const rootDefaults: TreeItem = {
   selector: 'si-tree-view',
   imports: [
     NgClass,
-    SiTranslateModule,
+    SiTranslatePipe,
     SiTreeViewItemComponent,
     CdkScrollableModule,
     SiTreeViewItemDirective

--- a/projects/element-ng/typeahead/si-typeahead.component.ts
+++ b/projects/element-ng/typeahead/si-typeahead.component.ts
@@ -21,7 +21,7 @@ import {
   SiAutocompleteOptionDirective
 } from '@siemens/element-ng/autocomplete';
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Subscription } from 'rxjs';
 
 import { SiTypeaheadDirective } from './si-typeahead.directive';
@@ -34,7 +34,7 @@ import { TypeaheadMatch } from './si-typeahead.model';
     SiAutocompleteOptionDirective,
     SiIconNextComponent,
     NgTemplateOutlet,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-typeahead.component.html',
   styleUrl: './si-typeahead.component.scss',

--- a/projects/element-ng/typeahead/si-typeahead.directive.spec.ts
+++ b/projects/element-ng/typeahead/si-typeahead.directive.spec.ts
@@ -8,7 +8,6 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ChangeDetectionStrategy, Component, TemplateRef, viewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { SiTypeaheadDirective, Typeahead, TypeaheadMatch, TypeaheadOptionItemContext } from '.';
@@ -18,7 +17,7 @@ import { SiTypeaheadHarness } from './testing/si-typeahead.harness';
 const testItems = ['test', 'item'];
 
 @Component({
-  imports: [SiTypeaheadDirective, FormsModule, SiTranslateModule],
+  imports: [SiTypeaheadDirective, FormsModule],
   template: `
     <ng-template #testTemplate let-matchItem="match">
       <div>Test Template: {{ matchItem.text }}</div>
@@ -95,7 +94,7 @@ describe('SiTypeaheadDirective', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiTypeaheadDirective, FormsModule, SiTranslateModule, WrapperComponent]
+      imports: [SiTypeaheadDirective, FormsModule, WrapperComponent]
     }).compileComponents();
     fixture = TestBed.createComponent(WrapperComponent);
     wrapperComponent = fixture.componentInstance;

--- a/projects/element-ng/unauthorized-page/si-unauthorized-page.component.ts
+++ b/projects/element-ng/unauthorized-page/si-unauthorized-page.component.ts
@@ -5,7 +5,7 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { SiIconNextComponent } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 /**
  * The component shall be use to indicate that an authenticated
@@ -18,7 +18,7 @@ import { SiTranslateModule, TranslatableString } from '@siemens/element-translat
  */
 @Component({
   selector: 'si-unauthorized-page',
-  imports: [SiLinkDirective, SiIconNextComponent, SiTranslateModule],
+  imports: [SiLinkDirective, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-unauthorized-page.component.html',
   styleUrl: './si-unauthorized-page.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/wizard/si-wizard.component.ts
+++ b/projects/element-ng/wizard/si-wizard.component.ts
@@ -32,7 +32,7 @@ import {
   SiIconNextComponent
 } from '@siemens/element-ng/icon';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -49,7 +49,7 @@ interface StepItem {
     NgClass,
     SiIconNextComponent,
     SiResizeObserverDirective,
-    SiTranslateModule,
+    SiTranslatePipe,
     NgTemplateOutlet
   ],
   templateUrl: './si-wizard.component.html',

--- a/projects/element-translate-ng/ngx-translate/si-translate-ngxt.spec.ts
+++ b/projects/element-translate-ng/ngx-translate/si-translate-ngxt.spec.ts
@@ -8,10 +8,7 @@ import { fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { Router, RouterModule, RouterOutlet } from '@angular/router';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { SiTranslateNgxTService } from '@siemens/element-translate-ng/ngx-translate/si-translate-ngxt.service';
-import {
-  injectSiTranslateService,
-  SiTranslateModule
-} from '@siemens/element-translate-ng/translate';
+import { injectSiTranslateService, SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Observable, of, Subject } from 'rxjs';
 
 import { SiTranslateNgxTModule } from './si-translate-ngxt.module';
@@ -28,7 +25,7 @@ class RootTestService {
 class HostComponent {}
 
 @Component({
-  imports: [SiTranslateModule],
+  imports: [SiTranslatePipe],
   template: `{{ missingKey | translate }}-{{ existingKey | translate }}`
 })
 class TestWithDefaultHostComponent {

--- a/projects/element-translate-ng/ngx-translate/si-translate-ngxt.test-module.spec.ts
+++ b/projects/element-translate-ng/ngx-translate/si-translate-ngxt.test-module.spec.ts
@@ -5,7 +5,6 @@
 import { Component, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 import { of } from 'rxjs';
 
 @Component({
@@ -25,7 +24,6 @@ class TestComponent {}
       },
       isolate: true
     }),
-    SiTranslateModule,
     RouterModule.forChild([{ path: '', component: TestComponent, pathMatch: 'full' }]),
     TestComponent
   ]

--- a/projects/element-translate-ng/translate/si-no-translate.spec.ts
+++ b/projects/element-translate-ng/translate/si-no-translate.spec.ts
@@ -4,19 +4,14 @@
  */
 import { TestBed } from '@angular/core/testing';
 
-import { SiTranslateModule } from './si-translate.module';
+import { injectSiTranslateService } from './si-translate.inject';
 import { SiTranslateService } from './si-translate.service';
 
 describe('SiNoTranslate', () => {
   let service: SiTranslateService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [SiTranslateModule]
-    });
-  });
-  beforeEach(() => {
-    service = TestBed.inject(SiTranslateService);
+    service = TestBed.runInInjectionContext(() => injectSiTranslateService());
   });
 
   it('should translate', () => {

--- a/projects/element-translate-ng/translate/si-translate.module.ts
+++ b/projects/element-translate-ng/translate/si-translate.module.ts
@@ -10,7 +10,10 @@ import { SiTranslateService } from './si-translate.service';
 
 /**
  * This provides declares SiTranslatePipe and provides a respective SiTranslateService.
- * It should be used internally of Element but NOT by any application
+ * It should be used internally of Element but NOT by any application.
+ *
+ * @deprecated This module is no longer needed.
+ * Replace it with the {@link SiTranslatePipe} if needed, otherwise drop it without replacement.
  *
  * @internal
  */

--- a/projects/element-translate-ng/translate/si-translate.pipe.spec.ts
+++ b/projects/element-translate-ng/translate/si-translate.pipe.spec.ts
@@ -10,16 +10,16 @@ import {
   Injectable
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { injectSiTranslateService } from '@siemens/element-translate-ng/translate';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { SiTranslateModule } from './si-translate.module';
 import { SiTranslatePipe } from './si-translate.pipe';
 import { SiTranslateService, TranslationResult } from './si-translate.service';
 import { provideMockTranslateServiceBuilder } from './testing/si-translate.mock-service-builder.factory';
 
 @Component({
-  imports: [SiTranslateModule],
+  imports: [SiTranslatePipe],
   template: `{{ toTranslateKey | translate: params }}`,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -96,7 +96,9 @@ describe('SiTranslatePipe', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(TestComponent);
       component = fixture.componentInstance;
-      translateService = TestBed.inject(SiTranslateService) as SiAsyncTranslateService;
+      translateService = TestBed.runInInjectionContext(() =>
+        injectSiTranslateService()
+      ) as SiAsyncTranslateService;
       nativeElement = fixture.nativeElement;
       fixture.detectChanges();
     });
@@ -131,7 +133,7 @@ describe('SiTranslatePipe', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [SiTranslateModule, TestComponent],
+        imports: [TestComponent],
         providers: [
           provideMockTranslateServiceBuilder(
             () =>
@@ -175,7 +177,7 @@ describe('SiTranslatePipe', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [SiTranslateModule, TestComponent]
+        imports: [TestComponent]
       }).compileComponents();
     });
 


### PR DESCRIPTION
Drop usages of `SiTranslateModule` and adds a deprecation notice.
Since the moduel was flagged as internal, there is no deprecation in the commit.

Most changes are automatically applied:
- Replace `SiTranslateModule` with `SiTranslatePipe`
- Run IntelliJ import optimizer on modified files (this also changes some imports from the icon package)
- Run lint and formatting

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
