### PR TITLE
fix(list-details): hide empty header

### DIFF
--- a/projects/element-ng/list-details/si-details-pane-header/si-details-pane-header.component.html
+++ b/projects/element-ng/list-details/si-details-pane-header/si-details-pane-header.component.html
@@ -1,19 +1,22 @@
-<div class="title-subgroup">
-  @if (!hasLargeSize() && !hideBackButton()) {
-    <button
-      #backButton
-      type="button"
-      class="si-details-header-back nav-link focus-inside px-6 pe-5"
-      (click)="backClicked()"
-      ><span
-        class="pe-2 d-inline-block position-relative element-back icon"
-        aria-hidden="true"
-      ></span
-      >{{ backButtonText() | translate }}</button
-    >
-  }
-  @if (title()) {
-    <span class="si-details-header-title nav-link px-6 pe-5">{{ title() | translate }}</span>
-  }
-</div>
+@if ((!hasLargeSize() && !hideBackButton()) || title()) {
+  <div class="title-subgroup">
+    @if (!hasLargeSize() && !hideBackButton()) {
+      <button
+        #backButton
+        type="button"
+        class="si-details-header-back nav-link focus-inside px-6 pe-5"
+        (click)="backClicked()"
+        ><span
+          class="pe-2 d-inline-block position-relative element-back icon"
+          role="img"
+          aria-hidden="true"
+        ></span
+        >{{ backButtonText() | translate }}</button
+      >
+    }
+    @if (title()) {
+      <span class="si-details-header-title nav-link px-6 pe-5">{{ title() | translate }}</span>
+    }
+  </div>
+}
 <ng-content />

--- a/projects/element-ng/list-details/si-details-pane-header/si-details-pane-header.component.scss
+++ b/projects/element-ng/list-details/si-details-pane-header/si-details-pane-header.component.scss
@@ -6,6 +6,10 @@
   inline-size: 100%;
   overflow: hidden;
 
+  &:empty {
+    display: none;
+  }
+
   &,
   .title-subgroup {
     display: flex;


### PR DESCRIPTION
Currently the height is fixed (inherited from nav-tab) and the border is always shown, but if there is no content and no title and we're in desktop mode (not mobile), we should completely hide it.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
