### PR TITLE
docs(dashboards-ng): correct typo in README

### DIFF
--- a/projects/dashboards-ng/README.md
+++ b/projects/dashboards-ng/README.md
@@ -72,7 +72,7 @@ import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
 export class AppModule { }
 ```
 
-Add `gridstack` CSS files to you application by editing
+Add `gridstack` CSS files to your application by editing
 the `angular.json` file.
 
 ```json


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the README's instructions for editing gridstack CSS files ("you application" → "your application") to improve clarity.
  * Clarified wording; no behavioral or functional changes were introduced. Low-risk, documentation-only update.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->