### PR TITLE
refactor(result-details-list): remove deprecations

### DIFF
--- a/projects/element-ng/result-details-list/si-result-details-list.datamodel.ts
+++ b/projects/element-ng/result-details-list/si-result-details-list.datamodel.ts
@@ -34,19 +34,11 @@ export interface ResultDetailStep {
 }
 
 /**
- * @deprecated This will be removed in a future release. Use the string values directly.
- */
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const ResultDetailStepState = {
-  Passed: 'passed',
-  Failed: 'failed',
-  Running: 'running',
-  NotSupported: 'not-supported',
-  NotStarted: 'not-started'
-} as const;
-
-/**
  * This type defines the state that a detailed result step can have.
  */
 export type ResultDetailStepState =
-  (typeof ResultDetailStepState)[keyof typeof ResultDetailStepState];
+  | 'passed'
+  | 'failed'
+  | 'running'
+  | 'not-supported'
+  | 'not-started';


### PR DESCRIPTION
BREAKING CHANGE: Removed `ResultDetailStepState` as object. Use `ResultDetailStepState` as type with direct string values.



- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
