### PR TITLE
refactor(typescript): use stricter path mappings

### DIFF
--- a/projects/element-ng/datepicker/testing/si-datepicker.harness.ts
+++ b/projects/element-ng/datepicker/testing/si-datepicker.harness.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { ComponentHarness, HarnessPredicate, TestElement } from '@angular/cdk/testing';
-import { ToggleHarness } from '@siemens/element-ng/testing/toggle.harness';
+import { ToggleHarness } from '@siemens/element-ng/testing';
 
 import { SiCalendarCellHarness, SiCalendarCellHarnessFilters } from './si-calendar-cell.harness';
 

--- a/projects/element-ng/testing/index.ts
+++ b/projects/element-ng/testing/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+export * from './toggle.harness';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,19 +22,16 @@
     "isolatedModules": true,
     "paths": {
       "@siemens/element-ng": ["projects/element-ng/public-api.ts"],
-      "@siemens/element-ng/*": ["projects/element-ng/*"],
-      "@siemens/element-translate-ng": ["dist/@siemens/element-translate-ng/public-api.ts"],
+      "@siemens/element-ng/*": ["projects/element-ng/*/index.ts"],
+      "@siemens/element-translate-ng": ["dist/@siemens/element-translate-ng"],
       "@siemens/element-translate-ng/*": ["dist/@siemens/element-translate-ng/*"],
       "@siemens/live-preview": ["projects/live-preview/public-api.ts"],
-      "@siemens/live-preview/*": ["projects/live-preview/*"],
-      "@siemens/charts-ng": ["projects/charts-ng/src/public-api.ts", "projects/charts-ng"],
-      "@siemens/native-charts-ng": [
-        "projects/native-charts-ng/public-api.ts",
-        "projects/native-charts-ng"
-      ],
+      "@siemens/live-preview/*": ["projects/live-preview/*/index.ts"],
+      "@siemens/charts-ng": ["projects/charts-ng/src/public-api.ts"],
+      "@siemens/native-charts-ng": ["projects/native-charts-ng/public-api.ts"],
       "@siemens/native-charts-ng/*": ["projects/native-charts-ng/*/index.ts"],
       "@siemens/dashboards-ng": ["projects/dashboards-ng/src/public-api.ts"],
-      "@siemens/dashboards-ng/*": ["projects/dashboards-ng/*"]
+      "@siemens/dashboards-ng/*": ["projects/dashboards-ng/*/index.ts"]
     }
   },
   "exclude": ["dist/**", "testing/**/*.ts"],


### PR DESCRIPTION
This ensures that even during development,
only valid paths are accepted.
Previously paths like this worked as well:
`@siemens/element-ng/entrypoint/file-in-entrypoint.ts`.

Since we have the convention that every entry-point has an `index.ts` we can enforce using it.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
