### PR TITLE
docs(buttons): remove leftovers from buttontypes

### DIFF
--- a/src/app/examples/buttons/buttontypes.html
+++ b/src/app/examples/buttons/buttontypes.html
@@ -154,11 +154,3 @@
     </div>
   </div>
 </div>
-
-<ng-template #dropdownMenu>
-  <si-menu>
-    @for (item of menuItems; track $index) {
-      <si-menu-item [icon]="item.icon">{{ item.text }}</si-menu-item>
-    }
-  </si-menu>
-</ng-template>

--- a/src/app/examples/buttons/buttontypes.ts
+++ b/src/app/examples/buttons/buttontypes.ts
@@ -2,13 +2,10 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { CdkMenuTrigger } from '@angular/cdk/menu';
 import { Component } from '@angular/core';
-import { SiMenuModule } from '@siemens/element-ng/menu';
 
 @Component({
   selector: 'app-sample',
-  imports: [SiMenuModule, CdkMenuTrigger],
   templateUrl: './buttontypes.html',
   host: {
     class: 'bg-base-1'
@@ -16,16 +13,4 @@ import { SiMenuModule } from '@siemens/element-ng/menu';
 })
 export class SampleComponent {
   disabled = false;
-  splitOpen1 = false;
-  splitOpen2 = false;
-  splitOpen3 = false;
-  splitOpen4 = false;
-  splitOpen5 = false;
-  splitOpen6 = false;
-
-  menuItems = [
-    { icon: 'element-download', text: 'Download as PDF' },
-    { icon: 'element-download', text: 'Download as CSV' },
-    { icon: 'element-share', text: 'Share' }
-  ];
 }


### PR DESCRIPTION
Removes code leftovers from `buttontypes` example.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
