### PR TITLE
refactor(form): use same spacing/line-height as in figma

### DIFF
--- a/projects/element-theme/src/styles/bootstrap/forms/_form-label.scss
+++ b/projects/element-theme/src/styles/bootstrap/forms/_form-label.scss
@@ -13,8 +13,8 @@
 
 .form-label {
   display: inline-block;
-  line-height: 0.875rem;
-  padding-block: map.get(spacers.$spacers, 3) map.get(spacers.$spacers, 2);
+  // As designed in figma --> diverging from the standard spacers
+  padding-block: 5px 3px;
 
   .text-end & {
     padding-inline-end: variables.$input-padding-x;


### PR DESCRIPTION
This is a preparation for the help pattern where we need the line-height of 16px (default).

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
