### PR TITLE
refactor(examples): remove unnecesary setting default theme

### DIFF
--- a/projects/dashboards-demo/src/app/widgets/charts/charts-widget.module.ts
+++ b/projects/dashboards-demo/src/app/widgets/charts/charts-widget.module.ts
@@ -4,7 +4,7 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SimplChartsNgModule, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SimplChartsNgModule } from '@siemens/charts-ng';
 import { SiResizeObserverModule } from '@siemens/element-ng/resize-observer';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
@@ -13,7 +13,6 @@ import { CircleComponent } from './circle/circle.component';
 import { GaugeComponent } from './gauge/gauge.component';
 import { ValueWidgetComponent } from './value-widget.component';
 
-themeSupport.setDefault(themeElement);
 @NgModule({
   imports: [
     CartesianComponent,

--- a/projects/dashboards-demo/src/bootstrap.ts
+++ b/projects/dashboards-demo/src/bootstrap.ts
@@ -3,14 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 import { bootstrapApplication } from '@angular/platform-browser';
-import { themeElement, themeSupport } from '@siemens/charts-ng';
 // FIXME: Check and update to native federation
 import { registerModuleFederatedWidgetLoader } from '@siemens/dashboards-ng/module-federation';
 
 import { AppComponent } from './app/app.component';
 import { appConfig } from './app/app.config';
 
-themeSupport.setDefault(themeElement);
 // FIXME: Check and update to native federation
 registerModuleFederatedWidgetLoader();
 

--- a/projects/dashboards-demo/webcomponents/src/app/app.module.ts
+++ b/projects/dashboards-demo/webcomponents/src/app/app.module.ts
@@ -6,7 +6,7 @@ import { DoBootstrap, inject, Injector, NgModule } from '@angular/core';
 import { createCustomElement } from '@angular/elements';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
-import { SimplChartsNgModule, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SimplChartsNgModule } from '@siemens/charts-ng';
 import { SiResizeObserverModule } from '@siemens/element-ng/resize-observer';
 import { SiThemeService } from '@siemens/element-ng/theme';
 
@@ -16,7 +16,6 @@ import { ContactWidgetComponent } from './contact-widget/contact-widget.componen
 import { NoteWidgetEditorComponent } from './note-widget-editor/note-widget-editor.component';
 import { NoteWidgetComponent } from './note-widget/note-widget.component';
 
-themeSupport.setDefault(themeElement);
 @NgModule({
   imports: [
     BrowserModule,

--- a/src/app/examples/si-charts/si-chart-bar-stacked.ts
+++ b/src/app/examples/si-charts/si-chart-bar-stacked.ts
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component } from '@angular/core';
-import { SiChartCartesianComponent, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SiChartCartesianComponent } from '@siemens/charts-ng';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-charts/si-chart-bar.ts
+++ b/src/app/examples/si-charts/si-chart-bar.ts
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component } from '@angular/core';
-import { SiChartCartesianComponent, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SiChartCartesianComponent } from '@siemens/charts-ng';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-charts/si-chart-circle-donut.ts
+++ b/src/app/examples/si-charts/si-chart-circle-donut.ts
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component } from '@angular/core';
-import { SiChartCircleComponent, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SiChartCircleComponent } from '@siemens/charts-ng';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-charts/si-chart-circle-pie.ts
+++ b/src/app/examples/si-charts/si-chart-circle-pie.ts
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component } from '@angular/core';
-import { SiChartCircleComponent, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SiChartCircleComponent } from '@siemens/charts-ng';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-charts/si-chart-gauge.ts
+++ b/src/app/examples/si-charts/si-chart-gauge.ts
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component } from '@angular/core';
-import { SiChartGaugeComponent, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SiChartGaugeComponent } from '@siemens/charts-ng';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-charts/si-chart-generic.ts
+++ b/src/app/examples/si-charts/si-chart-generic.ts
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component } from '@angular/core';
-import { EChartOption, SiChartComponent, themeElement, themeSupport } from '@siemens/charts-ng';
+import { EChartOption, SiChartComponent } from '@siemens/charts-ng';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-charts/si-chart-line.ts
+++ b/src/app/examples/si-charts/si-chart-line.ts
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component } from '@angular/core';
-import { SiChartCartesianComponent, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SiChartCartesianComponent } from '@siemens/charts-ng';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-charts/si-chart-progress-bar.ts
+++ b/src/app/examples/si-charts/si-chart-progress-bar.ts
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component } from '@angular/core';
-import { SiChartProgressBarComponent, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SiChartProgressBarComponent } from '@siemens/charts-ng';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-charts/si-chart-progress.ts
+++ b/src/app/examples/si-charts/si-chart-progress.ts
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component } from '@angular/core';
-import { SiChartProgressComponent, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SiChartProgressComponent } from '@siemens/charts-ng';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-charts/si-chart-scatter.ts
+++ b/src/app/examples/si-charts/si-chart-scatter.ts
@@ -3,15 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 import { Component } from '@angular/core';
-import {
-  CartesianChartSeries,
-  SiChartCartesianComponent,
-  themeElement,
-  themeSupport
-} from '@siemens/charts-ng';
+import { CartesianChartSeries, SiChartCartesianComponent } from '@siemens/charts-ng';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-dashboard/si-dashboard-layout.ts
+++ b/src/app/examples/si-dashboard/si-dashboard-layout.ts
@@ -10,9 +10,7 @@ import {
   SiChartCartesianComponent,
   SiChartCircleComponent,
   SiChartGaugeComponent,
-  SiChartProgressBarComponent,
-  themeElement,
-  themeSupport
+  SiChartProgressBarComponent
 } from '@siemens/charts-ng';
 import {
   SiApplicationHeaderComponent,
@@ -39,8 +37,6 @@ import { Link } from '@siemens/element-ng/link';
 import { NavbarVerticalItem, SiNavbarVerticalComponent } from '@siemens/element-ng/navbar-vertical';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
 import { LOG_EVENT } from '@siemens/live-preview';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-dashboard/si-dashboard.ts
+++ b/src/app/examples/si-dashboard/si-dashboard.ts
@@ -9,9 +9,7 @@ import {
   SiChartCartesianComponent,
   SiChartCircleComponent,
   SiChartGaugeComponent,
-  SiChartProgressBarComponent,
-  themeElement,
-  themeSupport
+  SiChartProgressBarComponent
 } from '@siemens/charts-ng';
 import { ContentActionBarMainItem } from '@siemens/element-ng/content-action-bar';
 import {
@@ -24,8 +22,6 @@ import { Link } from '@siemens/element-ng/link';
 import { NavbarVerticalItem } from '@siemens/element-ng/navbar-vertical';
 import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
 import { LOG_EVENT } from '@siemens/live-preview';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-layouts/content-1-2-layout-fixed-height.ts
+++ b/src/app/examples/si-layouts/content-1-2-layout-fixed-height.ts
@@ -4,7 +4,7 @@
  */
 import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { SiChartCircleComponent, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SiChartCircleComponent } from '@siemens/charts-ng';
 import {
   SiAccountDetailsComponent,
   SiApplicationHeaderComponent,
@@ -28,8 +28,6 @@ import { LOG_EVENT } from '@siemens/live-preview';
 import { NgxDatatableModule, SelectEvent } from '@siemens/ngx-datatable';
 
 import { CorporateEmployee, DataService, PageRequest } from '../datatable/data.service';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',

--- a/src/app/examples/si-layouts/content-1-2-layout-full-scroll.ts
+++ b/src/app/examples/si-layouts/content-1-2-layout-full-scroll.ts
@@ -4,7 +4,7 @@
  */
 import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { SiChartCircleComponent, themeElement, themeSupport } from '@siemens/charts-ng';
+import { SiChartCircleComponent } from '@siemens/charts-ng';
 import {
   SiAccountDetailsComponent,
   SiApplicationHeaderComponent,
@@ -28,8 +28,6 @@ import { LOG_EVENT } from '@siemens/live-preview';
 import { NgxDatatableModule, SelectEvent } from '@siemens/ngx-datatable';
 
 import { CorporateEmployee, DataService, PageRequest } from '../datatable/data.service';
-
-themeSupport.setDefault(themeElement);
 
 @Component({
   selector: 'app-sample',


### PR DESCRIPTION
The element theme is the default theme. no need to explicitly set it

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed automatic default theming initialization from charts and dashboard components. Users may need to manually apply theme settings if previously relying on default theming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->