### PR TITLE
refactor(typeahead): remove useless `margin-end` on items

### DIFF
--- a/projects/element-ng/typeahead/si-typeahead.component.html
+++ b/projects/element-ng/typeahead/si-typeahead.component.html
@@ -27,7 +27,7 @@
   @for (match of matches(); track $index) {
     <li
       #typeaheadMatch
-      class="dropdown-item me-4"
+      class="dropdown-item"
       [siAutocompleteOption]="match"
       [attr.aria-label]="match.text"
       [attr.aria-selected]="multiselect() ? match.itemSelected : null"


### PR DESCRIPTION
This `margin-end` had no effect.
It was only leading to items expand over the dropdown container.

<img width="637" height="392" alt="image" src="https://github.com/user-attachments/assets/f66bc757-1838-424d-95cd-692ab50cd1aa" />


> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
