### PR TITLE
refactor(form): use `col-form-label` in inline mode

### DIFF
--- a/projects/element-ng/form/form-fieldset/si-form-fieldset.component.html
+++ b/projects/element-ng/form/form-fieldset/si-form-fieldset.component.html
@@ -1,4 +1,9 @@
-<div class="form-label d-flex gap-2">
+<div
+  class="d-flex gap-2"
+  [class.form-label]="!container?.isInline()"
+  [class.col-form-label]="container?.isInline()"
+  [class.py-1]="container?.isInline()"
+>
   <span [class.required]="isRequired()" [id]="labelId">{{ label() | translate }}</span>
   <ng-content select="[si-help-button]" />
 </div>

--- a/projects/element-ng/form/form-fieldset/si-form-fieldset.component.ts
+++ b/projects/element-ng/form/form-fieldset/si-form-fieldset.component.ts
@@ -9,11 +9,13 @@ import {
   computed,
   DoCheck,
   HostBinding,
+  inject,
   input,
   signal
 } from '@angular/core';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
+import { SiFormContainerComponent } from '../si-form-container/si-form-container.component';
 import { SiFormItemComponent } from '../si-form-item/si-form-item.component';
 
 @Component({
@@ -78,6 +80,8 @@ export class SiFormFieldsetComponent implements DoCheck {
 
   @HostBinding('attr.aria-labelledby')
   protected labelId = `__si-form-fieldset-label-${SiFormFieldsetComponent.labelIdCounter++}`;
+
+  protected container = inject(SiFormContainerComponent, { optional: true });
 
   ngDoCheck(): void {
     this.touched.set(this.formItems().some(item => item.ngControl()?.touched));

--- a/projects/element-ng/form/si-form-container/si-form-container.component.ts
+++ b/projects/element-ng/form/si-form-container/si-form-container.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, Component, computed, inject, input } from '@angular/core';
+import { booleanAttribute, Component, computed, inject, input, viewChild } from '@angular/core';
 import { AbstractControl, FormGroup } from '@angular/forms';
 import { Breakpoints, SiResponsiveContainerDirective } from '@siemens/element-ng/resize-observer';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -115,6 +115,18 @@ export class SiFormContainerComponent<TControl extends { [K in keyof TControl]: 
     return {
       ...customMapper
     };
+  });
+
+  private readonly responsiveContainer = viewChild(SiResponsiveContainerDirective);
+
+  /** @internal */
+  readonly isInline = computed(() => {
+    const responsiveContainer = this.responsiveContainer();
+    if (responsiveContainer) {
+      return !responsiveContainer.xs();
+    } else {
+      return false;
+    }
   });
 
   /**

--- a/projects/element-ng/form/si-form-item/si-form-item.component.html
+++ b/projects/element-ng/form/si-form-item/si-form-item.component.html
@@ -1,6 +1,6 @@
 <!--Block the space if no form-field is provided. Otherwise it looks weird in the formly field inline representation.-->
-@if (fieldControl()?.isFormCheck && !fieldset) {
-  <div class="form-label"></div>
+@if (fieldControl()?.isFormCheck && !fieldset && container?.isInline()) {
+  <div class="col-form-label"></div>
 }
 @if (fieldControl()?.isFormCheck) {
   <div class="form-item-content">
@@ -20,7 +20,8 @@
   @if (label()) {
     <div
       class="d-flex gap-2"
-      [class.form-label]="!fieldControl()?.isFormCheck"
+      [class.form-label]="!fieldControl()?.isFormCheck && !container?.isInline()"
+      [class.col-form-label]="!fieldControl()?.isFormCheck && container?.isInline()"
       [class.form-check-label]="fieldControl()?.isFormCheck"
     >
       @let labeledBy = formItemLabelledBy;

--- a/projects/element-ng/form/si-form.shared.scss
+++ b/projects/element-ng/form/si-form.shared.scss
@@ -28,40 +28,15 @@
   }
 }
 
-/// ACCOUNT FOR MEASURED CONTAINERS
-:host-context(.si-container-sm),
-:host-context(.si-container-md),
-:host-context(.si-container-lg),
-:host-context(.si-container-xl),
-:host-context(.si-container-xxl) {
-  :host.si-form-input {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-  }
+:host:has(.col-form-label) {
+  // We need important here to override the fallback checkbox not inline style.
+  display: flex !important; // stylelint-disable-line declaration-no-important
+  flex-direction: row;
+  align-items: center;
+}
 
-  .form-label {
-    align-self: start;
-    padding-block: all-variables.add(
-      all-variables.$input-padding-y,
-      all-variables.$input-border-width
-    );
-    padding-inline: map.get(all-variables.$spacers, 6);
-    inline-size: var(--si-form-label-width, math.percentage(math.div(2, 12)));
-    line-height: all-variables.$input-line-height;
-
-    &:empty {
-      display: block;
-    }
-  }
-
-  :host-context(si-form-fieldset) .form-label {
-    padding-block: map.get(all-variables.$spacers, 1) 0;
-  }
-
-  :host(.form-check) {
-    .form-label {
-      padding-block: 2px;
-    }
-  }
+.col-form-label {
+  align-self: start;
+  padding-inline: map.get(all-variables.$spacers, 6);
+  inline-size: var(--si-form-label-width, math.percentage(math.div(2, 12)));
 }

--- a/projects/element-ng/form/testing/si-form-fieldset.harness.ts
+++ b/projects/element-ng/form/testing/si-form-fieldset.harness.ts
@@ -24,7 +24,7 @@ export class SiFormFieldsetHarness extends ComponentHarness {
     );
   }
 
-  private readonly getLabelElement = this.locatorFor('.form-label');
+  private readonly getLabelElement = this.locatorFor('.form-label, .col-form-label');
   private readonly getRequiredIndicator = this.locatorForOptional('.required');
   private readonly getInvalidFeedback = this.locatorForAll('.invalid-feedback div');
 

--- a/projects/element-ng/form/testing/si-form-item.harness.ts
+++ b/projects/element-ng/form/testing/si-form-item.harness.ts
@@ -30,7 +30,7 @@ export class SiFormItemHarness extends ComponentHarness {
     );
   }
 
-  private readonly getLabelElement = this.locatorForOptional('.form-label');
+  private readonly getLabelElement = this.locatorForOptional('.form-label, .col-form-label');
   private readonly getRequiredIndicator = this.locatorForOptional('.required');
   private readonly getFormCheckLabelElement = this.locatorForOptional('.form-check-label');
   private readonly getInvalidFeedback = this.locatorForAll('.invalid-feedback div');


### PR DESCRIPTION
Previously we overrode the `.form-label` when
the form-item was switched to the inline mode.
With this change, we just use the bootstrap standard class.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-609/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-609/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-609/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-609/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-59%25-yellow?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-609/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-609/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->



