### PR TITLE
build(release): fix broken pattern in maintenance branches

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -5,7 +5,7 @@ export default {
   branches: [
     {
       name: 'maintenance/+([0-9])?(.{+([0-9]),x}).x',
-      channel: "${name.replace(/^maintenance\\\\//g, '')}"
+      channel: "${name.replace(/^maintenance\\//g, '')}"
     },
     'main',
     {


### PR DESCRIPTION
Prepares the usage of maintenance release. This config bug is already resolved on main.

Otherwise maintenance release work https://www.npmjs.com/package/@spike-rabbit/element-ng?activeTab=versions

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
