### PR TITLE
test(e2e): pass mode via metadata

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -137,17 +137,17 @@ const config: PlaywrightTestConfig = {
   projects: [
     {
       name: `element-examples/chromium/light`,
-      metadata: { livePreviewer: true, theme: 'light' },
+      metadata: { livePreviewer: true, theme: 'light', isA11y, isVrt },
       testDir: './playwright/e2e/element-examples'
     },
     {
       name: `element-examples/chromium/dark`,
-      metadata: { livePreviewer: true, theme: 'dark', skipAriaSnapshot: true },
+      metadata: { livePreviewer: true, theme: 'dark', skipAriaSnapshot: true, isA11y, isVrt },
       testDir: './playwright/e2e/element-examples'
     },
     {
       name: `dashboards-demo/chromium/light`,
-      metadata: { theme: 'light' },
+      metadata: { theme: 'light', isA11y, isVrt },
       use: {
         baseURL: `http://${localAddress}:${dashboardsPort}`
       },
@@ -155,7 +155,7 @@ const config: PlaywrightTestConfig = {
     },
     {
       name: `dashboards-demo/chromium/dark`,
-      metadata: { theme: 'dark', skipAriaSnapshot: true },
+      metadata: { theme: 'dark', skipAriaSnapshot: true, isA11y, isVrt },
       use: {
         baseURL: `http://${localAddress}:${dashboardsPort}`
       },

--- a/playwright/support/test-helpers.ts
+++ b/playwright/support/test-helpers.ts
@@ -19,25 +19,6 @@ export { expect } from '@playwright/test';
 
 const SI_EXAMPLE_NAME_ID = 'siExampleName';
 
-const detectTestTypes = (): { isA11y: boolean; isVrt: boolean } => {
-  let isA11y =
-    !!process.env.PLAYWRIGHT_isa11y &&
-    process.env.PLAYWRIGHT_isa11y.toLocaleLowerCase() !== 'false';
-
-  let isVrt =
-    !!process.env.PLAYWRIGHT_isvrt && process.env.PLAYWRIGHT_isvrt.toLocaleLowerCase() !== 'false';
-
-  // Per default do both A11y and VRT
-  if (!isA11y && !isVrt) {
-    isA11y = true;
-    isVrt = true;
-  }
-
-  return { isA11y, isVrt };
-};
-
-const { isA11y, isVrt } = detectTestTypes();
-
 const staticTest = process.env.PLAYWRIGHT_staticTest
   ? new Set(process.env.PLAYWRIGHT_staticTest.split(':'))
   : undefined;
@@ -174,7 +155,7 @@ class SiTestHelpers {
     await test.step(
       'runVisualAndA11yTests: ' + testName,
       async () => {
-        if (isA11y) {
+        if (this.testInfo.project.metadata.isA11y) {
           await this.enableDisableAnimations(this.page, false);
           const rules = (options?.axeRulesSet ?? [])
             .filter(
@@ -224,7 +205,7 @@ class SiTestHelpers {
           }
           await expectNoA11yViolations(this.testInfo, axeResults.violations, testName);
         }
-        if (isVrt) {
+        if (this.testInfo.project.metadata.isVrt) {
           try {
             await this.showHideIgnores(this.page, false, options?.snapshotDelay);
             await expect(this.page).toHaveScreenshot(testName + '.png', {


### PR DESCRIPTION
Removes the redundant evaluation of the mode.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
