### PR TITLE
test(playwright): improve si-select e2e test to remove flakiness

### DIFF
--- a/playwright/e2e/element-examples/si-select.spec.ts
+++ b/playwright/e2e/element-examples/si-select.spec.ts
@@ -45,25 +45,46 @@ test.describe('si-select', () => {
   test(example + ' with filter', async ({ page, si }) => {
     await si.visitExample(example);
 
-    await page.locator('.form-check-inline').nth(2).click();
+    await page.getByRole('checkbox', { name: 'With filter' }).check();
+    const formControlSelect = page.getByRole('combobox', { name: 'FormControl' });
+    await formControlSelect.click();
 
-    await page.locator('si-select').nth(1).click();
+    const selectFormControlInput = page.getByRole('combobox', { name: 'FormControl' }).nth(1);
+    await expect(selectFormControlInput).toBeFocused();
+    await expect(selectFormControlInput).toHaveAttribute('aria-expanded', 'true');
+    await expect(formControlSelect.first()).toContainClass('active');
+
     await si.runVisualAndA11yTests('filter-opened');
-    await page.locator('*:focus').first().pressSequentially('Bad');
+    await selectFormControlInput.pressSequentially('Bad');
     await page.keyboard.press('ArrowDown');
     await si.runVisualAndA11yTests('filter-searched');
     await page.keyboard.press('Enter');
     await si.runVisualAndA11yTests('filter-selected');
 
-    await page.locator('si-select').nth(1).click();
-    await page.locator('*:focus').first().pressSequentially('no-value-found', { delay: 100 });
+    await formControlSelect.click();
+    await expect(selectFormControlInput).toBeFocused();
+    await expect(selectFormControlInput).toHaveAttribute('aria-expanded', 'true');
+    await expect(formControlSelect.first()).toContainClass('active');
+
+    await selectFormControlInput.pressSequentially('no-value-found');
     await si.runVisualAndA11yTests('filter-no-value-found');
     await page.locator('.cdk-overlay-backdrop').click({ position: { x: 0, y: 0 }, force: true });
 
-    await page.locator('si-select').nth(5).click();
-    await page.locator('*:focus').first().pressSequentially('New option');
+    const selectWithActions = page.getByRole('combobox', { name: 'Select with actions' });
+    await selectWithActions.click();
+
+    const selectInputWithActions = page
+      .getByRole('combobox', { name: 'Select with actions' })
+      .nth(1);
+    await expect(selectInputWithActions).toBeFocused();
+    await expect(selectInputWithActions).toHaveAttribute('aria-expanded', 'true');
+    await expect(selectWithActions.first()).toContainClass('active');
+
+    await selectInputWithActions.pressSequentially('New option');
     await si.runVisualAndA11yTests('actions-search');
-    await page.locator('[aria-label="create"]').click();
+    await page.getByRole('button', { name: 'create' }).click();
+    await selectInputWithActions.focus();
+    await page.keyboard.press('Backspace');
     await si.runVisualAndA11yTests('actions-option-created');
   });
 

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--actions-option-created-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--actions-option-created-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5a2382f7f58b8c8290d0db2ba591e9f3a6fa7d1c53aba6d258d4d3c80570aa7
-size 16572
+oid sha256:7733039e088dd371c5959018a19f80d4e676b3784d61be47a50b97c13a6fa25e
+size 18620

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--actions-option-created-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--actions-option-created-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:69dca85ee8993ae1da40db677a7e7d989790fcc364310da15cafb72da396bbec
-size 16242
+oid sha256:de083d107200758576df93998991a6ae0c008400255d4a66699187c3e0bd0654
+size 18214

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--actions-option-created.yaml
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--actions-option-created.yaml
@@ -19,17 +19,7 @@
 - text: With filter
 - combobox "Select with actions" [expanded]
 - listbox "Select with actions":
-  - option "Value 1" [selected]
-  - option "Value 2"
-  - option "Value 3" [selected]
-  - option "Value 4"
-  - option "Value 5"
-  - option "Value 6"
-  - option "Value 7"
-  - option "Value 8"
-  - option "Value 9"
-  - option /Value \d+/
-  - option /Value \d+/
   - option "New option"
 - button "clear": Clear selection
+- button "create": Create "New optio" item
 - button "close": Close


### PR DESCRIPTION
Currently, `si-select` e2e test with filters are flaky, these changes will make it stable

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
