### PR TITLE
fix(filtered-search): focus ring not visible in case of empty option value

### DIFF
--- a/playwright/e2e/element-examples/si-filtered-search.spec.ts
+++ b/playwright/e2e/element-examples/si-filtered-search.spec.ts
@@ -80,6 +80,18 @@ test.describe('filtered search', () => {
     await si.runVisualAndA11yTests('invalid-criterion');
   });
 
+  test('should show focus ring on empty criterion value', async ({ si, page }) => {
+    await si.visitExample('si-filtered-search/si-filtered-search-playground');
+    const searchCriteriaInput = page.getByPlaceholder(/Enter and assign search criteria/);
+    await searchCriteriaInput.fill(
+      '{ "criteria": [{"name":"location", "value":""}], "value": "" }'
+    );
+    await searchCriteriaInput.blur();
+    const criterionValue = page.locator('.criterion-value-text');
+    await criterionValue.focus();
+    await si.runVisualAndA11yTests('empty-value-focused');
+  });
+
   test('should not be interactive when disabled', async ({ si, page }) => {
     await si.visitExample('si-filtered-search/si-filtered-search-playground');
     await page.getByLabel('Disabled').check();

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--empty-value-focused-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--empty-value-focused-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4925b7efcf54fc0832f87a40ef43ee3a62d35e99781e5a5e178c93f84734dbad
+size 7949

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--empty-value-focused-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--empty-value-focused-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:788a674097ef19da5d7f542ed328c7cdf61b3fc74545cf23bf34473229c6623b
+size 7831

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--empty-value-focused.yaml
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--empty-value-focused.yaml
@@ -1,0 +1,33 @@
+- text: Filtered Search Location
+- button "clear"
+- combobox "search"
+- button "clear"
+- button "Submit search"
+- text: Control panel
+- checkbox "Disabled"
+- text: Disabled
+- checkbox "Search on input" [checked]
+- text: Search on input
+- checkbox "Disable free text search"
+- text: Disable free text search
+- checkbox "Only predefined criteria"
+- text: Only predefined criteria
+- checkbox "Only predefined criterion options"
+- text: Only predefined criterion options
+- checkbox "Only predefined criterion options and prevent typing"
+- text: Only predefined criterion options and prevent typing
+- checkbox "Exclusive criteria"
+- text: Exclusive criteria
+- checkbox "Disable free text pills" [checked]
+- text: Disable free text pills Search debounce time
+- spinbutton "Search debounce time"
+- text: Number of visible options
+- spinbutton "Number of visible options"
+- text: Max criteria
+- spinbutton "Max criteria"
+- text: Max options (0 means unlimited)
+- spinbutton "Max options (0 means unlimited)"
+- text: Search criteria input
+- textbox "Search criteria input":
+  - /placeholder: "Enter and assign search criteria as JSON e.g. { \"criterias\": [], \"value\": \"test\" }"
+  - text: "{ \"criteria\": [{\"name\":\"location\", \"value\":\"\"}], \"value\": \"\" }"

--- a/projects/element-ng/filtered-search/values/date-value/si-filtered-search-date-value.component.scss
+++ b/projects/element-ng/filtered-search/values/date-value/si-filtered-search-date-value.component.scss
@@ -1,3 +1,7 @@
 input {
   background: transparent;
 }
+
+.criterion-value-text {
+  min-block-size: 1.5rem;
+}

--- a/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.scss
+++ b/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.scss
@@ -1,3 +1,7 @@
 input {
   background: transparent;
 }
+
+.criterion-value-text {
+  min-block-size: 1.5rem;
+}

--- a/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.scss
+++ b/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.scss
@@ -8,3 +8,7 @@ input {
     margin: 0;
   }
 }
+
+.criterion-value-text {
+  min-block-size: 1.5rem;
+}


### PR DESCRIPTION
fixes the issue where focus ring is not visible due to element height being 0px when option value is empty even when focus is on the option value element. min block size is added to prevent 0px height.

Closes #879+

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-883/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-883/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-883/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-883/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-883/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-883/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-883/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-883/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-883/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-883/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

