### PR TITLE
build(release): update version in dependent package right after setting the version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "47.7.0",
       "license": "MIT",
       "workspaces": [
+        "projects/element-ng",
         "projects/element-translate-cli",
         "projects/element-translate-ng",
         "projects/element-theme",
@@ -8706,53 +8707,8 @@
       "link": true
     },
     "node_modules/@siemens/element-ng": {
-      "version": "47.7.0",
-      "resolved": "https://registry.npmjs.org/@siemens/element-ng/-/element-ng-47.7.0.tgz",
-      "integrity": "sha512-BBAZdtQBeKQ2vH0SrWlHme8eW18G4xX/u9Td4F0SKeaI1gNbcXUGaCn1hsARhX29y4VlfypCnadYB0VHfREbxQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/animations": "19 - 20",
-        "@angular/cdk": "19 - 20",
-        "@angular/common": "19 - 20",
-        "@angular/core": "19 - 20",
-        "@angular/forms": "19 - 20",
-        "@angular/router": "19 - 20",
-        "@ngx-formly/bootstrap": "^6.2.2",
-        "@ngx-formly/core": "^6.2.2",
-        "@siemens/element-theme": "47.7.0",
-        "@siemens/element-translate-ng": "47.7.0",
-        "@siemens/ngx-datatable": "22 - 24",
-        "flag-icons": "^7.3.2",
-        "google-libphonenumber": "^3.2.40",
-        "ngx-image-cropper": "^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@angular/animations": {
-          "optional": true
-        },
-        "@ngx-formly/bootstrap": {
-          "optional": true
-        },
-        "@ngx-formly/core": {
-          "optional": true
-        },
-        "@siemens/ngx-datatable": {
-          "optional": true
-        },
-        "flag-icons": {
-          "optional": true
-        },
-        "google-libphonenumber": {
-          "optional": true
-        },
-        "ngx-image-cropper": {
-          "optional": true
-        }
-      }
+      "resolved": "projects/element-ng",
+      "link": true
     },
     "node_modules/@siemens/element-theme": {
       "resolved": "projects/element-theme",
@@ -28792,6 +28748,50 @@
         "@siemens/element-ng": "47.7.0",
         "@siemens/element-theme": "47.7.0",
         "gridstack": "^11.1.0"
+      }
+    },
+    "projects/element-ng": {
+      "name": "@siemens/element-ng",
+      "version": "47.7.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "@angular/animations": "19 - 20",
+        "@angular/cdk": "19 - 20",
+        "@angular/common": "19 - 20",
+        "@angular/core": "19 - 20",
+        "@angular/forms": "19 - 20",
+        "@angular/router": "19 - 20",
+        "@ngx-formly/bootstrap": "^6.2.2",
+        "@ngx-formly/core": "^6.2.2",
+        "@siemens/element-theme": "47.7.0",
+        "@siemens/element-translate-ng": "47.7.0",
+        "@siemens/ngx-datatable": "22 - 24",
+        "flag-icons": "^7.3.2",
+        "google-libphonenumber": "^3.2.40",
+        "ngx-image-cropper": "^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/animations": {
+          "optional": true
+        },
+        "@ngx-formly/bootstrap": {
+          "optional": true
+        },
+        "@ngx-formly/core": {
+          "optional": true
+        },
+        "@siemens/ngx-datatable": {
+          "optional": true
+        },
+        "flag-icons": {
+          "optional": true
+        },
+        "google-libphonenumber": {
+          "optional": true
+        },
+        "ngx-image-cropper": {
+          "optional": true
+        }
       }
     },
     "projects/element-theme": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "live-preview:build": "ng build live-preview && cpy LICENSE.md \"./dist/@siemens/live-preview/\"",
     "prepare": "husky; exit 0",
     "prepare-brand": "cpy --flat node_modules/@simpl/brand/src/favicon/sie-favicon_internet_64px.png docs/_src --rename=favicon.png && cpy --flat node_modules/@simpl/brand/src/favicon/sie-favicon_internet_64px.png src --rename=favicon.png",
-    "postversion": "node ./postversion.js && npm run format",
+    "postversion": "npm run format",
     "charts:test": "ng test charts-ng",
     "charts:build": "ng build charts-ng && cpy \"{LICENSE.md,projects/charts-ng/README.md}\" \"./dist/@siemens/charts-ng/\"",
     "native-charts:test": "ng test native-charts-ng",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "dashboards-demo:build:mfe": "ng build dashboards-demo-mfe --configuration production --output-hashing none"
   },
   "workspaces": [
+    "projects/element-ng",
     "projects/element-translate-cli",
     "projects/element-translate-ng",
     "projects/element-theme",

--- a/postversion.js
+++ b/postversion.js
@@ -1,18 +1,23 @@
 import { glob } from 'node:fs/promises';
 import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 async function updatePeerDependencies() {
+  const rootDir = new URL('.', import.meta.url).pathname;
+
   const versions = new Map();
-  for await (const file of glob(['package.json', 'projects/**/package.json'])) {
+  for await (const file of glob([
+    join(rootDir, 'package.json'),
+    join(rootDir, 'projects/**/package.json')
+  ])) {
     const content = JSON.parse(await readFile(file, { encoding: 'utf8' }));
     versions.set(content.name, content.version);
-    console.log(file);
   }
 
   for await (const file of glob([
-    'package.json',
-    'projects/**/package.json',
-    'dist/**/package.json'
+    join(rootDir, 'package.json'),
+    join(rootDir, 'projects/**/package.json'),
+    join(rootDir, 'dist/**/package.json')
   ])) {
     let updated = false;
     const content = JSON.parse(await readFile(file, { encoding: 'utf8' }));

--- a/projects/element-ng/package.json
+++ b/projects/element-ng/package.json
@@ -16,6 +16,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {
+    "postversion": "node ../../postversion.js"
+  },
   "type": "module",
   "peerDependencies": {
     "@angular/animations": "19 - 20",

--- a/projects/element-theme/package.json
+++ b/projects/element-theme/package.json
@@ -16,6 +16,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {
+    "postversion": "node ../../postversion.js"
+  },
   "keywords": [
     "siemens",
     "theme",

--- a/projects/element-translate-ng/package.json
+++ b/projects/element-translate-ng/package.json
@@ -17,6 +17,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {
+    "postversion": "node ../../postversion.js"
+  },
   "peerDependencies": {
     "@angular/common": "19 - 20",
     "@angular/core": "19 - 20",


### PR DESCRIPTION
This should ideally solve our release problem.

The Problem is, that when bumping a package inside the workspace, the dependent packages are not automatically updated.
So they have an invalid peer dependency, since they depend on the old version.
This is hopefully solved by updating all dependent packages directly after a package was bumped.
We previously updated all packages after all were bumped.

This occurs since adding dashboards-ng.
We previously did not have this problem, as I forgot adding `element-ng` to the workspaces.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
