### PR TITLE
build(release): use release branches instead of maintenance branches

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -4,8 +4,8 @@ import { commitTypes, releaseRules } from './tools/semantic-release/config.js';
 export default {
   branches: [
     {
-      name: 'maintenance/+([0-9])?(.{+([0-9]),x}).x',
-      channel: "${name.replace(/^maintenance\\//g, '')}"
+      name: 'release/+([0-9])?(.{+([0-9]),x}).x',
+      channel: "${name.replace(/^release\\//g, '')}"
     },
     'main',
     {


### PR DESCRIPTION
This change was already done on main.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
