### PR TITLE
refactor(wizard): remove deprecations

### DIFF
--- a/projects/element-ng/wizard/si-wizard.component.html
+++ b/projects/element-ng/wizard/si-wizard.component.html
@@ -145,7 +145,7 @@
           {{ cancelText() | translate }}
         </button>
       }
-      @if (!shouldHideNavigation()) {
+      @if (!hideNavigation()) {
         <button
           type="button"
           class="btn btn-secondary"
@@ -187,7 +187,7 @@
 
 <ng-template #backBtnHorizontal>
   <div class="wizard-btn-container">
-    @if (!shouldHideNavigation()) {
+    @if (!hideNavigation()) {
       <div class="back" [class.invisible]="index === 0" (click)="back(1)">
         <button
           type="button"
@@ -204,7 +204,7 @@
 
 <ng-template #nextBtnHorizontal>
   <div class="wizard-btn-container" [class.wizard-text-deactivate]="!currentStep?.isValid()">
-    @if (!shouldHideNavigation()) {
+    @if (!hideNavigation()) {
       <div class="next" [class.invisible]="index === steps().length - 1" (click)="next(1)">
         <button
           type="button"

--- a/projects/element-ng/wizard/si-wizard.component.spec.ts
+++ b/projects/element-ng/wizard/si-wizard.component.spec.ts
@@ -16,7 +16,7 @@ import { SiWizardStepComponent, SiWizardComponent as TestComponent } from './ind
     <si-wizard
       #wizard
       [hasCancel]="hasCancel"
-      [hasNavigation]="hasNavigation"
+      [hideNavigation]="!hasNavigation"
       [inlineNavigation]="inlineNavigation"
       [verticalLayout]="verticalLayout()"
       [showVerticalDivider]="showVerticalDivider()"

--- a/projects/element-ng/wizard/si-wizard.component.ts
+++ b/projects/element-ng/wizard/si-wizard.component.ts
@@ -82,13 +82,6 @@ export class SiWizardComponent {
   readonly nextText = input($localize`:@@SI_WIZARD.NEXT:Next`);
 
   /**
-   * @deprecated Use {@link hideNavigation} instead.
-   *
-   * @defaultValue true
-   */
-  readonly hasNavigation = input(true, { transform: booleanAttribute });
-
-  /**
    * Hide the navigation buttons previous/next.
    *
    * @defaultValue false
@@ -204,12 +197,6 @@ export class SiWizardComponent {
   /** Callback function triggered if the wizard has been canceled. */
   readonly wizardCancel = output();
 
-  /**
-   * Callback function triggered if the wizard has been canceled.
-   * @deprecated use {@link wizardCancel} instead
-   */
-  readonly cancel = this.wizardCancel;
-
   /** Get the current step wizard step index. */
   get index(): number {
     return this._index();
@@ -231,9 +218,6 @@ export class SiWizardComponent {
   protected readonly showCompletionPage = signal(false);
   /** The list of visible steps. */
   protected readonly activeSteps = computed(() => this.computeVisibleSteps());
-  protected readonly shouldHideNavigation = computed(() => {
-    return this.hideNavigation() || !this.hasNavigation();
-  });
 
   private readonly _index = linkedSignal(() => {
     const currentStep = this._currentStep();

--- a/src/app/examples/si-wizard/si-wizard-playground.html
+++ b/src/app/examples/si-wizard/si-wizard-playground.html
@@ -6,7 +6,7 @@
       [enableCompletionPage]="configForm.value.enableCompletionPage!"
       [completionPageVisibleTime]="configForm.value.completionPageVisibleTime!"
       [hasCancel]="configForm.value.hasCancel!"
-      [hasNavigation]="configForm.value.hasNavigation!"
+      [hideNavigation]="!configForm.value.hasNavigation!"
       [verticalLayout]="configForm.value.verticalLayout"
       [verticalMinSize]="
         configForm.value.verticalLayoutMinSize


### PR DESCRIPTION
BREAKING CHANGE: Removed `hasNavigation` and `cancel`. Use `hideNavigation` and  `wizardCancel` respectively instead.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
