### PR TITLE
docs: provide advanced filter example

### DIFF
--- a/src/app/examples/filter-side-panel/advanced-filter-example.html
+++ b/src/app/examples/filter-side-panel/advanced-filter-example.html
@@ -1,0 +1,43 @@
+<div class="has-navbar-fixed-top si-layout-fixed-height h-100">
+  <si-application-header>
+    <si-header-brand>
+      <a siHeaderLogo routerLink="/" class="d-none d-md-flex"></a>
+      <span class="application-name">Application name</span>
+    </si-header-brand>
+  </si-application-header>
+  <si-side-panel mode="scroll" [collapsed]="!showFilters()" (collapsedChange)="toggleFilter()">
+    <div class="si-layout-fixed-height mb-6 si-layout-main-padding" siResponsiveContainer>
+      <div class="si-layout-header">
+        <h2 class="si-layout-title si-layout-top-element">
+          Title describing what page content to expect
+        </h2>
+        <p class="si-layout-subtitle">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+        </p>
+      </div>
+      <div class="d-flex flex-column gap-4">
+        <div class="d-flex gap-6">
+          <si-search-bar class="flex-grow-1" placeholder="Search..." [showIcon]="true" />
+          <button
+            type="button"
+            class="btn btn-secondary"
+            aria-label="Filters"
+            (click)="toggleFilter()"
+          >
+            <si-icon class="icon" [icon]="icons.elementFilter" />
+            Filters
+          </button>
+        </div>
+        @if (filters().length > 0) {
+          <si-filter-bar [filters]="filters()" (filtersChange)="deleteFilter($event)" />
+        }
+      </div>
+      <div class="si-layout-fixed-height align-items-stretch justify-content-center">
+        <div class="d-flex align-items-center justify-content-center">Content</div>
+      </div>
+    </div>
+    <si-side-panel-content heading="Select filters">
+      <app-filter-side-panel [showFilters]="showFilters()" (showFiltersChange)="toggleFilter()" />
+    </si-side-panel-content>
+  </si-side-panel>
+</div>

--- a/src/app/examples/filter-side-panel/advanced-filter-example.ts
+++ b/src/app/examples/filter-side-panel/advanced-filter-example.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import {
+  SiApplicationHeaderComponent,
+  SiHeaderBrandDirective
+} from '@siemens/element-ng/application-header';
+import { Filter, SiFilterBarComponent } from '@siemens/element-ng/filter-bar';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
+import { SiResponsiveContainerDirective } from '@siemens/element-ng/resize-observer';
+import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
+import { SiSidePanelComponent, SiSidePanelContentComponent } from '@siemens/element-ng/side-panel';
+import { LOG_EVENT } from '@siemens/live-preview';
+import { elementFilter } from '@simpl/element-icons/ionic';
+
+import { BackendService } from './backend.service';
+import { FilterSidePanelComponent } from './components/filter-side-panel';
+import { FilterModel } from './filter.model';
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    FilterSidePanelComponent,
+    SiApplicationHeaderComponent,
+    SiFilterBarComponent,
+    SiHeaderBrandDirective,
+    SiIconComponent,
+    SiResponsiveContainerDirective,
+    SiSearchBarComponent,
+    SiSidePanelComponent,
+    SiSidePanelContentComponent
+  ],
+  templateUrl: './advanced-filter-example.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SampleComponent {
+  protected readonly logEvent = inject(LOG_EVENT);
+  protected readonly service = inject(BackendService);
+  protected readonly showFilters = signal(false);
+  protected readonly icons = addIcons({ elementFilter });
+  /** Synchronize filters between main view and side panel */
+  protected readonly filters = computed<Filter[]>(() => {
+    const model = this.service.filter();
+    const filters: Filter[] = [];
+    if (model.states.length) {
+      filters.push({
+        filterName: 'states',
+        title: 'Status',
+        description: this.filterText(
+          'states',
+          model.states.map(s => s.title)
+        )
+      });
+    }
+    if (model.versions.length) {
+      filters.push({
+        filterName: 'versions',
+        title: 'Version',
+        description: this.filterText('versions', model.versions)
+      });
+    }
+    return filters;
+  });
+
+  protected toggleFilter(): void {
+    this.showFilters.update(v => !v);
+  }
+
+  protected filterText(suffix: string, items: string[]): string {
+    return items.length === 1 ? items[0] : `${items.length} ${suffix}`;
+  }
+
+  protected deleteFilter(filter: Filter[]): void {
+    this.service.filter.update(model => {
+      for (const key of Object.keys(model)) {
+        const k = key as keyof FilterModel;
+        if (!filter.find(f => f.filterName === key)) {
+          if (Array.isArray(model[k])) {
+            model[k] = [];
+          }
+        }
+      }
+      return { ...model };
+    });
+  }
+}

