### PR TITLE
docs(help-patterns): add link to help button

### DIFF
--- a/docs/patterns/help.md
+++ b/docs/patterns/help.md
@@ -47,8 +47,7 @@ The tour usually highlights key elements of the interface and provides brief ins
 
 ### Contextual help
 
-This provides immediate, on-the-spot assistance via a help button with an
-`element-help` icon, combined with a [popover](../components/status-notifications/popover.md).
+This provides immediate, on-the-spot assistance via a [help button](../components/buttons-menus/help-button.md).
 It’s designed to help users understand specific actions or features on the current page without needing to navigate away.
 
 ![Help - contextual elements](images/help-contextual-elements.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,11 +50,11 @@ nav:
       - Buttons:                          'components/buttons-menus/buttons.md'
       - Content Action Bar:               'components/buttons-menus/content-actions.md'
       - Dropdowns:                        'components/buttons-menus/dropdowns.md'
+      - Help Button:                      'components/buttons-menus/help-button.md'
       - Links:                            'components/buttons-menus/links.md'
       - Menu:                             'components/buttons-menus/menu.md'
       - Segmented Button:                 'components/buttons-menus/segmented-button.md'
       - Split buttons:                    'components/buttons-menus/split-button.md'
-      - Help Button:                      'components/buttons-menus/help-button.md'
     - Dashboards:
       - Overview:                         'components/dashboards/index.md'
       - Dashboard:                        'components/dashboards/dashboard.md'


### PR DESCRIPTION
This PR adds a link in the help patterns to the help button, and corrects the order of the chapters in the button and menu section.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
