### PR TITLE
feat(wizard): switch to footer navigation as default

### DIFF
--- a/projects/element-ng/wizard/si-wizard.component.ts
+++ b/projects/element-ng/wizard/si-wizard.component.ts
@@ -185,9 +185,9 @@ export class SiWizardComponent implements AfterContentInit, OnDestroy {
   /**
    * Set false to show navigation buttons in footer instead of inline.
    *
-   * @defaultValue true
+   * @defaultValue false
    */
-  readonly inlineNavigation = input(true, { transform: booleanAttribute });
+  readonly inlineNavigation = input(false, { transform: booleanAttribute });
   /**
    * Use number representation for steps.
    *

--- a/src/app/examples/si-wizard/si-wizard-cancel-button.html
+++ b/src/app/examples/si-wizard/si-wizard-cancel-button.html
@@ -1,4 +1,4 @@
-<si-wizard [inlineNavigation]="false" [hasCancel]="true" (wizardCancel)="logEvent('Canceled!')">
+<si-wizard [hasCancel]="true" (wizardCancel)="logEvent('Canceled!')">
   <si-wizard-step heading="Step 1" (next)="logEvent('Step 1 finished!')">
     <h1 class="text-center">Step 1</h1>
   </si-wizard-step>

--- a/src/app/examples/si-wizard/si-wizard-dynamical.html
+++ b/src/app/examples/si-wizard/si-wizard-dynamical.html
@@ -1,4 +1,4 @@
-<si-wizard [inlineNavigation]="false">
+<si-wizard>
   @for (item of steps$ | async; track item) {
     <si-wizard-step
       [heading]="item.heading"

--- a/src/app/examples/si-wizard/si-wizard-failed.html
+++ b/src/app/examples/si-wizard/si-wizard-failed.html
@@ -1,4 +1,4 @@
-<si-wizard [inlineNavigation]="false">
+<si-wizard>
   <si-wizard-step heading="Step 1" (next)="logEvent('Step 1 finished!')">
     <h1 class="text-center">Step 1</h1>
   </si-wizard-step>

--- a/src/app/examples/si-wizard/si-wizard-input-validation.html
+++ b/src/app/examples/si-wizard/si-wizard-input-validation.html
@@ -1,4 +1,4 @@
-<si-wizard [inlineNavigation]="false">
+<si-wizard>
   <si-wizard-step
     heading="Step 1"
     [isNextNavigable]="stepIsNextNavigable"

--- a/src/app/examples/si-wizard/si-wizard-numbered-steps.html
+++ b/src/app/examples/si-wizard/si-wizard-numbered-steps.html
@@ -1,4 +1,4 @@
-<si-wizard class="h-100" showStepNumbers="true" inlineNavigation="false">
+<si-wizard class="h-100" showStepNumbers="true">
   @let steps =
     [
       'Step 1',

--- a/src/app/examples/si-wizard/si-wizard-show-completion-page.html
+++ b/src/app/examples/si-wizard/si-wizard-show-completion-page.html
@@ -1,5 +1,4 @@
 <si-wizard
-  [inlineNavigation]="false"
   [enableCompletionPage]="true"
   [completionPageVisibleTime]="3000"
   (completionAction)="navigateTo('main/components/page-layout-&-navigation/si-wizard')"

--- a/src/app/examples/si-wizard/si-wizard.html
+++ b/src/app/examples/si-wizard/si-wizard.html
@@ -1,4 +1,4 @@
-<si-wizard [inlineNavigation]="false">
+<si-wizard>
   <si-wizard-step heading="Step 1" (next)="logEvent('Step 1 finished!')">
     <h1 class="text-center">Step 1</h1>
   </si-wizard-step>


### PR DESCRIPTION
BREAKING CHANGE:
`inlineNavigation` is now default set to `false` and will render navigation buttons in footer which is recommended. You can switch back to inline by explicitly setting `inlineNavigation` to `true`.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
