### PR TITLE
fix(date-range-filter): allow empty reference point

### DIFF
--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.html
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.html
@@ -63,7 +63,7 @@
   } @else {
     <si-datepicker
       [config]="dateRangeConfig()"
-      [focusedDate]="dateRange.end ?? dateRange.start"
+      [focusedDate]="focusedDate()"
       [(dateRange)]="dateRange"
       (dateRangeChange)="updateFromDateRange()"
     />

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
@@ -27,6 +27,7 @@ import {
   DatepickerConfig,
   DatepickerInputConfig,
   DateRange,
+  isValid,
   SiCalendarButtonComponent,
   SiDatepickerComponent,
   SiDatepickerDirective
@@ -337,6 +338,10 @@ export class SiDateRangeFilterComponent implements OnChanges {
     return (this.presetList() ?? []).filter(timeFilter);
   });
 
+  protected readonly focusedDate = computed(() => {
+    const date = this.dateRange.end ?? this.dateRange.start;
+    return isValid(date) ? date : undefined;
+  });
   protected readonly presetFilter = signal('');
   protected readonly presetOpen = signal(false);
   protected readonly inputMode = computed(


### PR DESCRIPTION
**DateRangeFilter issue:**

1. Open DateRangeFilter example 
2. Switch on advanced mode
3. Clear both `Reference point` and `Range`
4. Switch off advanced mode

Results in an exception and the datepicker isn't shown.


---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
