### PR TITLE
feat(accordion): allow using hcollapsed as html attribute

### DIFF
--- a/projects/element-ng/accordion/si-accordion.component.ts
+++ b/projects/element-ng/accordion/si-accordion.component.ts
@@ -42,7 +42,7 @@ export class SiAccordionComponent implements AfterContentInit, OnChanges {
   /** @defaultValue false */
   readonly fullHeight = input(false, { transform: booleanAttribute });
   /** @defaultValue false */
-  readonly hcollapsed = input(false);
+  readonly hcollapsed = input(false, { transform: booleanAttribute });
   /**
    * Color to use for component background
    * @deprecated This has no effect anymore. Will be removed in v48


### PR DESCRIPTION
allows to use `hcollapsed` as html element attribute.

For example, `<si-accordion [hcollapsed]="true" />` can now be also be written like `<si-accordion hcollapsed />`


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
