### PR TITLE
feat(tree-view): remove `SiTreeViewComponent.disableFilledIcons` input

### DIFF
--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de0d1782b5b6a728d59e49233ae0ac51c07935a8be0b1ac2a02ecf783ce2577f
-size 16213
+oid sha256:af1cdc9c68b418b2aa6780045e8ebb8de8b4fa1c780e607f565202051f1183e9
+size 16279

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4b5cc2ac0957145e4290112f2b93928093fced7fe62665e39f71835c3ceb54a
-size 15525
+oid sha256:30ed537f31de7abaf85f4869aea398a353a6791fe208765eea451d449e1d9d75
+size 15568

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-checkbox-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-checkbox-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b881dacbf0f56249fcf5a6d58f8e0c58df9c2dc19f1b64ed3aabe0434a42fa73
-size 16474
+oid sha256:51d98f2fd8ff64d9340af85fa3a5317a1090ed8b3c36636236a155415a018c34
+size 16558

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-checkbox-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-checkbox-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:547dddd408ef02b7c3c64ee8f70b570cf3b1e17f61c9336f1cc48a2e8abea212
-size 15808
+oid sha256:34984f3c454d45f4a722e39cb92e6d38241c5b4c84a8017a973d6bad0ebe1cb3
+size 15857

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-checkbox.yaml
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-checkbox.yaml
@@ -1,24 +1,24 @@
 - tree "Company locations":
-  - treeitem "Company1  Company1" [expanded] [level=1]:
+  - treeitem "Company1 Company1" [expanded] [level=1]:
     - checkbox "Company1"
     - heading "Company1" [level=5]
-  - treeitem "Milano  Milano MIL" [level=2]:
+  - treeitem "Milano Milano MIL" [level=2]:
     - checkbox "Milano" [disabled]
     - heading "Milano" [level=5]
     - paragraph: MIL
-  - treeitem "Chicago  Chicago CHI" [level=2]:
+  - treeitem "Chicago Chicago CHI" [level=2]:
     - checkbox "Chicago"
     - heading "Chicago" [level=5]
     - paragraph: CHI
-  - treeitem "Pune  Pune PUN" [level=2] [selected]:
+  - treeitem "Pune Pune PUN" [level=2] [selected]:
     - checkbox "Pune"
     - heading "Pune" [level=5]
     - paragraph: PUN
-  - treeitem "Zug  Zug ZG" [level=2]:
+  - treeitem "Zug Zug ZG" [level=2]:
     - checkbox "Zug"
     - heading "Zug" [level=5]
     - paragraph: ZG
-  - treeitem "Company2  Company2 GG" [level=1]:
+  - treeitem "Company2 Company2 GG" [level=1]:
     - checkbox "Company2"
     - heading "Company2" [level=5]
     - paragraph: GG
@@ -63,9 +63,7 @@
 - checkbox "Apply class .tree-sm (32px row height)"
 - text: Apply class .tree-sm (32px row height)
 - checkbox "Apply class .tree-xs (24px row height)"
-- text: Apply class .tree-xs (24px row height)
-- checkbox "Disable filled icons"
-- text: Disable filled icons Number of leaf items
+- text: Apply class .tree-xs (24px row height) Number of leaf items
 - spinbutton "Number of leaf items"
 - text: Number of folder items
 - spinbutton "Number of folder items"

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-data-field-2-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-data-field-2-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a436dd3d4a8595317dfc4ffd2fd3279f61ce016f3c0dc516aae481a20701ddf6
-size 20504
+oid sha256:0f65f7880e02eeeea84b33e8f93802c18296a618edcfd2d35be158eb1ac2f5ef
+size 20568

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-data-field-2-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-data-field-2-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0dbce014c643474dfa1714c060478f84e4e8ca10ea9d586c6e34ca337999b049
-size 19361
+oid sha256:90280a8c3b877bf8130d9689f5002c4d948e0222f2dcf859e9280e7183ee9bcd
+size 19403

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-data-field-2.yaml
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree-with-data-field-2.yaml
@@ -1,21 +1,21 @@
 - tree "Company locations":
-  - treeitem " Company1 Smart Infrastructure" [expanded] [level=1]:
+  - treeitem "Company1 Smart Infrastructure" [expanded] [level=1]:
     - heading "Company1" [level=5]
     - paragraph: Smart Infrastructure
