### PR TITLE
test(auto-collapsible-list): work around broken ResizeObserver on Chrome headless

### DIFF
--- a/karma.shared.cjs
+++ b/karma.shared.cjs
@@ -16,7 +16,7 @@ const browsers =
     : headless
       ? isFirefox
         ? ['FirefoxHeadless']
-        : ['ChromeHeadless']
+        : ['ChromeHeadlessBigger']
       : isFirefox
         ? ['Firefox']
         : ['Chrome'];
@@ -67,6 +67,12 @@ module.exports.buildConfig = (config, { name, testSuite }) => ({
   colors: true,
   logLevel: config.LOG_INFO,
   autoWatch: !isCI,
+  customLaunchers: {
+    ChromeHeadlessBigger: {
+      base: 'ChromeHeadless',
+      flags: ['--window-size=1024,768']
+    }
+  },
   browsers,
   singleRun: isCI,
   browserNoActivityTimeout: 100000


### PR DESCRIPTION
In new headless mode, ResizeObserver takes a long time to fire, delays of 1000ms seem to work, the previous 200ms don't. Firefox is ok. Since this is not testing the behaviour of the service, just mock to updates like in other specs.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
