### PR TITLE
refactor(element-translate-ng): make $localize pure

### DIFF
--- a/projects/element-translate-ng/ngx-translate/si-translate-ngxt.service.ts
+++ b/projects/element-translate-ng/ngx-translate/si-translate-ngxt.service.ts
@@ -71,7 +71,7 @@ export class SiTranslateNgxTService extends SiTranslateService {
     if (Array.isArray(keys) && !keys.length) {
       return of({} as TranslationResult<T>);
     }
-    return this.ngxTranslateService.stream(keys, params);
+    return this.ngxTranslateService.stream(this.extractDefaultTranslations(keys), params);
   }
 
   override translateAsync<T extends string | string[]>(
@@ -81,7 +81,7 @@ export class SiTranslateNgxTService extends SiTranslateService {
     if (Array.isArray(keys) && !keys.length) {
       return of({} as TranslationResult<T>);
     }
-    return this.ngxTranslateService.stream(keys, params);
+    return this.ngxTranslateService.stream(this.extractDefaultTranslations(keys), params);
   }
 
   override translateSync<T extends string | string[]>(
@@ -91,11 +91,30 @@ export class SiTranslateNgxTService extends SiTranslateService {
     if (Array.isArray(keys) && !keys.length) {
       return {} as TranslationResult<T>;
     }
-    return this.ngxTranslateService.instant(keys, params);
+    return this.ngxTranslateService.instant(this.extractDefaultTranslations(keys), params);
   }
 
   override setTranslation(key: string, value: string): void {
     this.defaultTranslations[key] = value;
+  }
+
+  private extractDefaultTranslations(value: string | string[]): string | string[] {
+    const parsed = this.parseTranslatableString(value);
+    if (Array.isArray(parsed)) {
+      return parsed.map(item => {
+        if (typeof item !== 'string') {
+          this.setTranslation(item.key, item.value);
+          return item.key;
+        }
+        return item;
+      });
+    } else {
+      if (typeof parsed !== 'string') {
+        this.setTranslation(parsed.key, parsed.value);
+        return parsed.key;
+      }
+      return parsed;
+    }
   }
 
   private handleMissingTranslation(params: MissingTranslationHandlerParams): string {

--- a/projects/element-translate-ng/translate/si-localize.spec.ts
+++ b/projects/element-translate-ng/translate/si-localize.spec.ts
@@ -26,11 +26,8 @@ describe('siLocalize', () => {
   });
 
   it('should resolve $localize calls', () => {
-    TestBed.inject(TestService); // we don't need a reference to this
-    const translatableMock = TestBed.inject(
-      SiTranslatableService
-    ) as jasmine.SpyObj<SiTranslatableService>;
-    expect(translatableMock.resolveText).toHaveBeenCalledWith('without', 'without-default');
-    expect(translatableMock.resolveText).toHaveBeenCalledWith('with', 'with-default');
+    const service = TestBed.inject(TestService);
+    expect(service.withDescription).toEqual(':with-desc@@with:with-default');
+    expect(service.withoutDescription).toEqual(':@@without:without-default');
   });
 });

--- a/projects/element-translate-ng/translate/si-localize.ts
+++ b/projects/element-translate-ng/translate/si-localize.ts
@@ -2,11 +2,9 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { inject } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate-types';
 
 import { globalScope } from './global.scope';
-import { SiTranslatableService } from './si-translatable.service';
 
 // an alternative implementation for $localize meant to be used for translation frameworks other than @angular/localize
 const $localize = (strings: TemplateStringsArray, ...expressions: string[]): TranslatableString => {
@@ -16,17 +14,42 @@ const $localize = (strings: TemplateStringsArray, ...expressions: string[]): Tra
     );
   }
 
-  const firstPart = strings[0];
-  const [, key, value] = /:.*?@@(.*?):(.*)/.exec(firstPart)!;
+  // No zone.js loaded (zoneless).
+  // We can assume that this is the new style of $localize call, which just gets a plain string.
+  if (!('Zone' in globalScope)) {
+    return strings[0];
+  }
 
-  return Zone.current.get('siResolveLocalize')(key, value);
+  if (Zone.current.get('siResolveLocalizeNew')) {
+    // This is the new style of $localize call, which just gets a plain string.
+    return Zone.current.get('siResolveLocalize')(strings[0]);
+  } else {
+    // Seems like this was provided by an older version of @siemens/element-ng.
+    // So we need to parse the string here already and call it with the key and value.
+    const [, key, value] = /:.*?@@(.*?):(.*)/.exec(strings[0])!;
+    return Zone.current.get('siResolveLocalize')(key, value);
+  }
 };
 
