### PR TITLE
fix(charts): empty series name in tooltip

### DIFF
--- a/projects/charts-ng/src/components/si-chart-cartesian/si-chart-cartesian.component.ts
+++ b/projects/charts-ng/src/components/si-chart-cartesian/si-chart-cartesian.component.ts
@@ -69,7 +69,8 @@ export class SiChartCartesianComponent extends SiChartComponent implements OnCha
       const name = isPie
         ? series.data.name
         : useName
-          ? (series.name ?? series.seriesName)
+          ? // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            series.name || series.seriesName
           : series.seriesName;
       const valIndex = (series.encode.value ?? series.encode.y)[0];
       const value = isCandle

--- a/projects/charts-ng/src/shared/themes/element.ts
+++ b/projects/charts-ng/src/shared/themes/element.ts
@@ -22,7 +22,8 @@ const tooltipFormatter = (p: object | object[]): string => {
     const name = isPie
       ? series.data.name
       : useName
-        ? (series.name ?? series.seriesName)
+        ? // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          series.name || series.seriesName
         : series.seriesName;
     const valIndex = (series.encode.value ?? series.encode.y)[0];
     const value = isCandle


### PR DESCRIPTION
The series name in the chart tooltip is empty

<img width="1032" height="381" alt="image" src="https://github.com/user-attachments/assets/2975486d-10d4-413b-b982-65fc00fe7638" />

This is because the `series.name` can be an empty string, in which case, it should fallback to the `series.seriesName` . this does not work right now because of how the `??` operator works
 


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
