### PR TITLE
test: textarea scrollbar

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -55,7 +55,8 @@ const chromeLaunchOptions = {
     '--disable-oop-rasterization',
     '--disable-composited-antialiasing',
     '--disable-smooth-scrolling'
-  ]
+  ],
+  ignoreDefaultArgs: ['--hide-scrollbars']
 };
 
 /**

--- a/playwright/e2e/element-examples/textarea.spec.ts
+++ b/playwright/e2e/element-examples/textarea.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { test } from '../../support/test-helpers';
+
+test.describe('textarea', () => {
+  const example = 'input-fields/multi-line';
+
+  test(example, async ({ page, si }) => {
+    await si.visitExample(example);
+
+    await page
+      .getByText('This is valid')
+      .fill('This is valid\nThis is valid\nThis is valid\nThis is valid');
+
+    await si.runVisualAndA11yTests('severity-icon-scrollbar');
+  });
+});

--- a/playwright/snapshots/textarea.spec.ts-snapshots/input-fields--multi-line--severity-icon-scrollbar-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/textarea.spec.ts-snapshots/input-fields--multi-line--severity-icon-scrollbar-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:980826f7d463d52049b0e6d0b88f48fb165cd366f8db8774df308e3c894f6e00
+size 29890

--- a/playwright/snapshots/textarea.spec.ts-snapshots/input-fields--multi-line--severity-icon-scrollbar-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/textarea.spec.ts-snapshots/input-fields--multi-line--severity-icon-scrollbar-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02c9964d2ee7473b3296d24b21554aa59bb5072834d7a049695828df64677bed
+size 29958

--- a/playwright/snapshots/textarea.spec.ts-snapshots/input-fields--multi-line--severity-icon-scrollbar.yaml
+++ b/playwright/snapshots/textarea.spec.ts-snapshots/input-fields--multi-line--severity-icon-scrollbar.yaml
@@ -1,0 +1,18 @@
+- heading "Multi-Line" [level=4]
+- text: Name
+- textbox "Name":
+  - /placeholder: Placeholder
+- text: Message Disabled textarea (empty with placeholder)
+- textbox "Disabled textarea (empty with placeholder)" [disabled]:
+  - /placeholder: Placeholder not visible
+- text: Placeholder text not displayed for disabled textarea Disabled textarea with value
+- textbox "Disabled textarea with value" [disabled]
+- text: Readonly textarea
+- textbox "Readonly textarea": This is the value
+- text: Name
+- textbox "Name": This is valid line This is valid line This is valid line This is valid line This is valid line This is valid line This is valid line This is valid line This is valid line This is valid line
+- text: Name
+- textbox "Name": This is ok-ish
+- text: Warning Message Name
+- textbox "Name": Just no
+- text: Error Message


### PR DESCRIPTION
Scrollbars will now be visible in the e2e test snapshots, which makes it easier to spot overlapping scenarios like the severity icon in the text-area.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
