### PR TITLE
fix(datepicker): update the AM/PM meridian for 12-hour clock

### DIFF
--- a/projects/element-ng/datepicker/si-timepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.spec.ts
@@ -243,6 +243,28 @@ describe('SiTimepickerComponent', () => {
     expect(select?.value).not.toBe(currentMeridian);
   });
 
+  it('should not toggle meridian', () => {
+    component.writeValue('2021-01-12 01:01:00.000');
+    fixture.detectChanges();
+    // Entering 12 am (midnight) should not toggle the meridian
+    enterValue(getHours(), '12');
+
+    fixture.detectChanges();
+    const select = element.querySelector<HTMLSelectElement>('select');
+    expect(select?.value).not.toBe('pm');
+  });
+
+  it('should toggle meridian when hours > 12', () => {
+    component.writeValue('2021-01-12 01:01:00.000');
+    fixture.detectChanges();
+    // Entering hours above 12 should toggle the meridian to PM
+    enterValue(getHours(), '13');
+
+    fixture.detectChanges();
+    const select = element.querySelector<HTMLSelectElement>('select');
+    expect(select?.value).toBe('pm');
+  });
+
   it('should not show meridian', () => {
     component.writeValue('2021-01-12 18:23:58.435');
     componentRef.setInput('showMeridian', false);

--- a/projects/element-ng/datepicker/si-timepicker.component.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.ts
@@ -441,7 +441,8 @@ export class SiTimepickerComponent implements ControlValueAccessor, SiFormItemCo
 
       let hours = time.getHours();
       if (this.use12HourClock()) {
-        this.meridian.set(hours >= 12 ? 'pm' : 'am');
+        // 12:00 am is midnight while 12:00 pm is noon when users enter a value greater than 12 we can assume it's pm
+        this.meridian.set(hours > 12 ? 'pm' : 'am');
         this.meridianChange.emit(this.meridian());
         hours = hours % 12;
         if (hours === 0) {


### PR DESCRIPTION
- Only update meridian to PM when the  user enter a hour value greater 12

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).

cherry-pick from main