### PR TITLE
fix(photo-upload): remove padding from the sides for default preview

### DIFF
--- a/projects/element-ng/photo-upload/si-photo-upload.component.scss
+++ b/projects/element-ng/photo-upload/si-photo-upload.component.scss
@@ -19,7 +19,7 @@
   inline-size: var(--si-photo-upload-photo-width);
   max-inline-size: 100%;
   block-size: var(--si-photo-upload-photo-height);
-  object-fit: contain; // maintain the aspect ratio of the image
+  object-fit: cover; // maintain the aspect ratio of the image
 
   &.round {
     border-radius: 50%;


### PR DESCRIPTION
This happens when the height and width are different (height is more than the width).

Issue was found in a product.

Sample base64 string for testing (https://gist.github.com/prasepic/d53bc69d6937767ac8e35ba751e6331a)

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
