### PR TITLE
fix(tree-view): use aria label for expand collapse icons

### DIFF
--- a/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--expand-collapse.yaml
+++ b/playwright/snapshots/si-tree-view.spec.ts-snapshots/si-tree-view--si-tree-view-playground--expand-collapse.yaml
@@ -1,5 +1,5 @@
-- button ""
-- button ""
+- button "Expand all"
+- button "Collapse all"
 - tree "Company locations":
   - treeitem "Company1" [expanded] [level=1]:
     - heading "Company1" [level=5]

--- a/projects/element-ng/tree-view/si-tree-view.component.html
+++ b/projects/element-ng/tree-view/si-tree-view.component.html
@@ -1,20 +1,20 @@
 @if (!flatTree() && expandCollapseAll()) {
   <div class="si-tree-view-expand-collapse-container p-4">
     <button
-      class="btn btn-sm btn-circle btn-tertiary"
+      class="btn btn-sm btn-circle btn-tertiary element-expand-all"
       type="button"
       [title]="expandAllTooltip() | translate"
+      [attr.aria-label]="expandAllTooltip() | translate"
       (click)="expandAll()"
     >
-      <span class="element-expand-all"></span>
     </button>
     <button
-      class="btn btn-sm btn-circle btn-tertiary ms-4"
+      class="btn btn-sm btn-circle btn-tertiary ms-4 element-collapse-all"
       type="button"
       [title]="collapseAllTooltip() | translate"
+      [attr.aria-label]="collapseAllTooltip() | translate"
       (click)="collapseAll()"
     >
-      <span class="element-collapse-all"></span>
     </button>
   </div>
 }


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
