### PR TITLE
test(resize-observer): improve stability of ResizeObserverService tests

### DIFF
--- a/projects/element-ng/resize-observer/mock-resize-observer.spec.ts
+++ b/projects/element-ng/resize-observer/mock-resize-observer.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+
+let resizeObserver: ResizeObserver;
+export interface TriggerResize {
+  target: HTMLElement;
+  inlineSize: number;
+  blockSize: number;
+}
+export const mockResizeObserver = (): void => {
+  resizeObserver = (window as any).ResizeObserver;
+  (window as any).ResizeObserver = MockResizeObserver;
+};
+
+export const restoreResizeObserver = (): void => {
+  (window as any).ResizeObserver = resizeObserver;
+};
+/**
+ * `ResizeObserver` mock for testing purposes.
+ */
+export class MockResizeObserver {
+  static instance: MockResizeObserver;
+  private callback: ResizeObserverCallback;
+  observed: [Element, ResizeObserverOptions | undefined][] = [];
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    MockResizeObserver.instance = this;
+  }
+
+  disconnect = jasmine.createSpy('disconnect').and.callFake(() => (this.observed = []));
+
+  observe = jasmine
+    .createSpy('observe')
+    .and.callFake((target: Element, options?: ResizeObserverOptions) =>
+      this.observed.push([target, options])
+    );
+
+  unobserve = jasmine
+    .createSpy('unobserve')
+    .and.callFake(
+      (target: Element) => (this.observed = this.observed.filter(x => x[0] !== target))
+    );
+
+  static triggerResize({ target, inlineSize, blockSize }: TriggerResize): void {
+    target.style.width = `${inlineSize}px`;
+    target.style.height = `${blockSize}px`;
+    const e: ResizeObserverEntry = {
+      target,
+      contentRect: target.getBoundingClientRect(),
+      borderBoxSize: [{ inlineSize, blockSize }],
+      contentBoxSize: [{ inlineSize, blockSize }],
+      devicePixelContentBoxSize: [{ inlineSize, blockSize }]
+    };
+    // Mock clientWidth and clientHeight to simulate size change
+    const instance = MockResizeObserver.instance;
+    if (instance.observed.filter(x => !!x).length !== 0) {
+      instance.callback?.([e], instance);
+    }
+  }
+}

--- a/projects/element-ng/resize-observer/resize-observer.service.spec.ts
+++ b/projects/element-ng/resize-observer/resize-observer.service.spec.ts
@@ -6,23 +6,17 @@ import { Component, ElementRef, viewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { Subscription } from 'rxjs';
 
+import {
+  MockResizeObserver,
+  mockResizeObserver,
+  restoreResizeObserver
+} from './mock-resize-observer.spec';
 import { ElementDimensions, ResizeObserverService } from './resize-observer.service';
 
 @Component({
-  template: `
-    <div
-      #theDiv
-      style="width: 100px; height: 100px;"
-      [style.width.px]="width"
-      [style.height.px]="height"
-    >
-      Testli
-    </div>
-  `
+  template: ` <div #theDiv style="width: 100px; height: 100px;">Testli</div> `
 })
 class TestHostComponent {
-  width = 100;
-  height = 100;
   readonly theDiv = viewChild.required<ElementRef>('theDiv');
 }
 
@@ -53,6 +47,7 @@ describe('ResizeObserverService', () => {
   }));
 
   beforeEach(fakeAsync(() => {
+    mockResizeObserver();
     service = TestBed.inject(ResizeObserverService);
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
@@ -64,12 +59,13 @@ describe('ResizeObserverService', () => {
 
   afterEach(() => {
     subscription?.unsubscribe();
+    restoreResizeObserver();
   });
 
   it('emits initial size event when asked', waitForAsync(async () => {
     subscribe(true);
     await timeout(10);
-    expect(spy).toHaveBeenCalledWith({ width: 100, height: 100 });
+    expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ width: 100, height: 100 }));
   }));
 
   it('emits no initial size event when not asked', waitForAsync(async () => {
@@ -81,7 +77,11 @@ describe('ResizeObserverService', () => {
   it('emits on width change', waitForAsync(async () => {
     subscribe(false);
 
-    component.width = 200;
+    MockResizeObserver.triggerResize({
+      target: component.theDiv().nativeElement,
+      inlineSize: 200,
+      blockSize: 100
+    });
     fixture.detectChanges();
 
     // Skip test when browser is not focussed to prevent failures.
@@ -91,14 +91,18 @@ describe('ResizeObserverService', () => {
       expect(spy).not.toHaveBeenCalled();
 
       await timeout(150);
-      expect(spy).toHaveBeenCalledWith({ width: 200, height: 100 });
+      expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ width: 200, height: 100 }));
     }
   }));
 
   it('emits on height change', waitForAsync(async () => {
     subscribe(false);
 
-    component.height = 200;
+    MockResizeObserver.triggerResize({
+      target: component.theDiv().nativeElement,
+      inlineSize: 100,
+      blockSize: 200
+    });
     fixture.detectChanges();
 
     // Skip test when browser is not focussed to prevent failures.
@@ -108,7 +112,7 @@ describe('ResizeObserverService', () => {
       expect(spy).not.toHaveBeenCalled();
 
       await timeout(150);
-      expect(spy).toHaveBeenCalledWith({ width: 100, height: 200 });
+      expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ width: 100, height: 200 }));
     }
   }));
 
@@ -123,15 +127,19 @@ describe('ResizeObserverService', () => {
         .subscribe(dim => spy2(dim));
 
       await timeout(20);
-      expect(spy).toHaveBeenCalledWith({ width: 100, height: 100 });
-      expect(spy2).toHaveBeenCalledWith({ width: 100, height: 100 });
+      expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ width: 100, height: 100 }));
+      expect(spy2).toHaveBeenCalledWith(jasmine.objectContaining({ width: 100, height: 100 }));
 
-      component.width = 200;
+      MockResizeObserver.triggerResize({
+        target: component.theDiv().nativeElement,
+        inlineSize: 200,
+        blockSize: 100
+      });
       fixture.detectChanges();
 
       await timeout(150);
-      expect(spy).toHaveBeenCalledWith({ width: 200, height: 100 });
-      expect(spy2).toHaveBeenCalledWith({ width: 200, height: 100 });
+      expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ width: 200, height: 100 }));
+      expect(spy2).toHaveBeenCalledWith(jasmine.objectContaining({ width: 200, height: 100 }));
 
       subs2.unsubscribe();
     }


### PR DESCRIPTION
- Migrate tests to a ResizeObserver mock implementation

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
