### PR TITLE
docs(chat-message): correctly document types

### DIFF
--- a/docs/components/chat-messages/chat-message.md
+++ b/docs/components/chat-messages/chat-message.md
@@ -110,3 +110,7 @@ The slots are:
 ### Markdown renderer
 
 <si-docs-component example="si-markdown-renderer/si-markdown-renderer"></si-docs-component>
+
+<si-docs-api component="SiMarkdownRendererComponent"></si-docs-api>
+
+<si-docs-types></si-docs-types>


### PR DESCRIPTION
Adds some missing tags from the change in #1001

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
