### PR TITLE
refactor(typeahead): use correct template guard internally

### DIFF
--- a/projects/element-ng/typeahead/si-typeahead.component.html
+++ b/projects/element-ng/typeahead/si-typeahead.component.html
@@ -1,5 +1,5 @@
 <!-- Template to be used for every match, can be replaced using an input. -->
-<ng-template #defaultItemTemplate let-match="match" siTypeaheadTemplate>
+<ng-template #defaultItemTemplate let-match="match" siTypeaheadItemTemplate>
   @if (multiselect()) {
     <div class="d-flex pe-4" aria-hidden="true">
       <span class="form-check-input si-form-checkbox" [class.checked]="match.itemSelected"></span>

--- a/projects/element-ng/typeahead/si-typeahead.component.ts
+++ b/projects/element-ng/typeahead/si-typeahead.component.ts
@@ -21,6 +21,7 @@ import {
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
+import { SiTypeaheadItemTemplateDirective } from './si-typeahead-item-template.directive';
 import { SiTypeaheadDirective } from './si-typeahead.directive';
 import { TypeaheadMatch } from './si-typeahead.model';
 
@@ -31,7 +32,8 @@ import { TypeaheadMatch } from './si-typeahead.model';
     SiAutocompleteOptionDirective,
     SiIconComponent,
     NgTemplateOutlet,
-    SiTranslatePipe
+    SiTranslatePipe,
+    SiTypeaheadItemTemplateDirective
   ],
   templateUrl: './si-typeahead.component.html',
   styleUrl: './si-typeahead.component.scss',


### PR DESCRIPTION
Previously there was a typo / missing import. This PR uses the correct directive which provides a type guard.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
