### PR TITLE
build(dashboards-demo): remove extraWebpackConfig from build configurations

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -646,12 +646,10 @@
           },
           "configurations": {
             "development": {
-              "buildTarget": "dashboards-demo-mfe:build:development",
-              "extraWebpackConfig": "projects/dashboards-demo/mfe/webpack.prod.config.cjs"
+              "buildTarget": "dashboards-demo-mfe:build:development"
             },
             "production": {
-              "buildTarget": "dashboards-demo-mfe:build:production",
-              "extraWebpackConfig": "projects/dashboards-demo/mfe/webpack.prod.config.cjs"
+              "buildTarget": "dashboards-demo-mfe:build:production"
             }
           },
           "defaultConfiguration": "development"


### PR DESCRIPTION
Currently, when we try to build mfe project in dashboards-demo build fails due to missing webpack config file. This change will add that file.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
