### PR TITLE
refactor(tabs-next): remove unused `activeTabIndex`

### DIFF
--- a/projects/element-ng/tabs-next/si-tab-next.component.ts
+++ b/projects/element-ng/tabs-next/si-tab-next.component.ts
@@ -38,11 +38,7 @@ export class SiTabNextComponent extends SiTabNextBaseDirective implements OnDest
 
   /** @internal */
   override selectTab(retainFocus?: boolean): void {
-    const tabs = this.tabset.tabPanels();
-    const currentTabIndex = this.tabset.activeTabIndex();
-    const currentTab = tabs[currentTabIndex];
-
-    currentTab?.deSelectTab();
+    this.tabset.activeTab()?.deSelectTab();
     this.active.set(true);
     super.selectTab(retainFocus);
   }

--- a/projects/element-ng/tabs-next/si-tabset-next.component.ts
+++ b/projects/element-ng/tabs-next/si-tabset-next.component.ts
@@ -51,8 +51,6 @@ export class SiTabsetNextComponent {
   readonly activeTab = computed(() => {
     return this.tabPanels().find(tab => tab.active());
   });
-  /** @internal */
-  readonly activeTabIndex = computed(() => this.activeTab()?.index() ?? -1);
 
   readonly tabPanels = contentChildren(SiTabNextBaseDirective);
 


### PR DESCRIPTION
The index is no longer needed, so just dropping it.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