-const siResolveLocalize = (key: string, value: string): TranslatableString =>
-  inject(SiTranslatableService).resolveText(key, value);
+const siResolveLocalize = (key: string, value?: string): TranslatableString => {
+  if (value) {
+    // This is the old style of $localize call, which has a key and a value.
+    // It is called with two params, if an older version of @siemens/element-ng patched the global scope.
+    return `:@@${key}:${value}`;
+  } else {
+    return key;
+  }
+};
 
-// Always register in the current zone. This is needed in MFE setups, where $localize is already patched.
-(Zone.current as any)._properties.siResolveLocalize = siResolveLocalize;
+// If no zone.js is loaded, we cannot set any properties.
+// So the app must use the new $localize implementation.
+// As with the older version, we did not support zoneless.
+if ('Zone' in globalScope) {
+  // Always register in the current zone. This is needed in MFE setups, where $localize is already patched.
+  (Zone.current as any)._properties.siResolveLocalize = siResolveLocalize;
+  // Flag this as the new implementation of $localize, so that we can distinguish it from the old one.
+  (Zone.current as any)._properties.siResolveLocalizeNew = true;
+}
 
 // Patch $localize in the global scope if it was not already patched by ourselves or Angular.
 // The default $localize function by Angular just throws an error.

--- a/projects/element-translate-ng/translate/si-no-translate.service.ts
+++ b/projects/element-translate-ng/translate/si-no-translate.service.ts
@@ -52,9 +52,18 @@ export class SiNoTranslateService extends SiTranslateService {
   override translate<T extends string | string[]>(
     keys: T,
     _params?: Record<string, unknown>
+  ): TranslationResult<T> | Observable<TranslationResult<T>> {
+    return this.translateSync(keys, _params);
+  }
+
+  override translateSync<T extends string | string[]>(
+    keys: T,
+    _params?: Record<string, unknown>
   ): TranslationResult<T> {
     const translateKey = (key: string): string => {
-      return _params ? replacePlaceholders(key, _params) : key;
+      const parsed = this.parseTranslatableString(key);
+      const value = typeof parsed === 'string' ? parsed : parsed.value;
+      return _params ? replacePlaceholders(value, _params) : value;
     };
 
     if (typeof keys === 'string') {
@@ -65,17 +74,10 @@ export class SiNoTranslateService extends SiTranslateService {
     }
   }
 
-  override translateSync<T extends string | string[]>(
-    keys: T,
-    params?: Record<string, unknown>
-  ): TranslationResult<T> {
-    return this.translate(keys, params);
-  }
-
   override translateAsync<T extends string | string[]>(
     keys: T,
     params?: Record<string, unknown>
   ): Observable<TranslationResult<T>> {
-    return of(this.translate(keys, params));
+    return of(this.translateSync(keys, params));
   }
 }

--- a/projects/element-translate-ng/translate/si-translate.service.ts
+++ b/projects/element-translate-ng/translate/si-translate.service.ts
@@ -119,6 +119,30 @@ export abstract class SiTranslateService {
   ): TranslationResult<T>;
 
   /**
+   * Parses a TranslatableString.
+   *
+   * @returns - An object if the string was a translatable string, otherwise the original string.
+   */
+  protected parseTranslatableString(value: string): { key: string; value: string } | string;
+  protected parseTranslatableString(value: string[]): ({ key: string; value: string } | string)[];
+  protected parseTranslatableString(
+    value: string | string[]
+  ): ({ key: string; value: string } | string)[] | ({ key: string; value: string } | string);
+  protected parseTranslatableString(
+    value: string | string[]
+  ): ({ key: string; value: string } | string)[] | ({ key: string; value: string } | string) {
+    if (Array.isArray(value)) {
+      return value.map(v => this.parseTranslatableString(v));
+    } else {
+      const parsed = /:.*?@@(.*?):(.*)/.exec(value);
+      if (parsed) {
+        return { key: parsed[1], value: parsed[2] };
+      }
+      return value;
+    }
+  }
+
+  /**
    * If supported by the underlying translation library, this method can be used to add a translation for a specific key.
    * It is intended to be used for adding the english default value.
    * It will be called whenever a key within element is resolved.


### PR DESCRIPTION
This effectively drops parsing and any injection
in `$localize` turning it into a pure function.

In addition, code is added trying to make this
as compatible as possible.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
