### PR TITLE
refactor(eslint): drop use of deprecated method

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,16 +1,16 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import typescriptEslint from 'typescript-eslint';
 import angularTypescriptConfig from '@siemens/eslint-config-angular';
 import angularTemplateConfig from '@siemens/eslint-config-angular/template';
 import tsdocPlugin from 'eslint-plugin-tsdoc';
 import eslintPluginHeaders from 'eslint-plugin-headers';
+import { defineConfig } from 'eslint/config';
 
 // mimic CommonJS variables
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-export const tsConfig = typescriptEslint.config({
+export const tsConfig = defineConfig({
   extends: [...angularTypescriptConfig],
   files: ['**/*.ts'],
   languageOptions: {
@@ -94,7 +94,7 @@ export const tsConfig = typescriptEslint.config({
   }
 });
 
-export const templateConfig = typescriptEslint.config({
+export const templateConfig = defineConfig({
   extends: [...angularTemplateConfig],
   files: ['**/*.html'],
   rules: {
@@ -120,4 +120,4 @@ export const templateConfig = typescriptEslint.config({
   }
 });
 
-export default typescriptEslint.config(...tsConfig, ...templateConfig);
+export default defineConfig(...tsConfig, ...templateConfig);

--- a/projects/charts-ng/eslint.config.js
+++ b/projects/charts-ng/eslint.config.js
@@ -1,7 +1,7 @@
-import typescriptEslint from 'typescript-eslint';
 import { tsConfig, templateConfig } from '../../eslint.config.js';
 import defaultValuePlugin from '@siemens/eslint-plugin-defaultvalue';
-export default typescriptEslint.config(
+import { defineConfig } from 'eslint/config';
+export default defineConfig(
   {
     extends: [...tsConfig],
     plugins: {

--- a/projects/dashboards-demo/eslint.config.js
+++ b/projects/dashboards-demo/eslint.config.js
@@ -1,7 +1,7 @@
-import typescriptEslint from 'typescript-eslint';
 import { tsConfig, templateConfig } from '../../eslint.config.js';
+import { defineConfig } from 'eslint/config';
 
-export default typescriptEslint.config(
+export default defineConfig(
   {
     extends: [...tsConfig],
     files: ['**/*.ts'],

--- a/projects/dashboards-demo/mfe/eslint.config.js
+++ b/projects/dashboards-demo/mfe/eslint.config.js
@@ -1,7 +1,7 @@
-import typescriptEslint from 'typescript-eslint';
 import { templateConfig, tsConfig } from '../../../eslint.config.js';
+import { defineConfig } from 'eslint/config';
 
-export default typescriptEslint.config(
+export default defineConfig(
   {
     extends: [...tsConfig],
     files: ['**/*.ts'],

--- a/projects/dashboards-demo/webcomponents/eslint.config.js
+++ b/projects/dashboards-demo/webcomponents/eslint.config.js
@@ -1,7 +1,7 @@
-import typescriptEslint from 'typescript-eslint';
 import { templateConfig, tsConfig } from '../../../eslint.config.js';
+import { defineConfig } from 'eslint/config';
 
-export default typescriptEslint.config(
+export default defineConfig(
   {
     extends: [...tsConfig],
     files: ['**/*.ts'],

--- a/projects/dashboards-ng/eslint.config.js
+++ b/projects/dashboards-ng/eslint.config.js
@@ -1,7 +1,7 @@
-import typescriptEslint from 'typescript-eslint';
 import { tsConfig, templateConfig } from '../../eslint.config.js';
 import defaultValuePlugin from '@siemens/eslint-plugin-defaultvalue';
-export default typescriptEslint.config(
+import { defineConfig } from 'eslint/config';
+export default defineConfig(
   {
     extends: [...tsConfig],
     plugins: {

--- a/projects/element-ng/eslint.config.js
+++ b/projects/element-ng/eslint.config.js
@@ -1,7 +1,7 @@
-import typescriptEslint from 'typescript-eslint';
 import { tsConfig, templateConfig } from '../../eslint.config.js';
 import defaultValuePlugin from '@siemens/eslint-plugin-defaultvalue';
-export default typescriptEslint.config(
+import { defineConfig } from 'eslint/config';
+export default defineConfig(
   {
     extends: [...tsConfig],
     plugins: {

--- a/projects/element-translate-ng/eslint.config.js
+++ b/projects/element-translate-ng/eslint.config.js
@@ -1,7 +1,7 @@
-import typescriptEslint from 'typescript-eslint';
 import { tsConfig, templateConfig } from '../../eslint.config.js';
+import { defineConfig } from 'eslint/config';
 
-export default typescriptEslint.config(
+export default defineConfig(
   {
     extends: [...tsConfig],
     files: ['**/*.ts'],

--- a/projects/live-preview/eslint.config.js
+++ b/projects/live-preview/eslint.config.js
@@ -1,7 +1,7 @@
-import typescriptEslint from 'typescript-eslint';
 import { tsConfig, templateConfig } from '../../eslint.config.js';
+import { defineConfig } from 'eslint/config';
 
-export default typescriptEslint.config(
+export default defineConfig(
   {
     extends: [...tsConfig],
     files: ['**/*.ts'],

--- a/projects/maps-ng/eslint.config.js
+++ b/projects/maps-ng/eslint.config.js
@@ -1,7 +1,7 @@
-import typescriptEslint from 'typescript-eslint';
 import { tsConfig, templateConfig } from '../../eslint.config.js';
 import defaultValuePlugin from '@siemens/eslint-plugin-defaultvalue';
-export default typescriptEslint.config(
+import { defineConfig } from 'eslint/config';
+export default defineConfig(
   {
     extends: [...tsConfig],
     plugins: {

--- a/projects/native-charts-ng/eslint.config.js
+++ b/projects/native-charts-ng/eslint.config.js
@@ -1,7 +1,7 @@
-import typescriptEslint from 'typescript-eslint';
 import { tsConfig, templateConfig } from '../../eslint.config.js';
 import defaultValuePlugin from '@siemens/eslint-plugin-defaultvalue';
-export default typescriptEslint.config(
+import { defineConfig } from 'eslint/config';
+export default defineConfig(
   {
     extends: [...tsConfig],
     plugins: {


### PR DESCRIPTION
replaces deprecated `typescriptEslint.config` method of `typescript-eslint` with `defineConfig` of `eslint/config`


---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