-  - treeitem " Milano MIL Details" [level=2]:
+  - treeitem "Milano MIL Details" [level=2]:
     - heading "Milano" [level=5]
     - paragraph: MIL
     - paragraph: Details
-  - treeitem " Chicago CHI" [level=2]:
+  - treeitem "Chicago CHI" [level=2]:
     - heading "Chicago" [level=5]
     - paragraph: CHI
-  - treeitem " Pune PUN" [level=2] [selected]:
+  - treeitem "Pune PUN" [level=2] [selected]:
     - heading "Pune" [level=5]
     - paragraph: PUN
-  - treeitem " Zug ZG" [level=2]:
+  - treeitem "Zug ZG" [level=2]:
     - heading "Zug" [level=5]
     - paragraph: ZG
-  - treeitem " Company2 GG We don't care about your privacy" [level=1]:
+  - treeitem "Company2 GG We don't care about your privacy" [level=1]:
     - heading "Company2" [level=5]
     - paragraph: GG
     - paragraph: We don't care about your privacy
@@ -60,9 +60,7 @@
 - checkbox "Apply class .tree-sm (32px row height)"
 - text: Apply class .tree-sm (32px row height)
 - checkbox "Apply class .tree-xs (24px row height)"
-- text: Apply class .tree-xs (24px row height)
-- checkbox "Disable filled icons"
-- text: Disable filled icons Number of leaf items
+- text: Apply class .tree-xs (24px row height) Number of leaf items
 - spinbutton "Number of leaf items"
 - text: Number of folder items
 - spinbutton "Number of folder items"

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree.yaml
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--base-tree.yaml
@@ -1,19 +1,19 @@
 - tree "Company locations":
-  - treeitem " Company1" [expanded] [level=1]:
+  - treeitem "Company1" [expanded] [level=1]:
     - heading "Company1" [level=5]
-  - treeitem " Milano MIL" [level=2]:
+  - treeitem "Milano MIL" [level=2]:
     - heading "Milano" [level=5]
     - paragraph: MIL
-  - treeitem " Chicago CHI" [level=2]:
+  - treeitem "Chicago CHI" [level=2]:
     - heading "Chicago" [level=5]
     - paragraph: CHI
-  - treeitem " Pune PUN" [level=2] [selected]:
+  - treeitem "Pune PUN" [level=2] [selected]:
     - heading "Pune" [level=5]
     - paragraph: PUN
-  - treeitem " Zug ZG" [level=2]:
+  - treeitem "Zug ZG" [level=2]:
     - heading "Zug" [level=5]
     - paragraph: ZG
-  - treeitem " Company2 GG" [level=1]:
+  - treeitem "Company2 GG" [level=1]:
     - heading "Company2" [level=5]
     - paragraph: GG
 - text: A complex example that allows playing with various settings of a si-tree-view.
@@ -57,9 +57,7 @@
 - checkbox "Apply class .tree-sm (32px row height)"
 - text: Apply class .tree-sm (32px row height)
 - checkbox "Apply class .tree-xs (24px row height)"
-- text: Apply class .tree-xs (24px row height)
-- checkbox "Disable filled icons"
-- text: Disable filled icons Number of leaf items
+- text: Apply class .tree-xs (24px row height) Number of leaf items
 - spinbutton "Number of leaf items"
 - text: Number of folder items
 - spinbutton "Number of folder items"

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--expand-collapse-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--expand-collapse-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ee6a5fb31a0053e153bd7b0eb5b5f4c47f57b48f6e92dc97a6cec556a9282f4
-size 16810
+oid sha256:a76d6a607422b634b8cd0bb870a310f6a2228a9a747b851cb7380057a934bb7b
+size 16875

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--expand-collapse-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--expand-collapse-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47fde50a29708e5d18cf32427e98f476fbeba124e219b879bcb88f5982daa210
-size 16065
+oid sha256:b5bb18782006cff034ef238fe3a4ce13bcf10feb02a7b74a7dcfc168baeae920
+size 16105

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--expand-collapse.yaml
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--expand-collapse.yaml
@@ -1,21 +1,21 @@
 - button ""
 - button ""
 - tree "Company locations":
-  - treeitem " Company1" [expanded] [level=1]:
+  - treeitem "Company1" [expanded] [level=1]:
     - heading "Company1" [level=5]
