### PR TITLE
docs(examples): migrate content-tile-layout-full-scroll-vertical-nav …

### DIFF
--- a/src/app/examples/si-layouts/content-tile-layout-full-scroll-vertical-nav.html
+++ b/src/app/examples/si-layouts/content-tile-layout-full-scroll-vertical-nav.html
@@ -1,6 +1,6 @@
-<si-side-panel #sidePanel [collapsed]="collapsed" [mode]="mode" [size]="size">
-  <div class="has-navbar-fixed-top" [class.has-system-banner]="(hideSystembanner | async) !== true">
-    @if ((hideSystembanner | async) !== true) {
+<si-side-panel [collapsed]="collapsed()" [mode]="mode()" [size]="size()">
+  <div class="has-navbar-fixed-top" [class.has-system-banner]="hideSystemBanner() !== true">
+    @if (hideSystemBanner() !== true) {
       <si-system-banner
         class="fixed-top"
         message="System maintenance scheduled for 2 AM - 4 AM UTC"
@@ -50,9 +50,9 @@
 
         <div class="si-layout-header">
           <h2 class="si-layout-title">Title describing what page content to expect</h2>
-          <p class="si-layout-subtitle"
-            >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do</p
-          >
+          <p class="si-layout-subtitle">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          </p>
         </div>
 
         <div class="row mt-8 mb-6">
@@ -63,10 +63,10 @@
                   Toggle side panel
                 </button>
                 <button type="button" class="btn btn-secondary mt-2 ms-2" (click)="toggleMode()">
-                  {{ mode + ' - Mode' }}
+                  {{ `${mode()} - Mode` }}
                 </button>
                 <button type="button" class="btn btn-secondary mt-2 ms-2" (click)="changeSize()">
-                  {{ size + ' - Width' }}
+                  {{ `${size()} - Width` }}
                 </button>
               </div>
             </si-card>

--- a/src/app/examples/si-layouts/content-tile-layout-full-scroll-vertical-nav.html
+++ b/src/app/examples/si-layouts/content-tile-layout-full-scroll-vertical-nav.html
@@ -1,6 +1,6 @@
-<si-side-panel #sidePanel [collapsed]="collapsed" [mode]="mode" [size]="size">
-  <div class="has-navbar-fixed-top" [class.has-system-banner]="(hideSystembanner | async) !== true">
-    @if ((hideSystembanner | async) !== true) {
+<si-side-panel [collapsed]="collapsed()" [mode]="mode()" [size]="size()">
+  <div class="has-navbar-fixed-top" [class.has-system-banner]="!hideSystemBanner()">
+    @if (!hideSystemBanner()) {
       <si-system-banner
         class="fixed-top"
         message="System maintenance scheduled for 2 AM - 4 AM UTC"
@@ -50,9 +50,9 @@
 
         <div class="si-layout-header">
           <h2 class="si-layout-title">Title describing what page content to expect</h2>
-          <p class="si-layout-subtitle"
-            >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do</p
-          >
+          <p class="si-layout-subtitle">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          </p>
         </div>
 
         <div class="row mt-8 mb-6">
@@ -63,10 +63,10 @@
                   Toggle side panel
                 </button>
                 <button type="button" class="btn btn-secondary mt-2 ms-2" (click)="toggleMode()">
-                  {{ mode + ' - Mode' }}
+                  {{ `${mode()} - Mode` }}
                 </button>
                 <button type="button" class="btn btn-secondary mt-2 ms-2" (click)="changeSize()">
-                  {{ size + ' - Width' }}
+                  {{ `${size()} - Width` }}
                 </button>
               </div>
             </si-card>

--- a/src/app/examples/si-layouts/content-tile-layout-full-scroll-vertical-nav.ts
+++ b/src/app/examples/si-layouts/content-tile-layout-full-scroll-vertical-nav.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { AsyncPipe } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { SiAccordionComponent, SiCollapsiblePanelComponent } from '@siemens/element-ng/accordion';
 import {
@@ -52,20 +52,22 @@ import { delay, of } from 'rxjs';
     SiHeaderBrandDirective,
     SiLaunchpadFactoryComponent,
     SiSystemBannerComponent,
-    AsyncPipe,
     SiHeaderLogoDirective
   ],
-  templateUrl: './content-tile-layout-full-scroll-vertical-nav.html'
+  templateUrl: './content-tile-layout-full-scroll-vertical-nav.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SampleComponent {
-  collapsed = true;
-  mode: SidePanelMode = 'scroll';
-  size: SidePanelSize = 'regular';
-  protected hideSystembanner = of(true).pipe(delay(navigator.webdriver ? 15000 : 5000));
+  private readonly logEvent = inject(LOG_EVENT);
+  protected readonly shouldBlink = !navigator.webdriver;
+  protected readonly hideSystemBanner = toSignal(
+    of(true).pipe(delay(navigator.webdriver ? 15000 : 5000))
+  );
+  protected readonly collapsed = signal(true);
+  protected readonly mode = signal<SidePanelMode>('scroll');
+  protected readonly size = signal<SidePanelSize>('regular');
 
-  logEvent = inject(LOG_EVENT);
-
-  menuItems: NavbarVerticalItem[] = [
+  protected readonly menuItems: NavbarVerticalItem[] = [
     {
       type: 'group',
       label: 'Home',
@@ -106,7 +108,7 @@ export class SampleComponent {
     }
   ];
 
-  statusItems: StatusBarItem[] = [
+  protected readonly statusItems: StatusBarItem[] = [
     { title: 'Emergency', status: 'danger', value: 4, action: item => this.logEvent(item) },
     { title: 'Life safety', status: 'danger', value: 0, action: item => this.logEvent(item) },
     { title: 'Security', status: 'danger', value: 0 },
@@ -115,21 +117,19 @@ export class SampleComponent {
     { title: 'Success', status: 'success', value: 200, action: item => this.logEvent(item) }
   ];
 
-  shouldBlink = !navigator.webdriver;
-
-  counter(i: number): undefined[] {
+  protected counter(i: number): undefined[] {
     return new Array(i);
   }
 
-  toggle(): void {
-    this.collapsed = !this.collapsed;
+  protected toggle(): void {
+    this.collapsed.update(value => !value);
   }
 
-  toggleMode(): void {
-    this.mode = this.mode === 'over' ? 'scroll' : 'over';
+  protected toggleMode(): void {
+    this.mode.update(value => (value === 'over' ? 'scroll' : 'over'));
   }
 
-  changeSize(): void {
-    this.size = this.size === 'regular' ? 'wide' : 'regular';
+  protected changeSize(): void {
+    this.size.update(value => (value === 'regular' ? 'wide' : 'regular'));
   }
 }

--- a/src/app/examples/si-layouts/content-tile-layout-full-scroll-vertical-nav.ts
+++ b/src/app/examples/si-layouts/content-tile-layout-full-scroll-vertical-nav.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { AsyncPipe } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { SiAccordionComponent, SiCollapsiblePanelComponent } from '@siemens/element-ng/accordion';
 import {
@@ -52,20 +52,22 @@ import { delay, of } from 'rxjs';
     SiHeaderBrandDirective,
     SiLaunchpadFactoryComponent,
     SiSystemBannerComponent,
-    AsyncPipe,
     SiHeaderLogoDirective
   ],
   templateUrl: './content-tile-layout-full-scroll-vertical-nav.html'
 })
 export class SampleComponent {
-  collapsed = true;
-  mode: SidePanelMode = 'scroll';
-  size: SidePanelSize = 'regular';
-  protected hideSystembanner = of(true).pipe(delay(navigator.webdriver ? 15000 : 5000));
+  private readonly logEvent = inject(LOG_EVENT);
+  protected readonly shouldBlink = !navigator.webdriver;
+  protected readonly hideSystemBanner = toSignal(
+    of(true).pipe(delay(navigator.webdriver ? 15000 : 5000)),
+    { initialValue: false }
+  );
+  protected readonly collapsed = signal(true);
+  protected readonly mode = signal<SidePanelMode>('scroll');
+  protected readonly size = signal<SidePanelSize>('regular');
 
-  logEvent = inject(LOG_EVENT);
-
-  menuItems: NavbarVerticalItem[] = [
+  protected readonly menuItems: NavbarVerticalItem[] = [
     {
       type: 'group',
       label: 'Home',
@@ -106,7 +108,7 @@ export class SampleComponent {
     }
   ];
 
-  statusItems: StatusBarItem[] = [
+  protected readonly statusItems: StatusBarItem[] = [
     { title: 'Emergency', status: 'danger', value: 4, action: item => this.logEvent(item) },
     { title: 'Life safety', status: 'danger', value: 0, action: item => this.logEvent(item) },
     { title: 'Security', status: 'danger', value: 0 },
@@ -115,21 +117,19 @@ export class SampleComponent {
     { title: 'Success', status: 'success', value: 200, action: item => this.logEvent(item) }
   ];
 
-  shouldBlink = !navigator.webdriver;
-
-  counter(i: number): undefined[] {
+  protected counter(i: number): undefined[] {
     return new Array(i);
   }
 
-  toggle(): void {
-    this.collapsed = !this.collapsed;
+  protected toggle(): void {
+    this.collapsed.update(value => !value);
   }
 
-  toggleMode(): void {
-    this.mode = this.mode === 'over' ? 'scroll' : 'over';
+  protected toggleMode(): void {
+    this.mode.update(value => (value === 'over' ? 'scroll' : 'over'));
   }
 
-  changeSize(): void {
-    this.size = this.size === 'regular' ? 'wide' : 'regular';
+  protected changeSize(): void {
+    this.size.update(value => (value === 'regular' ? 'wide' : 'regular'));
   }
 }


### PR DESCRIPTION
…example to OnPush

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-995/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-995/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-995/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-995/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-995/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-995/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-995/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-995/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-995/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-995/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

