### PR TITLE
feat(filter-bar): add disableAutoTranslation option to avoid unwanted translation

### DIFF
--- a/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--l-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--l-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c4c6511c05e2e79c9d882c5fe0cf4f1b7dacb1fe0b2a42e47152f02654fa4b9
-size 44540
+oid sha256:b8f56a6c6b487c4f4d969c28d1a9a5f5830811430f3f941e19b72c5df949c1ad
+size 43050

--- a/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--l-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--l-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04be0ce4ae1a9679a7be9f59f197d485ed9f54ec8e9f4ac43527eafc9593e14a
-size 44100
+oid sha256:ba170b298d89de7832b570a7c952cfea3bef7cd75776df5ca38c9c83a6a1f60e
+size 42397

--- a/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--l.yaml
+++ b/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--l.yaml
@@ -7,7 +7,7 @@
 - button "Remove"
 - text: "Company : Siemens"
 - button "Remove"
-- text: + 3 filters
+- text: + 4 filters
 - button "Remove"
 - button "Reset filters"
 - heading "Variant Dark" [level=4]
@@ -19,12 +19,12 @@
 - button "Remove"
 - text: "Company : Siemens"
 - button "Remove"
-- text: + 3 filters
+- text: + 4 filters
 - button "Remove"
 - button "Reset filters"
 - heading "Variant Light Disabled" [level=4]
-- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM Date : \\d+-\\d+-\\d+ Company : Siemens Location : Zug Only Key Only Value/"
+- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM Date : \\d+-\\d+-\\d+ Company : Siemens Location : Zug \\+ 3 filters/"
 - button "Reset filters" [disabled]
 - heading "Variant Dark Disabled" [level=4]
-- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM Date : \\d+-\\d+-\\d+ Company : Siemens Location : Zug Only Key Only Value/"
+- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM Date : \\d+-\\d+-\\d+ Company : Siemens Location : Zug \\+ 3 filters/"
 - button "Reset filters" [disabled]

--- a/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--s-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--s-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa1bebd962cd7f8d33d0aafa4f8c4aa55e0e6e94f57b5798edc331b441cf3452
-size 37792
+oid sha256:12893b7ca4cd683a33147609023db169b2538131511abbd61a32ed0538d79ed0
+size 38037

--- a/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--s-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--s-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b086d59aebdaa3c76e1c903a6673999ad0f3492471e613acbeaabda8d8d7970
-size 37223
+oid sha256:246f4377b88b1442f89dfddd65a9e5a19edfbe6535dfc07b19bfd5d4b041104d
+size 37505

--- a/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--s.yaml
+++ b/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--s.yaml
@@ -5,7 +5,7 @@
 - button "Remove"
 - text: "/Date : \\d+-\\d+-\\d+/"
 - button "Remove"
-- text: + 4 filters
+- text: + 5 filters
 - button "Remove"
 - button "Reset filters"
 - heading "Variant Dark" [level=4]
@@ -15,12 +15,12 @@
 - button "Remove"
 - text: "/Date : \\d+-\\d+-\\d+/"
 - button "Remove"
-- text: + 4 filters
+- text: + 5 filters
 - button "Remove"
 - button "Reset filters"
 - heading "Variant Light Disabled" [level=4]
-- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM Date : \\d+-\\d+-\\d+ \\+ 4 filters/"
+- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM Date : \\d+-\\d+-\\d+ \\+ 5 filters/"
 - button "Reset filters" [disabled]
 - heading "Variant Dark Disabled" [level=4]
-- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM Date : \\d+-\\d+-\\d+ \\+ 4 filters/"
+- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM Date : \\d+-\\d+-\\d+ \\+ 5 filters/"
 - button "Reset filters" [disabled]

--- a/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--xs-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--xs-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db9ae5d999cab6d9fdb4afd5a6b39d495c53d06621954a18dd054f5b999b6515
-size 31757
+oid sha256:6ed3bf02c1e98c322801317f82bf2947c956933298e5316a3c978091fce79dd4
+size 31613

--- a/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--xs-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--xs-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0fccfd62bb4b4beb51234e489fceb514a2721e26f3ce0303188df5cc3fda4f9f
-size 31324
+oid sha256:50f611c9c97132b5ac79ab416ec1e15d9ba9348c3be29f477e9abf4850871fec
+size 31182

--- a/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--xs.yaml
+++ b/playwright/snapshots/si-filter-bar.spec.ts-snapshots/si-filter-bar--si-filter-bar--xs.yaml
@@ -1,18 +1,18 @@
 - heading "Variant Light" [level=4]
 - text: "/Temperature : \\d+°/"
 - button "Remove"
-- text: + 6 filters
+- text: + 7 filters
 - button "Remove"
 - button "Reset filters"
 - heading "Variant Dark" [level=4]
 - text: "/Temperature : \\d+°/"
 - button "Remove"
-- text: + 6 filters
+- text: + 7 filters
 - button "Remove"
 - button "Reset filters"
 - heading "Variant Light Disabled" [level=4]
-- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM \\+ 5 filters/"
+- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM \\+ 6 filters/"
 - button "Reset filters" [disabled]
 - heading "Variant Dark Disabled" [level=4]
-- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM \\+ 5 filters/"
+- text: "/Temperature : \\d+° Time : \\d+:\\d+ AM \\+ 6 filters/"
 - button "Reset filters" [disabled]

