### PR TITLE
fix(live-preview): change initialization order to fix locale change loop

### DIFF
--- a/projects/live-preview/components/si-live-preview-wrapper/si-live-preview-wrapper.component.ts
+++ b/projects/live-preview/components/si-live-preview-wrapper/si-live-preview-wrapper.component.ts
@@ -61,8 +61,6 @@ export class SiLivePreviewWrapperComponent {
   private webcomponentService = inject(SiLivePreviewWebComponentService, { optional: true });
 
   constructor() {
-    this.sendMessage('ready');
-
     this.themeApi
       ?.getApplicationThemeObservable()
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -81,6 +79,9 @@ export class SiLivePreviewWrapperComponent {
       });
     this.initialUrl = window.location.toString();
     this.isMobile = this.internalConfig.isMobile;
+
+    // send ready message only when locale/theme are communicated to avoid loops
+    this.sendMessage('ready');
 
     this.ngZone.runOutsideAngular(() =>
       fromEvent<MessageEvent>(window, 'message')


### PR DESCRIPTION
This prevents loops when the client apps fully reloads, e.g. language switching

Fixes #451

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
