### PR TITLE
build(semantic-release): fix scope for hidden commit types with notes

### DIFF
--- a/tools/semantic-release/writer-opts.js
+++ b/tools/semantic-release/writer-opts.js
@@ -28,12 +28,13 @@ function transform(commit) {
 
   if (hiddenTypes.has(commit.type)) {
     if (normalizedNotes.length > 0) {
-      normalizedNotes.map(note => ({
+      const transformedNotes = normalizedNotes.map(note => ({
+        ...note,
         text: `${commit.scope ? `**${commit.scope}:** ` : ''}${note.text}`
       }));
       // Add to the hiddenTypeCommitNotes if there are notes and the type is hidden
       // The notes will be added to the context in finalizeContext
-      hiddenTypeCommitNotes.push(...normalizedNotes);
+      hiddenTypeCommitNotes.push(...transformedNotes);
     }
     return;
   }


### PR DESCRIPTION
Commits with hidden types with notes were not showing their scope, because .map() does not modify the original array and the return value was ignored.

> The term **notes** in the context of semantic release means all options like `NOTE:`, `DEPRECATED:` or `BREAKING CHANGE:`. See the example of the missing scopes in the [v48.0.0-next.1 release changelog](https://github.com/siemens/element/releases/tag/v48.0.0-next.1)

To test this locally the **Testing** section of the original [semantic release pr](https://github.com/siemens/element/pull/28#issue-3083160081) will explain everything.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
