### PR TITLE
fix(filtered-search): multi select options should call the lazyValueProvider on input event

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
@@ -438,6 +438,23 @@ describe('SiFilteredSearchComponent', () => {
       await newCriteriaValue!.focus();
       expect(component.lazyValueProvider).toHaveBeenCalledWith('location', '');
     });
+
+    it('should show selected criterion on label click', async () => {
+      component.criteria.set([
+        {
+          name: 'location',
+          label: 'Location',
+          multiSelect: true
+        }
+      ]);
+      component.searchCriteria.set({ criteria: [{ name: 'location', value: ['Bar'] }], value: '' });
+      const filteredSearch = await loader.getHarness(SiFilteredSearchHarness);
+      const criteria = await filteredSearch.getCriteria();
+      await criteria[0].clickLabel();
+      const criteriaValue = await criteria[0].value();
+      await criteriaValue?.click();
+      expect(await criteriaValue?.getItemLabels({ isSelected: true })).toEqual(['Bar']);
+    });
   });
 
   describe('with lazy loaded values and optiontype as return type', () => {

--- a/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.html
+++ b/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.html
@@ -32,5 +32,6 @@
     (keydown.backspace)="valueBackspace()"
     (keydown.enter)="valueEnter()"
     (typeaheadOnSelect)="valueTypeaheadSelect($event)"
+    (typeaheadOnInput)="inputChange.next($event)"
   />
 }

--- a/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.ts
+++ b/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.ts
@@ -83,18 +83,16 @@ export class SiFilteredSearchMultiSelectComponent
 
   protected override buildOptions(): Observable<TypeaheadOptionCriterion[]> | undefined {
     const translatedOptions = super.buildOptions();
-    if (this.definition().options) {
-      return translatedOptions?.pipe(
-        switchMap(options =>
-          this.selectionChange!.pipe(
-            tap(value => selectOptions(options, value)),
-            map(() => options)
-          )
+    return translatedOptions?.pipe(
+      switchMap(options =>
+        this.selectionChange!.pipe(
+          tap(value => {
+            selectOptions(options, value);
+          }),
+          map(() => options)
         )
-      );
-    } else {
-      return translatedOptions;
-    }
+      )
+    );
   }
 
   protected processTypeaheadOptions(options: TypeaheadOptionCriterion[]): void {

--- a/src/app/examples/si-filtered-search/si-filtered-search-lazy-values.html
+++ b/src/app/examples/si-filtered-search/si-filtered-search-lazy-values.html
@@ -11,7 +11,7 @@
     [disableFreeTextSearch]="disableFreeTextSearch"
     [criteria]="[
       { name: 'company', label: 'Company' },
-      { name: 'location', label: 'Location' },
+      { name: 'location', label: 'Location', multiSelect: true },
       { name: 'country', label: 'Country' }
     ]"
     [lazyValueProvider]="filteredSearch.lazyValueProvider"

--- a/src/app/examples/si-filtered-search/si-filtered-search-playground.html
+++ b/src/app/examples/si-filtered-search/si-filtered-search-playground.html
@@ -74,6 +74,7 @@
         [maxCriteria]="configForm.value.maxCriteria"
         [maxCriteriaOptions]="configForm.value.maxCriteriaOptions!"
         (doSearch)="logEvent('doSearch:', $event)"
+        (searchCriteriaChange)="logEvent('searchCriteriaChange:', $event)"
       />
     </div>
   </div>


### PR DESCRIPTION
 
This PR fixes two issue:
1. In case of multiselect lazyvalue - when the criteria is predefined and user opens the pill, the selection is lost
2. multi select option should call the lazyvalue provider incase of custom input
---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