--- a/src/app/examples/filter-side-panel/backend.service.ts
+++ b/src/app/examples/filter-side-panel/backend.service.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { inject, Injectable, LOCALE_ID, signal } from '@angular/core';
+import { delay, Observable, of } from 'rxjs';
+
+import { countryList, statusList, versionList } from './data-utils';
+import { Country, FilterModel, Result, Status, Version } from './filter.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BackendService {
+  private readonly locale = inject(LOCALE_ID);
+
+  countries(): Observable<Country[]> {
+    return of(countryList(this.locale)).pipe(delay(1000));
+  }
+
+  states(): Observable<Status[]> {
+    return of(statusList()).pipe(delay(500));
+  }
+
+  versions(count: number): Observable<Result<Version>> {
+    const list = versionList();
+    return of({
+      items: list.splice(0, count),
+      complete: count >= list.length,
+      count: list.length
+    }).pipe(delay(2000));
+  }
+
+  /** Current filter state */
+  readonly filter = signal<FilterModel>({ states: [], versions: [], countries: [] });
+}

--- a/src/app/examples/filter-side-panel/components/filter-side-panel.ts
+++ b/src/app/examples/filter-side-panel/components/filter-side-panel.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  model,
+  signal,
+  untracked,
+  viewChildren
+} from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { TreeItem } from '@siemens/element-ng/tree-view';
+import { BehaviorSubject, switchMap } from 'rxjs';
+
+import { BackendService } from '../backend.service';
+import { FilterModel } from '../filter.model';
+import { TreeFilterComponent, TreeFilterSelection } from './tree-filter.component';
+
+const toTreeItem = (label: string, customData: any): TreeItem => ({
+  label,
+  selectable: true,
+  state: 'leaf',
+  checked: 'unchecked',
+  customData
+});
+
+@Component({
+  selector: 'app-filter-side-panel',
+  imports: [TreeFilterComponent],
+  template: `
+    <div class="d-flex flex-column h-100">
+      <div class="flex-grow-1">
+        <app-tree-filter
+          name="states"
+          label="Status"
+          [items]="stateItems()"
+          (selectionChange)="treeModelChange('states', $event)"
+        />
+        <app-tree-filter
+          name="versions"
+          label="Version"
+          [filter]="filterVersion"
+          [items]="versionItems()"
+          [loadMore]="versionsComplete()"
+          [loading]="versionsPending()"
+          (selectionChange)="treeModelChange('versions', $event)"
+          (loadMoreItems)="loadMoreVersions()"
+        />
+      </div>
+      <div class="d-flex gap-6 ms-auto p-6">
+        <button type="button" class="btn btn-secondary" (click)="cancelFilters()">Cancel</button>
+        <button type="button" class="btn btn-primary" (click)="applyFilters()">Apply</button>
+      </div>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class FilterSidePanelComponent {
+  protected service = inject(BackendService);
+  protected readonly filterComponents = viewChildren(TreeFilterComponent);
+
+  readonly showFilters = model(true);
+
+  protected readonly statesResult = toSignal(this.service.states());
+  protected readonly stateItems = signal<TreeItem[] | undefined>(undefined);
+
+  protected readonly versionsRequested$ = new BehaviorSubject(5);
+  protected readonly versionsComplete = signal(false);
+  protected readonly versionsPending = signal(true);
+  protected readonly versionResult = toSignal(
+    this.versionsRequested$.pipe(
+      takeUntilDestroyed(),
+      switchMap(count => this.service.versions(count))
+    )
+  );
+  protected readonly versionItems = signal<TreeItem[] | undefined>(undefined);
+
+  protected filterVersion(item: TreeItem, searchString: string): boolean {
+    return item.label?.toLocaleLowerCase().includes(searchString.toLowerCase()) ?? false;
+  }
+
+  readonly filter = signal<FilterModel>({ states: [], versions: [], countries: [] });
+
+  constructor() {
+    effect(() => {
+      const result = this.versionResult();
+      if (result) {
+        this.versionsComplete.set(!result?.complete);
+        this.versionItems.set(result.items.map(i => toTreeItem(i, i)));
+        this.versionsPending.set(false);
+      }
+    });
+    effect(() => {
+      const result = this.statesResult();
+      if (result) {
+        this.stateItems.set(result.map(item => toTreeItem(item.title, item)));
+      }
+    });
+    effect(() => {
+      const filterModel = this.service.filter();
+      untracked(() => {
+        for (const [key, value] of Object.entries(filterModel)) {
+          if (Array.isArray(value) && value.length === 0) {
+            this.filterComponents()
+              .find(c => c.name() === key)
+              ?.reset();
+          }
+        }
+      });
+    });
+  }
+
+  protected treeModelChange(name: string, event: TreeFilterSelection): void {
+    this.filter.update(f => {
+      return { ...f, [name]: event.selected.map(i => i.customData!) };
+    });
+  }
+
+  protected loadMoreVersions(): void {
+    this.versionsPending.set(true);
+    this.versionsRequested$.next(this.versionsRequested$.value + 5);
+  }
+
+  protected cancelFilters(): void {
+    this.showFilters.set(false);
+  }
+
+  protected applyFilters(): void {
+    this.showFilters.set(false);
+    this.service.filter.set({ ...this.filter() });
+  }
+}

--- a/src/app/examples/filter-side-panel/components/tree-filter.component.ts
+++ b/src/app/examples/filter-side-panel/components/tree-filter.component.ts
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
+import { SiCollapsiblePanelComponent } from '@siemens/element-ng/accordion';
+import { SiLoadingSpinnerDirective } from '@siemens/element-ng/loading-spinner';
+import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
+import {
+  CheckboxClickEventArgs,
+  CheckboxState,
+  SiTreeViewComponent,
+  TreeItem
+} from '@siemens/element-ng/tree-view';
+import { TranslatableString } from '@siemens/element-translate-ng';
+import { SiTranslatePipe } from 'projects/element-translate-ng/translate';
+
+import { visitItems } from '../data-utils';
+
+export type Selection = 'all' | 'none' | 'some';
+
+export interface TreeFilterSelection {
+  selection: Selection;
+  selected: TreeItem[];
+}
+
+export type FilterFunction = (item: TreeItem, searchString: string) => boolean;
+
+const SELECT_ALL = 'select-all';
+
+const getItems = (items: TreeItem[], state: CheckboxState): TreeFilterSelection => {
+  const pending: TreeItem[] = [...items];
+  const selected: TreeItem[] = [];
+  let itemCount = 0;
+  let selectionCount = 0;
+  let item = pending.shift();
+  while (item) {
+    itemCount++;
+    if (item.checked === state) {
+      selectionCount++;
+      selected.push(item);
+    }
+    if (item.children) {
+      pending.push(...item.children);
+    }
+    item = pending.shift();
+  }
+
+  const selection = selectionCount === 0 ? 'none' : selectionCount === itemCount ? 'all' : 'some';
+  return { selection, selected };
+};
+
+@Component({
+  selector: 'app-tree-filter',
+  imports: [
+    SiCollapsiblePanelComponent,
+    SiLoadingSpinnerDirective,
+    SiSearchBarComponent,
+    SiTreeViewComponent,
+    SiTranslatePipe
+  ],
+  template: `
+    <si-collapsible-panel
+      contentCssClasses="p-6"
+      badgeColor="primary"
+      [heading]="label()"
+      [badge]="selectedItems() > 0 ? selectedItems() : undefined"
+    >
+      @if (filter()) {
+        <si-search-bar colorVariant="base-0" [showIcon]="true" (searchChange)="onSearch($event)" />
+      }
+      <si-tree-view
+        class="d-block h-100 tree-xs ms-n5 my-6"
+        [siLoading]="isLoading()"
+        [ariaLabel]="label()"
+        [enableCheckbox]="true"
+        [folderStateStart]="false"
+        [items]="visibleItems()"
+        (treeItemCheckboxClicked)="updateSelection($event)"
+      />
+      @if (!isLoading() && loadMore()) {
+        <button type="button" class="btn btn-link" (click)="loadMoreItems.emit()">{{
+          loadMoreText() | translate
+        }}</button>
+      }
+    </si-collapsible-panel>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'd-flex flex-column gap-2'
+  }
+})
+export class TreeFilterComponent {
+  readonly name = input.required<string>();
+  /** Label for the filter */
+  readonly label = input<string>();
+  /** Tree items */
+  readonly items = input<TreeItem[]>();
+  /** Whether to select all item is available */
+  readonly selectAll = input<boolean>(true);
+  /** Whether the filter should show a loading indicator */
+  readonly loading = input<boolean>(false);
+  /** Whether the filter should show a "load more" button */
+  readonly loadMore = input<boolean>(false);
+  /** Text for the "load more" button */
+  readonly loadMoreText = input<TranslatableString>('Show more');
+  readonly filter = input<FilterFunction | undefined>(undefined);
+
+  readonly loadMoreItems = output<void>();
+  readonly selectionChange = output<TreeFilterSelection>();
+  readonly searchChange = output<string>();
+
+  protected readonly searchTerm = signal('');
+  protected readonly isLoading = computed(() => this.loading() || !this.items());
+  protected readonly showSelectAll = computed(
+    () => this.selectAll() && this.items()?.length && this.searchTerm().length === 0
+  );
+  /** Actual tree items including select all. */
+  protected readonly visibleItems = computed<TreeItem[]>(() => {
+    const items = this.items();
+    if (!items) {
+      return [];
+    }
+    if (this.showSelectAll()) {
+      return [
+        {
+          label: 'Select all',
+          state: 'expanded',
+          customData: SELECT_ALL,
+          checked: 'unchecked',
+          children: items
+        }
+      ];
+    } else {
+      return this.filterTree(items, this.searchTerm());
+    }
+  });
+
+  /** Current selection count or undefined if nothing is selected */
+  protected readonly selectedItems = signal<number>(0);
+
+  /** Reset selection state of all items. */
+  reset(): void {
+    if (this.selectedItems()) {
+      visitItems(this.visibleItems(), item => (item.checked = 'unchecked'));
+      this.selectedItems.set(0);
+    }
+  }
+
+  protected updateSelection(event: CheckboxClickEventArgs): void {
+    const items = this.items()!;
+    const checked = event.newState === 'checked';
+    if (event.target.customData === SELECT_ALL) {
+      let count = 0;
+      visitItems(event.target.children ?? [], item => {
+        item.checked = event.newState;
+        count++;
+      });
+      this.selectedItems.set(checked ? count : 0);
+      this.selectionChange.emit({
+        selection: event.newState === 'checked' ? 'all' : 'none',
+        selected: event.newState === 'checked' ? items : []
+      });
+    } else {
+      const selected = getItems(items, 'checked');
+      this.selectedItems.set(selected.selected.length);
+      this.selectionChange.emit(selected);
+    }
+  }
+
+  protected onSearch(searchString: string): void {
+    this.searchTerm.set(searchString);
+    this.searchChange.emit(searchString);
+  }
+
+  protected filterTree(items: TreeItem[], searchString: string): TreeItem[] {
+    if (searchString.length === 0) {
+      return items;
+    }
+    const filter = this.filter()!;
+    const filtered: TreeItem[] = [];
+    for (const current of items) {
+      if (filter(current, searchString)) {
+        filtered.push(current);
+      } else {
+        if (current.children) {
+          const filteredChildren = this.filterTree(current.children, searchString);
+          if (filteredChildren.length) {
+            const newItem = { ...current, children: filteredChildren };
+            filtered.push(newItem);
+          }
+        }
+      }
+    }
+    return filtered;
+  }
+}

