### PR TITLE
fix(dashboards): prevent footer button focus ring from being clipped

### DIFF
--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.scss
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.scss
@@ -32,3 +32,11 @@
     margin-inline-start: map.get(variables.$spacers, 6);
   }
 }
+
+/* Need to override parent style to prevent clipping of focus rings on footer buttons */
+::ng-deep {
+  .si-dashboard-content {
+    padding-block: 4px;
+    margin-block: -4px;
+  }
+}


### PR DESCRIPTION
on flexible dashboard while adding widget focus ring of footer buttons are not fully visible from bottom.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
