### PR TITLE
docs: build relative path to preview examples

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -254,11 +254,11 @@ jobs:
           UV_INDEX_CODE_DOCS_THEME_PASSWORD: ${{ secrets.SIEMENS_NPM_TOKEN }}
       - run: npm run docs:build:generate
         env:
-          EXAMPLES_BASE: /element-examples
+          EXAMPLES_BASE: /element-examples/
         if: ${{ github.ref == 'refs/heads/main' }}
       - run: npm run docs:build:api
         env:
-          EXAMPLES_BASE: /element-examples
+          EXAMPLES_BASE: /element-examples/
         if: ${{ github.ref != 'refs/heads/main' }}
       - run: mv dist/element-examples/ dist/design/
       - run: mv dist/dashboards-demo/ dist/design/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,6 +242,7 @@ markdown_extensions:
   - md_in_html
   - element-docs:
       examples_base: !ENV [ EXAMPLES_BASE, 'http://localhost:4200' ]
+      md_file: !relative
   - toc:
       permalink: true
 


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR implements relative path resolution for documentation preview examples, allowing the build system to compute paths relative to the current page instead of using absolute URLs.

**Changes:**
- **mkdocs.yml**: Adds `md_file: !relative` configuration to the `element-docs` markdown extension to pass MkDocs page context
- **extension.py**: 
  - Updates `ElementExamplePreProcessor.__init__` to accept a `page` parameter containing the current page's absolute URL
  - Adds relative path computation: when `examples_base` lacks a URL scheme, calculates the relative path from the current page to the repository root and rewrites `examples_base` accordingly
  - Adds `md_file` configuration option to `ElementDocsExtension` to carry page metadata
  - Updates `extendMarkdown` to extract and pass the current page context to the preprocessor
- **.github/workflows/build-and-test.yaml**: Sets `EXAMPLES_BASE` environment variable with trailing slash (`/element-examples/`) in build steps

**Impact:** Enables portable documentation builds where example paths are resolved relative to each page location, improving flexibility for different deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->