### PR TITLE
refactor(tabs-next): fully rely on routing for link tabs

### DIFF
--- a/projects/element-ng/tabs-next/si-tab-next-base.directive.ts
+++ b/projects/element-ng/tabs-next/si-tab-next-base.directive.ts
@@ -13,10 +13,10 @@ import {
   input,
   OnDestroy,
   output,
+  Signal,
   TemplateRef,
   untracked,
-  viewChild,
-  WritableSignal
+  viewChild
 } from '@angular/core';
 import { addIcons, elementCancel } from '@siemens/element-ng/icon';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -31,7 +31,9 @@ import { SI_TABSET_NEXT } from './si-tabs-tokens';
     '[class.disabled]': 'disabledTab()',
     '[class.icon-only]': '!!icon()',
     '[class.pe-3]': 'closable()',
+    '[class.active]': 'active()',
     '[attr.id]': "'tab-' + tabId",
+    '[attr.aria-selected]': 'active()',
     '[attr.aria-disabled]': 'disabledTab()',
     '[attr.tabindex]': 'tabset.focusKeyManager.activeItem === this && !disabledTab() ? 0 : -1',
     '[attr.aria-controls]': "'content-' + tabId",
@@ -39,7 +41,7 @@ import { SI_TABSET_NEXT } from './si-tabs-tokens';
   }
 })
 export abstract class SiTabNextBaseDirective implements OnDestroy, FocusableOption {
-  abstract readonly active: WritableSignal<boolean>;
+  abstract readonly active: Signal<boolean | undefined>;
   /** Title of the tab item. */
   readonly heading = input.required<TranslatableString>();
   /**
@@ -143,11 +145,18 @@ export abstract class SiTabNextBaseDirective implements OnDestroy, FocusableOpti
     return this.disabledTab();
   }
 
+  /**
+   * Programmatically selects the current tab.
+   */
   selectTab(retainFocus?: boolean): void {
     this.tabset.focusKeyManager.updateActiveItem(this.index());
     if (retainFocus) {
       // We need the timeout to wait for cdkMenu to restore the focus before we move it again.
       setTimeout(() => this.focus());
     }
+  }
+
+  deSelectTab(): void {
+    // Empty be default, can be overridden in derived classes.
   }
 }

--- a/projects/element-ng/tabs-next/si-tab-next.component.ts
+++ b/projects/element-ng/tabs-next/si-tab-next.component.ts
@@ -18,10 +18,8 @@ import { SiTabNextBaseDirective } from './si-tab-next-base.directive';
   providers: [{ provide: SiTabNextBaseDirective, useExisting: SiTabNextComponent }],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    '[class.active]': 'active()',
-    '[attr.aria-selected]': 'active()',
-    '(click)': 'selectTab()',
-    '(keydown.enter)': 'selectTab()'
+    '(click)': 'selectTabByUser()',
+    '(keydown.enter)': 'selectTabByUser()'
   }
 })
 export class SiTabNextComponent extends SiTabNextBaseDirective implements OnDestroy {
@@ -32,31 +30,41 @@ export class SiTabNextComponent extends SiTabNextBaseDirective implements OnDest
    * */
   override readonly active = model(false);
 
-  /** @internal */
-  override selectTab(retainFocus?: boolean): void {
+  protected selectTabByUser(): void {
     const tabs = this.tabset.tabPanels();
     const newTabIndex = this.index();
     const currentTabIndex = this.tabset.activeTabIndex();
     let continueWithSelection = newTabIndex !== currentTabIndex;
+    const currentTab = tabs[currentTabIndex];
 
-    if (continueWithSelection && currentTabIndex !== -1) {
-      const currentTab = tabs[currentTabIndex];
+    if (continueWithSelection && currentTab) {
       const deselectEvent = {
         target: currentTab,
         tabIndex: currentTabIndex,
         cancel: () => {
           continueWithSelection = false;
-          currentTab.active.set(true);
         }
       };
-
-      currentTab.active.set(false);
       this.tabset.deselect.emit(deselectEvent);
     }
 
     if (continueWithSelection) {
-      this.active.set(true);
-      super.selectTab(retainFocus);
+      this.selectTab();
     }
+  }
+
+  /** @internal */
+  override selectTab(retainFocus?: boolean): void {
+    const tabs = this.tabset.tabPanels();
+    const currentTabIndex = this.tabset.activeTabIndex();
+    const currentTab = tabs[currentTabIndex];
+
+    currentTab?.deSelectTab();
+    this.active.set(true);
+    super.selectTab(retainFocus);
+  }
+
+  override deSelectTab(): void {
+    this.active.set(false);
   }
 }

--- a/projects/element-ng/tabs-next/si-tabset-next.component.ts
+++ b/projects/element-ng/tabs-next/si-tabset-next.component.ts
@@ -92,7 +92,7 @@ export class SiTabsetNextComponent {
   }
 
   /** @internal */
-  removedTabByUser(index: number, active: boolean): void {
+  removedTabByUser(index: number, active?: boolean): void {
     // The tab was already removed from the tabPanels list when this function is called.
     // We need to:
     // - focus another tab if the closed one was focused
@@ -107,7 +107,7 @@ export class SiTabsetNextComponent {
           this.focusKeyManager.setActiveItem(checkIndex);
         }
         if (active) {
-          checkTab.active.set(true);
+          checkTab.selectTab(true);
         }
         return;
       }


### PR DESCRIPTION
Previously, the active flag of all tabs implementation must have been a WritableSignal.
This was causing problems in the link tabs, as there everything is managed by the router.
So we needed an effect to react to changes on the active signal.

Wit this change, we now have methods to programmatically select and deselect tabs.
Those methods never cause the emitting of events and could also be used by applications.
The active flag is now also readonly in the base class to prevent setting it directly
if the router is used.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
