### PR TITLE
feat(tooltip): support template context with tooltip template

### DIFF
--- a/projects/element-ng/tooltip/si-tooltip.component.html
+++ b/projects/element-ng/tooltip/si-tooltip.component.html
@@ -13,7 +13,10 @@
     @if (tooltipText()) {
       <div class="si-body-2">{{ tooltipText() | translate }}</div>
     } @else if (tooltipTemplate()) {
-      <ng-template [ngTemplateOutlet]="tooltipTemplate()" />
+      <ng-template
+        [ngTemplateOutlet]="tooltipTemplate()"
+        [ngTemplateOutletContext]="tooltipContext()"
+      />
     } @else if (tooltipComponent()) {
       <ng-container [ngComponentOutlet]="tooltipComponent()" />
     }

--- a/projects/element-ng/tooltip/si-tooltip.component.ts
+++ b/projects/element-ng/tooltip/si-tooltip.component.ts
@@ -30,6 +30,7 @@ export class TooltipComponent {
   protected readonly arrowPos = signal<OverlayArrowPosition | undefined>(undefined);
   /** @internal */
   readonly id = input('');
+  readonly tooltipContext = input();
 
   private elementRef = inject(ElementRef);
 

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -89,10 +89,14 @@ describe('SiTooltipDirective', () => {
 
     @Component({
       imports: [SiTooltipModule],
-      template: ` <button type="button" [siTooltip]="template">Test</button>
-        <ng-template #template let-tooltip>Template content</ng-template>`
+      template: ` <button type="button" [siTooltip]="template" [tooltipContext]="tooltipContext"
+          >Test</button
+        >
+        <ng-template #template let-tooltip="tooltip">Template content {{ tooltip }}</ng-template>`
     })
-    class TestHostComponent {}
+    class TestHostComponent {
+      tooltipContext = {};
+    }
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
@@ -111,6 +115,17 @@ describe('SiTooltipDirective', () => {
       button.dispatchEvent(new Event('focus'));
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')?.innerHTML).toContain('Template content');
+      button.dispatchEvent(new Event('focusout'));
+      await fixture.whenStable();
+      expect(document.querySelector('.tooltip')).toBeFalsy();
+    });
+
+    it('should render the template with context', async () => {
+      fixture.componentInstance.tooltipContext = { tooltip: 'test' };
+      fixture.detectChanges();
+      button.dispatchEvent(new Event('focus'));
+      await fixture.whenStable();
+      expect(document.querySelector('.tooltip')?.innerHTML).toContain('Template content test');
       button.dispatchEvent(new Event('focusout'));
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).toBeFalsy();

--- a/projects/element-ng/tooltip/si-tooltip.directive.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.ts
@@ -54,6 +54,11 @@ export class SiTooltipDirective implements OnDestroy {
    */
   readonly isDisabled = input(false, { transform: booleanAttribute });
 
+  /**
+   * The context for the attached template
+   */
+  readonly tooltipContext = input();
+
   protected describedBy = `__tooltip_${SiTooltipDirective.idCounter++}`;
 
   private tooltipRef?: TooltipRef;
@@ -77,7 +82,7 @@ export class SiTooltipDirective implements OnDestroy {
       element: this.elementRef,
       placement: this.placement()
     });
-    this.tooltipRef.show(this.siTooltip());
+    this.tooltipRef.show(this.siTooltip(), this.tooltipContext());
   }
 
   @HostListener('focus')

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -32,7 +32,7 @@ class TooltipRef {
     private injector?: Injector
   ) {}
 
-  show(content: TranslatableString | TemplateRef<any> | Type<any>): void {
+  show(content: TranslatableString | TemplateRef<any> | Type<any>, tooltipContext?: unknown): void {
     if (this.overlayRef.hasAttached()) {
       return;
     }
@@ -42,6 +42,7 @@ class TooltipRef {
 
     tooltipRef.setInput('tooltip', content);
     tooltipRef.setInput('id', this.describedBy);
+    tooltipRef.setInput('tooltipContext', tooltipContext);
 
     const positionStrategy = getPositionStrategy(this.overlayRef);
     positionStrategy?.positionChanges.subscribe(change =>


### PR DESCRIPTION
added `tooltipContext` input which can be used to pass custom template context while using template for `siTooltip`.

This is useful when having tooltip in datatable cells and need to show information based on specific row values.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
