### PR TITLE
docs(native-charts/gauge): update code comment for no of decimals range

### DIFF
--- a/projects/native-charts-ng/gauge/si-nchart-gauge.component.ts
+++ b/projects/native-charts-ng/gauge/si-nchart-gauge.component.ts
@@ -131,16 +131,19 @@ export class SiNChartGaugeComponent implements OnInit, OnChanges {
   readonly unit = input('');
   /**
    * Min number of decimals.
+   * Possible values are from 0 to 100.
    * @defaultValue 0
    */
   readonly minNumberOfDecimals = input(0);
   /**
    * Max number of decimals.
+   * Possible values are from 0 to 100.
    * @defaultValue 2
    */
   readonly maxNumberOfDecimals = input(2);
   /**
    * Number of decimals on the axis.
+   * Possible values are from 0 to 100.
    * @defaultValue 0
    */
   readonly axisNumberOfDecimals = input(0);

--- a/src/app/examples/si-ncharts/si-nchart-gauge.html
+++ b/src/app/examples/si-ncharts/si-nchart-gauge.html
@@ -59,6 +59,7 @@
         <si-number-input
           required
           class="form-control"
+          [min]="0"
           [ngModelOptions]="{ standalone: true }"
           [step]="1"
           [(ngModel)]="minDecimals"
@@ -70,6 +71,7 @@
         <si-number-input
           required
           class="form-control"
+          [min]="0"
           [ngModelOptions]="{ standalone: true }"
           [step]="1"
           [(ngModel)]="maxDecimals"
@@ -81,6 +83,7 @@
         <si-number-input
           required
           class="form-control"
+          [min]="0"
           [ngModelOptions]="{ standalone: true }"
           [step]="1"
           [(ngModel)]="axisDecimals"


### PR DESCRIPTION
Error when the no of decimals is negative - 

<img width="797" height="902" alt="image" src="https://github.com/user-attachments/assets/b76a2e0d-f6fe-449e-822b-9f64e151e95a" />


- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
