### PR TITLE
feat(dashboards-ng): custom id provider for widget instance

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -121,9 +121,6 @@ export type LoadRemoteModuleScriptOptions = {
     exposedModule: string;
 };
 
-// @public (undocumented)
-export const NEW_WIDGET_PREFIX = "new-widget-";
-
 // @public
 export type ObjectFit = 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
 
@@ -138,6 +135,9 @@ export const setupWidgetInstance: (widgetComponentFactory: WidgetComponentFactor
 
 // @public
 export const SI_DASHBOARD_CONFIGURATION: InjectionToken<Config>;
+
+// @public
+export const SI_WIDGET_ID_PROVIDER: InjectionToken<SiWidgetIdProvider>;
 
 // @public
 export const SI_WIDGET_STORE: InjectionToken<SiWidgetStorage>;
@@ -165,7 +165,7 @@ export class SiDefaultWidgetStorage extends SiWidgetStorage {
     // (undocumented)
     load(dashboardId?: string): Observable<WidgetConfig[]>;
     // (undocumented)
-    save(widgets: (WidgetConfig | Omit<WidgetConfig, 'id'>)[], removedWidgets?: WidgetConfig[], dashboardId?: string): Observable<WidgetConfig[]>;
+    save(modifiedWidgets: WidgetConfig[], addedWidgets: WidgetConfig[], removedWidgets?: WidgetConfig[], dashboardId?: string): Observable<WidgetConfig[]>;
     // (undocumented)
     storage: Storage;
 }
@@ -256,6 +256,20 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
 }
 
 // @public
+export class SiWidgetDefaultIdProvider extends SiWidgetIdProvider {
+    generateWidgetId(widget: Omit<WidgetConfig, 'id'>, dashboardId?: string): string;
+    // (undocumented)
+    static ɵfac: _angular_core.ɵɵFactoryDeclaration<SiWidgetDefaultIdProvider, never>;
+    // (undocumented)
+    static ɵprov: _angular_core.ɵɵInjectableDeclaration<SiWidgetDefaultIdProvider>;
+}
+
+// @public
+export abstract class SiWidgetIdProvider {
+    abstract generateWidgetId(widget: Omit<WidgetConfig, 'id'>, dashboardId?: string): string;
+}
+
+// @public
 export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy {
     readonly closed: _angular_core.OutputEmitterRef<WidgetConfig | undefined>;
     readonly editorSetupCompleted: _angular_core.OutputEmitterRef<void>;
@@ -278,7 +292,7 @@ export abstract class SiWidgetStorage {
         secondary: Observable<(MenuItem | DashboardToolbarItem)[]>;
     };
     abstract load(dashboardId?: string): Observable<WidgetConfig[]>;
-    abstract save(widgets: (WidgetConfig | Omit<WidgetConfig, 'id'>)[], removedWidgets?: WidgetConfig[], dashboardId?: string): Observable<WidgetConfig[]>;
+    abstract save(modifiedWidgets: WidgetConfig[], addedWidgets: WidgetConfig[], removedWidgets?: WidgetConfig[], dashboardId?: string): Observable<WidgetConfig[]>;
 }
 
 // @public

--- a/projects/dashboards-demo/src/app/app-widget-id-provider.ts
+++ b/projects/dashboards-demo/src/app/app-widget-id-provider.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { SiWidgetIdProvider, WidgetConfig } from '@siemens/dashboards-ng';
+
+export class AppWidgetIdProvider extends SiWidgetIdProvider {
+  override generateWidgetId(widget: Omit<WidgetConfig, 'id'>, dashboardId?: string): string {
+    return crypto.randomUUID();
+  }
+}

