### PR TITLE
chore(releaserc.js): use proper branches config for semantic release

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -7,14 +7,15 @@ export default {
   branches: [
     {
       name: 'release/+([0-9])?(.{+([0-9]),x}).x',
+      range: "${name.replace(/^release\\//g, '')}",
       channel: "${name.replace(/^release\\//g, '')}"
     },
+    'main',
     {
       name: 'next',
       channel: 'next',
-      prerelease: true
-    },
-    'main'
+      prerelease: 'rc'
+    }
   ],
   plugins: [
     [
@@ -94,12 +95,6 @@ export default {
       '@semantic-release/npm',
       {
         pkgRoot: 'projects/element-translate-cli'
-      }
-    ],
-    [
-      '@semantic-release/npm',
-      {
-        pkgRoot: 'projects/dashboards-demo'
       }
     ],
     // Only update remaining package.json that are not directly published


### PR DESCRIPTION
This PR addresses 4 points:
- v48 releases are marked as pre-release in GitHub and miss the `latest` tag on npmjs.com
- v47.x maintenance releases should have the `range` property set to ensure no accidential releaes of a major version happens form a maintenance branch
- we're currently releasing our RCs as `.next-X` versions, which is OK, but RC is more specific and so we should use RC also here.
- the release pipeline for v48.0.1 failed because it tried to publish `dashboards-demo`, so removing that here.

AI summary for the first 3 fixes about the branches config:
The issue you're describing—where a release from the `main` branch unexpectedly gets treated as a prerelease—is most likely caused by the order of branches in your configuration array. Semantic-release processes the branches in the specified order, and this order is critical because versions released from each subsequent branch must be higher than those from the previous one to avoid conflicts (e.g., duplicate versions across branches). Prerelease branches like `next` are intended for future or experimental versions and should come *after* stable branches like `main` (and after maintenance branches). Placing `next` before `main` disrupts this versioning logic, which can result in miscalculated release types, including inadvertently applying prerelease identifiers to stable releases or triggering internal errors that manifest as prerelease behavior.

Additionally, your maintenance branch config omits the `range` property, which is optional but recommended to enforce version boundaries (e.g., only allowing patches/minors within `1.x` on `release/1.x`). Without it, there's no restriction, which could contribute to versioning inconsistencies if combined with the order issue.

Here's the fixed configuration, with the branches reordered correctly (maintenance → stable → prerelease), `range` added back for maintenance branches, `prerelease` set to a string identifier ("rc") instead of `true` (to avoid defaulting to the branch name "next" as the identifier, which is less conventional for RCs), and `channel` preserved or added where appropriate for npm dist-tags:

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
