### PR TITLE
refactor(translate): drop unnecessary import of `SiTranslateModule`

### DIFF
--- a/projects/element-translate-ng/angular-localize/si-translate-ng-localize.module.ts
+++ b/projects/element-translate-ng/angular-localize/si-translate-ng-localize.module.ts
@@ -3,10 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgModule } from '@angular/core';
-import {
-  SiTranslateModule,
-  SiTranslateServiceBuilder
-} from '@siemens/element-translate-ng/translate';
+import { SiTranslateServiceBuilder } from '@siemens/element-translate-ng/translate';
 
 import { SiTranslateNgLocalizeServiceBuilder } from './si-translate-ng-localize-service-builder.service';
 
@@ -15,7 +12,6 @@ import { SiTranslateNgLocalizeServiceBuilder } from './si-translate-ng-localize-
  * It should only be imported once in an application's root module (typically `app.module.ts`)
  */
 @NgModule({
-  imports: [SiTranslateModule],
   providers: [{ provide: SiTranslateServiceBuilder, useClass: SiTranslateNgLocalizeServiceBuilder }]
 })
 export class SiTranslateNgLocalizeModule {}

--- a/projects/element-translate-ng/angular-localize/si-translate-ng-localize.provider.ts
+++ b/projects/element-translate-ng/angular-localize/si-translate-ng-localize.provider.ts
@@ -2,11 +2,8 @@
  * Copyright Siemens 2016 - 2025.
  * SPDX-License-Identifier: MIT
  */
-import { EnvironmentProviders, importProvidersFrom, Provider } from '@angular/core';
-import {
-  SiTranslateModule,
-  SiTranslateServiceBuilder
-} from '@siemens/element-translate-ng/translate';
+import { EnvironmentProviders, Provider } from '@angular/core';
+import { SiTranslateServiceBuilder } from '@siemens/element-translate-ng/translate';
 
 import { SiTranslateNgLocalizeServiceBuilder } from './si-translate-ng-localize-service-builder.service';
 
@@ -15,8 +12,5 @@ import { SiTranslateNgLocalizeServiceBuilder } from './si-translate-ng-localize-
  * It should only be imported once in an application's configuration (typically `app.config.ts`)
  */
 export const provideNgLocalizeForElement = (): (EnvironmentProviders | Provider)[] => {
-  return [
-    { provide: SiTranslateServiceBuilder, useClass: SiTranslateNgLocalizeServiceBuilder },
-    importProvidersFrom(SiTranslateModule)
-  ];
+  return [{ provide: SiTranslateServiceBuilder, useClass: SiTranslateNgLocalizeServiceBuilder }];
 };

--- a/projects/element-translate-ng/ngx-translate/si-translate-ngxt.module.ts
+++ b/projects/element-translate-ng/ngx-translate/si-translate-ngxt.module.ts
@@ -3,10 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgModule } from '@angular/core';
-import {
-  SiTranslateModule,
-  SiTranslateServiceBuilder
-} from '@siemens/element-translate-ng/translate';
+import { SiTranslateServiceBuilder } from '@siemens/element-translate-ng/translate';
 
 import { SiTranslateNgxTServiceBuilder } from './si-translate-ngxt.service-builder';
 
@@ -15,7 +12,6 @@ import { SiTranslateNgxTServiceBuilder } from './si-translate-ngxt.service-build
  * It should only be imported once in an applications root module (typically `app.module.ts`)
  */
 @NgModule({
-  imports: [SiTranslateModule],
   providers: [{ provide: SiTranslateServiceBuilder, useClass: SiTranslateNgxTServiceBuilder }]
 })
 export class SiTranslateNgxTModule {}

--- a/projects/element-translate-ng/ngx-translate/si-translate-ngxt.provider.ts
+++ b/projects/element-translate-ng/ngx-translate/si-translate-ngxt.provider.ts
@@ -2,11 +2,8 @@
  * Copyright Siemens 2016 - 2025.
  * SPDX-License-Identifier: MIT
  */
