### PR TITLE
docs(typeahead): add missing examples

### DIFF
--- a/playwright/e2e/element-examples/si-typeahead.spec.ts
+++ b/playwright/e2e/element-examples/si-typeahead.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { expect, test } from '../../support/test-helpers';
+
+test.describe('si-typeahead', () => {
+  const example = 'si-typeahead/si-typeahead-basic';
+
+  test(example, async ({ page, si }) => {
+    await si.visitExample(example);
+    await page.locator('input[type="text"]').fill('al');
+    await expect(page.getByText('Alabama')).toHaveCount(1);
+    await page.waitForTimeout(1000); // Wait for model (output) to update
+    await si.runVisualAndA11yTests();
+  });
+
+  const customExample = 'si-typeahead/si-typeahead-custom';
+
+  test(customExample, async ({ page, si }) => {
+    await si.visitExample(customExample);
+    await page.getByRole('textbox').fill('al');
+    await expect(page.getByText('Alabama')).toHaveCount(1);
+    await page.waitForTimeout(1000); // Wait for model (output) to update
+    await si.runVisualAndA11yTests();
+  });
+});

--- a/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-basic-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-basic-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7ce501af5d861611a748e28e596bceba2244defea5a50ddc9cc262c188e7e63
+size 9263

--- a/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-basic-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-basic-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:939a7601b4947e14d821cc7b4766a70b8e3593b26aa58e34d8fdc4f48b91b7ce
+size 9319

--- a/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-basic.yaml
+++ b/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-basic.yaml
@@ -1,0 +1,18 @@
+- text: "Model: \"al\""
+- combobox "States" [expanded]:
+  - textbox "Placeholder"
+  - button "clear"
+- text: Settings Color Variant
+- combobox "Color Variant":
+  - option "base-1" [selected]
+  - option "base-0"
+- checkbox "Disable"
+- text: Disable
+- checkbox "Show Icon"
+- text: Show Icon
+- checkbox "Disable free text search"
+- text: Disable free text search
+- listbox "Suggestions":
+  - option "Alabama": Al abama
+  - option "Alaska": Al aska
+  - option "California": C al ifornia

--- a/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-custom-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-custom-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:072ba5d136e150414626499c92a930bfcba7b51620a19fb1447458d49a81351e
+size 12057

--- a/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-custom-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-custom-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95592edd3d5886176457b103ec8dd91309901f941a30a78eacfa91fbeaae5c36
+size 12154

--- a/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-custom.yaml
+++ b/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-custom.yaml
@@ -1,0 +1,18 @@
+- paragraph: Home sweet home
+- combobox "States" [expanded]:
+  - textbox "Placeholder"
+  - button "clear"
+- text: Settings Color Variant
+- combobox "Color Variant":
+  - option "base-1" [selected]
+  - option "base-0"
+- checkbox "Disable"
+- text: Disable
+- checkbox "Show Icon"
+- text: Show Icon
+- checkbox "Disable free text search"
+- text: Disable free text search
+- listbox "Suggestions":
+  - option "Alabama": sweet home Al abama
+  - option "Alaska": sweet home Al aska
+  - option "California": sweet home C al ifornia

--- a/src/app/examples/si-typeahead/si-typeahead-async.html
+++ b/src/app/examples/si-typeahead/si-typeahead-async.html
@@ -1,0 +1,15 @@
+<app-filter-settings [(variant)]="variant" [(disabled)]="disable" [(showIcon)]="showIcon">
+  <pre class="code-preview">Model: {{ selected | json }}</pre>
+  <si-search-bar
+    aria-label="States"
+    [typeaheadSkipSortingMatches]="false"
+    [siTypeahead]="states"
+    [colorVariant]="variant"
+    [typeaheadTokenize]="false"
+    [disabled]="disable"
+    [showIcon]="showIcon"
+    [typeaheadAutoSelectIndex]="1"
+    [typeaheadCloseOnEsc]="false"
+    [(ngModel)]="selected"
+  />
+</app-filter-settings>

