### PR TITLE
docs(list-details): simplify example

### DIFF
--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--first-details-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--first-details-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c44e4e5f4aa0dffe3338e824ea0ef8460f43508fac2997a6fb2cc0dad8015f2
-size 49201
+oid sha256:b88d4652c4000e0175ee18c63c9443f2d707910adcc816b2ab380525dde8c4ff
+size 49224

--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--first-details-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--first-details-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cab99f7b819f51f1b8b0ade2da5d2bab907e3f33a6bd9af95be1795da42cf7c1
-size 46277
+oid sha256:2667346ae1b4f0697270717ec0badf658c70d0118d3079b3733e13a550c6debd
+size 46245

--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--resized-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--resized-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:847f1287dea8a9ecea7c4a8c74f1a28277a032fbc5fccc1fa64d7247ed4883b5
-size 46058
+oid sha256:8513725bba1da0c582a0f94cd5a93b9c8eb24c3d98c3e5274a6f3f7f25a18078
+size 46245

--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--resized-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--resized-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e24a450cbeb8d244e96461538f90369c278bdfbf790c45a741f50a97965b9a70
-size 43139
+oid sha256:20c142260c400372a01f3bd41b10c1a38be50b0f4e29c3d5b97f56e63c91bf8d
+size 43280

--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--second-details-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--second-details-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec619bab6a6d7ca597491c793b085c7e3f55238ebe4c93570ea6624afbeb8d5d
-size 48805
+oid sha256:6d213f4b69025f81c1baadfd0a72665ffa8214d36c05d1118ff97b6d1b4b9960
+size 48827

--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--second-details-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--second-details-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cfcefe015c00951f457c7f4b50cf1422591fd9282bc74e9e71ece6f08919dbe5
-size 45824
+oid sha256:83c387a111aced03562e9599e9d982c95620fa7f7ff4190cd1d8f4b6b886be66
+size 45793

--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--small-viewport-first-details-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--small-viewport-first-details-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a508908e0ed6fd4a49a1afc6c10e8ca48da17e9114f09a924315d14c127a2514
-size 15701
+oid sha256:a815d10c6a59718d661f80ac514c4d80bb6d963a691bd4e77637040090e8409e
+size 15481

--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--small-viewport-first-details-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--small-viewport-first-details-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:83296f322de90c0697bd552b843ea2e0c4bf098a4f65e9beeab1aaa58d0c1b1f
-size 15106
+oid sha256:4457062d71e82bc6f5b8e562f10f66dcd22a53a0fb24fe94c047dadfeba04c50
+size 15105

--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--small-viewport-second-details-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--small-viewport-second-details-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca5c44db9e544bcf65166c16b0086c4fd747825d0e79267612792a95432f1460
-size 15500
+oid sha256:3723cd175276763e4c45f9fd645ccab1990a8c7028ff447adf972a50845cbeff
+size 15254

--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--small-viewport-second-details-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details--small-viewport-second-details-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e386804b651aa7adc297d7db5a4356737cdc8ab6b07c00d29e53456cd2efcd83
-size 14925
+oid sha256:901b494abbdf2dda61f56505428d31942be5d188a03a9c8aeac9f49787b8e246
+size 14924

--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5460bf199a2d8382dbae6760266dadfe3d9d23fd98950d881c24546f37eb10f0
-size 45417
+oid sha256:725ad14d47ce697b8165904934afdc01454cfdf5b80610167f926015f16f224d
+size 45433

--- a/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-list-details.spec.ts-snapshots/si-list-details--si-list-details-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:949c166c97f76c0ab650d805e4df53f460e32d95ddd49dddc4be0b2b7b3fb6c2
-size 42323
+oid sha256:813678794f64834093ce906b37d0b786f5d669331a79fafecb4bea9192cbcab9
+size 42287

--- a/src/app/examples/si-list-details/si-list-details.html
+++ b/src/app/examples/si-list-details/si-list-details.html
@@ -79,23 +79,10 @@
   </si-list-pane>
   <si-details-pane class="card">
     <si-details-pane-header title="Title" [hideBackButton]="false">
-      <si-tabset
-        style="width: 0"
-        class="flex-grow-1 flex-shrink-1"
-        [(selectedTabIndex)]="selectedTabIndex"
-        (selectedTabIndexChange)="logEvent($event)"
-      >
-        @for (tab of tabs; track tab) {
-          <si-tab
-            [badgeColor]="tab.badgeColor"
-            [badgeContent]="tab.badgeContent"
-            [closable]="tab.closable"
-            [heading]="tab.heading"
-            [icon]="tab.icon"
-            [iconAltText]="tab.iconAltText"
-            (closeTriggered)="closeTab(tab)"
-          />
-        }
+      <si-tabset style="width: 0" class="flex-grow-1 flex-shrink-1">
+        <si-tab heading="Overview" />
+        <si-tab heading="History" />
+        <si-tab heading="Advanced" [disabled]="true" />
       </si-tabset>
       <si-menu-bar>
         <si-menu-item icon="element-edit" (triggered)="logEvent('editing')">Edit</si-menu-item>

--- a/src/app/examples/si-list-details/si-list-details.ts
+++ b/src/app/examples/si-list-details/si-list-details.ts
@@ -34,16 +34,6 @@ import { NgxDatatableModule } from '@siemens/ngx-datatable';
 
 import { CorporateEmployee, DataService, PageRequest } from '../datatable/data.service';
 
-interface TabModel {
-  heading: string;
-  closable?: boolean;
-  disabled?: boolean;
-  icon?: string;
-  iconAltText?: string;
-  badgeColor?: string;
-  badgeContent?: string;
-}
-
 @Component({
   selector: 'app-sample',
   imports: [
@@ -147,23 +137,6 @@ export class SampleComponent {
       action: () => this.logEvent('Edit triggered')
     }
   ];
-
-  selectedTabIndex = 0;
-
-  tabs: TabModel[] = [
-    { heading: 'Overview' },
-    {
-      heading: 'History'
-    },
-    {
-      heading: 'Advanced',
-      disabled: true
-    }
-  ];
-
-  closeTab(tab: TabModel): void {
-    this.tabs.splice(this.tabs.indexOf(tab), 1);
-  }
 
   onDiscard(): void {
     this.logEvent('Discard');


### PR DESCRIPTION
Inline the tabs to increase readability of the example. Since the focus is here on the list-details and not on tabs, we should keep it as simple as possible.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