-import { EnvironmentProviders, importProvidersFrom, Provider } from '@angular/core';
-import {
-  SiTranslateModule,
-  SiTranslateServiceBuilder
-} from '@siemens/element-translate-ng/translate';
+import { EnvironmentProviders, Provider } from '@angular/core';
+import { SiTranslateServiceBuilder } from '@siemens/element-translate-ng/translate';
 
 import { SiTranslateNgxTServiceBuilder } from './si-translate-ngxt.service-builder';
 
@@ -15,8 +12,5 @@ import { SiTranslateNgxTServiceBuilder } from './si-translate-ngxt.service-build
  * It should only be imported once in an application's configuration (typically `app.config.ts`)
  */
 export const provideNgxTranslateForElement = (): (EnvironmentProviders | Provider)[] => {
-  return [
-    { provide: SiTranslateServiceBuilder, useClass: SiTranslateNgxTServiceBuilder },
-    importProvidersFrom(SiTranslateModule)
-  ];
+  return [{ provide: SiTranslateServiceBuilder, useClass: SiTranslateNgxTServiceBuilder }];
 };

--- a/projects/element-translate-ng/ngx-translate/si-translate-ngxt.spec.ts
+++ b/projects/element-translate-ng/ngx-translate/si-translate-ngxt.spec.ts
@@ -3,19 +3,22 @@
  * SPDX-License-Identifier: MIT
  */
 import { DOCUMENT } from '@angular/common';
-import { Component, inject, Injectable } from '@angular/core';
+import { Component, Injectable } from '@angular/core';
 import { fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { Router, RouterModule, RouterOutlet } from '@angular/router';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { SiTranslateNgxTService } from '@siemens/element-translate-ng/ngx-translate/si-translate-ngxt.service';
-import { SiTranslateModule, SiTranslateService } from '@siemens/element-translate-ng/translate';
+import {
+  injectSiTranslateService,
+  SiTranslateModule
+} from '@siemens/element-translate-ng/translate';
 import { Observable, of, Subject } from 'rxjs';
 
 import { SiTranslateNgxTModule } from './si-translate-ngxt.module';
 
 @Injectable()
 class RootTestService {
-  siTranslateService = inject(SiTranslateService);
+  siTranslateService = injectSiTranslateService();
 }
 
 @Component({
@@ -106,7 +109,9 @@ describe('SiTranslateNgxT', () => {
       });
     });
     beforeEach(() => {
-      service = TestBed.inject(SiTranslateService) as SiTranslateNgxTService;
+      service = TestBed.runInInjectionContext(() =>
+        injectSiTranslateService()
+      ) as SiTranslateNgxTService;
       service.setCurrentLanguage('test');
     });
 

--- a/projects/element-translate-ng/translate/si-translatable.service.ts
+++ b/projects/element-translate-ng/translate/si-translatable.service.ts
@@ -7,6 +7,7 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate-type
 
 import { SiNoTranslateService } from './si-no-translate.service';
 import { SI_TRANSLATABLE_VALUES } from './si-translatable.model';
+import { injectSiTranslateService } from './si-translate.inject';
 import { SiTranslateService } from './si-translate.service';
 
 @Injectable({
@@ -18,8 +19,7 @@ export class SiTranslatableService {
   private readonly siTranslateService: SiTranslateService;
 
   constructor() {
-    this.siTranslateService =
-      inject(SiTranslateService, { optional: true }) ?? inject(SiNoTranslateService);
+    this.siTranslateService = injectSiTranslateService();
     const translateValues = inject(SI_TRANSLATABLE_VALUES, { optional: true });
 
     this.translatableValues = translateValues?.reduce((a, b) => ({ ...a, ...b })) ?? {};


### PR DESCRIPTION
No need to import the Module as we have the new inject function.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
