### PR TITLE
docs(ai-chat): add links to the chat components

### DIFF
--- a/docs/patterns/ai/ai-chat.md
+++ b/docs/patterns/ai/ai-chat.md
@@ -99,7 +99,7 @@ The slots are:
 - `si-chat-input/siChatContainerInput (helper directive)` -> For the input (whether default or custom).
 - `si-inline-notification` -> Slotted above the input for displaying the status.
 
-<si-docs-component example="si-chat-messages/si-chat-container"></si-docs-component>
+<si-docs-component example="si-chat-messages/si-chat-container" height="600"></si-docs-component>
 
 <si-docs-api component="SiChatContainerComponent"></si-docs-api>
 


### PR DESCRIPTION
<img width="1583" height="566" alt="image" src="https://github.com/user-attachments/assets/c5f4eae0-37a9-4bf7-ba93-27a8d4c425e3" />


---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
