### PR TITLE
build(renovate): rebase when conflicting

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,6 +19,7 @@
       datasourceTemplate: "docker"
     }
   ],
+  rebaseWhen: "conflicted",
   packageRules: [
     {
       description: [


### PR DESCRIPTION
In theory only rebasing if the PR is conflicting should already be the case, since
the default value is `àuto`.
See: https://docs.renovatebot.com/configuration-options/#rebasewhen

In reality, this seems to be broken, renovate always rebases. So just force-setting it to `conflicted` should help.

The current situation costs us money, as renovate rebases after every merge.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
