### PR TITLE
feat(tabs): provide canActivate and canDeactivate guards

### DIFF
--- a/projects/element-ng/tabs/si-tab.component.ts
+++ b/projects/element-ng/tabs/si-tab.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, model, OnDestroy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, model, OnDestroy } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
@@ -41,14 +41,33 @@ export class SiTabComponent extends SiTabBaseDirective implements OnDestroy {
    * */
   override readonly active = model(false);
 
+  /**
+   * Guard to check if the tab can be activated.
+   * If not provided, the tab can always be activated.
+   */
+  readonly canActivate = input<() => boolean>();
+  /**
+   * Guard to check if the tab can be deactivated.
+   * If not provided, the tab can always be deactivated.
+   */
+  readonly canDeactivate = input<() => boolean>();
+
   protected selectTabByUser(): void {
-    if (!this.active()) {
+    const canActivate = this.canActivate();
+    if (!this.active() && (canActivate ? canActivate() : true)) {
       this.selectTab();
     }
   }
 
   /** {@inheritDoc} */
   override selectTab(retainFocus?: boolean): void {
+    const activeTab = this.tabset.activeTab();
+    if (activeTab instanceof SiTabComponent) {
+      const canDeactivate = activeTab?.canDeactivate();
+      if (canDeactivate ? !canDeactivate() : false) {
+        return;
+      }
+    }
     this.tabset.activeTab()?.deSelectTab();
     this.active.set(true);
     super.selectTab(retainFocus);

--- a/projects/element-ng/tabs/si-tabset.component.spec.ts
+++ b/projects/element-ng/tabs/si-tabset.component.spec.ts
@@ -39,6 +39,8 @@ class SiTabRouteComponent {}
               [heading]="tab.heading"
               [closable]="!!tab.closable"
               [style.max-width.px]="tabButtonMaxWidth()"
+              [canDeactivate]="tab.canDeactivate"
+              [canActivate]="tab.canActivate"
               (closeTriggered)="closeTriggered(tab)"
             />
           }
@@ -56,7 +58,14 @@ class TestComponent {
 
   set tabs(
     value: (
-      | { heading: string; closable?: true; routerLinkUrl?: string; active?: boolean }
+      | {
+          heading: string;
+          closable?: true;
+          routerLinkUrl?: string;
+          active?: boolean;
+          canDeactivate?: () => boolean;
+          canActivate?: () => boolean;
+        }
       | string
     )[]
   ) {
@@ -308,6 +317,41 @@ describe('SiTabset', () => {
     fixture.detectChanges();
     testComponent.tabs = ['1', { heading: '2', active: true }, '3'];
     expect(await tabsetHarness.isTabFocussable(1)).toBeTrue();
+  });
+
+  it('should not change active if canDeactivate returns false', async () => {
+    testComponent.tabs = [
+      { heading: '1', active: true },
+      { heading: '2', closable: true, canDeactivate: () => false }
+    ];
+    fixture.detectChanges();
+    expect(await tabsetHarness.isTabItemActive(0)).toBeTrue();
+    expect(await tabsetHarness.isTabItemActive(1)).toBeFalse();
+
+    (await tabsetHarness.getTabItemButtonAt(1)).click();
+    fixture.detectChanges();
+    expect(await tabsetHarness.isTabItemActive(0)).toBeFalse();
+    expect(await tabsetHarness.isTabItemActive(1)).toBeTrue();
+
+    (await tabsetHarness.getTabItemButtonAt(0)).click();
+    fixture.detectChanges();
+    expect(await tabsetHarness.isTabItemActive(0)).toBeFalse();
+    expect(await tabsetHarness.isTabItemActive(1)).toBeTrue();
+  });
+
+  it('should not change active if canActivate returns false', async () => {
+    testComponent.tabs = [
+      { heading: '1', active: true },
+      { heading: '2', closable: true, canActivate: () => false }
+    ];
+    fixture.detectChanges();
+    expect(await tabsetHarness.isTabItemActive(0)).toBeTrue();
+    expect(await tabsetHarness.isTabItemActive(1)).toBeFalse();
+
+    (await tabsetHarness.getTabItemButtonAt(1)).click();
+    fixture.detectChanges();
+    expect(await tabsetHarness.isTabItemActive(0)).toBeTrue();
+    expect(await tabsetHarness.isTabItemActive(1)).toBeFalse();
   });
 });
 

--- a/src/app/examples/si-tabs/si-tabs.html
+++ b/src/app/examples/si-tabs/si-tabs.html
@@ -6,12 +6,13 @@
       [badgeContent]="tab.badgeContent"
       [closable]="tab.closable"
       [heading]="tab.heading"
+      [canActivate]="tab.heading === 'Lobby' ? canActivate : undefined"
       (closeTriggered)="closeTab(tab)"
     >
       <p class="mt-4"> Content for {{ tab.heading }} </p>
     </si-tab>
   }
-  <si-tab heading="Deselectable">
+  <si-tab heading="Deselectable" [canDeactivate]="canDeactivate">
     <p class="mt-4">Uncheck to prevent switching to another tab.</p>
     <label class="form-check">
       <input type="checkbox" class="form-check-input" [(ngModel)]="deselectable" />
@@ -19,3 +20,10 @@
     </label>
   </si-tab>
 </si-tabset>
+
+<div class="e2e-ignore">
+  <label class="form-check">
+    <input type="checkbox" class="form-check-input" [(ngModel)]="activable" />
+    <span class="form-check-label">Allow Lobby tab activation</span>
+  </label>
+</div>

--- a/src/app/examples/si-tabs/si-tabs.ts
+++ b/src/app/examples/si-tabs/si-tabs.ts
@@ -27,6 +27,7 @@ interface TabModel {
 export class SampleComponent {
   selectedTabIndex = 0;
   deselectable = true;
+  activable = true;
   logEvent = inject(LOG_EVENT);
 
   tabs: TabModel[] = [
@@ -58,4 +59,15 @@ export class SampleComponent {
       1
     );
   }
+
+  canDeactivate = (): boolean => {
+    return this.deselectable;
+  };
+
+  canActivate = (): boolean => {
+    if (!this.activable) {
+      this.logEvent('Enable Allow Lobby tab activation to activate this tab');
+    }
+    return this.activable;
+  };
 }


### PR DESCRIPTION
added `SiTabComponent.canActivate` and `SiTabComponent.canDeactivate` to control activation/deactivation of tabs similar to angular router guards.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
