### PR TITLE
docs(ux-text-style-guide): display in ix style

### DIFF
--- a/docs/_src/dos-and-donts.css
+++ b/docs/_src/dos-and-donts.css
@@ -1,0 +1,112 @@
+/* Wrapper for Side-by-Side Layout */
+.dos-and-donts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  margin: 1em 0;
+}
+
+/* Mobile Responsiveness */
+@media screen and (max-width: 768px) {
+  .dos-and-donts {
+    flex-direction: column;
+  }
+}
+
+/* Common Card Styling (.dos and .donts) */
+.dos,
+.donts {
+  flex: 1;
+  min-width: 0;
+  background-color: var(--md-default-bg-color);
+  border: 1px solid var(--md-table-border-color);
+  border-block-start-width: 4px;
+  border-radius: 6px;
+
+  padding: 12px 0;
+
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  margin-block-end: 1em;
+}
+
+/* Remove bottom margin when inside the wrapper */
+.dos-and-donts .dos,
+.dos-and-donts .donts {
+  margin-block-end: 0;
+}
+
+/* Accessible Hidden Title */
+.dos h4,
+.donts h4 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* List Styling */
+.dos ul,
+.donts ul {
+  list-style: none;
+
+  margin: 0 !important;
+}
+
+.dos li,
+.donts li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-block-end: 18px;
+  line-height: 1.4;
+  color: var(--md-footer-fg-color);
+}
+
+.dos li:last-child,
+.donts li:last-child {
+  margin-block-end: 0;
+}
+
+/* Icons (Shared Base) */
+.dos li::before,
+.donts li::before {
+  content: '';
+  display: inline-block;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  margin-block-start: -1px;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}
+
+/* "DO" Specifics */
+.dos {
+  border-block-start-color: var(--md-admonition-success-color);
+}
+
+.dos li::before {
+  background-color: var(--md-admonition-success-color);
+  -webkit-mask-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjU2IDY0QzE1MC4xMyA2NCA2NCAxNTAuMTMgNjQgMjU2czg2LjEzIDE5MiAxOTIgMTkyIDE5Mi04Ni4xMyAxOTItMTkyUzM2MS44NyA2NCAyNTYgNjRabTEwOC40OSAxMzEuNzRMMjI3IDMzMy4yNGExMiAxMiAwIDAgMS0xNyAwbC02Mi41LTYyLjVhMTIgMTIgMCAwIDEgMTctMTdsNTQgNTQgMTI5LTEyOWExMiAxMiAwIDAgMSAxNyAxN1oiPjwvcGF0aD48L3N2Zz4=');
+  mask-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjU2IDY0QzE1MC4xMyA2NCA2NCAxNTAuMTMgNjQgMjU2czg2LjEzIDE5MiAxOTIgMTkyIDE5Mi04Ni4xMyAxOTItMTkyUzM2MS44NyA2NCAyNTYgNjRabTEwOC40OSAxMzEuNzRMMjI3IDMzMy4yNGExMiAxMiAwIDAgMS0xNyAwbC02Mi41LTYyLjVhMTIgMTIgMCAwIDEgMTctMTdsNTQgNTQgMTI5LTEyOWExMiAxMiAwIDAgMSAxNyAxN1oiPjwvcGF0aD48L3N2Zz4=');
+}
+
+/* "DON'T" Specifics */
+.donts {
+  border-block-start-color: var(--md-admonition-failure-color);
+}
+
+.donts li::before {
+  background-color: var(--md-admonition-failure-color);
+  -webkit-mask-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjU2IDY0QzE1MC4xMyA2NCA2NCAxNTAuMTMgNjQgMjU2czg2LjEzIDE5MiAxOTIgMTkyIDE5Mi04Ni4xMyAxOTItMTkyUzM2MS44NyA2NCAyNTYgNjRabTEwNC40OSAyNzkuNTFhMTIgMTIgMCAwIDEtMTcgMTdMMjU2IDI3M2wtODcuNTEgODcuNTJhMTIgMTIgMCAwIDEtMTctMTdMMjM5IDI1NmwtODcuNTItODcuNTFhMTIgMTIgMCAwIDEgMTctMTdMMjU2IDIzOWw4Ny41MS04Ny41MmExMiAxMiAwIDAgMSAxNyAxN0wyNzMgMjU2WiI+PC9wYXRoPjwvc3ZnPg==');
+  mask-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjU2IDY0QzE1MC4xMyA2NCA2NCAxNTAuMTMgNjQgMjU2czg2LjEzIDE5MiAxOTIgMTkyIDE5Mi04Ni4xMyAxOTItMTkyUzM2MS44NyA2NCAyNTYgNjRabTEwNC40OSAyNzkuNTFhMTIgMTIgMCAwIDEtMTcgMTdMMjU2IDI3M2wtODcuNTEgODcuNTJhMTIgMTIgMCAwIDEtMTctMTdMMjM5IDI1NmwtODcuNTItODcuNTFhMTIgMTIgMCAwIDEgMTctMTdMMjU2IDIzOWw4Ny41MS04Ny41MmExMiAxMiAwIDAgMSAxNyAxN0wyNzMgMjU2WiI+PC9wYXRoPjwvc3ZnPg==');
+}

--- a/docs/fundamentals/ux-text-style-guide/basics.md
+++ b/docs/fundamentals/ux-text-style-guide/basics.md
@@ -21,14 +21,34 @@ writing errors to avoid when creating industrial products and experiences.
 - Use positive instead of negative framing
 - Avoid using contractions in general
 
-| Dos                                            | Don'ts                                                 |
-| ---------------------------------------------- | ------------------------------------------------------ |
-| their, them, theirs, salesperson               | his, hers, him, salesman                               |
-| Welcome to Building X                          | Hey there!                                             |
-| Welcome Werner von Siemens                     | Hey there!                                             |
-| X appears when detail view has selected events | X doesn't appear if detail view has no selected events |
-| cannot, will not                               | can't, won't                                           |
-| you will, we have                              | you'll, we've                                          |
+<!-- markdownlint-disable MD033 -->
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- their, them, theirs, salesperson
+- Welcome to Building X
+- Welcome Werner von Siemens
+- X appears when detail view has selected events
+- cannot, will not
+- you will, we have
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- his, hers, him, salesman
+- Hey there!
+- Hey there!
+- X doesn't appear if detail view has no selected events
+- can't, won't
+- you'll, we've
+
+</div>
+</div>
+<!-- markdownlint-enable MD033 -->
 
 ## Length
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -209,6 +209,9 @@ theme:
     - content.action.edit
     - content.code.copy
 
+extra_css:
+  - '_src/dos-and-donts.css'
+
 extra_javascript:
   - '//w3.siemens.com/ote/ote_config.js'
   - '//w3.siemens.com/ote/sinet/ote.js'


### PR DESCRIPTION
Emulates the iX do's and don'ts style as good as possible without using custom scripts or components.

Could easily be adapted to also work in the iX docusaurus setup (basically only spacing and tokens would need to be adjusted)

Icons are currently incorrect (hard-coded SVG)

Courtesy of the Amazing Gemini 3 Pro


<img width="2089" height="1278" alt="image" src="https://github.com/user-attachments/assets/52132c3f-add3-4a45-8f51-abf77822ce8a" />


---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced the UX text style guide with improved visual presentation for "Dos and Don'ts" guidance.

* **Style**
  * Added responsive CSS module for side-by-side "Dos and Don'ts" display with card-based styling, color-coded borders, and icons that adapts to mobile devices.

* **Configuration**
  * Updated `mkdocs.yml` to load the new stylesheet site-wide.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->