### PR TITLE
refactor(charts/gauge): remove deprecated usage of labelformatter

### DIFF
--- a/projects/charts-ng/gauge/si-chart-gauge.component.ts
+++ b/projects/charts-ng/gauge/si-chart-gauge.component.ts
@@ -354,18 +354,12 @@ export class SiChartGaugeComponent extends SiChartBaseComponent implements OnCha
   private valueFormatterInternal(): (val: number) => string {
     const unit = this.unit();
     const valueFormatter = this.valueFormatter();
-    const labelFormatter = this.labelFormatter();
 
     const formattedUnit = unit ? (unit.length > 5 ? `\n{unit|${unit}}` : ` {unit|${unit}}`) : '';
 
     return (value: number): string => {
       if (valueFormatter) {
         return `{value|${valueFormatter(value)}}${formattedUnit}`;
-      }
-      // DEPRECATED: Use the new input `valueFormatter` to format the value.
-      // labelFormatter should be removed from here in future versions.
-      if (labelFormatter) {
-        return labelFormatter(value);
       }
       return `{value|${this.numberFormat().format(value)}}${formattedUnit}`;
     };

--- a/projects/charts-ng/src/components/si-chart-gauge/si-chart-gauge.component.ts
+++ b/projects/charts-ng/src/components/si-chart-gauge/si-chart-gauge.component.ts
@@ -366,18 +366,12 @@ export class SiChartGaugeComponent extends SiChartComponent implements OnChanges
   private valueFormatterInternal(): (val: number) => string {
     const unit = this.unit();
     const valueFormatter = this.valueFormatter();
-    const labelFormatter = this.labelFormatter();
 
     const formattedUnit = unit ? (unit.length > 5 ? `\n{unit|${unit}}` : ` {unit|${unit}}`) : '';
 
     return (value: number): string => {
       if (valueFormatter) {
         return `{value|${valueFormatter(value)}}${formattedUnit}`;
-      }
-      // DEPRECATED: Use the new input `valueFormatter` to format the value.
-      // labelFormatter should be removed from here in future versions.
-      if (labelFormatter) {
-        return labelFormatter(value);
       }
       return `{value|${this.numberFormat().format(value)}}${formattedUnit}`;
     };


### PR DESCRIPTION
BREAKING CHANGE: Input `SiChartGaugeComponent.labelFormatter` should no longer be used to format the value. Use `SiChartGaugeComponent.valueFormatter` instead.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-946/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-946/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-946/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-946/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-946/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-946/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-946/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-946/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-946/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-946/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
