### PR TITLE
chore(demo): rename WebpackTranslateLoader to CustomTranslateLoader

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -37,10 +37,10 @@ import {
 } from '@siemens/live-preview';
 import { lastValueFrom, Observable, take } from 'rxjs';
 
+import { CustomTranslateLoader } from './custom-translate-loader';
 import { FileUploadInterceptor } from './examples/si-file-uploader/file-upload-interceptor';
 import { CustomWrapperComponent } from './examples/si-formly/dynamic-form-custom-wrapper';
 import { LivePreviewThemeApiService } from './shared/live-preview-theme.api.service';
-import { WebpackTranslateLoader } from './webpack-translate-loader';
 
 const componentLoader =
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -112,7 +112,7 @@ export const APP_CONFIG: ApplicationConfig = {
       TranslateModule.forRoot({
         loader: {
           provide: TranslateLoader,
-          useClass: WebpackTranslateLoader
+          useClass: CustomTranslateLoader
         }
       }),
       SiLivePreviewRoutingModule,

--- a/src/app/custom-translate-loader.ts
+++ b/src/app/custom-translate-loader.ts
@@ -5,7 +5,7 @@
 import { TranslateLoader } from '@ngx-translate/core';
 import { from, Observable } from 'rxjs';
 
-export class WebpackTranslateLoader implements TranslateLoader {
+export class CustomTranslateLoader implements TranslateLoader {
   getTranslation(lang: string): Observable<any> {
     // Esbuild is preventing extensions of imported json files.
     // So we clone it.


### PR DESCRIPTION
name webpack makes no sense as we don't use webpack builder anymore

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
