### PR TITLE
fix(list-details): prevent overflow

### DIFF
--- a/projects/element-ng/list-details/si-details-pane-body/si-details-pane-body.component.scss
+++ b/projects/element-ng/list-details/si-details-pane-body/si-details-pane-body.component.scss
@@ -4,4 +4,5 @@
   flex-direction: column;
   justify-content: space-between;
   max-inline-size: 100%;
+  overflow-y: auto;
 }

--- a/projects/element-ng/list-details/si-list-pane-body/si-list-pane-body.component.scss
+++ b/projects/element-ng/list-details/si-list-pane-body/si-list-pane-body.component.scss
@@ -4,4 +4,5 @@
   flex-direction: column;
   justify-content: space-between;
   max-inline-size: 100%;
+  overflow-y: auto;
 }


### PR DESCRIPTION
Currently, if a user fails to handle overflow themselves in either the list or details, it creates a buggy scrolling behavior, which is confusing for the user to figure out and solve. Adding overflow-y: auto to the two body components should not have any side effects (still works for flex layout or if there's a nested scrollable) but prevent this weird behavior.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
