### PR TITLE
feat(schematics): install all needed packages on ng-add

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -64,6 +64,9 @@ jobs:
         with:
           node-version: lts/jod
           cache: 'npm'
+      - run: npm config set //code.siemens.com/api/v4/packages/npm/:_authToken $SIEMENS_NPM_TOKEN
+        env:
+          SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
       - uses: actions/download-artifact@v5
         with:
           name: dist

--- a/projects/element-ng/package.json
+++ b/projects/element-ng/package.json
@@ -22,7 +22,7 @@
   "type": "module",
   "schematics": "./schematics/collection.json",
   "ng-add": {
-    "save": "dependencies"
+    "save": "false"
   },
   "peerDependencies": {
     "@angular/animations": "20",

--- a/projects/element-ng/schematics/ng-add/index.spec.ts
+++ b/projects/element-ng/schematics/ng-add/index.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing/index.js';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+describe('ngAdd', () => {
+  let runner: SchematicTestRunner;
+  let tree: UnitTestTree;
+
+  beforeEach(() => {
+    tree = new UnitTestTree(Tree.empty());
+    tree.create('/tsconfig.json', '{}');
+    tree.create(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          t: { root: '', architect: { build: { options: { tsConfig: './tsconfig.json' } } } }
+        }
+      })
+    );
+    const collectionJsonPath = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      '../collection.json'
+    );
+    runner = new SchematicTestRunner('test', collectionJsonPath);
+  });
+
+  it('should add dependencies to package.json', async () => {
+    tree.create(
+      '/package.json',
+      JSON.stringify({
+        dependencies: {
+          '@angular/core': '^20.0.0',
+          '@simpl/element-ng': '47.0.0',
+          '@simpl/element-theme': '47.0.0',
+          '@simpl/charts-ng': '47.0.0',
+          '@simpl/element-translate-ng': '47.0.0',
+          '@simpl/maps-ng': '47.0.0',
+          '@simpl/dashboards-ng': '47.0.0'
+        }
+      })
+    );
+    tree = await runner.runSchematic('ng-add', {}, tree);
+    const updatedPackage = JSON.parse(tree.readContent('/package.json')).dependencies;
+    expect(updatedPackage['@simpl/element-ng']).toBeDefined();
+    expect(updatedPackage['@siemens/element-ng']).toBeDefined();
+    expect(updatedPackage['@simpl/element-theme']).toBeDefined();
+    expect(updatedPackage['@siemens/element-theme']).toBeDefined();
+    expect(updatedPackage['@simpl/element-translate-ng']).toBeDefined();
+    expect(updatedPackage['@siemens/element-translate-ng']).toBeDefined();
+    expect(updatedPackage['@simpl/maps-ng']).toBeDefined();
+    expect(updatedPackage['@siemens/maps-ng']).toBeDefined();
+    expect(updatedPackage['@simpl/charts-ng']).toBeDefined();
+    expect(updatedPackage['@siemens/charts-ng']).toBeDefined();
+    expect(updatedPackage['@simpl/dashboards-ng']).toBeDefined();
+    expect(updatedPackage['@siemens/dashboards-ng']).toBeDefined();
+  });
+});