--- a/src/app/examples/si-typeahead/si-typeahead-async.ts
+++ b/src/app/examples/si-typeahead/si-typeahead-async.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BackgroundColorVariant } from '@siemens/element-ng/common';
+import { SiSearchBarModule } from '@siemens/element-ng/search-bar';
+import { SiTypeaheadDirective } from '@siemens/element-ng/typeahead';
+import { of } from 'rxjs';
+import { delay } from 'rxjs/operators';
+
+import { SiFilterSettingsComponent } from '../si-filter-settings/si-filter-settings.component';
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    CommonModule,
+    SiFilterSettingsComponent,
+    SiSearchBarModule,
+    FormsModule,
+    SiTypeaheadDirective
+  ],
+  templateUrl: './si-typeahead-async.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SampleComponent {
+  variant: BackgroundColorVariant = 'base-1';
+  disable = false;
+  showIcon = false;
+  selected!: string;
+  states = of([
+    'Alabama',
+    'Alaska',
+    'Arizona',
+    'Arkansas',
+    'California',
+    'Colorado',
+    'Connecticut',
+    'Delaware',
+    'Florida',
+    'Georgia',
+    'Hawaii',
+    'Idaho',
+    'Illinois',
+    'Indiana',
+    'Iowa',
+    'Kansas',
+    'Kentucky',
+    'Louisiana',
+    'Maine',
+    'Maryland',
+    'Massachusetts',
+    'Michigan',
+    'Minnesota',
+    'Mississippi',
+    'Missouri',
+    'Montana',
+    'Nebraska',
+    'Nevada',
+    'New Hampshire',
+    'New Jersey',
+    'New Mexico',
+    'New York',
+    'North Dakota',
+    'North Carolina',
+    'Ohio',
+    'Oklahoma',
+    'Oregon',
+    'Pennsylvania',
+    'Rhode Island',
+    'South Carolina',
+    'South Dakota',
+    'Tennessee',
+    'Texas',
+    'Utah',
+    'Vermont',
+    'Virginia',
+    'Washington',
+    'West Virginia',
+    'Wisconsin',
+    'Wyoming'
+  ]).pipe(delay(1000));
+}

--- a/src/app/examples/si-typeahead/si-typeahead-basic.html
+++ b/src/app/examples/si-typeahead/si-typeahead-basic.html
@@ -1,0 +1,14 @@
+<app-filter-settings [(variant)]="variant" [(disabled)]="disable" [(showIcon)]="showIcon">
+  <pre class="code-preview">Model: {{ selected | json }}</pre>
+  <si-search-bar
+    placeholder="Placeholder"
+    aria-label="States"
+    [siTypeahead]="states"
+    [typeaheadSkipSortingMatches]="false"
+    [typeaheadTokenize]="false"
+    [colorVariant]="variant"
+    [disabled]="disable"
+    [showIcon]="showIcon"
+    [(ngModel)]="selected"
+  />
+</app-filter-settings>

--- a/src/app/examples/si-typeahead/si-typeahead-basic.ts
+++ b/src/app/examples/si-typeahead/si-typeahead-basic.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BackgroundColorVariant } from '@siemens/element-ng/common';
+import { SiSearchBarModule } from '@siemens/element-ng/search-bar';
+import { SiTypeaheadDirective } from '@siemens/element-ng/typeahead';
+
+import { SiFilterSettingsComponent } from '../si-filter-settings/si-filter-settings.component';
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    CommonModule,
+    SiFilterSettingsComponent,
+    SiSearchBarModule,
+    FormsModule,
+    SiTypeaheadDirective
+  ],
+  templateUrl: './si-typeahead-basic.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SampleComponent {
+  variant: BackgroundColorVariant = 'base-1';
+  disable = false;
+  showIcon = false;
+  selected!: string;
+  states = [
+    'Alabama',
+    'Alaska',
+    'Arizona',
+    'Arkansas',
+    'California',
+    'Colorado',
+    'Connecticut',
+    'Delaware',
+    'Florida',
+    'Georgia',
+    'Hawaii',
+    'Idaho',
+    'Illinois',
+    'Indiana',
+    'Iowa',
+    'Kansas',
+    'Kentucky',
+    'Louisiana',
+    'Maine',
+    'Maryland',
+    'Massachusetts',
+    'Michigan',
+    'Minnesota',
+    'Mississippi',
+    'Missouri',
+    'Montana',
+    'Nebraska',
+    'Nevada',
+    'New Hampshire',
+    'New Jersey',
+    'New Mexico',
+    'New York',
+    'North Dakota',
+    'North Carolina',
+    'Ohio',
+    'Oklahoma',
+    'Oregon',
+    'Pennsylvania',
+    'Rhode Island',
+    'South Carolina',
+    'South Dakota',
+    'Tennessee',
+    'Texas',
+    'Utah',
+    'Vermont',
+    'Virginia',
+    'Washington',
+    'West Virginia',
+    'Wisconsin',
+    'Wyoming'
+  ];
+}

