### PR TITLE
refactor(dashboards-ng): use signal for grid service widgetCatalog

### DIFF
--- a/projects/dashboards-ng/src/components/grid/si-grid.component.ts
+++ b/projects/dashboards-ng/src/components/grid/si-grid.component.ts
@@ -210,13 +210,13 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     if (changes.widgetCatalog) {
-      this.gridService.widgetCatalog = this.widgetCatalog();
+      this.gridService.widgetCatalog.set(this.widgetCatalog());
     }
   }
 
   ngOnInit(): void {
     queueMicrotask(() => this.loadAndSubscribeWidgets());
-    this.gridService.widgetCatalog = this.widgetCatalog();
+    this.gridService.widgetCatalog.set(this.widgetCatalog());
   }
 
   ngOnDestroy(): void {

--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
@@ -40,7 +40,7 @@ describe('SiGridstackWrapperComponent', () => {
       providers: [SiActionDialogService, SiGridService]
     }).compileComponents();
     gridService = TestBed.inject(SiGridService);
-    gridService.widgetCatalog = [];
+    gridService.widgetCatalog.set([]);
   });
 
   describe('initialization', () => {
@@ -56,7 +56,7 @@ describe('SiGridstackWrapperComponent', () => {
     it('should mount the grid items', () => {
       fixture = TestBed.createComponent(HostComponent);
       host = fixture.componentInstance;
-      gridService.widgetCatalog = [TEST_WIDGET];
+      gridService.widgetCatalog.set([TEST_WIDGET]);
       host.widgets = TEST_WIDGET_CONFIGS;
       const gridStackWrapper = host.gridStackWrapper();
       spyOn(gridStackWrapper!, 'mount');
@@ -69,7 +69,7 @@ describe('SiGridstackWrapperComponent', () => {
     it('should render grid items', () => {
       fixture = TestBed.createComponent(HostComponent);
       host = fixture.componentInstance;
-      gridService.widgetCatalog = [TEST_WIDGET];
+      gridService.widgetCatalog.set([TEST_WIDGET]);
       host.widgets = [TEST_WIDGET_CONFIG_0, TEST_WIDGET_CONFIG_1];
       fixture.detectChanges();
 
@@ -81,7 +81,7 @@ describe('SiGridstackWrapperComponent', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(HostComponent);
       host = fixture.componentInstance;
-      gridService.widgetCatalog = [TEST_WIDGET];
+      gridService.widgetCatalog.set([TEST_WIDGET]);
       host.widgets = [TEST_WIDGET_CONFIG_0, TEST_WIDGET_CONFIG_1];
       fixture.detectChanges();
     });
@@ -117,7 +117,7 @@ describe('SiGridstackWrapperComponent', () => {
     it('should return layout of grid items', () => {
       fixture = TestBed.createComponent(HostComponent);
       host = fixture.componentInstance;
-      gridService.widgetCatalog = [TEST_WIDGET];
+      gridService.widgetCatalog.set([TEST_WIDGET]);
       host.widgets = TEST_WIDGET_CONFIGS;
       fixture.detectChanges();
       const layout = host.gridStackWrapper()!.getLayout();
@@ -135,7 +135,7 @@ describe('SiGridstackWrapperComponent', () => {
     it('should return empty array without widgets', () => {
       fixture = TestBed.createComponent(HostComponent);
       host = fixture.componentInstance;
-      gridService.widgetCatalog = [TEST_WIDGET];
+      gridService.widgetCatalog.set([TEST_WIDGET]);
       host.widgets = [];
       fixture.detectChanges();
       const layout = host.gridStackWrapper()!.getLayout();

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
@@ -51,7 +51,7 @@ describe('SiWidgetHostComponent', () => {
       SiActionDialogService
     ) as unknown as SiActionDialogMockService;
     gridService = TestBed.inject(SiGridService);
-    gridService.widgetCatalog = [TEST_WIDGET];
+    gridService.widgetCatalog.set([TEST_WIDGET]);
     fixture.componentRef.setInput('widgetConfig', TEST_WIDGET_CONFIG_0);
   });
 
@@ -68,7 +68,7 @@ describe('SiWidgetHostComponent', () => {
   });
 
   it('should not create widget instance without widget', (done: DoneFn) => {
-    gridService.widgetCatalog = [];
+    gridService.widgetCatalog.set([]);
     component.initCompleted.subscribe(_ => {
       expect(component.widgetHost().length).toBe(0);
       done();

--- a/projects/dashboards-ng/src/services/si-grid.service.spec.ts
+++ b/projects/dashboards-ng/src/services/si-grid.service.spec.ts
@@ -26,7 +26,7 @@ describe('SiGridService', () => {
     });
 
     it('should return the widget of the id', () => {
-      service.widgetCatalog = [
+      service.widgetCatalog.set([
         {
           id: 'id',
           name: 'widget',
@@ -36,8 +36,8 @@ describe('SiGridService', () => {
             moduleLoader: () => Promise.reject()
           }
         }
-      ];
-      expect(service.getWidget('id')).toBe(service.widgetCatalog[0]);
+      ]);
+      expect(service.getWidget('id')).toBe(service.widgetCatalog()[0]);
     });
   });
 });

--- a/projects/dashboards-ng/src/services/si-grid.service.ts
+++ b/projects/dashboards-ng/src/services/si-grid.service.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Injectable } from '@angular/core';
+import { computed, Injectable, signal } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
 import { Widget } from '../model/widgets.model';
@@ -10,7 +10,11 @@ import { Widget } from '../model/widgets.model';
 @Injectable()
 export class SiGridService {
   /** @defaultValue [] */
-  widgetCatalog: Widget[] = [];
+  readonly widgetCatalog = signal<Widget[]>([]);
+
+  private readonly widgetCatalogMap = computed(
+    () => new Map(this.widgetCatalog().map(widget => [widget.id, widget]))
+  );
 
   /**
    * Observable that emits true if si-grid is set to editable.
@@ -21,6 +25,6 @@ export class SiGridService {
   editable$ = new BehaviorSubject<boolean>(false);
 
   getWidget(id: string): Widget | undefined {
-    return this.widgetCatalog.find(widget => widget.id === id);
+    return this.widgetCatalogMap().get(id);
   }
 }


### PR DESCRIPTION
convert `widgetCatalog` to signal and use `Map` for faster lookup on id.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