-  - treeitem " Milano MIL" [level=2]:
+  - treeitem "Milano MIL" [level=2]:
     - heading "Milano" [level=5]
     - paragraph: MIL
-  - treeitem " Chicago CHI" [level=2]:
+  - treeitem "Chicago CHI" [level=2]:
     - heading "Chicago" [level=5]
     - paragraph: CHI
-  - treeitem " Pune PUN" [level=2] [selected]:
+  - treeitem "Pune PUN" [level=2] [selected]:
     - heading "Pune" [level=5]
     - paragraph: PUN
-  - treeitem " Zug ZG" [level=2]:
+  - treeitem "Zug ZG" [level=2]:
     - heading "Zug" [level=5]
     - paragraph: ZG
-  - treeitem " Company2 GG" [level=1]:
+  - treeitem "Company2 GG" [level=1]:
     - heading "Company2" [level=5]
     - paragraph: GG
 - text: A complex example that allows playing with various settings of a si-tree-view.
@@ -59,9 +59,7 @@
 - checkbox "Apply class .tree-sm (32px row height)"
 - text: Apply class .tree-sm (32px row height)
 - checkbox "Apply class .tree-xs (24px row height)"
-- text: Apply class .tree-xs (24px row height)
-- checkbox "Disable filled icons"
-- text: Disable filled icons Number of leaf items
+- text: Apply class .tree-xs (24px row height) Number of leaf items
 - spinbutton "Number of leaf items"
 - text: Number of folder items
 - spinbutton "Number of folder items"

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--flat-tree-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--flat-tree-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff12efad2351b6f452d527e94c02089a26ae695c8ae98c2cd439b6bb26186823
-size 13775
+oid sha256:de3443dc9bd5e2d73a820371c73ef6532415e799b95c4a793a43358731df8da7
+size 13845

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--flat-tree-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--flat-tree-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:080d8931555288c4ae45169cdd8a039c635f61e7ce429dc0bd5aa616f46bcbcf
-size 13208
+oid sha256:3cd3bf1071637c1f05eca9431068ef3d6b8de2ef89269a9f2bca4f6f87c3e6be
+size 13252

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--flat-tree.yaml
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--flat-tree.yaml
@@ -1,15 +1,15 @@
 - text:   Company1
 - tree "Company locations":
-  - treeitem " Milano MIL" [level=2]:
+  - treeitem "Milano MIL" [level=2]:
     - heading "Milano" [level=5]
     - paragraph: MIL
-  - treeitem " Chicago CHI" [level=2]:
+  - treeitem "Chicago CHI" [level=2]:
     - heading "Chicago" [level=5]
     - paragraph: CHI
-  - treeitem " Pune PUN" [level=2] [selected]:
+  - treeitem "Pune PUN" [level=2] [selected]:
     - heading "Pune" [level=5]
     - paragraph: PUN
-  - treeitem " Zug ZG" [level=2]:
+  - treeitem "Zug ZG" [level=2]:
     - heading "Zug" [level=5]
     - paragraph: ZG
 - text: A complex example that allows playing with various settings of a si-tree-view.
@@ -53,9 +53,7 @@
 - checkbox "Apply class .tree-sm (32px row height)"
 - text: Apply class .tree-sm (32px row height)
 - checkbox "Apply class .tree-xs (24px row height)"
-- text: Apply class .tree-xs (24px row height)
-- checkbox "Disable filled icons"
-- text: Disable filled icons Number of leaf items
+- text: Apply class .tree-xs (24px row height) Number of leaf items
 - spinbutton "Number of leaf items"
 - text: Number of folder items
 - spinbutton "Number of folder items"

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--grouped-tree-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--grouped-tree-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6c91225770a56af2edfcaf02d9ddabe6ef690829c707af53161c937973578a5
-size 14617
+oid sha256:c7ffe62d2c8bbbfa0c72344e28341b731e1ecafdbdf924efc435570755a68722
+size 14689

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--grouped-tree-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--grouped-tree-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aed5123e015d50c20a017f09cb9868a41e39af5d6dc7d8c46dd89d43a77a4166
-size 14000
+oid sha256:567cf72e0ba34d6cb182795ecc40ca8955cfbffe2985c3c440936f129725be85
+size 14042

--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--grouped-tree.yaml
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--grouped-tree.yaml
@@ -1,16 +1,16 @@
 - tree "Company locations":
   - treeitem "Company1" [expanded] [level=1]:
     - paragraph: Company1
