### PR TITLE
docs(docs-builder): fix component height

### DIFF
--- a/projects/element-docs-builder/md_extension_element_docs/extension.py
+++ b/projects/element-docs-builder/md_extension_element_docs/extension.py
@@ -113,6 +113,7 @@ class ElementExamplePreProcessor(ElementHtmlPreProcessor):
       examples.append([child.get('example'), child.get('heading')])
 
     ## updating element
+    prev_height = element.get('height')
     element.clear()
     element.tag = 'iframe'
     element.set('class', 'component-preview')
@@ -120,7 +121,6 @@ class ElementExamplePreProcessor(ElementHtmlPreProcessor):
     # dev: http://localhost:4200
     encode_object = {'base': examples_base if examples_base else '','e': list(map(lambda x: f'{x[0]};{x[1]}' if len(x) > 1 else x[0], examples))}
     element.set('data-src', f'{self.examples_base}#/viewer/editor?{urlencode(encode_object, doseq=True)}')
-    prev_height = element.get("height")
     element.set('height', f'{int(prev_height if prev_height else 204) + 411}px')
     element.set('width', f'100%')
     element.set('style', 'opacity: 0;')


### PR DESCRIPTION
Fixes the docs-component height.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