--- a/src/app/examples/filter-side-panel/data-utils.ts
+++ b/src/app/examples/filter-side-panel/data-utils.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { TreeItem } from '@siemens/element-ng/tree-view';
+
+import { Country, Status } from './filter.model';
+
+export const countryList = (locale: string): Country[] => {
+  const countryName = new Intl.DisplayNames([locale], { type: 'region' });
+  const countries: Country[] = [];
+  for (let firstLetter = 65; firstLetter <= 90; ++firstLetter) {
+    for (let secondLetter = 65; secondLetter <= 90; ++secondLetter) {
+      const code = String.fromCharCode(firstLetter) + String.fromCharCode(secondLetter);
+      const name = countryName.of(code);
+      if (name && code !== name) {
+        countries.push({ code, name });
+      }
+    }
+  }
+  return countries.sort((a, b) => a.name!.localeCompare(b.name!));
+};
+
+export const statusList = (): Status[] =>
+  ['Created', 'Open', 'Alarmed', 'Reserved', 'Waiting', 'Finished', 'Archived'].map(t => ({
+    title: t,
+    id: t.toLowerCase()
+  }));
+
+export const versionList = (): string[] => {
+  return [
+    '1.0',
+    '1.1',
+    '1.2',
+    '2.0',
+    '2.1',
+    '3.0',
+    '3.1',
+    '4.0',
+    '4.1',
+    '5.0',
+    '5.1',
+    '6.0',
+    '6.1',
+    '7.0',
+    '7.1',
+    '8.0',
+    '8.1',
+    '9.0',
+    '9.1',
+    '10.0'
+  ];
+};
+
+export const visitItems = (items: TreeItem[], visitor: (i: TreeItem) => void): void => {
+  const pending: TreeItem[] = [...items];
+  let item = pending.shift();
+  while (item) {
+    visitor(item);
+    if (item.children) {
+      pending.push(...item.children);
+    }
+    item = pending.shift();
+  }
+};