-  - treeitem " Milano MIL" [level=2]:
+  - treeitem "Milano MIL" [level=2]:
     - heading "Milano" [level=5]
     - paragraph: MIL
-  - treeitem " Chicago CHI" [level=2]:
+  - treeitem "Chicago CHI" [level=2]:
     - heading "Chicago" [level=5]
     - paragraph: CHI
-  - treeitem " Pune PUN" [level=2] [selected]:
+  - treeitem "Pune PUN" [level=2] [selected]:
     - heading "Pune" [level=5]
     - paragraph: PUN
-  - treeitem " Zug ZG" [level=2]:
+  - treeitem "Zug ZG" [level=2]:
     - heading "Zug" [level=5]
     - paragraph: ZG
   - treeitem "Company2" [level=1]:
@@ -56,9 +56,7 @@
 - checkbox "Apply class .tree-sm (32px row height)"
 - text: Apply class .tree-sm (32px row height)
 - checkbox "Apply class .tree-xs (24px row height)"
-- text: Apply class .tree-xs (24px row height)
-- checkbox "Disable filled icons"
-- text: Disable filled icons Number of leaf items
+- text: Apply class .tree-xs (24px row height) Number of leaf items
 - spinbutton "Number of leaf items"
 - text: Number of folder items
 - spinbutton "Number of folder items"

--- a/playwright/snapshots/static.spec.ts-snapshots/si-tree-view--si-tree-view.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-tree-view--si-tree-view.yaml
@@ -1,7 +1,7 @@
 - tree "Company locations":
-  - treeitem " Company1 SI" [level=1]:
+  - treeitem "Company1 SI" [level=1]:
     - heading "Company1" [level=5]
     - paragraph: SI
-  - treeitem " Company2 GG" [level=1]:
+  - treeitem "Company2 GG" [level=1]:
     - heading "Company2" [level=5]
     - paragraph: GG

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.html
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.html
@@ -55,7 +55,7 @@
       >
         @if (showIcon()) {
           <div class="si-tree-stretch-center">
-            <span class="si-tree-view-item-icon" [ngClass]="getIconClass()"></span>
+            <si-icon class="si-tree-view-item-icon" [icon]="treeItem.icon!" />
           </div>
         }
         <div

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
@@ -22,6 +22,7 @@ import {
   viewChild
 } from '@angular/core';
 import { correctKeyRTL, MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
+import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiLoadingSpinnerComponent } from '@siemens/element-ng/loading-spinner';
 import { MenuItem, SiMenuFactoryComponent } from '@siemens/element-ng/menu';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
@@ -50,6 +51,7 @@ import {
     CdkMenuTrigger,
     NgClass,
     NgTemplateOutlet,
+    SiIconComponent,
     SiLoadingSpinnerComponent,
     SiMenuFactoryComponent,
     SiTranslatePipe
@@ -281,20 +283,6 @@ export class SiTreeViewItemComponent
       }
     }
     return '';
