### PR TITLE
chore/use proper branches config for semantic release backport in releaserc.js

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -5,13 +5,14 @@ export default {
   branches: [
     {
       name: 'release/+([0-9])?(.{+([0-9]),x}).x',
+      range: "${name.replace(/^release\\//g, '')}",
       channel: "${name.replace(/^release\\//g, '')}"
     },
     'main',
     {
       name: 'next',
       channel: 'next',
-      prerelease: true
+      prerelease: 'rc'
     }
   ],
   plugins: [


### PR DESCRIPTION
Backport from main

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
