### PR TITLE
feat(header-dropdown): add class `header-dropdown-overlay` when rendered as overlay

### DIFF
--- a/api-goldens/element-ng/header-dropdown/index.api.md
+++ b/api-goldens/element-ng/header-dropdown/index.api.md
@@ -19,16 +19,6 @@ import { TemplateRef } from '@angular/core';
 export class SiHeaderDropdownComponent {
     constructor();
     // (undocumented)
-    protected escape(): void;
-    // (undocumented)
-    protected get show(): boolean;
-    // (undocumented)
-    protected get submenu(): boolean;
-    // (undocumented)
-    protected get trapFocus(): boolean;
-    // (undocumented)
-    protected trigger: SiHeaderDropdownTriggerDirective;
-    // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiHeaderDropdownComponent, "si-header-dropdown", never, {}, {}, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<SiHeaderDropdownComponent, never>;

--- a/projects/element-ng/header-dropdown/si-header-dropdown.component.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown.component.ts
@@ -34,6 +34,7 @@ import { SI_HEADER_DROPDOWN_OPTIONS } from './si-header.model';
   }
 })
 export class SiHeaderDropdownComponent {
+  /** @internal */
   protected trigger = inject(SiHeaderDropdownTriggerDirective);
 
   private readonly focusTrap = viewChild.required(CdkTrapFocus);
@@ -61,19 +62,23 @@ export class SiHeaderDropdownComponent {
     });
   }
 
+  /** @internal */
   @HostBinding('class.show')
   protected get show(): boolean {
     return this.trigger.isOpen;
   }
 
+  /** @internal */
   @HostBinding('class.header-dropdown-overlay') protected get overlay(): boolean {
     return this.trigger.isOverlay;
   }
 
+  /** @internal */
   @HostBinding('class.sub-menu') protected get submenu(): boolean {
     return this.trigger.level > 1;
   }
 
+  /** @internal */
   protected get trapFocus(): boolean {
     return (
       this.trigger.isOverlay ||
@@ -81,6 +86,7 @@ export class SiHeaderDropdownComponent {
     );
   }
 
+  /** @internal */
   @HostListener('keydown.escape')
   protected escape(): void {
     this.trigger?.close();


### PR DESCRIPTION
Adds `header-dropdown-overlay` class based on rendering mode, enabling distinct styling between inline and overlay dropdown modes.

Can be used in cases like #791

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
