### PR TITLE
build(dashboards-ng): build dashboards demo for docs

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -29,9 +29,9 @@ jobs:
       - run: npm run build:all:update-translatable-keys # Output is needed in dist for providing default translations
       - run: git diff --exit-code "projects/**/*-translatable-keys.interface.ts"
       - run: npm run build:examples
-      - run: npm run dashboards-demo:build
-      - run: npm run dashboards-demo:build:webcomponents
-      - run: npm run dashboards-demo:build:mfe
+      - run: npm run dashboards-demo:build:demo -- --progress=false
+      - run: npm run dashboards-demo:build:webcomponents -- --progress=false
+      - run: npm run dashboards-demo:build:mfe -- --progress=false
       - uses: actions/upload-artifact@v4
         with:
           name: dist
@@ -170,6 +170,7 @@ jobs:
           UV_INDEX_CODE_DOCS_THEME_PASSWORD: ${{ secrets.SIEMENS_NPM_TOKEN }}
           EXAMPLES_BASE: /element-examples
       - run: mv dist/element-examples/ dist/design/
+      - run: mv dist/dashboards-demo/ dist/design/
       - uses: actions/upload-artifact@v4
         with:
           name: pages

--- a/angular.json
+++ b/angular.json
@@ -648,7 +648,7 @@
         "build": {
           "builder": "ngx-build-plus:browser",
           "options": {
-            "outputPath": "dist/dashboards-demo-mfe",
+            "outputPath": "dist/dashboards-demo/mfe",
             "index": "projects/dashboards-demo/mfe/src/index.html",
             "main": "projects/dashboards-demo/mfe/src/main.ts",
             "polyfills": ["zone.js"],

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,10 @@ which implement the Element design system. The components are developed in the
 Open our [demo playground](https://element.siemens.io/element-examples/#/overview)
 to see examples for all our components.
 
+## Flexible dashboard demo
+
+Open our [flexible dashboard demo](https://element.siemens.io/dashboards-demo/).
+
 ## Figma design assets
 
 Our Figma library contains all designed components, styles, and blueprints

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "dashboards-demo:build:demo": "ng build dashboards-demo --configuration demo-deployment",
     "dashboards-demo:build:prod": "ng build dashboards-demo --configuration production",
     "dashboards-demo:build:webcomponents": "ng build dashboards-demo-webcomponents --configuration production --output-hashing none && node projects/dashboards-demo/webcomponents/concat.cjs",
-    "dashboards-demo:build:mfe": "ng build dashboards-demo-mfe --configuration production --output-hashing none "
+    "dashboards-demo:build:mfe": "ng build dashboards-demo-mfe --configuration production --output-hashing none"
   },
   "workspaces": [
     "projects/element-translate-cli",

--- a/projects/dashboards-demo/webcomponents/concat.cjs
+++ b/projects/dashboards-demo/webcomponents/concat.cjs
@@ -1,10 +1,12 @@
 var concat = require('concat');
+var fs = require('fs');
 
 build = async () => {
   const files = [
     './dist/dashboards-demo-webcomponents/runtime.js',
     './dist/dashboards-demo-webcomponents/main.js'
   ];
-  await concat(files, 'dist/dashboards-demo-webcomponents/webcomponent-widgets.js');
+  fs.mkdirSync('./dist/dashboards-demo/webcomponents/');
+  await concat(files, 'dist/dashboards-demo/webcomponents/webcomponent-widgets.js');
 };
 build();


### PR DESCRIPTION
This commit changes mainly two things:
- emit all dashboards-demo artifacts already in the desired target directory
- uploads the example to gh pages

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
