### PR TITLE
refactor(dashboard): drop use of deprecated module

### DIFF
--- a/projects/element-ng/dashboard/si-dashboard-card.component.ts
+++ b/projects/element-ng/dashboard/si-dashboard-card.component.ts
@@ -19,13 +19,13 @@ import {
   ContentActionBarMainItem,
   SiContentActionBarComponent
 } from '@siemens/element-ng/content-action-bar';
-import { SiTranslateModule, t } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
 import { SiDashboardService } from './si-dashboard.service';
 
 @Component({
   selector: 'si-dashboard-card',
-  imports: [SiContentActionBarComponent, SiTranslateModule],
+  imports: [SiContentActionBarComponent, SiTranslatePipe],
   templateUrl: './si-dashboard-card.component.html',
   styleUrl: './si-dashboard-card.component.scss',
   host: {

--- a/projects/element-ng/dashboard/si-dashboard.component.ts
+++ b/projects/element-ng/dashboard/si-dashboard.component.ts
@@ -26,7 +26,7 @@ import {
   ElementDimensions,
   ResizeObserverService
 } from '@siemens/element-ng/resize-observer';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -37,7 +37,7 @@ const FIX_SCROLL_PADDING_RESIZE_OBSERVER_THROTTLE = 10;
 
 @Component({
   selector: 'si-dashboard',
-  imports: [PortalModule, SiTranslateModule],
+  imports: [PortalModule, SiTranslatePipe],
   templateUrl: './si-dashboard.component.html',
   styleUrl: './si-dashboard.component.scss',
   providers: [SiDashboardService],

--- a/projects/element-ng/dashboard/widgets/si-link-widget.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-link-widget.component.ts
@@ -5,7 +5,7 @@
 import { booleanAttribute, Component, computed, input } from '@angular/core';
 import { addIcons, SiIconComponent, elementRight2 } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiWidgetBaseComponent } from './si-widget-base.component';
 
@@ -15,7 +15,7 @@ import { SiWidgetBaseComponent } from './si-widget-base.component';
  */
 @Component({
   selector: 'si-link-widget',
-  imports: [SiIconComponent, SiLinkDirective, SiTranslateModule],
+  imports: [SiIconComponent, SiLinkDirective, SiTranslatePipe],
   templateUrl: './si-link-widget.component.html',
   host: { class: 'si-link-widget' }
 })

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.ts
@@ -6,7 +6,7 @@ import { booleanAttribute, Component, computed, input, model, OnChanges } from '
 import { FormsModule } from '@angular/forms';
 import { Link } from '@siemens/element-ng/link';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
-import { SiTranslateModule, t } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
 import { SiWidgetBaseComponent } from '../si-widget-base.component';
 import { SiListWidgetItem, SiListWidgetItemComponent } from './si-list-widget-item.component';
@@ -20,7 +20,7 @@ export type SortOrder = 'ASC' | 'DSC';
  */
 @Component({
   selector: 'si-list-widget-body',
-  imports: [SiListWidgetItemComponent, SiSearchBarComponent, SiTranslateModule, FormsModule],
+  imports: [SiListWidgetItemComponent, SiSearchBarComponent, SiTranslatePipe, FormsModule],
   templateUrl: './si-list-widget-body.component.html',
   styleUrl: './si-list-widget-body.component.scss',
   host: { class: '' }

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-item.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-item.component.ts
@@ -6,7 +6,7 @@ import { NgClass } from '@angular/common';
 import { Component, computed } from '@angular/core';
 import { addIcons, elementRight2, SiIconComponent } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiWidgetBaseComponent } from '../si-widget-base.component';
 
@@ -39,7 +39,7 @@ export interface SiListWidgetItem {
  */
 @Component({
   selector: 'si-list-widget-item',
-  imports: [NgClass, SiIconComponent, SiLinkDirective, SiTranslateModule],
+  imports: [NgClass, SiIconComponent, SiLinkDirective, SiTranslatePipe],
   templateUrl: './si-list-widget-item.component.html',
   host: {
     class: 'list-group-item d-flex align-items-center',

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget.component.ts
@@ -15,7 +15,7 @@ import {
   elementSortUp
 } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslateModule, t, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiWidgetBaseComponent } from '../si-widget-base.component';
 import { SiListWidgetBodyComponent, SortOrder } from './si-list-widget-body.component';
@@ -33,7 +33,7 @@ import { SiListWidgetItem } from './si-list-widget-item.component';
     SiIconComponent,
     SiLinkDirective,
     SiListWidgetBodyComponent,
-    SiTranslateModule
+    SiTranslatePipe
   ],
   templateUrl: './si-list-widget.component.html',
   host: { class: 'si-list-widget' }

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.ts
@@ -9,7 +9,7 @@ import { Component, inject, input, OnChanges, OnInit } from '@angular/core';
 import { ActivatedRoute, NavigationExtras, RouterLink } from '@angular/router';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { MenuItem, SiMenuModule } from '@siemens/element-ng/menu';
-import { SiTranslateModule, t, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiWidgetBaseComponent } from '../si-widget-base.component';
 
@@ -114,7 +114,7 @@ export interface SiTimelineWidgetItem {
   selector: 'si-timeline-widget-item',
   imports: [
     SiIconComponent,
-    SiTranslateModule,
+    SiTranslatePipe,
     NgClass,
     A11yModule,
     RouterLink,

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget.component.ts
@@ -9,7 +9,7 @@ import { AccentLineType, MenuItem as MenuItemLegacy } from '@siemens/element-ng/
 import { ContentActionBarMainItem } from '@siemens/element-ng/content-action-bar';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
 import { MenuItem } from '@siemens/element-ng/menu';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiWidgetBaseComponent } from '../si-widget-base.component';
 import { SiTimelineWidgetBodyComponent } from './si-timeline-widget-body.component';
@@ -21,8 +21,8 @@ import { SiTimelineWidgetItem } from './si-timeline-widget-item.component';
     NgClass,
     SiLinkDirective,
     SiCardComponent,
-    SiTranslateModule,
-    SiTimelineWidgetBodyComponent
+    SiTimelineWidgetBodyComponent,
+    SiTranslatePipe
   ],
   templateUrl: './si-timeline-widget.component.html'
 })

--- a/projects/element-ng/dashboard/widgets/si-value-widget-body.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-value-widget-body.component.ts
@@ -5,7 +5,7 @@
 import { Component, input, OnInit } from '@angular/core';
 import { EntityStatusType } from '@siemens/element-ng/common';
 import { SiIconComponent, SiStatusIconComponent } from '@siemens/element-ng/icon';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiWidgetBaseComponent } from './si-widget-base.component';
 
@@ -14,7 +14,7 @@ import { SiWidgetBaseComponent } from './si-widget-base.component';
  */
 @Component({
   selector: 'si-value-widget-body',
-  imports: [SiIconComponent, SiStatusIconComponent, SiTranslateModule],
+  imports: [SiIconComponent, SiStatusIconComponent, SiTranslatePipe],
   templateUrl: './si-value-widget-body.component.html'
 })
 export class SiValueWidgetBodyComponent

--- a/projects/element-ng/dashboard/widgets/si-value-widget.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-value-widget.component.ts
@@ -13,7 +13,7 @@ import {
 import { ContentActionBarMainItem } from '@siemens/element-ng/content-action-bar';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
 import { MenuItem } from '@siemens/element-ng/menu';
-import { SiTranslateModule, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiValueWidgetBodyComponent } from './si-value-widget-body.component';
 
@@ -31,13 +31,7 @@ import { SiValueWidgetBodyComponent } from './si-value-widget-body.component';
  */
 @Component({
   selector: 'si-value-widget',
-  imports: [
-    NgClass,
-    SiCardComponent,
-    SiLinkDirective,
-    SiTranslateModule,
-    SiValueWidgetBodyComponent
-  ],
+  imports: [NgClass, SiCardComponent, SiLinkDirective, SiTranslatePipe, SiValueWidgetBodyComponent],
   templateUrl: './si-value-widget.component.html'
 })
 export class SiValueWidgetComponent {


### PR DESCRIPTION
dropped import of `SiTranslateModule` with `SiTranslatePipe`


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
