### PR TITLE
docs(sizing): document sizing utils

### DIFF
--- a/docs/fundamentals/styles/sizing.md
+++ b/docs/fundamentals/styles/sizing.md
@@ -1,0 +1,55 @@
+# Sizing
+
+Apply dimensional constraints to elements through sizing utility classes that manage width and height properties.
+
+## Parent-relative dimensions
+
+Sizing utilities allow elements to scale proportionally based on their containing element's size.
+Available presets include `25%`, `50%`, `75%`, `100%`, and `auto` sizing options.
+
+```html
+<div class="w-25 p-3 mb-5">Width 25%</div>
+<div class="w-50 p-3 mb-5">Width 50%</div>
+<div class="w-75 p-3 mb-5">Width 75%</div>
+<div class="w-100 p-3 mb-5">Width 100%</div>
+<div class="w-auto p-3 mb-5">Width auto</div>
+```
+
+```html
+<div style="height: 100px;">
+  <div class="h-25 d-inline-block" style="width: 120px;">Height 25%</div>
+  <div class="h-50 d-inline-block" style="width: 120px;">Height 50%</div>
+  <div class="h-75 d-inline-block" style="width: 120px;">Height 75%</div>
+  <div class="h-100 d-inline-block" style="width: 120px;">Height 100%</div>
+  <div class="h-auto d-inline-block" style="width: 120px;">Height auto</div>
+</div>
+```
+
+<si-docs-component example="sizing/parent-relative-dimensions" height="300"></si-docs-component>
+
+Maximum dimension constraints can be applied when needed to prevent elements from exceeding specific thresholds.
+
+```html
+<div style="inline-size: 50%; block-size: 100px">
+  <div class="mw-100 p-3" style="inline-size: 200%">Max-width 100%</div>
+</div>
+```
+
+```html
+<div style="inline-size: 50%; block-size: 100px">
+  <div class="mh-100 p-3" style="inline-size: 100px; block-size: 200px">Max-height 100%</div>
+</div>
+```
+
+<si-docs-component example="sizing/max-size" height="300"></si-docs-component>
+
+## Viewport-based dimensions
+
+Dimension utilities can also reference the browser viewport dimensions, enabling elements to size themselves according to the visible screen area.
+
+```html
+<div class="min-vw-100">Min-width 100vw</div>
+<div class="min-vh-100">Min-height 100vh</div>
+<div class="vw-100">Width 100vw</div>
+<div class="vh-100">Height 100vh</div>
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
     - Styles:
       - Display:                           'fundamentals/styles/display.md'
       - Flex:                              'fundamentals/styles/flex.md'
+      - Sizing:                            'fundamentals/styles/sizing.md'
     - UX Writing:
       - Overview:                           'fundamentals/ux-text-style-guide/index.md'
       - Basics:                             'fundamentals/ux-text-style-guide/basics.md'

--- a/src/app/examples/sizing/max-size.html
+++ b/src/app/examples/sizing/max-size.html
@@ -1,0 +1,8 @@
+<h3>Max inline-size</h3>
+<div style="inline-size: 50%; block-size: 100px">
+  <div class="mw-100 p-3" style="inline-size: 200%">Max-width 100%</div>
+</div>
+<h3>Max block-size</h3>
+<div style="inline-size: 50%; block-size: 100px">
+  <div class="mh-100 p-3" style="inline-size: 100px; block-size: 200px">Max-height 100%</div>
+</div>

--- a/src/app/examples/sizing/max-size.ts
+++ b/src/app/examples/sizing/max-size.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-sample',
+  templateUrl: './max-size.html',
+  styles: `
+    :host {
+      div {
+        background-color: rgb(from var(--element-ui-2) r g b / 0.3);
+      }
+    }
+  `,
+  host: {
+    class: 'p-5'
+  }
+})
+export class SampleComponent {}

--- a/src/app/examples/sizing/parent-relative-dimensions.html
+++ b/src/app/examples/sizing/parent-relative-dimensions.html
@@ -1,0 +1,14 @@
+<h3>Width relative to parent</h3>
+<div class="w-25 p-3 mb-5">Width 25%</div>
+<div class="w-50 p-3 mb-5">Width 50%</div>
+<div class="w-75 p-3 mb-5">Width 75%</div>
+<div class="w-100 p-3 mb-5">Width 100%</div>
+<div class="w-auto p-3 mb-5">Width auto</div>
+<h3>Height relative to parent</h3>
+<div style="block-size: 120px">
+  <div class="h-25 d-inline-block p-3" style="inline-size: 100px">Height 25%</div>
+  <div class="h-50 d-inline-block p-3" style="inline-size: 100px">Height 50%</div>
+  <div class="h-75 d-inline-block p-3" style="inline-size: 100px">Height 75%</div>
+  <div class="h-100 d-inline-block p-3" style="inline-size: 100px">Height 100%</div>
+  <div class="h-auto d-inline-block p-3" style="inline-size: 100px">Height auto</div>
+</div>

--- a/src/app/examples/sizing/parent-relative-dimensions.ts
+++ b/src/app/examples/sizing/parent-relative-dimensions.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-sample',
+  templateUrl: './parent-relative-dimensions.html',
+  styles: `
+    :host {
+      div {
+        background-color: rgb(from var(--element-ui-2) r g b / 0.3);
+      }
+    }
+  `,
+  host: {
+    class: 'p-5'
+  }
+})
+export class SampleComponent {}


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds documentation and interactive examples for sizing utilities.

- New docs/fundamentals/styles/sizing.md covering:
  - Parent-relative dimensions (w-25/50/75/100, w-auto; h-25/50/75/100, h-auto) with usage snippets and live example placeholders
  - Maximum-dimension utilities (mw-100, mh-100, inline-size/block-size examples)
  - Viewport-based sizing (min-vw-*, min-vh-*, vw-*, vh-*) with snippets
  - Integration placeholders via si-docs-component for live demos

- mkdocs.yml updated to add "Sizing" under Fundamentals > Styles.

- Example/demo files added:
  - src/app/examples/sizing/parent-relative-dimensions.html
  - src/app/examples/sizing/parent-relative-dimensions.ts (Angular SampleComponent)
  - src/app/examples/sizing/max-size.html
  - src/app/examples/sizing/max-size.ts (Angular SampleComponent)

No changes to public APIs or library exports; documentation and example components only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->