### PR TITLE
fix(filtered-search): visually clear input text in active mode if clear is pressed

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
@@ -232,6 +232,21 @@ describe('SiFilteredSearchComponent', () => {
       await criteria[0].clickClearButton();
       expect(await loader.getAllHarnesses(SiFilteredSearchCriterionHarness)).toHaveSize(0);
     });
+
+    it('should clear input value if clear is pressed while criterion is active', async () => {
+      // Having an option used to be responsible for preventing the criterion text to be cleared.
+      component.criteria.set([{ name: 'foo', options: [{ value: 'bar', label: 'Bar' }] }]);
+      const criteria = await loader.getAllHarnesses(SiFilteredSearchCriterionHarness);
+      expect(criteria).toHaveSize(1);
+      await criteria[0].clickLabel();
+      expect(await criteria[0].value().then(value => value?.getValue())).toBe('Bar');
+      await criteria[0].clickClearButton();
+      expect(criteria).toHaveSize(1);
+      expect(await criteria[0].value().then(value => value?.getValue())).toBe('');
+      const harness = await loader.getHarness(SiFilteredSearchHarness);
+      await harness.freeTextSearch().then(search => search.focus());
+      expect(await criteria[0].value().then(value => value?.text())).toBe('');
+    });
   });
 
   describe('with lazy loaded category values', () => {


### PR DESCRIPTION
Previously, the text was not cleared visually but in the internal data. This change also removes the text visually.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
