### PR TITLE
fix(search-filter-value): multiple clicks required for clearing a sea…

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
@@ -168,15 +168,9 @@ export class SiFilteredSearchValueComponent implements OnInit {
   }
 
   protected clear(): void {
-    if (!this.active() || !this.value().value?.length) {
-      this.deleteCriterion.emit({ triggerSearch: true });
-      return;
-    }
-
-    this.value.update(v => ({
-      ...v,
-      dateValue: undefined,
-      value: this.definition().multiSelect ? [] : ''
-    }));
+    // Clear the input value first
+    this.value.update(v => ({ ...v, value: '', dateValue: undefined }));
+    // Always delete the criterion when clear button is clicked
+    this.deleteCriterion.emit({ triggerSearch: true });
   }
 }


### PR DESCRIPTION
Fixed two clicks required for clearing out a search filter in si-filtered-search component.

Fixes : [si-filtered-search component Search field search cross button needs to be clicked twice while clearing the filter.](https://code.siemens.com/simpl/simpl-element/-/issues/2559)