--- a/projects/element-ng/schematics/ng-add/index.ts
+++ b/projects/element-ng/schematics/ng-add/index.ts
@@ -5,6 +5,8 @@
 import { chain, Rule, schematic, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { getPackageJsonDependency } from '@schematics/angular/utility/dependencies';
 
+import { installPackages } from './install-packages.js';
+
 export const ngAdd = (options: { path: string }): Rule => {
   return (tree: Tree, context: SchematicContext) => {
     context.logger.info('🔧 Adding @siemens/element-ng to your project...');
@@ -12,8 +14,8 @@ export const ngAdd = (options: { path: string }): Rule => {
     const hasSimplElementNgDependency = getPackageJsonDependency(tree, '@simpl/element-ng');
 
     if (hasSimplElementNgDependency) {
-      const chainedRules = chain([schematic('simpl-siemens-migration', options)]);
-      return chainedRules(tree, context);
+      context.addTask(installPackages(tree));
+      return chain([schematic('simpl-siemens-migration', options)])(tree, context);
     }
   };
 };

--- a/projects/element-ng/schematics/ng-add/install-packages.ts
+++ b/projects/element-ng/schematics/ng-add/install-packages.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import {
+  getPackageJsonDependency,
+  addPackageJsonDependency,
+  NodeDependencyType
+} from '@schematics/angular/utility/dependencies';
+import { execSync } from 'child_process';
+
+export const installPackages = (tree: Tree): NodePackageInstallTask => {
+  try {
+    const latestSimplVersion = execSync('npm view @simpl/element-ng version').toString().trim();
+    const latestMappedSiemensVersion = execSync(
+      'npm view @simpl/element-ng peerDependencies.@siemens/element-ng'
+    )
+      .toString()
+      .trim();
+
+    addPackageJsonDependency(tree, {
+      type: NodeDependencyType.Default,
+      name: '@simpl/element-ng',
+      version: latestSimplVersion,
+      overwrite: true
+    });
+    addPackageJsonDependency(tree, {
+      type: NodeDependencyType.Default,
+      name: '@siemens/element-ng',
+      version: latestMappedSiemensVersion,
+      overwrite: true
+    });
+    addPackageJsonDependency(tree, {
+      type: NodeDependencyType.Default,
+      name: '@simpl/element-theme',
+      version: latestSimplVersion,
+      overwrite: true
+    });
+    addPackageJsonDependency(tree, {
+      type: NodeDependencyType.Default,
+      name: '@siemens/element-theme',
+      version: latestMappedSiemensVersion,
+      overwrite: true
+    });
+    addPackageJsonDependency(tree, {
+      type: NodeDependencyType.Default,
+      name: '@simpl/element-translate-ng',
+      version: latestSimplVersion,
+      overwrite: true
+    });
+    addPackageJsonDependency(tree, {
+      type: NodeDependencyType.Default,
+      name: '@siemens/element-translate-ng',
+      version: latestMappedSiemensVersion,
+      overwrite: true
+    });
+
+    if (getPackageJsonDependency(tree, '@simpl/charts-ng')) {
+      addPackageJsonDependency(tree, {
+        type: NodeDependencyType.Default,
+        name: '@simpl/charts-ng',
+        version: latestSimplVersion,
+        overwrite: true
+      });
+      addPackageJsonDependency(tree, {
+        type: NodeDependencyType.Default,
+        name: '@siemens/charts-ng',
+        version: latestMappedSiemensVersion,
+        overwrite: true
+      });
+    }
+
+    if (getPackageJsonDependency(tree, '@simpl/maps-ng')) {
+      addPackageJsonDependency(tree, {
+        type: NodeDependencyType.Default,
+        name: '@simpl/maps-ng',
+        version: latestSimplVersion,
+        overwrite: true
+      });
+      addPackageJsonDependency(tree, {
+        type: NodeDependencyType.Default,
+        name: '@siemens/maps-ng',
+        version: latestMappedSiemensVersion,
+        overwrite: true
+      });
+    }
+
+    if (getPackageJsonDependency(tree, '@simpl/dashboards-ng')) {
+      addPackageJsonDependency(tree, {
+        type: NodeDependencyType.Default,
+        name: '@simpl/dashboards-ng',
+        version: latestSimplVersion,
+        overwrite: true
+      });
+      addPackageJsonDependency(tree, {
+        type: NodeDependencyType.Default,
+        name: '@siemens/dashboards-ng',
+        version: latestMappedSiemensVersion,
+        overwrite: true
+      });
+    }
+  } catch (error) {
+    const schematicsException = new SchematicsException(
+      `Failed to update dependencies. Ensure that:
+    - 'npm' is installed
+    - the '@simpl' scope is configured in your '.npmrc' and proper authentication is provided`
+    );
+    schematicsException.cause = error;
+    throw schematicsException;
+  }
+
+  return new NodePackageInstallTask();
+};


### PR DESCRIPTION
Installing the required dependencies for v48 requires some effort.
The internal `@simpl/*` package versions are not guaranteed to match the corresponding `@siemens/*` versions.
So when running `ng add @siemens/element-ng` we must NOT let Angular save this package.
Instead, we need to fetch the latest `@simpl/element-ng` package and check the used version of `@siemens/element-ng`.
Then we install all needed packages of `@simpl/*` and `@siemens/*` with the latest possible version.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
