### PR TITLE
docs(contributing): use `release` instead of `maintenance`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -473,9 +473,9 @@ which automates all release tasks.
 
 - to create a new release push changes to the `main` branch
 - to create a pre-release push changes to the `next` branch
-- to create a maintenance release push changes to a branch following this
-  pattern: `maintenance/N.N.x` / `maintenance/N.x.x` / `maintenance/N.x` branch
-  where `N` is any existing version
+- to create a back-merge release push changes to a branch following this
+  pattern: `release/N.N.x` / `release/N.x.x` / `release/N.x` branch where `N` is
+  any existing version
 
 ## Attribution
 


### PR DESCRIPTION
Same as https://github.com/siemens/lint/pull/32.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
