### PR TITLE
fix(theme): fix unintended alignment change for icons in card header

### DIFF
--- a/projects/element-ng/card/si-card.component.scss
+++ b/projects/element-ng/card/si-card.component.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
 
-@use '@siemens/element-theme/src/styles/variables';
+@use '@siemens/element-theme/src/styles/variables/spacers';
 
 :host {
   &.card-horizontal {
@@ -35,6 +35,11 @@
   inline-size: 50%;
   object-fit: var(--si-card-img-object-fit, scale-down);
   object-position: var(--si-card-img-object-position, left center);
+}
+
+.card-header ::ng-deep .icon[headerIcon] {
+  // The icon would be 8px too high without this.
+  margin-block: - map.get(spacers.$spacers, 2);
 }
 
 .card-content-split {

--- a/projects/element-theme/src/styles/bootstrap/_card.scss
+++ b/projects/element-theme/src/styles/bootstrap/_card.scss
@@ -127,11 +127,6 @@ button.card {
   background-color: variables.$card-cap-bg;
   line-height: typography.$si-font-size-h5;
 
-  .icon {
-    // The icon would be 8px too high without this.
-    margin-block: - map.get(spacers.$spacers, 2);
-  }
-
   + .card-body {
     margin-block-start: map.get(spacers.$spacers, 2) * -1;
     padding-block-start: map.get(spacers.$spacers, 2);


### PR DESCRIPTION
w/o this:

![0cdfb0f9-6911-4e1e-9fbf-aedf318d0d1b](https://github.com/user-attachments/assets/8848e92e-fc86-47c7-b1d3-d5fce1cc869c)


---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
