### PR TITLE
docs(common): deprecate leftover position helper

### DIFF
--- a/projects/element-ng/common/helpers/positioning.helpers.ts
+++ b/projects/element-ng/common/helpers/positioning.helpers.ts
@@ -4,12 +4,22 @@
  */
 import { isRTL } from './rtl';
 
+/** @deprecated Use the CDK Overlay instead. */
 export type Direction = 'down' | 'up' | 'start' | 'end';
+
+/** @deprecated Use the CDK Overlay instead. */
 export type PlacementBasicVertical = 'top' | 'bottom';
+
+/** @deprecated Use the CDK Overlay instead. */
 export type PlacementBasic = 'start' | 'end' | PlacementBasicVertical;
+
+/** @deprecated Use the CDK Overlay instead. */
 export type Placement = '' | PlacementBasic | `${PlacementBasic} ${PlacementBasic}`;
+
+/** @deprecated Use the CDK Overlay instead. */
 export type Align = 'start' | 'center' | 'end';
 
+/** @deprecated Use the CDK Overlay instead. */
 export const AXIS_X = {
   axis: 'X',
   directionRegular: 'end',
@@ -19,6 +29,8 @@ export const AXIS_X = {
   size: 'width',
   windowSize: 'innerWidth'
 } as const;
+
+/** @deprecated Use the CDK Overlay instead. */
 export const AXIS_Y = {
   axis: 'Y',
   directionRegular: 'down',
@@ -28,6 +40,8 @@ export const AXIS_Y = {
   size: 'height',
   windowSize: 'innerHeight'
 } as const;
+
+/** @deprecated Use the CDK Overlay instead. */
 export const BOUNDING_RECT_WINDOW = {
   getBoundingClientRect: () => ({
     top: 0,
@@ -37,6 +51,7 @@ export const BOUNDING_RECT_WINDOW = {
   })
 };
 
+/** @deprecated Use the CDK Overlay instead. */
 export const resolveReference = (
   hostElement: HTMLElement,
   reference: string
@@ -237,6 +252,7 @@ const getRelativeContentPosition = (params: {
   return { left: leftOffset, top: topOffset };
 };
 
+/** @deprecated Use the CDK Overlay instead. */
 export const getContentPositionString = (params: {
   contentElement: HTMLElement;
   direction: Direction;
@@ -257,6 +273,7 @@ export const getContentPositionString = (params: {
   return `translate3d(${position.left}px, ${position.top}px, 0px)`;
 };
 
+/** @deprecated Use the CDK Overlay instead. */
 export const responsivelyCheckDirection = (params: {
   isScrolling?: boolean;
   currentDirection: Direction;


### PR DESCRIPTION
None of those helpers are used in element.
Those are leftover from `siDropdown` and similar components we no longer have.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