--- a/src/app/examples/si-typeahead/si-typeahead-custom.html
+++ b/src/app/examples/si-typeahead/si-typeahead-custom.html
@@ -1,0 +1,28 @@
+<app-filter-settings [(variant)]="variant" [(disabled)]="disable" [(showIcon)]="showIcon">
+  <ng-template #newItemTemplate let-match="match" siTypeaheadTemplate>
+    <span class="text-info me-2">sweet home</span>
+    @for (segment of match.result; track $index) {
+      <span [class.typeahead-match-segment-matching]="segment.isMatching">{{ segment.text }}</span>
+    }
+  </ng-template>
+
+  @if (!selectedOption) {
+    <p class="mt-11">Home sweet home</p>
+  }
+  @if (selectedOption) {
+    <p class="mt-11">Sweet home {{ selectedOption }}</p>
+  }
+  <si-search-bar
+    typeaheadMatchAllTokens="once"
+    typeaheadFullWidth
+    aria-label="States"
+    placeholder="Placeholder"
+    [siTypeahead]="states"
+    [colorVariant]="variant"
+    [disabled]="disable"
+    [showIcon]="showIcon"
+    [typeaheadItemTemplate]="newItemTemplate"
+    [(ngModel)]="selected"
+    (typeaheadOnSelect)="onOptionSelected($event)"
+  />
+</app-filter-settings>

--- a/src/app/examples/si-typeahead/si-typeahead-custom.ts
+++ b/src/app/examples/si-typeahead/si-typeahead-custom.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BackgroundColorVariant } from '@siemens/element-ng/common';
+import { SiSearchBarModule } from '@siemens/element-ng/search-bar';
+import { SiTypeaheadDirective, TypeaheadMatch } from '@siemens/element-ng/typeahead';
+
+import { SiFilterSettingsComponent } from '../si-filter-settings/si-filter-settings.component';
+
+@Component({
+  selector: 'app-sample',
+  imports: [SiFilterSettingsComponent, SiSearchBarModule, FormsModule, SiTypeaheadDirective],
+  templateUrl: './si-typeahead-custom.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SampleComponent {
+  variant: BackgroundColorVariant = 'base-1';
+  disable = false;
+  showIcon = false;
+  selected!: string;
+  states = [
+    'Alabama',
+    'Alaska',
+    'Arizona',
+    'Arkansas',
+    'California',
+    'Colorado',
+    'Connecticut',
+    'Delaware',
+    'Florida',
+    'Georgia',
+    'Hawaii',
+    'Idaho',
+    'Illinois',
+    'Indiana',
+    'Iowa',
+    'Kansas',
+    'Kentucky',
+    'Louisiana',
+    'Maine',
+    'Maryland',
+    'Massachusetts',
+    'Michigan',
+    'Minnesota',
+    'Mississippi',
+    'Missouri',
+    'Montana',
+    'Nebraska',
+    'Nevada',
+    'New Hampshire',
+    'New Jersey',
+    'New Mexico',
+    'New York',
+    'North Dakota',
+    'North Carolina',
+    'Ohio',
+    'Oklahoma',
+    'Oregon',
+    'Pennsylvania',
+    'Rhode Island',
+    'South Carolina',
+    'South Dakota',
+    'Tennessee',
+    'Texas',
+    'Utah',
+    'Vermont',
+    'Virginia',
+    'Washington',
+    'West Virginia',
+    'Wisconsin',
+    'Wyoming'
+  ];
+
+  selectedOption = '';
+
+  onOptionSelected(match: TypeaheadMatch): void {
+    this.selectedOption = match.text;
+    this.selected = '';
+  }
+}

--- a/src/app/examples/si-typeahead/si-typeahead-onfocus-scrollable.html
+++ b/src/app/examples/si-typeahead/si-typeahead-onfocus-scrollable.html
@@ -1,0 +1,18 @@
+<app-filter-settings [(variant)]="variant" [(disabled)]="disable" [(showIcon)]="showIcon">
+  <pre class="code-preview">Model: {{ selected | json }}</pre>
+  <si-search-bar
+    aria-label="States"
+    [siTypeahead]="states"
+    [typeaheadSkipSortingMatches]="false"
+    [typeaheadTokenize]="false"
+    [colorVariant]="variant"
+    [disabled]="disable"
+    [showIcon]="showIcon"
+    [typeaheadMinLength]="0"
+    [typeaheadWaitMs]="500"
+    [typeaheadScrollable]="true"
+    [typeaheadOptionsInScrollableView]="4"
+    [typeaheadScrollableAdditionalHeight]="12"
+    [(ngModel)]="selected"
+  />
+</app-filter-settings>

--- a/src/app/examples/si-typeahead/si-typeahead-onfocus-scrollable.ts
+++ b/src/app/examples/si-typeahead/si-typeahead-onfocus-scrollable.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BackgroundColorVariant } from '@siemens/element-ng/common';
+import { SiSearchBarModule } from '@siemens/element-ng/search-bar';
+import { SiTypeaheadDirective } from '@siemens/element-ng/typeahead';
+
+import { SiFilterSettingsComponent } from '../si-filter-settings/si-filter-settings.component';
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    CommonModule,
+    SiFilterSettingsComponent,
+    SiSearchBarModule,
+    FormsModule,
+    SiTypeaheadDirective
+  ],
+  templateUrl: './si-typeahead-onfocus-scrollable.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SampleComponent {
+  variant: BackgroundColorVariant = 'base-1';
+  showIcon = true;
+  disable = false;
+  disableFreeTextSearch = false;
+  selected!: string;
+  states = [
+    'Alabama',
+    'Alaska',
+    'Arizona',
+    'Arkansas',
+    'California',
+    'Colorado',
+    'Connecticut',
+    'Delaware',
+    'Florida',
+    'Georgia',
+    'Hawaii',
+    'Idaho',
+    'Illinois',
+    'Indiana',
+    'Iowa',
+    'Kansas',
+    'Kentucky',
+    'Louisiana',
+    'Maine',
+    'Maryland',
+    'Massachusetts',
+    'Michigan',
+    'Minnesota',
+    'Mississippi',
+    'Missouri',
+    'Montana',
+    'Nebraska',
+    'Nevada',
+    'New Hampshire',
+    'New Jersey',
+    'New Mexico',
+    'New York',
+    'North Dakota',
+    'North Carolina',
+    'Ohio',
+    'Oklahoma',
+    'Oregon',
+    'Pennsylvania',
+    'Rhode Island',
+    'South Carolina',
+    'South Dakota',
+    'Tennessee',
+    'Texas',
+    'Utah',
+    'Vermont',
+    'Virginia',
+    'Washington',
+    'West Virginia',
+    'Wisconsin',
+    'Wyoming'
+  ];
+}

