### PR TITLE
fix(date-range-filter): provide empty label when end date is not selected

### DIFF
--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.html
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.html
@@ -87,8 +87,12 @@
     {{ previewLabel() | translate }}:
     <span class="preview">
       @if (calculatedRange().valid) {
+        @let endDatePreview =
+          selectionPending()
+            ? (endDatePreviewLabel() | translate)
+            : (calculatedRange().end | date: pipeFormat());
         {{ calculatedRange().start | date: pipeFormat() }} -
-        {{ calculatedRange().end | date: pipeFormat() }}
+        {{ endDatePreview }}
       } @else {
         ?
       }

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
@@ -291,6 +291,17 @@ export class SiDateRangeFilterComponent implements OnChanges {
    * ```
    */
   readonly applyLabel = input($localize`:@@SI_DATE_RANGE_FILTER.APPLY:Apply`);
+  /**
+   * label for the "end date" in preview
+   *
+   * @defaultValue
+   * ```
+   * $localize`:@@SI_DATE_RANGE_FILTER.END_DATE_PREVIEW:End date`
+   * ```
+   */
+  readonly endDatePreviewLabel = input(
+    $localize`:@@SI_DATE_RANGE_FILTER.END_DATE_PREVIEW:End date`
+  );
 
   /** Event fired when the apply button has been clicked */
   readonly applyClicked = output<void>();
@@ -317,6 +328,7 @@ export class SiDateRangeFilterComponent implements OnChanges {
       ? (this.datepickerConfig()?.dateTimeFormat ?? 'short')
       : (this.datepickerConfig()?.dateFormat ?? 'shortDate')
   );
+  protected readonly selectionPending = signal(false);
 
   protected readonly datepickerConfigInternal = computed<DatepickerConfig>(() => ({
     ...(this.datepickerConfig() ?? {}),
@@ -458,6 +470,8 @@ export class SiDateRangeFilterComponent implements OnChanges {
   protected updateFromDateRange(): void {
     this.point1date = this.range().point1 = this.dateRange.start ?? this.getDateNow();
     this.point2date = this.range().point2 = this.dateRange.end ?? this.getDateNow();
+    const setSelectionState = this.dateRange.end ? false : true;
+    this.selectionPending.set(setSelectionState);
     this.range.update(oldRange => ({ ...oldRange, range: undefined }));
     this.point2Mode = 'date';
     this.point2offset = 0;

--- a/projects/element-ng/translate/si-translatable-keys.interface.ts
+++ b/projects/element-ng/translate/si-translatable-keys.interface.ts
@@ -44,6 +44,7 @@ export interface SiTranslatableKeys {
   'SI_DATE_RANGE_FILTER.DATE'?: string;
   'SI_DATE_RANGE_FILTER.DATE_PLACEHOLDER'?: string;
   'SI_DATE_RANGE_FILTER.DAYS'?: string;
+  'SI_DATE_RANGE_FILTER.END_DATE_PREVIEW'?: string;
   'SI_DATE_RANGE_FILTER.FROM'?: string;
   'SI_DATE_RANGE_FILTER.HOURS'?: string;
   'SI_DATE_RANGE_FILTER.MINUTES'?: string;


### PR DESCRIPTION
Provide blank label when end date is not yet selected

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