-  }
-
-  /**
-   * Show icon if the item is selected.
-   * Per default the `filled` icon is used, this can be configured using {@link disableFilledIcons}.
-   **/
-  protected getIconClass(): string {
-    let iconClass = this.treeItem.icon;
-    if (this.treeItem.selected && this.treeItem.selectable && this.enableSelection()) {
-      iconClass =
-        iconClass +
-        (!this.treeViewComponent.disableFilledIcons() ? ' ' + iconClass + '-filled' : '');
-    }
-    return iconClass ?? '';
   }
 
   protected getStateIndicatorColor(): string {

--- a/projects/element-ng/tree-view/si-tree-view.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.spec.ts
@@ -53,7 +53,6 @@ import { LoadChildrenEventArgs, TreeItem } from './si-tree-view.model';
     [pagesVirtualized]="pagesVirtualized"
     [horizontalScrolling]="horizontalScrolling"
     [deleteChildrenOnCollapse]="deleteChildrenOnCollapse"
-    [disableFilledIcons]="disableFilledIcons"
     [expandCollapseAll]="expandCollapseAll"
     (loadChildren)="loadChildren($event)"
   />`,
@@ -107,7 +106,6 @@ class WrapperComponent {
   pageSize?: number = 10;
   pagesVirtualized?: number = 6;
   horizontalScrolling = false;
-  disableFilledIcons = false;
   deleteChildrenOnCollapse = false;
   expandCollapseAll = false;
   cdRef = inject(ChangeDetectorRef);
@@ -161,7 +159,8 @@ describe('SiTreeViewComponent', () => {
 
   it('should contain set items', () => {
     fixture.detectChanges();
-    expect(debugElement.query(By.css('.si-tree-view-item-icon.element-project'))).toBeTruthy();
+    const icon = debugElement.query(By.css('.si-tree-view-item-icon'));
+    expect(icon.attributes['data-icon']).toBe('element-project');
   });
 
   it('should contain folder state start', () => {
@@ -1104,25 +1103,18 @@ describe('SiTreeViewComponent', () => {
     });
 
     it('should display icons', fakeAsync(() => {
-      expect(debugElement.queryAll(By.css('span.si-tree-view-item-icon')).length).toBe(10);
+      expect(
+        debugElement.queryAll(By.css('.si-tree-view-item-icon :not(.si-tree-view-menu-btn)')).length
+      ).toBe(10);
     }));
 
     it('should hide icons', fakeAsync(() => {
       component.enableIcon = false;
       component.cdRef.markForCheck();
       fixture.detectChanges();
-      expect(debugElement.queryAll(By.css('span.si-tree-view-item-icon')).length).toBe(0);
-    }));
-
-    it('should display filled icons', fakeAsync(() => {
-      expect(element.querySelector('span.sample-icon-filled')).toBeTruthy();
-    }));
-
-    it('should not display filled icons if disabled', fakeAsync(() => {
-      component.disableFilledIcons = true;
-      component.cdRef.markForCheck();
-      fixture.detectChanges();
-      expect(element.querySelector('span.sample-icon-filled')).toBeNull();
+      expect(
+        debugElement.queryAll(By.css('.si-tree-view-item-icon :not(.si-tree-view-menu-btn)')).length
+      ).toBe(0);
     }));
   });
 

--- a/projects/element-ng/tree-view/si-tree-view.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.ts
@@ -200,13 +200,6 @@ export class SiTreeViewComponent
   });
 
   /**
-   * Whether "filled" icons should not be used when a tree item is selected.
-   * Per default filled icons are used when available.
-   * @defaultValue false
-   */
-  readonly disableFilledIcons = input(false, { transform: booleanAttribute });
-
-  /**
    * Sets if the folder state icon shall be shown on the left (in LTR) or on the right (in LTR) side
    * of the tree item. Per default the icon will be shown on the left (in LTR). Has no
    * effect if flatTree is enabled.

--- a/src/app/examples/si-tree-view/si-tree-view-playground.html
+++ b/src/app/examples/si-tree-view/si-tree-view-playground.html
@@ -28,7 +28,6 @@
       [items]="treeItems"
       [expandOnClick]="expandOnClick"
       [expandCollapseAll]="showExpandCollapseAll"
-      [disableFilledIcons]="disableFilledIcons"
       (treeItemFolderClicked)="logEvent('treeItemFolderClicked', $event.treeItem.label)"
       (treeItemFolderStateChanged)="logEvent('treeItemFolderStateChanged', $event.treeItem.label)"
       (treeItemClicked)="logEvent('treeItemClicked', $event.label)"
@@ -99,9 +98,6 @@
     </si-form-item>
     <si-form-item label="Apply class .tree-xs (24px row height)">
       <input type="checkbox" class="form-check-input" [(ngModel)]="classTreeXs" />
-    </si-form-item>
-    <si-form-item label="Disable filled icons">
-      <input type="checkbox" class="form-check-input" [(ngModel)]="disableFilledIcons" />
     </si-form-item>
     <si-form-item class="col-3" label="Number of leaf items">
       <si-number-input

--- a/src/app/examples/si-tree-view/si-tree-view-playground.ts
+++ b/src/app/examples/si-tree-view/si-tree-view-playground.ts
@@ -236,7 +236,6 @@ export class SampleComponent {
   classTreeXs = false;
   expandOnClick = false;
   showExpandCollapseAll = false;
-  disableFilledIcons = false;
   readonly menuItems: MenuItemAction[] = [
     {
       type: 'action',


### PR DESCRIPTION
BREAKING CHANGE: Removed `SiTreeViewComponent.disableFilledIcons` input.

Tree items no longer show a filled icon on selection.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
