### PR TITLE
fix(icon-status): add missing ng-package.json file

### DIFF
--- a/projects/element-ng/icon-status/ng-package.json
+++ b/projects/element-ng/icon-status/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/projects/element-ng/icon-status/si-icon-status.component.ts
+++ b/projects/element-ng/icon-status/si-icon-status.component.ts
@@ -1,7 +1,11 @@
 /**
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
- *
+ */
+import { SiStatusCounterComponent } from '@siemens/element-ng/status-counter';
+
+/**
  * @deprecated Using `SiIconStatusComponent` is deprecated. Use `SiStatusCounterComponent` instead.
  */
-export { SiStatusCounterComponent as SiIconStatusComponent } from '../status-counter';
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const SiIconStatusComponent = SiStatusCounterComponent;

--- a/projects/element-ng/icon-status/si-icon-status.module.ts
+++ b/projects/element-ng/icon-status/si-icon-status.module.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgModule } from '@angular/core';
-
-import { SiStatusCounterComponent } from '../status-counter/si-status-counter.component';
+import { SiStatusCounterComponent } from '@siemens/element-ng/status-counter';
 
 /**
  * @deprecated Using `SiIconStatusModule` and `SiIconStatusComponent` is deprecated. Instead


### PR DESCRIPTION
The PR https://github.com/siemens/element/pull/632 was missing the ng-package.json file for the deprecated module.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