--- a/projects/dashboards-demo/src/app/app-widget-storage.ts
+++ b/projects/dashboards-demo/src/app/app-widget-storage.ts
@@ -117,12 +117,15 @@ export class AppWidgetStorage extends SiDefaultWidgetStorage implements SiWidget
   }
 
   override save(
-    widgets: (WidgetConfig | Omit<WidgetConfig, 'id'>)[],
-    removedWidgets?: WidgetConfig[] | undefined,
+    modifiedWidgets: WidgetConfig[],
+    addedWidgets: WidgetConfig[],
+    removedWidgets?: WidgetConfig[],
     dashboardId?: string | undefined
   ): Observable<WidgetConfig[]> {
     const milliseconds = navigator.webdriver ? 0 : Math.random() * 4000;
-    return super.save(widgets, removedWidgets, dashboardId).pipe(delay(milliseconds));
+    return super
+      .save(modifiedWidgets, addedWidgets, removedWidgets, dashboardId)
+      .pipe(delay(milliseconds));
   }
 
   override load(dashboardId?: string | undefined): Observable<WidgetConfig[]> {

--- a/projects/dashboards-demo/src/app/app.config.ts
+++ b/projects/dashboards-demo/src/app/app.config.ts
@@ -7,10 +7,16 @@ import { ApplicationConfig, importProvidersFrom } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, withHashLocation } from '@angular/router';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
-import { Config, SI_DASHBOARD_CONFIGURATION, SI_WIDGET_STORE } from '@siemens/dashboards-ng';
+import {
+  Config,
+  SI_DASHBOARD_CONFIGURATION,
+  SI_WIDGET_ID_PROVIDER,
+  SI_WIDGET_STORE
+} from '@siemens/dashboards-ng';
 import { provideNgxTranslateForElement } from '@siemens/element-translate-ng/ngx-translate';
 import { MultiTranslateHttpLoader } from 'ngx-translate-multi-http-loader';
 
+import { AppWidgetIdProvider } from './app-widget-id-provider';
 import { AppWidgetStorage } from './app-widget-storage';
 import { routes } from './app.routes';
 
@@ -30,6 +36,7 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes, withHashLocation()),
     { provide: SI_WIDGET_STORE, useClass: AppWidgetStorage },
     { provide: SI_DASHBOARD_CONFIGURATION, useValue: config },
