### PR TITLE
refactor(dashboards-ng): type safe webcomponent element and use it

### DIFF
--- a/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-editor-wrapper.component.ts
+++ b/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-editor-wrapper.component.ts
@@ -19,7 +19,7 @@ import { SiWebComponentWrapperBaseComponent } from './si-web-component-wrapper-b
   templateUrl: './si-web-component-wrapper.component.html'
 })
 export class SiWebComponentEditorWrapperComponent
-  extends SiWebComponentWrapperBaseComponent
+  extends SiWebComponentWrapperBaseComponent<WidgetInstanceEditor>
   implements WidgetInstanceEditor, WidgetInstanceEditorWizard, AfterViewInit, OnDestroy
 {
   state!: WidgetInstanceEditorWizardState;

--- a/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper-base.component.ts
+++ b/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper-base.component.ts
@@ -13,12 +13,14 @@ import {
   DOCUMENT
 } from '@angular/core';
 
-import { WidgetConfig } from '../../model/widgets.model';
+import { WidgetConfig, WidgetInstance, WidgetInstanceEditor } from '../../model/widgets.model';
 
 @Component({
   template: ''
 })
-export class SiWebComponentWrapperBaseComponent implements AfterViewInit {
+export class SiWebComponentWrapperBaseComponent<T extends WidgetInstance | WidgetInstanceEditor>
+  implements AfterViewInit
+{
   private _config!: WidgetConfig;
   get config(): WidgetConfig {
     return this._config;
@@ -26,8 +28,8 @@ export class SiWebComponentWrapperBaseComponent implements AfterViewInit {
 
   @Input() set config(config: WidgetConfig) {
     this._config = config;
-    if (this.webComponentHost.nativeElement.children.length > 0) {
-      this.webComponentHost.nativeElement.children[0].config = config;
+    if (this.webComponent) {
+      this.webComponent.config = config;
     }
   }
 
@@ -35,7 +37,7 @@ export class SiWebComponentWrapperBaseComponent implements AfterViewInit {
   @Input() url!: string;
   @ViewChild('webComponentHost', { static: true, read: ElementRef })
   protected webComponentHost!: ElementRef;
-  protected webComponent?: HTMLElement;
+  protected webComponent?: HTMLElement & T;
 
   private renderer2 = inject(Renderer2);
   private document = inject(DOCUMENT);
@@ -48,7 +50,9 @@ export class SiWebComponentWrapperBaseComponent implements AfterViewInit {
     }
 
     this.webComponent = this.renderer2.createElement(this.elementTagName);
-    (this.webComponent as any).config = this.config;
+    if (this.webComponent) {
+      this.webComponent.config = this.config;
+    }
   }
 
   private isScriptLoaded(url: string): boolean {

--- a/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper.component.ts
+++ b/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper.component.ts
@@ -15,7 +15,7 @@ import { SiWebComponentWrapperBaseComponent } from './si-web-component-wrapper-b
   templateUrl: './si-web-component-wrapper.component.html'
 })
 export class SiWebComponentWrapperComponent
-  extends SiWebComponentWrapperBaseComponent
+  extends SiWebComponentWrapperBaseComponent<WidgetInstance>
   implements WidgetInstance, AfterViewInit, OnDestroy
 {
   private _editable?: boolean;
@@ -25,8 +25,8 @@ export class SiWebComponentWrapperComponent
 
   @Input() set editable(editable: boolean) {
     this._editable = editable;
-    if (this.webComponentHost.nativeElement.children.length > 0) {
-      this.webComponentHost.nativeElement.children[0].editable = editable;
+    if (this.webComponent) {
+      this.webComponent.editable = editable;
     }
   }
 


### PR DESCRIPTION
extend type on webcomponent element and directly use webcomponent element to set values.



- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
