### PR TITLE
refactor(dashboards-ng): convert web component wrapper base from component to directive

### DIFF
--- a/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper-base.component.ts
+++ b/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper-base.component.ts
@@ -4,22 +4,21 @@
  */
 import {
   AfterViewInit,
-  Component,
   ElementRef,
   inject,
   Input,
   Renderer2,
   ViewChild,
-  DOCUMENT
+  DOCUMENT,
+  Directive
 } from '@angular/core';
 
 import { WidgetConfig, WidgetInstance, WidgetInstanceEditor } from '../../model/widgets.model';
 
-@Component({
-  template: ''
-})
-export class SiWebComponentWrapperBaseComponent<T extends WidgetInstance | WidgetInstanceEditor>
-  implements AfterViewInit
+@Directive()
+export abstract class SiWebComponentWrapperBaseComponent<
+  T extends WidgetInstance | WidgetInstanceEditor
+> implements AfterViewInit
 {
   private _config!: WidgetConfig;
   get config(): WidgetConfig {


### PR DESCRIPTION

- Use @Directive decorator instead of @Component
- Mark class as abstract since it's designed to be extended


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured the base web component wrapper into an abstract directive form, adjusting its public declaration and lifecycle handling while preserving its exported availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->