### PR TITLE
chore: set OnPush as default change detection strategy for components

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -672,7 +672,8 @@
   "schematics": {
     "@schematics/angular:component": {
       "style": "scss",
-      "type": "component"
+      "type": "component",
+      "changeDetection": "OnPush"
     },
     "@schematics/angular:directive": {
       "type": "directive"


### PR DESCRIPTION
Update angular.json schematics configuration to set OnPush change detection as default for component generation.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
