### PR TITLE
fix(loading-spinner): slow down animation isof stopping for reduced-motion

### DIFF
--- a/projects/element-ng/loading-spinner/si-loading-spinner.component.scss
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.component.scss
@@ -36,12 +36,13 @@ svg {
 }
 
 path {
+  --spinner-speed: calc(0.2s - 0.1s * var(--element-animations-enabled, 1));
   fill: var(--loading-spinner-color, variables.$element-ui-2);
-  animation: spinner-fade variables.element-transition-duration(1s) infinite linear;
+  animation: spinner-fade calc(2s - 1s * var(--element-animations-enabled, 1)) infinite linear;
 
   @for $i from 0 through 9 {
     &:nth-child(#{$i + 1}) {
-      animation-delay: #{$i * 0.1}s;
+      animation-delay: calc($i * var(--spinner-speed));
       opacity: 1 - $i * 0.1;
     }
   }


### PR DESCRIPTION
Completely stopping the animation gives the impression that the application is stuck.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
