### PR TITLE
docs(dashboards-ng): use absolute urls

### DIFF
--- a/projects/dashboards-ng/README.md
+++ b/projects/dashboards-ng/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-Check out our [dashboard demo project](../dashboards-demo/) for examples on how
+Check out our [dashboard demo project](https://github.com/siemens/element/blob/main/projects/dashboards-demo/) for examples on how
 to integrate the Siemens Dashboards library in your project.
 
 ### Install dependencies
@@ -173,11 +173,11 @@ The widget instance component has to implement the `WidgetInstance` interface an
 editor has to implement the `WidgetInstanceEditor` interface. You have to provide a
 module loader function that is used to load the widget when needed.
 
-The library ships with a [hello-widget](./src/app/widgets/hello-widget/) example for illustration.
+The library ships with a [hello-widget](https://github.com/siemens/element/blob/main/projects/dashboards-demo/src/app/widgets/hello-widget/) example for illustration.
 
 E.g. a widget implements a user interface that is added at runtime into the body of a dashboard card.
 Optionally, the widget template may include a `<ng-template/>` to provides a footer implementation like
-`<ng-template #footer><a [siLink]="link">Go to issues</a></ng-template>` in the [value-widget](./src/app/widgets/charts/value-widget.component.ts).
+`<ng-template #footer><a [siLink]="link">Go to issues</a></ng-template>` in the [value-widget](https://github.com/siemens/element/blob/main/projects/dashboards-demo/src/app/widgets/charts/value-widget.component.ts).
 The Angular component should export the template as the public attribute `footer`.
 
 ```ts
@@ -187,7 +187,7 @@ The Angular component should export the template as the public attribute `footer
 ### Dashboard persistence
 
 The library persists a dashboard configuration by the default `SiDefaultWidgetStorage` implementation
-of the API [SiWidgetStorage](./projects/dashboards-ng/src/model/si-widget-storage.ts). The
+of the API [SiWidgetStorage](https://github.com/siemens/element/blob/main/projects/dashboards-ng/src/model/si-widget-storage.ts). The
 `SiDefaultWidgetStorage` uses the `Storage` implementation `sessionStorage`. You can set a different
 `Storage` like the `localStorage` by providing the `DEFAULT_WIDGET_STORAGE_TOKEN` in the related module.
 
@@ -196,7 +196,7 @@ providers: [..., { provide: DEFAULT_WIDGET_STORAGE_TOKEN, useValue: localStorage
 ```
 
 For persistence in a backend service, you should implement your own
-[SiWidgetStorage](./projects/dashboards-ng/src/model/si-widget-storage.ts) and provide it in
+[SiWidgetStorage](https://github.com/siemens/element/blob/main/projects/dashboards-ng/src/model/si-widget-storage.ts) and provide it in
 the library module definition.
 
 ```ts
@@ -213,17 +213,17 @@ SiDashboardsNgModule.forRoot({
 
 The dashboard is configurable through the Angular inputs of the exposed components and by
 the usage of the configuration object `Config`, which includes a `GridConfig` and including
-the [GridStackOptions](./projects/dashboards-ng/src/model/gridstack.model.ts).
+the [GridStackOptions](https://github.com/siemens/element/blob/main/projects/dashboards-ng/src/model/gridstack.model.ts).
 
 To configure all dashboard instances, you can leverage dependency injection when importing
 the `SiDashboardsNgModule` using `SiDashboardsNgModule.forRoot({...})`.
 Alternatively, you have the option to configure individual dashboard instances by setting
 the input property `SiFlexibleDashboardComponent.config = {...}`.
 
-Here is the [demo](./src/app/pages/fixed-widgets-dashboard/fixed-widgets-dashboard.component.ts)
+Here is the [demo](https://github.com/siemens/element/blob/main/projects/dashboards-demo/src/app/pages/fixed-widgets-dashboard/fixed-widgets-dashboard.component.ts)
 
 ## License
 
 Code and documentation Copyright (c) Siemens 2016 - 2025
 
-See [LICENSE.md](../../LICENSE.md).
+See [LICENSE.md](https://github.com/siemens/element/blob/main/LICENSE.md).


### PR DESCRIPTION
use absolute urls as relative urls will not work on npm.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation links to direct to the GitHub repository for easier access to project references, examples, and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->