### PR TITLE
test(maps): use dummy fallbacks for color tokens

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -77,6 +77,7 @@ jobs:
       - run: npm run lib:test -- --watch=false --progress=false --code-coverage
       - run: npm run charts:test -- --watch=false --progress=false
       - run: npm run dashboards:test -- --watch=false --progress=false
+      - run: npm run maps:test -- --watch=false --progress=false
       # TODO: Upload coverage reports
 
   aot:

--- a/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
@@ -28,6 +28,25 @@ describe('SiMapComponent', () => {
   let component: SiMapComponent;
   let componentRef: ComponentRef<SiMapComponent>;
 
+  beforeAll(() => {
+    // Define style variables from element.ts to prevent test failures
+    document.documentElement.style.setProperty('--element-status-information', '#0070F2');
+    document.documentElement.style.setProperty('--element-status-success', '#00A04B');
+    document.documentElement.style.setProperty('--element-status-warning', '#FF7F00');
+    document.documentElement.style.setProperty('--element-status-danger', '#D8371C');
+    document.documentElement.style.setProperty('--element-status-caution', '#FFD322');
+    document.documentElement.style.setProperty('--element-status-critical', '#B71E24');
+    document.documentElement.style.setProperty('--element-ui-0', '#0070F2');
+    document.documentElement.style.setProperty('--element-ui-3', '#004987');
+    document.documentElement.style.setProperty('--element-base-1', '#FFFFFF');
+    document.documentElement.style.setProperty('--element-text-primary', '#1F2937');
+    document.documentElement.style.setProperty('--element-data-red-2', '#D8371C');
+    document.documentElement.style.setProperty('--element-data-orange-4', '#FF7F00');
+    document.documentElement.style.setProperty('--element-data-green-2', '#00A04B');
+    document.documentElement.style.setProperty('--element-petrol', '#007C7C');
+    document.documentElement.style.setProperty('--element-data-17', '#004A87');
+  });
+
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [SiMapModule, TranslateModule.forRoot()],


### PR DESCRIPTION
when tests runs they cannot find our tokens and falls back to empty string which openlayer doesn't like and breaks.

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
