### PR TITLE
refactor(dashboards-ng): replace JSON.parse/stringify with structuredClone

### DIFF
--- a/projects/dashboards-ng/src/components/grid/si-grid.component.ts
+++ b/projects/dashboards-ng/src/components/grid/si-grid.component.ts
@@ -342,7 +342,7 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
    */
   editWidgetInstance(widgetInstanceConfig: WidgetConfig): void {
     // Need to edit a clone to avoid runtime editing
-    const widgetConfigClone: WidgetConfig = JSON.parse(JSON.stringify(widgetInstanceConfig));
+    const widgetConfigClone = structuredClone(widgetInstanceConfig);
     if (this.emitWidgetInstanceEditEvents()) {
       this.widgetInstanceEdit.emit(widgetConfigClone);
     } else {


### PR DESCRIPTION
Replace `JSON.parse(JSON.stringify())` pattern with native `structuredClone()` method for deep cloning widget configuration in `editWidgetInstance` method. `structuredClone` provides better performance and handles more data types correctly.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
