### PR TITLE
refactor(tour): remove deprecated property ModalPosition

### DIFF
--- a/projects/element-ng/tour/si-tour.model.ts
+++ b/projects/element-ng/tour/si-tour.model.ts
@@ -35,10 +35,6 @@ export interface TourStep extends TourStepCommonOptions {
   /** The element, the step should be attached to on the page. */
   attachTo?: {
     element: string | HTMLElement | (() => string | HTMLElement);
-    /**
-     * @deprecated this has no effect, position is automatic
-     */
-    on?: ModalPosition;
   };
 }
 
@@ -48,20 +44,3 @@ export interface TourOptions {
   defaultStepOptions?: TourStepCommonOptions;
 }
 
-/**
- * The position of the modal dialog with respect to the highlighted element.
- * @deprecated this has no effect, position is automatic
- */
-export type ModalPosition =
-  | 'top'
-  | 'top-start'
-  | 'top-end'
-  | 'bottom'
-  | 'bottom-start'
-  | 'bottom-end'
-  | 'right'
-  | 'right-start'
-  | 'right-end'
-  | 'left'
-  | 'left-start'
-  | 'left-end';


### PR DESCRIPTION
BREAKING CHANGE: Removed the deprecated property `attachTo.on` of `TourStep` interface. It has no effect, position is automatic.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
