### PR TITLE
refactor(resize-observer): drop TODO

### DIFF
--- a/projects/element-ng/resize-observer/si-resize-observer.directive.ts
+++ b/projects/element-ng/resize-observer/si-resize-observer.directive.ts
@@ -33,7 +33,6 @@ export class SiResizeObserverDirective implements OnInit, OnDestroy {
   /** @defaultValue 100 */
   readonly resizeThrottle = input(100);
   /** @defaultValue true */
-  // TODO: switch default to false in v48.0.0
   readonly emitInitial = input(true, { transform: booleanAttribute });
   readonly siResizeObserver = output<ElementDimensions>();
 


### PR DESCRIPTION
As it makes no sense. Changing the default would break _most_ consumers. Instead, the booleanTransform should be dropped as it makes also no sense for defaults that are true.


---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