--- a/src/app/examples/filter-side-panel/filter.model.ts
+++ b/src/app/examples/filter-side-panel/filter.model.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+export interface Country {
+  code: string;
+  name: string;
+}
+
+export interface Status {
+  id: string;
+  title: string;
+}
+
+export type Version = string;
+
+export interface FilterModel {
+  states: Status[];
+  versions: Version[];
+  countries: Country[];
+}
+
+export interface Result<T> {
+  complete: boolean;
+  count: number;
+  items: T[];
+}


### PR DESCRIPTION
See https://www.figma.com/design/k7BHyP9Vw0HJMwyTpMcMeG/%E2%9C%85-filter-patterns?node-id=316-67180&m=dev

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Advanced Filter Example Documentation

Adds a comprehensive advanced filter example implementation demonstrating a side panel filter pattern as referenced in the Figma design. The implementation includes:

**New Components:**
- `SampleComponent` - Main component showcasing the advanced filter UI with reactive signals for filter state management
- `FilterSidePanelComponent` - Side panel component with nested tree filters for states and versions, supporting incremental loading and apply/cancel actions
- `TreeFilterComponent` - Reusable collapsible tree filter with search capability, "Select all" option, and selection state tracking

**Supporting Files:**
- `filter.model.ts` - Data models (Country, Status, Version, FilterModel, Result) for filter structures
- `backend.service.ts` - Service providing simulated async data for countries, states, and versions with configurable delays
- `data-utils.ts` - Utility functions for generating locale-aware country lists, status lists, version lists, and tree traversal
- `advanced-filter-example.html` - HTML template with fixed-height header, responsive side panel, search bar, and filter bar UI

The example demonstrates filtering patterns with reactive Angular signals, OnPush change detection, and integration with element's si-* web components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->