### PR TITLE
fix(threshold): ensure number input and buttons are above other elements

### DIFF
--- a/projects/element-ng/threshold/si-threshold.component.scss
+++ b/projects/element-ng/threshold/si-threshold.component.scss
@@ -49,6 +49,9 @@ si-select {
   // This is a weird one. When zooming, it seems like `border-width` and relative `line-height` are scaled differently on inputs
   // Since the threshold needs correct size to keep the lines aligned, setting it to a fixed value here.
   block-size: calc(1rem + (map.get(variables.$spacers, 4) * 2));
+  // Ensure the number input and its buttons are above other elements
+  position: relative;
+  z-index: 1;
 }
 
 .line {


### PR DESCRIPTION
Currently, the number input and button is overriden by div which disable half of the increment button to be clicked. This fix will make sure that number input and increment and decrement buttons are above.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
