### PR TITLE
refactor(lint): prefer output instead of @Output

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,7 +46,6 @@ export const tsConfig = typescriptEslint.config({
       'error',
       { preferInputSignals: false, preferQuerySignals: false }
     ],
-    '@angular-eslint/prefer-output-emitter-ref': ['off'],
     '@angular-eslint/no-experimental': ['off'],
     '@angular-eslint/no-developer-preview': ['off'],
     'no-console': [

--- a/projects/element-ng/split/si-split-part.component.ts
+++ b/projects/element-ng/split/si-split-part.component.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+/* eslint-disable @angular-eslint/prefer-output-emitter-ref */
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,

--- a/projects/element-ng/split/si-split.component.ts
+++ b/projects/element-ng/split/si-split.component.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+/* eslint-disable @angular-eslint/prefer-output-emitter-ref */
 import {
   AfterContentInit,
   ChangeDetectionStrategy,

--- a/projects/element-ng/tabs/si-tab/si-tab.component.ts
+++ b/projects/element-ng/tabs/si-tab/si-tab.component.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+/* eslint-disable @angular-eslint/prefer-output-emitter-ref */
 import {
   booleanAttribute,
   ChangeDetectionStrategy,

--- a/projects/element-ng/tabs/si-tabset/si-tabset.component.ts
+++ b/projects/element-ng/tabs/si-tabset/si-tabset.component.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+/* eslint-disable @angular-eslint/prefer-output-emitter-ref */
 import { NgClass } from '@angular/common';
 import {
   AfterViewInit,

--- a/projects/live-preview/components/si-live-preview-iframe/si-live-preview-iframe.component.ts
+++ b/projects/live-preview/components/si-live-preview-iframe/si-live-preview-iframe.component.ts
@@ -6,14 +6,13 @@ import {
   Component,
   DestroyRef,
   ElementRef,
-  EventEmitter,
   HostBinding,
   inject,
   Input,
   NgZone,
   OnChanges,
   OnInit,
-  Output,
+  output,
   SimpleChanges,
   viewChild
 } from '@angular/core';
@@ -53,13 +52,13 @@ export class SiLivePreviewIframeComponent implements OnInit, OnChanges {
   @Input() loadJs?: boolean;
   @Input() reactVueTemplate?: string;
 
-  @Output() readonly templateFromComponent = new EventEmitter<string | undefined>(true);
-  @Output() readonly logClear = new EventEmitter();
-  @Output() readonly logMessage = new EventEmitter<string>();
-  @Output() readonly logRenderingError = new EventEmitter<any>();
-  @Output() readonly inProgress = new EventEmitter<boolean>();
-  @Output() readonly themeChange = new EventEmitter<string>();
-  @Output() readonly localeChange = new EventEmitter<string>();
+  readonly templateFromComponent = output<string | undefined>();
+  readonly logClear = output<void>();
+  readonly logMessage = output<string>();
+  readonly logRenderingError = output<any>();
+  readonly inProgress = output<boolean>();
+  readonly themeChange = output<string>();
+  readonly localeChange = output<string>();
 
   private originalTemplate = '';
   private templateModified = false;

--- a/projects/live-preview/components/si-live-preview-qr/si-live-preview-qr.component.ts
+++ b/projects/live-preview/components/si-live-preview-qr/si-live-preview-qr.component.ts
@@ -5,11 +5,10 @@
 import {
   AfterViewInit,
   Component,
-  EventEmitter,
   Input,
   OnChanges,
   OnDestroy,
-  Output,
+  output,
   SimpleChanges
 } from '@angular/core';
 import qrcode from 'qrcode-generator';
@@ -22,7 +21,7 @@ import qrcode from 'qrcode-generator';
 export class SiLivePreviewQrComponent implements AfterViewInit, OnDestroy, OnChanges {
   @Input() url?: string;
   @Input() urlShort?: string;
-  @Output() readonly closed = new EventEmitter<void>();
+  readonly closed = output<void>();
 
   qrImg = '';
   qrShort = false;

--- a/projects/live-preview/components/si-live-preview-renderer/si-live-preview-renderer.component.ts
+++ b/projects/live-preview/components/si-live-preview-renderer/si-live-preview-renderer.component.ts
@@ -14,7 +14,6 @@ import {
   DoCheck,
   ElementRef,
   EnvironmentInjector,
-  EventEmitter,
   HostBinding,
   inject,
   Injector,
@@ -23,12 +22,12 @@ import {
   NgModuleRef,
   OnChanges,
   OnDestroy,
-  Output,
   ɵresetCompiledComponents as resetCompiledComponents,
   SimpleChanges,
   ViewContainerRef,
   viewChild,
-  ViewChild
+  ViewChild,
+  output
 } from '@angular/core';
 import { ɵDomRendererFactory2 as DomRendererFactory2 } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
@@ -83,12 +82,12 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
 
   @Input() template = '';
 
-  @Output() readonly templateFromComponent = new EventEmitter<string | undefined>(true);
-  @Output() readonly logClear = new EventEmitter();
-  @Output() readonly logMessage = new EventEmitter<string>(true);
-  @Output() readonly logRenderingError = new EventEmitter<any>(true);
-  @Output() readonly inProgress = new EventEmitter<boolean>();
-  @Output() readonly supportsLandscapeMode = new EventEmitter<boolean>();
+  readonly templateFromComponent = output<string | undefined>();
+  readonly logClear = output<void>();
+  readonly logMessage = output<string>();
+  readonly logRenderingError = output<any>();
+  readonly inProgress = output<boolean>();
+  readonly supportsLandscapeMode = output<boolean>();
 
   private componentRef?: ComponentRef<unknown>;
   private moduleRef?: NgModuleRef<unknown>;

--- a/projects/live-preview/components/si-live-preview-renderer/webcomponent/si-live-preview-web.component.ts
+++ b/projects/live-preview/components/si-live-preview-renderer/webcomponent/si-live-preview-web.component.ts
@@ -5,11 +5,10 @@
 import {
   Component,
   ElementRef,
-  EventEmitter,
   HostBinding,
   Input,
   OnChanges,
-  Output,
+  output,
   SimpleChanges,
   viewChild
 } from '@angular/core';
@@ -28,7 +27,7 @@ export class SiLivePreviewWebComponent implements OnChanges {
   @Input() webcomponentTemplateCode = '';
   @Input() exampleUrl!: string;
   @Input() config!: SiLivePreviewConfig;
-  @Output() readonly inProgress = new EventEmitter<boolean>();
+  readonly inProgress = output<boolean>();
 
   @HostBinding('class.live-preview-done') renderingDone = false;
 
@@ -64,7 +63,7 @@ export class SiLivePreviewWebComponent implements OnChanges {
       this.reactRoot = this.getDefault(reactDom).createRoot(this.root().nativeElement);
       const moduleInput = code;
       import('@babel/standalone').then(babel => {
-        const output: any = this.getDefault(babel).transform(moduleInput, {
+        const moduleOutput: any = this.getDefault(babel).transform(moduleInput, {
           presets: [
             // `modules: false` creates a module that can be imported
             ['env', { modules: false }],
@@ -76,7 +75,7 @@ export class SiLivePreviewWebComponent implements OnChanges {
 
         import('react').then(react => {
           window.React = this.getDefault(react);
-          const dataUrl = 'data:text/javascript;base64,' + btoa(output);
+          const dataUrl = 'data:text/javascript;base64,' + btoa(moduleOutput);
 
           import(/* webpackIgnore: true  */ /* @vite-ignore */ dataUrl).then(module => {
             this.reactRoot.render(this.getDefault(react).createElement(module.default));

--- a/src/app/examples/si-filter-settings/si-filter-settings.component.ts
+++ b/src/app/examples/si-filter-settings/si-filter-settings.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { booleanAttribute, Component, EventEmitter, Input, Output } from '@angular/core';
+import { booleanAttribute, Component, Input, output, OutputEmitterRef } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SiCardComponent } from '@siemens/element-ng/card';
 import { BackgroundColorVariant } from '@siemens/element-ng/common';
@@ -13,20 +13,20 @@ import { BackgroundColorVariant } from '@siemens/element-ng/common';
 })
 export class SiFilterSettingsComponent {
   @Input() variant: BackgroundColorVariant = 'base-1';
-  @Output() readonly variantChange = new EventEmitter<BackgroundColorVariant>();
+  readonly variantChange = output<BackgroundColorVariant>();
 
   @Input({ transform: booleanAttribute }) disabled = false;
-  @Output() readonly disabledChange = new EventEmitter<boolean>();
+  readonly disabledChange = output<boolean>();
 
   @Input({ transform: booleanAttribute }) showIcon?: boolean;
-  @Output() readonly showIconChange = new EventEmitter<boolean>();
+  readonly showIconChange = output<boolean>();
 
   @Input({ transform: booleanAttribute }) disableFreeTextSearch = false;
-  @Output() readonly disableFreeTextSearchChange = new EventEmitter<boolean>();
+  readonly disableFreeTextSearchChange = output<boolean>();
 
   updateInput(field: 'variant' | 'disabled' | 'showIcon' | 'disableFreeTextSearch'): void {
     if (field) {
-      (this[`${field}Change` as keyof SiFilterSettingsComponent] as EventEmitter<any>).emit(
+      (this[`${field}Change` as keyof SiFilterSettingsComponent] as OutputEmitterRef<any>).emit(
         this[field]
       );
     }


### PR DESCRIPTION
Addresses #234 

This however is a breaking change. `EventEmitter` extends `Subject` by default and is pipeable. 
`output` signal cannot be piped on.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
