### PR TITLE
fix(tabs-next): ensure that the active tab is focussed by default

### DIFF
--- a/projects/element-ng/tabs-next/si-tabset-next.component.spec.ts
+++ b/projects/element-ng/tabs-next/si-tabset-next.component.spec.ts
@@ -35,7 +35,7 @@ class SiTabRouteComponent {}
         <si-tabset-next>
           @for (tab of tabsObject(); track tab) {
             <si-tab-next
-              [active]="$first"
+              [active]="tab.active ?? false"
               [heading]="tab.heading"
               [closable]="!!tab.closable"
               [style.max-width.px]="tabButtonMaxWidth()"
@@ -50,9 +50,16 @@ class SiTabRouteComponent {}
 class TestComponent {
   readonly tabButtonMaxWidth = signal<number | undefined>(undefined);
   readonly wrapperWidth = signal(200);
-  protected readonly tabsObject = signal<{ heading: string; closable?: boolean }[]>([]);
+  protected readonly tabsObject = signal<
+    { heading: string; closable?: boolean; active?: boolean }[]
+  >([]);
 
-  set tabs(value: ({ heading: string; closable?: true; routerLinkUrl?: string } | string)[]) {
+  set tabs(
+    value: (
+      | { heading: string; closable?: true; routerLinkUrl?: string; active?: boolean }
+      | string
+    )[]
+  ) {
     this.tabsObject.set(
       value.map(tab => {
         if (typeof tab === 'string') {
@@ -147,7 +154,7 @@ describe('SiTabsetNext', () => {
     const tabs = await tabsetHarness.getTabItemsLength();
     expect(tabs).toEqual(0);
 
-    testComponent.tabs = ['test'];
+    testComponent.tabs = [{ heading: 'test', active: true }];
     fixture.detectChanges();
 
     const updatedTabs = await tabsetHarness.getTabItemsLength();
@@ -158,7 +165,7 @@ describe('SiTabsetNext', () => {
   });
 
   it('should be possible to add a few tabs to the tabComponent', async () => {
-    testComponent.tabs = ['1', '2', '3'];
+    testComponent.tabs = [{ heading: '1', active: true }, '2', '3'];
     fixture.detectChanges();
     expect(await tabsetHarness.isTabItemActive(0)).toBeTrue();
     expect(await tabsetHarness.isTabItemActive(1)).toBeFalse();
@@ -186,7 +193,7 @@ describe('SiTabsetNext', () => {
   });
 
   it('should handle focus correctly', fakeAsync(async () => {
-    testComponent.tabs = ['1', '2', '3'];
+    testComponent.tabs = [{ heading: '1', active: true }, '2', '3'];
     testComponent.wrapperWidth.set(300);
     detectSizeChange();
     tick(10);
@@ -294,6 +301,13 @@ describe('SiTabsetNext', () => {
 
     expect(await tabsetHarness.getOptionsMenuButton()).toBe(null);
     expect(await tabsetHarness.isTabVisible(1)).toBe(true);
+  });
+
+  it('should mark active tab as focussable after delayed adding', async () => {
+    testComponent.tabs = [];
+    fixture.detectChanges();
+    testComponent.tabs = ['1', { heading: '2', active: true }, '3'];
+    expect(await tabsetHarness.isTabFocussable(1)).toBeTrue();
   });
 });
 

--- a/projects/element-ng/tabs-next/si-tabset-next.component.ts
+++ b/projects/element-ng/tabs-next/si-tabset-next.component.ts
@@ -6,7 +6,6 @@ import { FocusKeyManager } from '@angular/cdk/a11y';
 import { CdkMenuTrigger } from '@angular/cdk/menu';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   computed,
@@ -64,7 +63,7 @@ export interface SiTabNextDeselectionEvent {
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SiTabsetNextComponent implements AfterViewInit {
+export class SiTabsetNextComponent {
   /**
    * Event emitter to notify when a tab became inactive.
    */
@@ -87,13 +86,6 @@ export class SiTabsetNextComponent implements AfterViewInit {
   /** @internal */
 
   protected readonly showMenuButton = signal(false);
-
-  ngAfterViewInit(): void {
-    // To avoid ExpressionChangedAfterItHasBeenCheckedError
-    setTimeout(() => {
-      this.focusKeyManager.updateActiveItem(this.tabPanels().findIndex(tab => !tab.disabledTab()));
-    });
-  }
 
   protected tabIsLink(tab: unknown): tab is SiTabNextLinkComponent {
     return tab instanceof SiTabNextLinkComponent;

--- a/projects/element-ng/tabs-next/testing/si-tabset-next.harness.ts
+++ b/projects/element-ng/tabs-next/testing/si-tabset-next.harness.ts
@@ -131,4 +131,10 @@ export class SiTabsetNextHarness extends ComponentHarness {
       Math.round(rectRight) <= Math.round(containerRectRight)
     );
   }
+
+  async isTabFocussable(index: number): Promise<boolean> {
+    const tabButton = await this.getTabItemButtonAt(index);
+    const tabIndex = await tabButton.getAttribute('tabindex');
+    return tabIndex === '0' || tabIndex === null;
+  }
 }


### PR DESCRIPTION
Unless actively operated,
the focuskeymanger should initially always point to the active tab. Previously, this only worked if the tabset is initialized with tabs on load. If tabs are added later or the active flag was changed programmatically, tha focuskeymanager was not updated.
This commit ensures
that the focuskeymanager is always updated if the active flag has changed.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
