### PR TITLE
refactor(dashboards-ng): use actual type instead of any

### DIFF
--- a/projects/dashboards-ng/module-federation/index.ts
+++ b/projects/dashboards-ng/module-federation/index.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { loadRemoteModule } from '@angular-architects/module-federation';
-import { ComponentRef, EnvironmentInjector, Injector, ViewContainerRef } from '@angular/core';
+import { ComponentRef, EnvironmentInjector, Injector, ViewContainerRef, Type } from '@angular/core';
 import { FederatedModule, SetupComponentFn, widgetFactoryRegistry } from '@siemens/dashboards-ng';
 import { Observable, Subject } from 'rxjs';
 
@@ -16,8 +16,8 @@ const setupRemoteComponent = <T>(
 ): Observable<ComponentRef<T>> => {
   const result = new Subject<ComponentRef<T>>();
 
-  loadRemoteModule(factory).then(
-    (module: any) => {
+  loadRemoteModule<Type<T>[]>(factory).then(
+    module => {
       const componentType = module[factory[componentName]];
       const widgetInstanceRef = host.createComponent<T>(componentType, {
         injector,

--- a/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-editor-wrapper.component.ts
+++ b/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-editor-wrapper.component.ts
@@ -31,14 +31,23 @@ export class SiWebComponentEditorWrapperComponent
    */
   statusChangesHandler?: (statusChanges: Partial<WidgetConfigStatus>) => void;
 
-  private webComponentEventListener = (event: any): void => this.configChange.next(event.detail);
+  private webComponentEventListener = (event: CustomEventInit<WidgetConfig>): void =>
+    event.detail && this.configChange.next(event.detail);
 
-  private webComponentStateChangeListener = (event: any): void => {
-    this.state = event.detail;
-    this.stateChange.next(event.detail);
+  private webComponentStateChangeListener = (
+    event: CustomEventInit<WidgetInstanceEditorWizardState>
+  ): void => {
+    if (event.detail) {
+      this.state = event.detail;
+      this.stateChange.next(event.detail);
+    }
   };
-  private webComponentStatusChangesListener = (event: any): void => {
-    this.statusChangesHandler?.(event.detail);
+  private webComponentStatusChangesListener = (
+    event: CustomEventInit<Partial<WidgetConfigStatus>>
+  ): void => {
+    if (event.detail) {
+      this.statusChangesHandler?.(event.detail);
+    }
   };
 
   override ngAfterViewInit(): void {

--- a/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper.component.ts
+++ b/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper.component.ts
@@ -37,7 +37,8 @@ export class SiWebComponentWrapperComponent
 
   configChange = new EventEmitter<WidgetConfigEvent>();
 
-  private webComponentEventListener = (event: any): void => this.configChanged(event.detail);
+  private webComponentEventListener = (event: CustomEventInit<WidgetConfigEvent>): void =>
+    event.detail && this.configChanged(event.detail);
 
   override ngAfterViewInit(): void {
     super.ngAfterViewInit();


### PR DESCRIPTION
replace any with actual type for better type safety.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
