### PR TITLE
refactor(form): replace flex wrap with block layout in si-form-item for improved structure

### DIFF
--- a/playwright/snapshots/si-pills-input.spec.ts-snapshots/si-pills-input--si-pills-input-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-pills-input.spec.ts-snapshots/si-pills-input--si-pills-input-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:927e573fc9dc0414c9b4bbfac8bf4d86ab5d65db7174d1d3ce24a988e8b9dabd
-size 17945
+oid sha256:1d5428acbbfb692f7fd71291a1105f0f05e3f3c1c766a54effd5793906b5eeb7
+size 17615

--- a/playwright/snapshots/si-pills-input.spec.ts-snapshots/si-pills-input--si-pills-input-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-pills-input.spec.ts-snapshots/si-pills-input--si-pills-input-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe1ba41e5b14edb6042b31fdeb6a1cc83ae1bbf911e1b1a45b1d78d718e685ac
-size 17551
+oid sha256:354a8097a756dc52021889bd78f9e1de80aebf6e610a8a0af68bc7d155a334a2
+size 17179

--- a/projects/element-ng/form/si-form-item/si-form-item.component.html
+++ b/projects/element-ng/form/si-form-item/si-form-item.component.html
@@ -1,71 +1,56 @@
-@if (!fieldControl()?.isFormCheck) {
+<!--Block the space if no form-field is provided. Otherwise it looks weird in the formly field inline representation.-->
+@if (fieldControl()?.isFormCheck && !fieldset) {
+  <div class="form-label"></div>
+}
+@if (fieldControl()?.isFormCheck) {
+  <div class="form-item-content">
+    <ng-container [ngTemplateOutlet]="content" />
+    <ng-container [ngTemplateOutlet]="labelTemplate" />
+    <ng-container [ngTemplateOutlet]="feedbackTemplate" />
+  </div>
+} @else {
+  <ng-container [ngTemplateOutlet]="labelTemplate" />
+  <div class="form-item-content">
+    <ng-container [ngTemplateOutlet]="content" />
+    <ng-container [ngTemplateOutlet]="feedbackTemplate" />
+  </div>
+}
+
+<ng-template #labelTemplate>
   @if (label()) {
     @let labeledBy = formItemLabelledBy;
     @if (labeledBy) {
       <span
-        class="text-break form-label"
+        class="text-break"
         [id]="labeledBy"
+        [class.form-label]="!fieldControl()?.isFormCheck"
+        [class.form-check-label]="fieldControl()?.isFormCheck"
         [class.required]="required() && !this.fieldset?.hasOnlyRadios()"
-        >{{ label() | translate }}</span
+        >{{ label()! | translate }}</span
       >
     } @else {
-      <label class="text-break form-label" [for]="formItemId" [class.required]="required()">{{
-        label() | translate
-      }}</label>
+      <label
+        class="text-break"
+        [for]="formItemId"
+        [class.form-label]="!fieldControl()?.isFormCheck"
+        [class.form-check-label]="fieldControl()?.isFormCheck"
+        [class.required]="required() && !this.fieldset?.hasOnlyRadios()"
+        >{{ label()! | translate }}</label
+      >
     }
   }
-  <div class="form-item-content">
-    <ng-container [ngTemplateOutlet]="content" />
-    @if (printErrors() && !fieldset?.hasOnlyRadios()) {
-      <div class="invalid-feedback" [attr.id]="formItemErrormessageId">
-        @for (error of errors(); track error.key) {
-          <div>
-            {{ error.message | translate: error.params }}
-          </div>
-        }
-      </div>
-    }
-  </div>
-} @else {
-  <!--Block the space if no form-field is provided. Otherwise it looks weird.-->
-  @if (!fieldset) {
-    <div class="form-label"></div>
-  }
-  <div class="form-item-content">
-    <ng-container [ngTemplateOutlet]="checkbox" />
-    @if (label()) {
-      @let labeledBy = formItemLabelledBy;
-      @if (labeledBy) {
-        <span
-          class="text-break form-check-label"
-          [id]="labeledBy"
-          [class.required]="required() && !this.fieldset?.hasOnlyRadios()"
-          >{{ label()! | translate }}</span
-        >
-      } @else {
-        <label
-          class="text-break form-check-label"
-          [for]="formItemId"
-          [class.required]="required() && !this.fieldset?.hasOnlyRadios()"
-          >{{ label()! | translate }}</label
-        >
+</ng-template>
+<ng-template #feedbackTemplate>
+  @if (printErrors() && !fieldset?.hasOnlyRadios()) {
+    <div class="invalid-feedback" [attr.id]="formItemErrormessageId">
+      @for (error of errors(); track error.key) {
+        <div>
+          {{ error.message | translate: error.params }}
+        </div>
       }
-    }
-    <ng-container [ngTemplateOutlet]="content" />
-    @if (printErrors() && !fieldset?.hasOnlyRadios()) {
-      <div class="invalid-feedback" [attr.id]="formItemErrormessageId">
-        @for (error of errors(); track error.key) {
-          <div>
-            {{ error.message | translate: error.params }}
-          </div>
-        }
-      </div>
-    }
-  </div>
-}
-
-<ng-template #checkbox>
-  <ng-content select="input[type='checkbox'], input[type='radio']" />
+    </div>
+  }
+  <ng-content select=".warning-feedback, .info-feedback, .invalid-feedback" />
 </ng-template>
 <ng-template #content>
   <ng-content />

--- a/projects/element-ng/form/si-form.shared.scss
+++ b/projects/element-ng/form/si-form.shared.scss
@@ -4,16 +4,12 @@
 @use '@siemens/element-theme/src/styles/all-variables';
 
 :host.si-form-input {
-  margin-block-end: map.get(all-variables.$spacers, 5);
   display: flex;
   flex-direction: column;
+  margin-block-end: map.get(all-variables.$spacers, 5);
 
   .form-item-content {
-    flex: 1 1 0;
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap; // this is to ensure validation feedback gets placed underneath
-    position: relative; // this is to ensure validation tooltips are positioned correctly
+    flex-grow: 1;
   }
 }
 
@@ -23,7 +19,7 @@
 
 // maintain compatibility with the old style of si-form-item which allows wrapping multiple checkbox
 :host(.form-check) {
-  :host-context(si-form-fieldset) &:not(.form-check-inline) {
+  &:not(.form-check-inline) {
     display: block;
   }
 
@@ -38,9 +34,14 @@
 :host-context(.si-container-lg),
 :host-context(.si-container-xl),
 :host-context(.si-container-xxl) {
-  flex-direction: row;
+  :host.si-form-input {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
 
   .form-label {
+    align-self: start;
     padding-block: all-variables.add(
       all-variables.$input-padding-y,
       all-variables.$input-border-width


### PR DESCRIPTION
Switch si-form-item from flex wrap to a block-based layout to enhance consistency and maintainability across form elements.

The change enable the use of paddings / margins for checkboxes and radio buttons.

**Prerequisite:** https://github.com/siemens/element/pull/446

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
