### PR TITLE
refactor(examples): adapt type-styles to latest typography definition

### DIFF
--- a/playwright/snapshots/static.spec.ts-snapshots/typography--type-styles-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/typography--type-styles-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0999a01d7bc0d3640a7afa8acc054d1f8cdce861a5caa0b4d8d6d36cdbb1e01f
-size 33835
+oid sha256:d7eef55c13d9f1a1c6114cc1adc0380d16a86fe2ffedb8a1b7bb2b18e59f3246
+size 41601

--- a/playwright/snapshots/static.spec.ts-snapshots/typography--type-styles-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/typography--type-styles-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4adefd279c8416eb8cee039cfb3e525e80eeba15b211f56c850ba252932e7a3b
-size 33883
+oid sha256:76bab6bbaff4cadfcdc953ef07e1c55c4d6711b21b8e42d1b76ac086d1f21541
+size 41921

--- a/playwright/snapshots/static.spec.ts-snapshots/typography--type-styles.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/typography--type-styles.yaml
@@ -1,18 +1,23 @@
 - heading "H1 Heading" [level=1]
-- heading "H1 Heading Black" [level=1]
-- heading "H2 Subheading" [level=2]
-- heading "H3 Subheading" [level=3]
-- paragraph: Title 2
-- paragraph: Body 2
+- heading "H1 Heading Bold" [level=1]
+- heading "H2 Heading" [level=2]
+- heading "H3 Heading" [level=3]
+- heading "H4 Heading" [level=4]
+- heading "H4 Heading Bold" [level=4]
+- heading "H5 Heading" [level=5]
+- heading "H5 Heading Bold" [level=5]
+- paragraph: Body
+- paragraph: Body Bold
+- paragraph: Body Italic
 - separator
 - paragraph: H1 Heading
-- paragraph: H1 Heading Black
-- paragraph: H2 Subheading
-- paragraph: H3 Subheading
-- paragraph: Title 1 Bold
-- paragraph: Title 1
-- paragraph: Body 1
-- paragraph: Title 2 Bold
-- paragraph: Title 2
-- paragraph: Body 2
+- paragraph: H1 Heading Bold
+- paragraph: H2 Heading
+- paragraph: H3 Heading
+- paragraph: H4 Heading
+- paragraph: H4 Heading Bold
+- paragraph: H5 Heading
+- paragraph: H5 Heading Bold
+- paragraph: Body Large
+- paragraph: Body
 - paragraph: Caption

--- a/src/app/examples/typography/type-styles.html
+++ b/src/app/examples/typography/type-styles.html
@@ -1,21 +1,27 @@
 <!-- Default Semantic -->
 <h1>H1 Heading</h1>
-<h1 class="si-h1-bold">H1 Heading Black</h1>
-<h2>H2 Subheading</h2>
-<h3>H3 Subheading</h3>
+<h1 class="si-h1-bold">H1 Heading Bold</h1>
+<h2>H2 Heading</h2>
+<h3>H3 Heading</h3>
+<h4>H4 Heading</h4>
+<h4 class="si-h4-bold">H4 Heading Bold</h4>
+<h5>H5 Heading</h5>
+<h5 class="si-h5-bold">H5 Heading Bold</h5>
 <br />
-<p><b>Title 2</b></p>
-<p>Body 2</p>
+<p>Body</p>
+<p><b>Body Bold</b></p>
+<p><i>Body Italic</i></p>
 
 <!-- Alternative Classes --><hr />
 <p class="si-h1">H1 Heading</p>
-<p class="si-h1-bold">H1 Heading Black</p>
-<p class="si-h2">H2 Subheading</p>
-<p class="si-h3">H3 Subheading</p>
-<p class="si-h4-bold">Title 1 Bold</p>
-<p class="si-h4">Title 1</p>
-<p class="si-body-lg">Body 1</p>
-<p class="si-h5-bold">Title 2 Bold</p>
-<p class="si-h5">Title 2</p>
-<p class="si-body">Body 2</p>
+<p class="si-h1-bold">H1 Heading Bold</p>
+<p class="si-h2">H2 Heading</p>
+<p class="si-h3">H3 Heading</p>
+<p class="si-h4">H4 Heading</p>
+<p class="si-h4-bold">H4 Heading Bold</p>
+<p class="si-h5">H5 Heading</p>
+<p class="si-h5-bold">H5 Heading Bold</p>
+<br />
+<p class="si-body-lg">Body Large</p>
+<p class="si-body">Body</p>
 <p class="si-caption">Caption</p>


### PR DESCRIPTION
Updates the typography semantic for the leftover type-styles example.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
