### PR TITLE
fix(icon): handle undefined icon use case

### DIFF
--- a/projects/element-ng/icon/si-icon.component.ts
+++ b/projects/element-ng/icon/si-icon.component.ts
@@ -120,7 +120,7 @@ export class SiIconComponent {
 
   private camelToKebabCase(str: string): string {
     return str
-      .replace(/([a-z])([A-Z0-9])/g, '$1-$2')
+      ?.replace(/([a-z])([A-Z0-9])/g, '$1-$2')
       .replace(/([0-9])([A-Z])/g, '$1-$2')
       .toLowerCase();
   }

--- a/projects/element-ng/icon/si-icons.ts
+++ b/projects/element-ng/icon/si-icons.ts
@@ -86,6 +86,6 @@ export class IconService {
   }
 
   private kebabToCamelCase(str: string): string {
-    return str.replace(/-./g, match => match.charAt(1).toUpperCase());
+    return str?.replace(/-./g, match => match.charAt(1).toUpperCase());
   }
 }


### PR DESCRIPTION
Reported from a project...
For ex - In side panel content, click on content1 [exapmple](https://element.siemens.io/element-examples/#/viewer/editor?theme=dark&locale=en&t=%0A%3Csi-side-panel%20%23sidePanel%20%5Bcollapsed%5D%3D%22true%22%20%5Bmode%5D%3D%22mode%22%20%5Bsize%5D%3D%22size%22%3E%0A%20%20%3Cdiv%20class%3D%22has-navbar-fixed-top%20px-6%22%3E%0A%20%20%20%20%3Csi-application-header%3E%0A%20%20%20%20%20%20%3Csi-header-brand%3E%0A%20%20%20%20%20%20%20%20%3Ca%20siHeaderLogo%20routerLink%3D%22%2F%22%20class%3D%22d-none%20d-md-flex%22%3E%3C%2Fa%3E%0A%20%20%20%20%20%20%20%20%3Ch1%20class%3D%22application-name%22%3ESide%20panel%20portal%3C%2Fh1%3E%0A%20%20%20%20%20%20%3C%2Fsi-header-brand%3E%0A%20%20%20%20%3C%2Fsi-application-header%3E%0A%20%20%20%20%3Cbr%20%2F%3E%0A%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22btn%20btn-secondary%20mt-2%20ms-2%22%20(click)%3D%22toggle()%22%3E%0A%20%20%20%20%20%20Toggle%20side%20panel%0A%20%20%20%20%3C%2Fbutton%3E%0A%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22btn%20btn-secondary%20mt-2%20ms-2%22%20(click)%3D%22toggleMode()%22%3E%0A%20%20%20%20%20%20%7B%7B%20mode%20%2B%20'%20-%20Mode'%20%7D%7D%0A%20%20%20%20%3C%2Fbutton%3E%0A%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22btn%20btn-secondary%20mt-2%20ms-2%22%20(click)%3D%22changeSize()%22%3E%0A%20%20%20%20%20%20%7B%7B%20size%20%2B%20'%20-%20Width'%20%7D%7D%0A%20%20%20%20%3C%2Fbutton%3E%0A%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22btn%20btn-secondary%20mt-2%20ms-2%22%20(click)%3D%22setContent1()%22%0A%20%20%20%20%20%20%3EContent%201%3C%2Fbutton%0A%20%20%20%20%3E%0A%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22btn%20btn-secondary%20mt-2%20ms-2%22%20(click)%3D%22setContent2()%22%0A%20%20%20%20%20%20%3EContent%202%3C%2Fbutton%0A%20%20%20%20%3E%0A%20%20%20%20%3Chr%20%2F%3E%0A%20%20%20%20%3Cp%3E%0A%20%20%20%20%20%20Hey%20there!%20Lorem%20ipsum%20dolor%2C%20sit%20amet%20consectetur%20adipisicing%20elit.%20Alias%2C%20ab%20ex%20quis%20iste%0A%20%20%20%20%20%20non%20nemo%20delectus%20sequi%20tempore%20nihil%20sit%20ducimus%20illo%20reprehenderit%20saepe%20iusto%20cum%20tenetur%2C%0A%20%20%20%20%20%20voluptatibus%20corrupti%20unde%3F%20Lorem%20ipsum%20dolor%20sit%20amet%20consectetur%20adipisicing%20elit.%20Placeat%0A%20%20%20%20%20%20autem%20ducimus%20minus!%20Ducimus%20qui%20quam%20laborum%20enim%20nihil%2C%20accusantium%20maiores%20inventore%0A%20%20%20%20%20%20aliquam%20laudantium%20eveniet%20reiciendis%20praesentium%20libero%20consectetur%20eum%20eius!%0A%20%20%20%20%3C%2Fp%3E%0A%20%20%3C%2Fdiv%3E%0A%3C%2Fsi-side-panel%3E%0A%0A%3Cng-template%20%23content1%20cdkPortal%3E%0A%20%20%3Csi-side-panel-content%20%5BstatusActions%5D%3D%22%5B%7B%20%7D%5D%22%20heading%3D%22Content%201%22%3E%0A%20%20%20%20%3Csi-accordion%3E%0A%20%20%20%20%20%20%3Csi-collapsible-panel%20heading%3D%22Hey%20there%EF%B8%8F%22%3E%0A%20%20%20%20%20%20%20%20%3Cdiv%20class%3D%22p-6%22%3E%20And%20here%20we%20have%20some%20content%20%3C%2Fdiv%3E%0A%20%20%20%20%20%20%3C%2Fsi-collapsible-panel%3E%0A%20%20%20%20%20%20%3Csi-collapsible-panel%20heading%3D%22Another%20one%22%3E%0A%20%20%20%20%20%20%20%20%3Cdiv%20class%3D%22p-6%22%3E%20And%20this%20is%20the%20content%20%3C%2Fdiv%3E%0A%20%20%20%20%20%20%3C%2Fsi-collapsible-panel%3E%0A%20%20%20%20%20%20%3Csi-collapsible-panel%20heading%3D%22Number%20three%22%3E%0A%20%20%20%20%20%20%20%20%3Cdiv%20class%3D%22p-6%22%3E%20Nothing%20to%20see%20here%20%3C%2Fdiv%3E%0A%20%20%20%20%20%20%3C%2Fsi-collapsible-panel%3E%0A%20%20%20%20%3C%2Fsi-accordion%3E%0A%20%20%3C%2Fsi-side-panel-content%3E%0A%3C%2Fng-template%3E%0A%0A%3Cng-template%20%23content2%20cdkPortal%3E%0A%20%20%3Csi-side-panel-content%20heading%3D%22Content%202%22%3E%0A%20%20%20%20%3Cdiv%20class%3D%22p-6%22%3EDifferent%20content%3C%2Fdiv%3E%0A%20%20%3C%2Fsi-side-panel-content%3E%0A%3C%2Fng-template%3E%0A&e=si-side-panel%2Fsi-side-panel-portal)

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
