### PR TITLE
docs(image-cropper): document the usage of ngx-image-cropper

### DIFF
--- a/docs/components/forms-inputs/photo-upload.md
+++ b/docs/components/forms-inputs/photo-upload.md
@@ -106,9 +106,49 @@ import { SiPhotoUploadComponent } from '@siemens/element-ng/photo-upload';
 export class SampleComponent {}
 ```
 
-### Example
-
 <si-docs-component example="si-photo-upload/si-photo-upload" height="600"></si-docs-component>
+
+### Image cropping
+
+To implement custom image cropping — whether in an upload dialog, an image editor, or a photo workflow — you can use the image cropper as a standalone component.
+
+Simply wrap the `<image-cropper>` element from the [ngx-image-cropper](https://github.com/Mawi137/ngx-image-cropper) library with `<si-image-cropper-style>`.
+
+This ensures the component matches Element’s theming while granting you full control over its configuration and behavior.
+
+```ts
+import { Component } from '@angular/core';
+import { SiImageCropperStyleComponent } from '@siemens/element-ng/photo-upload';
+import { ImageCropperComponent, ImageCroppedEvent } from 'ngx-image-cropper';
+
+@Component({
+  selector: 'app-sample',
+  template: `
+    <si-image-cropper-style>
+      <image-cropper
+        format="jpeg"
+        [imageURL]="imageSource"
+        [maintainAspectRatio]="true"
+        [aspectRatio]="1"
+        (imageCropped)="onImageCropped($event)"
+      />
+    </si-image-cropper-style>
+  `,
+  standalone: true,
+  imports: [ImageCropperComponent, SiImageCropperStyleComponent]
+})
+export class SampleComponent {
+  imageSource = 'path/to/your/image.jpg'; // URL to your image
+
+  onImageCropped(event: ImageCroppedEvent) {
+    // Handle the cropped image
+    const croppedImage = event.base64;
+    // Use the cropped image as needed
+  }
+}
+```
+
+<si-docs-component example="si-photo-upload/image-cropping" height="450"></si-docs-component>
 
 <si-docs-api component="SiPhotoUploadComponent"></si-docs-api>
 

--- a/projects/element-ng/photo-upload/si-image-cropper-style.component.ts
+++ b/projects/element-ng/photo-upload/si-image-cropper-style.component.ts
@@ -2,11 +2,12 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
   selector: 'si-image-cropper-style',
   template: '<ng-content />',
-  styleUrl: './si-image-cropper-style.component.scss'
+  styleUrl: './si-image-cropper-style.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SiImageCropperStyleComponent {}

--- a/src/app/examples/si-photo-upload/image-cropping.html
+++ b/src/app/examples/si-photo-upload/image-cropping.html
@@ -1,0 +1,16 @@
+<div class="card">
+  <div class="card-header">
+    <h5>Image cropper</h5>
+  </div>
+  <div class="card-body">
+    <si-image-cropper-style>
+      <image-cropper
+        format="jpeg"
+        [imageURL]="imageSource"
+        [maintainAspectRatio]="true"
+        [aspectRatio]="1"
+        (imageCropped)="onImageCropped($event)"
+      />
+    </si-image-cropper-style>
+  </div>
+</div>

--- a/src/app/examples/si-photo-upload/image-cropping.ts
+++ b/src/app/examples/si-photo-upload/image-cropping.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { SiImageCropperStyleComponent } from '@siemens/element-ng/photo-upload';
+import { LOG_EVENT } from '@siemens/live-preview';
+import { ImageCropperComponent, ImageCroppedEvent } from 'ngx-image-cropper';
+
+@Component({
+  selector: 'app-sample',
+  imports: [ImageCropperComponent, SiImageCropperStyleComponent],
+  templateUrl: './image-cropping.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { 'class': 'p-5' }
+})
+export class SampleComponent {
+  protected readonly logEvent = inject(LOG_EVENT);
+  protected imageSource = 'assets/images/beach.jpg';
+
+  protected onImageCropped(event: ImageCroppedEvent): void {
+    this.logEvent('Image cropped', event);
+  }
+}


### PR DESCRIPTION
closes #974

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds documentation for integrating ngx-image-cropper with the SiMPL design system. The new guide covers component usage, design elements (preview, crop frame, handles), supported crop shapes (square, rectangle, circle), interactions (drag, resize, zoom), and includes code examples for wrapping the library with `SiImageCropperStyleComponent`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->