### PR TITLE
fix(dashboards-ng): cannot add or edit webcomponent widgets

### DIFF
--- a/projects/dashboards-demo/webcomponents/concat.cjs
+++ b/projects/dashboards-demo/webcomponents/concat.cjs
@@ -6,7 +6,11 @@ build = async () => {
     './dist/dashboards-demo-webcomponents/runtime.js',
     './dist/dashboards-demo-webcomponents/main.js'
   ];
-  fs.mkdirSync('./dist/dashboards-demo/webcomponents/');
+  const dir = './dist/dashboards-demo/webcomponents/';
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir);
+  }
   await concat(files, 'dist/dashboards-demo/webcomponents/webcomponent-widgets.js');
+  await concat(files, 'dist/dashboards-demo-webcomponents/webcomponent-widgets.js');
 };
 build();


### PR DESCRIPTION
fix issue where host application cannot resolve translation service when widget is added as webcomponent.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
