### PR TITLE
refactor(split): remove deprecations

### DIFF
--- a/projects/element-ng/split/si-split-part.component.ts
+++ b/projects/element-ng/split/si-split-part.component.ts
@@ -60,21 +60,6 @@ export class SiSplitPartComponent implements OnChanges {
    */
   @Input({ transform: booleanAttribute }) collapseToMinSize = false;
 
-  /**
-   * Sets the status color on the split part header, visible as a bottom border and,
-   * if a headerStatusIcon is defined, as the icon´s background color.
-   *
-   * @deprecated Legacy input with no functionality. Will be removed in future major release.
-   */
-  @Input() headerStatusColor?: string;
-
-  /**
-   * Sets the icon class that is used as status icon in the split part header.
-   *
-   * @deprecated Legacy input with no functionality. Will be removed in future major release.
-   */
-  @Input() headerStatusIconClass?: string;
-
   @Input() headerTemplate?: TemplateRef<any>;
 
   /**

--- a/projects/element-ng/split/si-split.component.spec.ts
+++ b/projects/element-ng/split/si-split.component.spec.ts
@@ -52,8 +52,6 @@ class SynchronousMockStore implements UIStateStorage {
           [collapseDirection]="collapseDirection1"
           [collapseIconClass]="collapseIconClass1"
           [collapseToMinSize]="collapseToMinSize1"
-          [headerStatusColor]="headerStatusColor1"
-          [headerStatusIconClass]="headerStatusIconClass1"
           [headerTemplate]="headerTemplate1"
           [heading]="heading1"
           [minSize]="minSize1"
@@ -74,8 +72,6 @@ class SynchronousMockStore implements UIStateStorage {
           [collapseDirection]="collapseDirection2"
           [collapseIconClass]="collapseIconClass2"
           [collapseToMinSize]="collapseToMinSize2"
-          [headerStatusColor]="headerStatusColor2"
-          [headerStatusIconClass]="headerStatusIconClass2"
           [headerTemplate]="headerTemplate2"
           [heading]="heading2"
           [minSize]="minSize2"
@@ -97,8 +93,6 @@ class SynchronousMockStore implements UIStateStorage {
           [collapseDirection]="collapseDirection3"
           [collapseIconClass]="collapseIconClass3"
           [collapseToMinSize]="collapseToMinSize3"
-          [headerStatusColor]="headerStatusColor3"
-          [headerStatusIconClass]="headerStatusIconClass3"
           [headerTemplate]="headerTemplate3"
           [heading]="heading3"
           [minSize]="minSize3"
@@ -148,8 +142,6 @@ class WrapperComponent {
   collapseDirection2: CollapseTo = 'start';
   collapseIconClass2 = 'element-command-arrow';
   collapseToMinSize2 = false;
-  headerStatusColor2?: string;
-  headerStatusIconClass2?: string;
   headerTemplate2?: TemplateRef<any>;
   heading2 = '';
   minSize2 = 0;
@@ -165,8 +157,6 @@ class WrapperComponent {
   collapseDirection3: CollapseTo = 'start';
   collapseIconClass3 = 'element-command-arrow';
   collapseToMinSize3 = false;
-  headerStatusColor3?: string;
-  headerStatusIconClass3?: string;
   headerTemplate3?: TemplateRef<any>;
   heading3 = '';
   minSize3 = 0;


### PR DESCRIPTION
BREAKING CHANGE: Removed unused `headerStatusColor` and `headerStatusIconClass` without any replacement.

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
