### PR TITLE
fix(navbar-vertical): support flexible drop down positioning

### DIFF
--- a/projects/element-ng/navbar-vertical/si-navbar-vertical-group.component.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical-group.component.ts
@@ -23,6 +23,7 @@ import { SI_NAVBAR_VERTICAL } from './si-navbar-vertical.provider';
     :host {
       display: block;
       overflow: hidden;
+      position: static;
     }
   `,
   host: {


### PR DESCRIPTION
The vertical navigation menu didn't support flexible positioning since the `cdk-overlay-pane` size was always 0.

Since the `cdk-overlay-pane` size was always zero, the content of the vertical navbar dropdown was always forced to fit, causing it to incorrectly render in the initial position of the `SiNavbarVerticalGroupTriggerDirective`.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
