### PR TITLE
fix(datepicker): correct si-timepicker input field validation

### DIFF
--- a/projects/element-ng/datepicker/si-timepicker.component.html
+++ b/projects/element-ng/datepicker/si-timepicker.component.html
@@ -20,10 +20,13 @@
         [attr.aria-label]="config.ariaLabel | translate"
         [attr.aria-describedby]="errormessageId()"
         [attr.maxlength]="config.maxLength"
-        [class.is-invalid]="!unitValidation()[config.name] || this.forceInvalid()"
+        [class.is-invalid]="
+          !unitValidation()[config.name] ||
+          !isValidLimit(this.max(), this.min()) ||
+          this.forceInvalid()
+        "
         [disabled]="disabled()"
         [name]="config.name"
-        [pattern]="config.pattern"
         [placeholder]="config.placeholder"
         [readonly]="readonly()"
         [value]="unitValues()[config.name]"


### PR DESCRIPTION
The validation of the input field limits was not correct:

- On user input hours 24 the field is invalid
- On user input minutes 60 the field is invalid
- On user input seconds 60 the field is invalid
- if one of the input field contain an invalid value we should not expose an previous value instead the value is set to undefined

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