--- a/projects/element-ng/filter-bar/filter.ts
+++ b/projects/element-ng/filter-bar/filter.ts
@@ -25,4 +25,10 @@ export interface Filter {
    * Status of filter pill
    */
   status: FilterStatusType;
+  /**
+   * Disables automatic translation of title and description text.
+   * When set to true, the title and description will be displayed as-is without
+   * attempting translation.
+   */
+  disableAutoTranslation?: boolean;
 }

--- a/projects/element-ng/filter-bar/si-filter-bar.component.spec.ts
+++ b/projects/element-ng/filter-bar/si-filter-bar.component.spec.ts
@@ -349,6 +349,6 @@ describe('SiFilterBarComponent', () => {
     await timeout(200);
     fixture.detectChanges();
     const values = element.querySelectorAll<HTMLElement>('si-filter-pill .value');
-    expect(values[values.length - 1].innerHTML).toBe('+ 2 filters');
+    expect(values[values.length - 1].innerHTML.trim()).toBe('+ 2 filters');
   });
 });

--- a/projects/element-ng/filter-bar/si-filter-pill.component.html
+++ b/projects/element-ng/filter-bar/si-filter-pill.component.html
@@ -1,18 +1,23 @@
+@let filter = this.filter();
 <div
   class="pill responsive"
   [class.pe-0]="!disabled()"
   [class.disabled]="disabled()"
-  [ngClass]="filter().status ? 'pill-' + filter().status : ''"
+  [ngClass]="filter.status ? 'pill-' + filter.status : ''"
   [attr.aria-disabled]="disabled()"
 >
   <div class="wrapper">
-    @if (filter().title) {
-      <div class="name">{{ filter().title | translate }}</div>
+    @if (filter.title) {
+      <div class="name">
+        {{ filter.disableAutoTranslation ? filter.title : (filter.title | translate) }}
+      </div>
     }
-    @if (filter().title && filter().description) {
+    @if (filter.title && filter.description) {
       <span class="name pe-4">:</span>
     }
-    <div class="value">{{ filter().description | translate }}</div>
+    <div class="value">
+      {{ filter.disableAutoTranslation ? filter.description : (filter.description | translate) }}
+    </div>
   </div>
   @if (!disabled()) {
     <ng-container *ngTemplateOutlet="remove" />

--- a/projects/element-ng/filter-bar/si-filter-pill.component.spec.ts
+++ b/projects/element-ng/filter-bar/si-filter-pill.component.spec.ts
@@ -4,6 +4,11 @@
  */
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
+import {
+  provideMockTranslateServiceBuilder,
+  SiTranslateService
+} from '@siemens/element-translate-ng/translate';
+import { of } from 'rxjs';
 
 import { Filter } from './filter';
 import { SiFilterPillComponent } from './index';
@@ -27,7 +32,16 @@ describe('SiFilterPillComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiFilterPillComponent, TestHostComponent]
+      imports: [SiFilterPillComponent, TestHostComponent],
+      providers: [
+        provideMockTranslateServiceBuilder(
+          () =>
+            ({
+              translate: (key: string) => `translated:${key}`,
+              translateAsync: (key: string) => of(`translated:${key}`)
+            }) as SiTranslateService
+        )
+      ]
     })
   );
 
@@ -45,8 +59,8 @@ describe('SiFilterPillComponent', () => {
       status: 'warning'
     };
     fixture.detectChanges();
-    expect(element.querySelector('div.name')!.innerHTML).toBe('Current Location');
-    expect(element.querySelector('div.value')!.innerHTML).toBe('Florida');
+    expect(element.querySelector('div.name')!.innerHTML.trim()).toBe('translated:Current Location');
+    expect(element.querySelector('div.value')!.innerHTML.trim()).toBe('translated:Florida');
     expect(element.querySelector('.pill.pill-warning')!.innerHTML).toBeDefined();
   }));
 
@@ -63,5 +77,20 @@ describe('SiFilterPillComponent', () => {
     element.querySelector<HTMLElement>('[aria-label="Remove"]')?.click();
     fixture.detectChanges();
     expect(spyEvent).toHaveBeenCalled();
+  }));
+
+  it('should not translate the title and description if disableAutoTranslation is true', fakeAsync(() => {
+    component.filter = {
+      filterName: 'language',
+      title: 'LANGUAGE',
+      description: 'LANGUAGE',
+      status: 'default',
+      disableAutoTranslation: true
+    };
+    fixture.detectChanges();
+    flush();
+
+    expect(element.querySelector('div.name')!.innerHTML.trim()).toBe('LANGUAGE');
+    expect(element.querySelector('div.value')!.innerHTML.trim()).toBe('LANGUAGE');
   }));
 });

--- a/src/app/examples/si-filter-bar/si-filter-bar.ts
+++ b/src/app/examples/si-filter-bar/si-filter-bar.ts
@@ -48,6 +48,13 @@ export class SampleComponent {
       status: 'default'
     },
     {
+      filterName: 'language',
+      title: 'LANGUAGE',
+      description: 'LANGUAGE',
+      status: 'default',
+      disableAutoTranslation: true
+    },
+    {
       filterName: 'only-key',
       title: 'Only Key',
       description: '',


### PR DESCRIPTION
When user types a word that matches the translation keys then filter pill displays the actual translated value.
Using `disableAutoTranslation` will prevent automatic translation of filter pill text when it matches translation keys

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
