### PR TITLE
Fix/column dialog row icons misaligned on long title

### DIFF
--- a/projects/element-ng/column-selection-dialog/column-selection-editor/si-column-selection-editor.component.html
+++ b/projects/element-ng/column-selection-dialog/column-selection-editor/si-column-selection-editor.component.html
@@ -1,5 +1,5 @@
 <div class="d-flex p-4" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
-  <div class="d-flex w-100" [attr.aria-label]="column().title">
+  <div class="flex-fill overflow-hidden" [attr.aria-label]="column().title">
     @if (editing) {
       <input
         #title
@@ -23,7 +23,7 @@
     }
   </div>
 
-  <div class="d-flex align-items-center">
+  <div class="d-flex align-items-center flex-shrink-0">
     @if (columnVisibilityConfigurable()) {
       <span
         class="btn btn-circle btn-sm btn-tertiary ms-4"


### PR DESCRIPTION
Backport for the issue - https://github.com/siemens/element/pull/726

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
