### PR TITLE
fix(navbar-vertical): prevent letters getting clipped

### DIFF
--- a/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.scss
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.scss
@@ -18,6 +18,8 @@
 
   .item-title {
     margin-inline-start: map.get(variables.$spacers, 5);
+    // We use a custom line-height here to avoid font clipping vertically in some browsers
+    line-height: 1.3;
   }
 
   .icon {


### PR DESCRIPTION
Increase line height so that letter like `g, j, p, y` etc are not clipped from bottom.

Closes #981



- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
