### PR TITLE
refactor(tabs-next): drop `SiTabsetNextComponent.deselect` event

### DIFF
--- a/projects/element-ng/tabs-next/si-tab-next.component.ts
+++ b/projects/element-ng/tabs-next/si-tab-next.component.ts
@@ -31,24 +31,7 @@ export class SiTabNextComponent extends SiTabNextBaseDirective implements OnDest
   override readonly active = model(false);
 
   protected selectTabByUser(): void {
-    const tabs = this.tabset.tabPanels();
-    const newTabIndex = this.index();
-    const currentTabIndex = this.tabset.activeTabIndex();
-    let continueWithSelection = newTabIndex !== currentTabIndex;
-    const currentTab = tabs[currentTabIndex];
-
-    if (continueWithSelection && currentTab) {
-      const deselectEvent = {
-        target: currentTab,
-        tabIndex: currentTabIndex,
-        cancel: () => {
-          continueWithSelection = false;
-        }
-      };
-      this.tabset.deselect.emit(deselectEvent);
-    }
-
-    if (continueWithSelection) {
+    if (!this.active()) {
       this.selectTab();
     }
   }

--- a/projects/element-ng/tabs-next/si-tabset-next.component.ts
+++ b/projects/element-ng/tabs-next/si-tabset-next.component.ts
@@ -12,7 +12,6 @@ import {
   contentChildren,
   inject,
   INJECTOR,
-  output,
   signal
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
@@ -24,22 +23,6 @@ import { SiTabBadgeComponent } from './si-tab-badge.component';
 import { SiTabNextBaseDirective } from './si-tab-next-base.directive';
 import { SiTabNextLinkComponent } from './si-tab-next-link.component';
 import { SI_TABSET_NEXT } from './si-tabs-tokens';
-
-/** @experimental */
-export interface SiTabNextDeselectionEvent {
-  /**
-   * The target tab
-   */
-  target: SiTabNextBaseDirective;
-  /**
-   * The index of target tab
-   */
-  tabIndex: number;
-  /**
-   * To be called to prevent switching the tab
-   */
-  cancel: () => void;
-}
 
 /** @experimental */
 @Component({
@@ -64,11 +47,6 @@ export interface SiTabNextDeselectionEvent {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SiTabsetNextComponent {
-  /**
-   * Event emitter to notify when a tab became inactive.
-   */
-  readonly deselect = output<SiTabNextDeselectionEvent>();
-
   /** @internal */
   readonly activeTab = computed(() => {
     return this.tabPanels().find(tab => tab.active());

--- a/src/app/examples/si-tabs/si-tabs-next-icons.html
+++ b/src/app/examples/si-tabs/si-tabs-next-icons.html
@@ -1,4 +1,4 @@
-<si-tabset-next (deselect)="deselection($event)">
+<si-tabset-next>
   @for (tab of tabs; track tab) {
     <si-tab-next
       [active]="tab.active ?? false"

--- a/src/app/examples/si-tabs/si-tabs-next-icons.ts
+++ b/src/app/examples/si-tabs/si-tabs-next-icons.ts
@@ -3,11 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component, inject } from '@angular/core';
-import {
-  SiTabNextComponent,
-  SiTabNextDeselectionEvent,
-  SiTabsetNextComponent
-} from '@siemens/element-ng/tabs-next';
+import { SiTabNextComponent, SiTabsetNextComponent } from '@siemens/element-ng/tabs-next';
 import { LOG_EVENT } from '@siemens/live-preview';
 
 interface TabModel {
@@ -57,12 +53,6 @@ export class SampleComponent {
       badgeContent: '1'
     }
   ];
-
-  deselection(e: SiTabNextDeselectionEvent): void {
-    if (e.target.heading() === 'Deselectable' && !this.deselectable) {
-      e.cancel();
-    }
-  }
 
   closeTab(tab: TabModel): void {
     this.tabs.splice(

--- a/src/app/examples/si-tabs/si-tabs-next.html
+++ b/src/app/examples/si-tabs/si-tabs-next.html
@@ -1,4 +1,4 @@
-<si-tabset-next (deselect)="deselection($event)">
+<si-tabset-next>
   @for (tab of tabs; track tab) {
     <si-tab-next
       [active]="tab.active ?? false"

--- a/src/app/examples/si-tabs/si-tabs-next.ts
+++ b/src/app/examples/si-tabs/si-tabs-next.ts
@@ -4,11 +4,7 @@
  */
 import { Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import {
-  SiTabNextComponent,
-  SiTabNextDeselectionEvent,
-  SiTabsetNextComponent
-} from '@siemens/element-ng/tabs-next';
+import { SiTabNextComponent, SiTabsetNextComponent } from '@siemens/element-ng/tabs-next';
 import { LOG_EVENT } from '@siemens/live-preview';
 
 interface TabModel {
@@ -55,12 +51,6 @@ export class SampleComponent {
       badgeContent: '2'
     }
   ];
-
-  deselection(e: SiTabNextDeselectionEvent): void {
-    if (e.target.heading() === 'Deselectable' && !this.deselectable) {
-      e.cancel();
-    }
-  }
 
   closeTab(tab: TabModel): void {
     this.tabs.splice(


### PR DESCRIPTION
Using this event in application is pointless.
1. It only works with normal tabs. (but one can also subscribe when using routed tabs)
2. There is a much better option available by listening to the tabs directly.
3. The name is really poor, the main event is an active tab change.
4. It only notifies by user interaction, so one cannot use this to generally track the status.
5. preventing a tab activation violates a11y, is not a typical tab behavior and just in general a very bad approach

Since this is a next component, we can just drop it without a breaking change note.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