+    { provide: SI_WIDGET_ID_PROVIDER, useClass: AppWidgetIdProvider },
     importProvidersFrom(
       TranslateModule.forRoot({
         loader: {

--- a/projects/dashboards-ng/README.md
+++ b/projects/dashboards-ng/README.md
@@ -184,6 +184,53 @@ The Angular component should export the template as the public attribute `footer
 @ViewChild('footer', { static: true }) footer?: TemplateRef<unknown>;
 ```
 
+### Widget instance ID generation
+
+Each widget instance on a dashboard requires a unique ID for identification and persistence. The library
+provides a flexible system for generating these IDs through the `SiWidgetIdProvider` abstract class.
+
+#### Default ID generation
+
+By default, the library uses `SiWidgetDefaultIdProvider`, which generates unique IDs using
+a RFC4122 version 4 UUID (e.g.,`'550e8400-e29b-41d4-a716-446655440000'`). This default implementation
+uses `crypto.randomUUID()` to ensure cryptographically secure uniqueness with 122 bits of entropy.
+
+#### Custom ID generation
+
+To implement custom ID generation logic (e.g., UUID-based, sequential or
+context-aware IDs), create a class that extends `SiWidgetIdProvider` and implement the
+`generateWidgetId` method:
+
+```ts
+import { Injectable } from '@angular/core';
+import { SiWidgetIdProvider } from '@siemens/dashboards-ng';
+
+@Injectable()
+export class CustomWidgetIdProvider extends SiWidgetIdProvider {
+  override generateWidgetId(widget: WidgetConfig, dashboardId?: string): string {
+    // Example: Create a composite ID from dashboard and widget type
+    const prefix = dashboardId ?? 'default';
+    const timestamp = Date.now();
+    return `${prefix}-${widget.widgetId}-${timestamp}`;
+  }
+}
+```
+
+#### Providing a custom ID provider
+
+To use your custom ID provider, register it in your application's providers:
+
+```ts
+// For standalone applications
+providers: [{ provide: SI_WIDGET_ID_PROVIDER, useClass: CustomWidgetIdProvider }];
+
+// For module-based applications
+@NgModule({
+  providers: [{ provide: SI_WIDGET_ID_PROVIDER, useClass: CustomWidgetIdProvider }]
+})
+export class AppModule {}
+```
+
 ### Dashboard persistence
 
 The library persists a dashboard configuration by the default `SiDefaultWidgetStorage` implementation

--- a/projects/dashboards-ng/src/model/si-widget-id-provider.ts
+++ b/projects/dashboards-ng/src/model/si-widget-id-provider.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { inject, Injectable, InjectionToken } from '@angular/core';
+
+import type { WidgetConfig } from './widgets.model';
+
+/**
+ * Injection token to optionally inject the {@link SiWidgetIdProvider} implementation
+ * to provide custom widget id generation logic. The default implementation
+ * is {@link SiWidgetDefaultIdProvider}.
+ *
+ * * @example
+ * The following shows how to provide your own widget id provider.
+ * ```
+ * providers: [..., { provide: SI_WIDGET_ID_PROVIDER, useClass: CustomWidgetIdProvider }]
+ * ```
+ *
+ */
+export const SI_WIDGET_ID_PROVIDER = new InjectionToken<SiWidgetIdProvider>(
+  'Injection token to configure your widget id provider.',
+  { providedIn: 'root', factory: () => inject(SiWidgetDefaultIdProvider) }
+);
+
+/**
+ * Abstract class to provide widget id generation logic.
+ */
+export abstract class SiWidgetIdProvider {
+  /**
+   * Generates a transient widget id for newly added widgets in edit mode.
+   *
+   * @param widget - The widget instance config without any id.
+   * @param dashboardId - The id of the dashboard where the widget is added.
+   * @returns A transient widget id as a string.
+   */
+  abstract generateWidgetId(widget: Omit<WidgetConfig, 'id'>, dashboardId?: string): string;
+}
+
+/**
+ * The default implementation of the {@link SiWidgetIdProvider} which
+ * generates random widget ids.
+ */
+@Injectable({ providedIn: 'root' })
+export class SiWidgetDefaultIdProvider extends SiWidgetIdProvider {
+  /**
+   * Generates a unique widget id.
+   *
+   * The method uses `crypto.randomUUID()` which generates a RFC4122 version 4 UUID
+   * (a cryptographically secure random identifier with 122 bits of entropy).
+   *
+   * @param widget - The widget instance config without any id.
+   * @param dashboardId - The id of the dashboard where the widget is added.
+   * @returns A unique widget id string in the format `crypto.randomUUID()`.
+   */
+  override generateWidgetId(widget: Omit<WidgetConfig, 'id'>, dashboardId?: string): string {
+    return crypto.randomUUID();
+  }
+}

--- a/projects/dashboards-ng/src/public-api.ts
+++ b/projects/dashboards-ng/src/public-api.ts
@@ -12,6 +12,7 @@ export * from './model/gridstack.model';
 export * from './model/si-widget-storage';
 export * from './model/widgets.model';
 export * from './model/si-dashboard-toolbar.model';
+export * from './model/si-widget-id-provider';
 export * from './widget-loader';
 
 export * from '@siemens/dashboards-ng/translate';


### PR DESCRIPTION
- Add `SiWidgetIdProvider` abstract class and injection token for custom widget ID generation
- Implement `SiWidgetDefaultIdProvider` with random ID generation as default
- Update `SiGridComponent` to use widget ID provider
- Update `SiDefaultWidgetStorage` to support custom ID provider for new widgets
- Add documentation in README.md for widget instance ID generation
- Add example `AppWidgetIdProvider` implementation in dashboards-demo
- Remove hardcoded `NEW_WIDGET_PREFIX` and counter-based ID generation
- Add unit tests for custom ID provider integration

BREAKING CHANGE: New widgets are now assigned transient IDs upon creation using the `SiWidgetIdProvider.transientWidgetIdResolver`, rather than using temporary `NEW_WIDGET_PREFIX` IDs that are replaced on save.

The `save()` method signature in the abstract class `SiWidgetStorage` has been modified to separate existing widgets from new widgets:

Before:

```
abstract save(
  widgets: (WidgetConfig | Omit<WidgetConfig, 'id'>)[],
  removedWidgets?: WidgetConfig[],
  dashboardId?: string
): Observable<WidgetConfig[]>;
```

After:
```
abstract save(
  modifiedWidgets: WidgetConfig[],
  addedWidgets: WidgetConfig[],
  removedWidgets?: WidgetConfig[],
  dashboardId?: string
): Observable<WidgetConfig[]>;
```

`addedWidgets` array will contain new widgets with ids generated by `SiWidgetIdProvider.transientWidgetIdResolver`.


[Diagram](https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=0000ff&edit=_blank&layers=1&nav=1&dark=auto#R%3Cmxfile%3E%3Cdiagram%20name%3D%22Page-1%22%20id%3D%22lDSv-x10U81y6obFrwpL%22%3E7V1tc5s4EP41nmk%2F2MOLwfAxsdNeZpo2E%2Ffau08d2cg2V4x8gsROf%2F1JIIHAgDEGx%2B4pkxmjRQhY7T5aPVrZPX283n3EYLN6QA70epri7Hr6pKdpqqJo5INKXmOJqSqxYIldh1VKBVP3F%2BRXMumz68AgUzFEyAvdTVY4R74P52FGBjBG22y1BfKyd92AJdwTTOfA25d%2Bd51wFUstbZTK%2F4DucsXvrJp2fGYNeGX2JsEKOGgriPS7nj7GCIXx0Xo3hh5VHtdLfN2HkrPJg2Hoh3Uu0L8oYLKcPHz%2B7P71zZ%2Fbj%2Bq91i9ohYmC8JXrINi6aw%2F4pHS7QH44ZWdUUgaeu%2FTJ8ZxcDjERvEAcukR9N%2BxEiDZEOl%2B5nvMJvKJnepMgBPOfvHS7Qtj9RZoFHmuTnMYhswRTydSY0iuJmEoxDEidR%2F7kak70AHaZip9AEDLBHHke2ATuLHmNNcBL179FYYjWrNJ25YZwugFzWmdLjJs%2BSLjmDxkr6QV4z0xJPc0Ea1rJC6PTYgnMghADYp1cuszU4aWoruO%2BkMN9kdAh5r%2FP1GhuZ0QZS4yefadPXgkR9d%2BQeng5e6cZRk8bk4J48D5qUqFd2F%2BAteu9xhc8QN9Dca0H5IM5O04ej91tjJ6xS%2FpYUz7Dbf5kfMka%2BSiIVZbcacu8g97JR3hNu5me9Fwf9lfCSdXa7OJTker7rCF6aoPjFs3kblkFkap%2BoYYEtfQ0XTNHC9subGnqEu9ewvDeecTohUAO5m0Th4qbz96SiAt6Ki%2BNbIR4BNwJvsXc8yNEaxjiV1JlJSKIwfBim8KNNmIy1oyuszID1SErAgZ2y6TpFA%2FIAYOEI%2BBhuA8PVTAiYAZ55ahnQox%2BwnHcDRMfxSDiel5OxHHEg4uwFEWoRbj%2B8lNUZzJMJU9MfVSEyLULLwLales40KcIgEIQgtjdqW9vkOuHka6MW%2FJPtDdWBkbPmFAzNm7VtEz%2BaXUcjpFPfdiN1AAJlmwhxZMGMJH6vT8LNkdaMXVulZoRdTd7GH%2FqFnPtYkDwqHb6DsA%2F31VgQ3QUNW%2FFx%2Bnn%2B7MjR20EWEIfYhBC7r0HvLYrFV8O5h6DnYVWeKzmihVCXMUPOGzcRvFZmT0q8XvwD8ESizX6vvB13h14%2FhkuHFVrvuQF9J%2BSMzemL9Vkn5pVrJjoqehgQvyj3T6%2BAqPv3Ox4bNEK6ugccensIjow9N8NdmKgJqPpwl22a46tDXNt28wldkN0tQTMcsB0QLCaIYCd5jHF1frsGVDzw2nAeWFKqgbv%2FNuTeQSZszSaXx7jgtL8Ss1PI1eeZH81g94LU2YHZlontGlnEL1ac94Hv0Nzrc64JbuCWuL8fFdUknkC0xyRtk0pZM3sFVJO18IqXzUFfJks7wQuwLPXnOxtQutqBb7HZawZK%2BuKutGVL9o1aV1T0rqXS%2BtejpOfwta2wkGeKdjIx3fHcpD%2Fqwm0ZBwl43gRoCMZx4voBsk4SsZRMo4XTOVIxlEyjldrpm2QY8PyCTqbkWtmRxNylWXJQmcvG3WfLiNdNYdHzdqh79zQXFhSmnmIcl23RMT4MdWMix9c%2BszRRFqY6UYmBx12Au7c8C96PBhZNiv%2FLZyb7MTCq1B4hNgluqI5orHMJ3qLm9J0Xo6aGtgjlQvS9qLSq1jKt8iSgwGm046DKW3C3P1uF5LXD4otBEMPhO5LtlcEE1GrCNOoOaJ58CpUYCxFJlX3kcp6CRE0NIcD27DTv6wVKvbAFk9b2SeIDYQ1WXEXPcc3aXruVWJd7jUUWXiiohOMXq9DCQu2WETKSMb0RMZUDFQpDEUHdglCT%2B9%2FfL%2BffLz7%2BuN%2B8uPx6cu3%2B8ndU%2FfkKc9vFaGZr2WUpMQaVoVfnobVtVYycsynQF8uIpwVMdbBaPOV41bZKkGpoW8KezheeyBdrETWExf7EeF6Y0YiSuX22WPeJPn75cY0S1n0j9h1xmi9QT7VQNrPs4K%2B3%2BRlK%2BoNAd%2Fowe%2BmijcucluEHYj77MRNgDzaSRWPe4xa4k664Y7Wljvl532%2FD6fS73GCT1hDia5okki%2FZyKy787Sd9MQ4Wj7k9hxXHhMrzVZD1OMg5ieW5oedbY2rdotht9qZfyNNtHSlRB%2Ba3QEAMEqCrLVyug7jZlVxRKDZnWgxPH4sUFzGtBbtMuSgL6vDBSNR%2Fj1o%2FqaMTiP%2FITR7N7%2FB87DzoLwveDXztrWcJRroW4QrRkHGuo4iOYzVBlEdxVEl%2Bmg%2FB4nJjAoykiZqwfi7%2BnXL093b0WVFGxRS%2FIb%2BBR2mANvazQwOoJvbvBXA9%2B9DN9hHAJuhtGqgM%2FsqlJwrgnEvNPeEIh1LQ%2BgTemMfEPqmZFYq4PEMsNNDjWXM9RU5sqxLLkjpwVvtys6%2BWoJPuSonQ04BcxlJSbIDLpOMuguHRtqr5GV5v7tLZGBl0M%2B%2BHtr6002D8uxKZcIoAj%2F7fBr%2BduukeMuXOjEo09Q1kGZNfXTs96a5I5RpJxks5sO5VF0rz5AAF7qrpnuMFyTsfKg9j5IBZYosEYmW%2FfaazGZRA4ChYZ05qT84qzJ92%2BEbl9mAcQvUehcamLZ7wN7e5Qo%2Brqx7mZsWkE%2BVW5Fp7N8Kn7vVhjB5Av8KhOqMhxgNp0qxxYeJgjp6oti9rIs4ShJk2qywNMFebi%2FinM21tDI0ct7e%2BXqsoaWYWQbOnMSlGYcYaldriiOsiuKysDWTzI4ZaCaRi%2B3olhpduULiq3T06zz6TPZVja7Ls8aV9gir4IWiwBmrKNBzp9p6ANNK8v5G6nDgdmQGDd0fWDbZS2bql109lzmL7eFS9L8tJi0%2FZBq%2FByQrnnz3eHDLFiNlHNtD0%2B%2F3PgQvS03iMsN4nKDuNwgLjeIX85ihtwgfiToyA3iF9ENWRZbbhDfA0y5QVxuED%2FKvOQG8esxP7lB%2FCo3iOdo6O4WNKw2FzS63CGeMsqWmmxJYYyylaxpNGSU4zUQgVFWR72O9qh0tU88pZ7TX5Fi1tMfHbsMomYvaIeIVq2BIvypWdZJjXj8RkR0fk%2BAfuYMbb3VbV56Z4syib0PzfyerFH1yt2Bb1oYWobokSrxn%2FN%2B1cKfATzRfer7xjC3H8CwjIZma%2BZAXjmv2Q4L6NjSH1w6sNPrWF629Hfd1q7j0FvnbLd0peJ0kvN8kUtmZzyN%2BGJyujKmaRTaHqI%2F35VmtzSJX%2FjKtuBWuUFJP1sG%2FbDgK2ilTf%2BONs2%2FJuAJBsgjGj%2B3TZu5Dbpmgy8GIcX0dzpjWE9%2F7VS%2F%2Bw8%3D%3C%2Fdiagram%3E%3C%2Fmxfile%3E)


<img width="881" height="839" alt="image" src="https://github.com/user-attachments/assets/b9e887a2-2f85-4070-ba27-3e1de4e2b222" />


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable widget instance ID generation via SI_WIDGET_ID_PROVIDER with default SiWidgetDefaultIdProvider; demo AppWidgetIdProvider included.

* **Breaking Changes / Persistence**
  * New widgets now get transient IDs from the ID provider instead of NEW_WIDGET_PREFIX/counter.
  * SiWidgetStorage.save signature changed to save(modifiedWidgets, addedWidgets, removedWidgets?, dashboardId?) — callers/implementations must be updated.
  * Save flow now separates modified vs. added widgets and resolves IDs for added widgets before persistence.

* **Code**
  * SiGridComponent, SiDefaultWidgetStorage, and related code updated to use the provider-based ID flow; NEW_WIDGET_PREFIX removed.
  * Public API updated to export SI_WIDGET_ID_PROVIDER, SiWidgetIdProvider, and SiWidgetDefaultIdProvider.

* **Docs & Tests**
  * README docs and dashboards-demo example added for custom ID providers.
  * Unit tests added/updated to cover custom ID provider integration.
  * Note: reviewer reported outdated golden files (no resolution in PR).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->