### PR TITLE
fix(typeahead): remove `icon` component if no icon is provided

### DIFF
--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--operator-open-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--operator-open-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1a6b0d6466fd13e0a12492b42003f5e3b2e51bf619b47ba12cf734fbba6cb68
-size 11967
+oid sha256:94bbee1ab28ce2efe5667971def2f957f733c53f9ebc651c36fd80028d18e62f
+size 11962

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--operator-open-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--operator-open-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40f5870b64564f77e59bceb3dcee3998726e9776edc29b27cc69877d6a3cbb11
-size 12165
+oid sha256:7315c0b6d644b4b3474a4049952d49431dc6da841f38f5203f6e8ac30659c425
+size 12158

--- a/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-basic-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-basic-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c20577cee5da63a8204a49acc27a1727b92f857c078e11aaacf3cb3be8fd58fb
-size 9674
+oid sha256:6edd1d67b5e6a97ff084338c761d5467940a80364eff73df00aa9c9466735d10
+size 9666

--- a/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-basic-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-typeahead.spec.ts-snapshots/si-typeahead--si-typeahead-basic-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bcb6d8c2a60ddce2ba92c09026224174123369af845db8974589493975f0acad
-size 9711
+oid sha256:2acc12ce4e25ee9ca9541e6c75c95d179375708f87a419ba9df7a1b560496a94
+size 9704

--- a/projects/element-ng/typeahead/si-typeahead.directive.ts
+++ b/projects/element-ng/typeahead/si-typeahead.directive.ts
@@ -385,10 +385,35 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
     this.typeaheadOpenChange.emit(true);
   }
 
-  // Get the matches and push them to the subject of the component, then set the query of the component.
-  // If the typeahead options are objects, pick the specified field/property.
-  private getOptionValue(option: TypeaheadOption, field: string): string {
-    return typeof option !== 'object' ? option.toString() : (option[field] ?? '');
+  /**
+   * Extracts the display value from a typeahead option.
+   *
+   * For string options, returns the string value directly.
+   * For object options, returns the value of the field specified by {@link typeaheadOptionField}
+   * (defaults to 'name'), or an empty string if the field doesn't exist.
+   *
+   * @param option - The typeahead option to extract the value from
+   * @returns The string representation of the option for display purposes
+   */
+  private getOptionValue(option: TypeaheadOption): string {
+    return typeof option !== 'object'
+      ? option.toString()
+      : (option[this.typeaheadOptionField()] ?? '');
+  }
+
+  /**
+   * Extracts a specific field value from a typeahead option.
+   *
+   * This method is used to access additional properties of object-type options,
+   * such as 'selected' for multi-select functionality or 'iconClass' for displaying icons.
+   *
+   * @param option - The typeahead option to extract the field from
+   * @param field - The name of the field to extract
+   * @returns The field value as a string if the option is an object and the field exists,
+   *          otherwise undefined
+   */
+  private getOptionField(option: TypeaheadOption, field: string): string | undefined {
+    return typeof option !== 'object' ? undefined : option[field];
   }
 
   // If enabled, process the matches and sort through them.
@@ -413,11 +438,11 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
           // Check if the options need to be processed, if not just return an unprocessed object.
           if (!this.typeaheadProcess()) {
             return options.map(option => {
-              const optionValue = this.getOptionValue(option, this.typeaheadOptionField());
+              const optionValue = this.getOptionValue(option);
               const itemSelected = this.typeaheadMultiSelect()
-                ? this.getOptionValue(option, 'selected')
+                ? this.getOptionField(option, 'selected')
                 : false;
-              const iconClass = this.getOptionValue(option, 'iconClass');
+              const iconClass = this.getOptionField(option, 'iconClass');
               return {
                 option,
                 itemSelected,
@@ -441,13 +466,13 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
             // Process the options.
             const matches: TypeaheadMatch[] = [];
             options.forEach(option => {
-              const optionValue = this.getOptionValue(option, this.typeaheadOptionField());
+              const optionValue = this.getOptionValue(option);
               const stringMatch =
                 optionValue.toLocaleLowerCase().trim() === query.toLocaleLowerCase().trim();
               const itemSelected = this.typeaheadMultiSelect()
                 ? option['selected' as keyof TypeaheadOption]
                 : false;
-              const iconClass = this.getOptionValue(option, 'iconClass');
+              const iconClass = this.getOptionField(option, 'iconClass');
               const candidate: TypeaheadMatch = {
                 option,
                 itemSelected,


### PR DESCRIPTION
Currently, the `si-icon` is always rendered in the typeahead if the options are provided as a string.
This is due to `getOptionField` previously always returning a string if string options were provided.
So when trying to read the `iconClass` a value was always returned, so the `si-icon` was always rendered adding a `2px` `margin-start`.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
