### PR TITLE
build(github): only run e2e summary on failure

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -124,8 +124,8 @@ jobs:
           retention-days: 1
 
   e2e-merge-reports:
-    # Merge reports after playwright-tests, even if some shards have failed
-    if: ${{ !cancelled() }}
+    # Merge reports after playwright-tests, only if some shards have failed
+    if: ${{ !cancelled() && !success() }}
     container: mcr.microsoft.com/playwright:v1.54.1-noble
     needs: [e2e]
     runs-on: ubuntu-latest


### PR DESCRIPTION
No need for a summary, if tests succeeded.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
