### PR TITLE
fix(list-details): make back button outline complete on focus

### DIFF
--- a/projects/element-ng/list-details/si-details-pane-header/si-details-pane-header.component.scss
+++ b/projects/element-ng/list-details/si-details-pane-header/si-details-pane-header.component.scss
@@ -28,6 +28,10 @@
     }
   }
 
+  .si-details-header-back {
+    isolation: isolate; // Otherwise the bottom outline of the button is not visible on focus without hover.
+  }
+
   ::ng-deep si-menu-bar si-menu-item {
     block-size: auto;
     margin-block-end: 2px; // So it's centered with the bottom line


### PR DESCRIPTION
Need a new stacking context so the focus outline of the back button also shows when not hovering

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
