### PR TITLE
refactor(tabs-next): use the base class where possible

### DIFF
--- a/projects/element-ng/tabs-next/si-tab-next-link.component.ts
+++ b/projects/element-ng/tabs-next/si-tab-next-link.component.ts
@@ -18,6 +18,7 @@ import { SiTabNextBaseDirective } from './si-tab-next-base.directive';
   imports: [NgClass, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-tab-next.component.html',
   styleUrl: './si-tab-next.component.scss',
+  providers: [{ provide: SiTabNextBaseDirective, useExisting: SiTabNextLinkComponent }],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.active]': 'routerLinkActive.isActive',

--- a/projects/element-ng/tabs-next/si-tab-next.component.ts
+++ b/projects/element-ng/tabs-next/si-tab-next.component.ts
@@ -15,6 +15,7 @@ import { SiTabNextBaseDirective } from './si-tab-next-base.directive';
   imports: [NgClass, SiIconNextComponent, SiTranslatePipe],
   templateUrl: './si-tab-next.component.html',
   styleUrl: './si-tab-next.component.scss',
+  providers: [{ provide: SiTabNextBaseDirective, useExisting: SiTabNextComponent }],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.active]': 'active()',

--- a/projects/element-ng/tabs-next/si-tabset-next.component.ts
+++ b/projects/element-ng/tabs-next/si-tabset-next.component.ts
@@ -22,8 +22,8 @@ import { SiMenuDirective, SiMenuItemComponent } from '@siemens/element-ng/menu';
 import { SiResizeObserverModule } from '@siemens/element-ng/resize-observer';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
+import { SiTabNextBaseDirective } from './si-tab-next-base.directive';
 import { SiTabNextLinkComponent } from './si-tab-next-link.component';
-import { SiTabNextComponent } from './si-tab-next.component';
 import { SI_TABSET_NEXT } from './si-tabs-tokens';
 
 /** @experimental */
@@ -31,7 +31,7 @@ export interface SiTabNextDeselectionEvent {
   /**
    * The target tab
    */
-  target: SiTabNextComponent | SiTabNextLinkComponent;
+  target: SiTabNextBaseDirective;
   /**
    * The index of target tab
    */
@@ -78,19 +78,10 @@ export class SiTabsetNextComponent implements AfterViewInit {
   readonly activeTabIndex = computed(() => this.activeTab()?.index() ?? -1);
 
   /** @internal */
-  focusKeyManager?: FocusKeyManager<SiTabNextComponent | SiTabNextLinkComponent>;
-
-  private readonly tabPanelsLinks = contentChildren(SiTabNextLinkComponent);
-  private readonly tabPanelsComponents = contentChildren(SiTabNextComponent);
+  focusKeyManager?: FocusKeyManager<SiTabNextBaseDirective>;
 
   /** @internal */
-  readonly tabPanels = computed(() => {
-    const allTabs: (SiTabNextLinkComponent | SiTabNextComponent)[] = [
-      ...this.tabPanelsLinks(),
-      ...this.tabPanelsComponents()
-    ];
-    return allTabs;
-  });
+  readonly tabPanels = contentChildren(SiTabNextBaseDirective);
 
   protected readonly menu = viewChild('menu', { read: CdkMenu });
   protected readonly showMenuButton = signal(false);


### PR DESCRIPTION
Previously, in theory the order of tabs could have been wrong. This should never be an issue though, as mixing routing and the buttons tabs should e avoided.

Anyway, this is fixed with this.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