--- a/src/app/examples/si-typeahead/si-typeahead-tokenized.html
+++ b/src/app/examples/si-typeahead/si-typeahead-tokenized.html
@@ -1,0 +1,14 @@
+<app-filter-settings [(variant)]="variant" [(disabled)]="disable" [(showIcon)]="showIcon">
+  <pre class="code-preview">Model: {{ selected | json }}</pre>
+  <si-search-bar
+    typeaheadMatchAllTokens="separately"
+    placeholder="Placeholder"
+    aria-label="States"
+    [siTypeahead]="states"
+    [typeaheadSkipSortingMatches]="false"
+    [colorVariant]="variant"
+    [disabled]="disable"
+    [showIcon]="showIcon"
+    [(ngModel)]="selected"
+  />
+</app-filter-settings>

--- a/src/app/examples/si-typeahead/si-typeahead-tokenized.ts
+++ b/src/app/examples/si-typeahead/si-typeahead-tokenized.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BackgroundColorVariant } from '@siemens/element-ng/common';
+import { SiSearchBarModule } from '@siemens/element-ng/search-bar';
+import { SiTypeaheadDirective } from '@siemens/element-ng/typeahead';
+
+import { SiFilterSettingsComponent } from '../si-filter-settings/si-filter-settings.component';
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    CommonModule,
+    SiSearchBarModule,
+    SiFilterSettingsComponent,
+    FormsModule,
+    SiTypeaheadDirective
+  ],
+  templateUrl: './si-typeahead-tokenized.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SampleComponent {
+  variant: BackgroundColorVariant = 'base-1';
+  disable = false;
+  showIcon = false;
+  selected!: string;
+  states = [
+    'Alabama',
+    'Alaska',
+    'Arizona',
+    'Arkansas',
+    'California',
+    'Colorado',
+    'Connecticut',
+    'Delaware',
+    'Florida',
+    'Georgia',
+    'Hawaii',
+    'Idaho',
+    'Illinois',
+    'Indiana',
+    'Iowa',
+    'Kansas',
+    'Kentucky',
+    'Louisiana',
+    'Maine',
+    'Maryland',
+    'Massachusetts',
+    'Michigan',
+    'Minnesota',
+    'Mississippi',
+    'Missouri',
+    'Montana',
+    'Nebraska',
+    'Nevada',
+    'New Hampshire',
+    'New Jersey',
+    'New Mexico',
+    'New York',
+    'North Dakota',
+    'North Carolina',
+    'Ohio',
+    'Oklahoma',
+    'Oregon',
+    'Pennsylvania',
+    'Rhode Island',
+    'South Carolina',
+    'South Dakota',
+    'Tennessee',
+    'Texas',
+    'Utah',
+    'Vermont',
+    'Virginia',
+    'Washington',
+    'West Virginia',
+    'Wisconsin',
+    'Wyoming'
+  ];
+}


### PR DESCRIPTION
This does on purpose NOT add the vrts from the static file, as those are redundant.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
