### PR TITLE
feat(filtered-search): add searchCriteriaBlur event for handling focus loss on criteria

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
@@ -64,6 +64,7 @@ export class SiFilteredSearchValueComponent implements OnInit {
 
   readonly deleteCriterion = output<{ triggerSearch: boolean } | void>();
   readonly submitCriterion = output<{ freeText: string } | void>();
+  readonly searchCriteriaBlur = output<void>();
 
   protected readonly active = signal<boolean>(false);
   protected readonly icons = addIcons({ elementCancel });
@@ -139,8 +140,9 @@ export class SiFilteredSearchValueComponent implements OnInit {
       return;
     }
     setTimeout(() => {
-      // We need to wait for the overlay, that might be shown and now close as well on onside click.
+      // We need to wait for the overlay, that might be shown and now close as well on outside click.
       if (this.active() && !focusOrigin && !this.valueInput()?.focusInOverlay()) {
+        this.searchCriteriaBlur.emit();
         this.active.set(false);
       }
     });

--- a/projects/element-ng/filtered-search/si-filtered-search.component.html
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.html
@@ -23,6 +23,7 @@
       (submitCriterion)="focusNext($index, $event)"
       (deleteCriterion)="deleteCriterion(criterion.value, $index, $event)"
       (valueChange)="valueChange($event, criterion)"
+      (searchCriteriaBlur)="handleSearchCriteriaBlur()"
     />
   }
   <!-- criterion input -->

--- a/projects/element-ng/filtered-search/si-filtered-search.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.ts
@@ -85,6 +85,14 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges, OnDestroy {
   readonly doSearchOnInputChange = input(false, {
     transform: booleanAttribute
   });
+
+  /**
+   * Emits when any search criterion loses focus (becomes inactive).
+   * This event is triggered for all criterion types when the user finishes
+   * interacting with a criterion and it becomes inactive.
+   */
+  readonly searchCriteriaBlur = output<SearchCriteria>();
+
   /**
    * In addition to lazy loaded value, you can also lazy load the criteria itself
    */
@@ -704,5 +712,9 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges, OnDestroy {
     if (this.doSearchOnInputChange()) {
       this.searchEmitQueue.next(this.searchCriteria());
     }
+  }
+
+  protected handleSearchCriteriaBlur(): void {
+    this.searchCriteriaBlur.emit(this.searchCriteria()!);
   }
 }

--- a/src/app/examples/si-filtered-search/si-filtered-search-multiselect.html
+++ b/src/app/examples/si-filtered-search/si-filtered-search-multiselect.html
@@ -36,5 +36,6 @@
     }"
     (doSearch)="logEvent($event)"
     (searchCriteriaChange)="logEvent('searchCriteriaChange', $event)"
+    (searchCriteriaBlur)="logEvent('searchCriteriaBlur', $event)"
   />
 </app-filter-settings>


### PR DESCRIPTION
Currently, in case of filtered-search-multiselect whenever the option is selected then we emit the change event, this PR will add new blur event for the cases where we have focus blurred from the selection option

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
