### PR TITLE
build(ci): use `pull_request_target` instead of `pull_request`

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -8,7 +8,7 @@ on:
         required: true
       MAPTILER_KEY:
         required: true
-  pull_request:
+  pull_request_target:
 
 # Stops the workflow run if the PR is updated
 # https://stackoverflow.com/a/72408109


### PR DESCRIPTION
This is needed to allow 3rd party pull requests to create PR comments, as we do for coverage and built artifacts.

I am not sure how this will influence credentials, but they seem not to work anyway on 3rd party requests.

See for details https://github.com/cli/cli/issues/8374.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
