### PR TITLE
build: include dashboards-demo in semantic-release version updates

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -96,6 +96,12 @@ export default {
         pkgRoot: 'projects/element-translate-cli'
       }
     ],
+    [
+      '@semantic-release/npm',
+      {
+        pkgRoot: 'projects/dashboards-demo'
+      }
+    ],
     // Only update remaining package.json that are not directly published
     [
       '@semantic-release/npm',
@@ -143,6 +149,13 @@ export default {
       '@semantic-release/npm',
       {
         pkgRoot: 'projects/maps-ng',
+        npmPublish: false
+      }
+    ],
+    [
+      '@semantic-release/npm',
+      {
+        pkgRoot: 'projects/dashboards-demo',
         npmPublish: false
       }
     ],

--- a/projects/dashboards-demo/package.json
+++ b/projects/dashboards-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siemens/dashboards-demo",
-  "version": "47.7.0",
+  "version": "48.0.0",
   "description": "Siemens Dashboards demo",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
