### PR TITLE
build(dashboards-demo): use port 4201 by default

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -494,6 +494,7 @@
         "serve": {
           "builder": "ngx-build-plus:dev-server",
           "options": {
+            "port": 4201,
             "extraWebpackConfig": "projects/dashboards-demo/webpack.config.cjs",
             "buildTarget": "dashboards-demo:build"
           },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "native-charts:build": "ng build native-charts-ng && cpy LICENSE.md \"./dist/@siemens/native-charts-ng/\"",
     "dashboards:test": "ng test dashboards-ng",
     "dashboards:build": "ng build dashboards-ng && cpy LICENSE.md \"./dist/@siemens/dashboards-ng/\"",
-    "dashboards-demo:start": "ng serve dashboards-demo --port 4201",
+    "dashboards-demo:start": "ng serve dashboards-demo",
     "dashboards-demo:start:prod": "http-server dist/dashboards-demo -s -p 4201 -a 127.0.0.1",
     "dashboards-demo:start:webcomponents": "http-server dist/dashboards-demo-webcomponents -s -p 4202",
     "dashboards-demo:start:mfe": "ng serve dashboards-demo-mfe",


### PR DESCRIPTION
Moving the port definition into the angular.json

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
