### PR TITLE
chore(docs): add micro charts to API docs

### DIFF
--- a/projects/native-charts-ng/docs.ts
+++ b/projects/native-charts-ng/docs.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+
+export * from './micro-bar';
+export * from './micro-donut';
+export * from './micro-line';
+export * from './micro-progress';

--- a/projects/native-charts-ng/tsconfig.docs.json
+++ b/projects/native-charts-ng/tsconfig.docs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "files": ["./docs.ts"]
+}


### PR DESCRIPTION
Currently the API docs aren't working for the [micro charts](https://element.siemens.io/components/charts/micro-charts/#simicrobarcomponent-api-documentation).

An alternative solution would be to add the mico chart components to the files:
- `projects/native-charts-ng/public-api.ts`
- `projects/native-charts-ng/public-api.module.ts`

Seeing that we are not using the public-api nor a global module approach for `element-ng` either I think the current solution is better than the alternative approach.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
