### PR TITLE
fix(schematics): add Windows compatibility for template file resolution

### DIFF
--- a/projects/element-ng/schematics/migrations/wizard-migration/index.ts
+++ b/projects/element-ng/schematics/migrations/wizard-migration/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { Rule, SchematicContext, Tree, UpdateRecorder } from '@angular-devkit/schematics';
-import { join, dirname } from 'path';
+import { join, dirname } from 'path/posix';
 import * as ts from 'typescript';
 
 import {

--- a/projects/element-ng/schematics/ts-import-to-siemens-migration/mappings/dashboards-ng-mappings.ts
+++ b/projects/element-ng/schematics/ts-import-to-siemens-migration/mappings/dashboards-ng-mappings.ts
@@ -49,5 +49,6 @@ export const DASHBOARDS_NG_MAPPINGS: { [symbol: string]: string } = {
   'WidgetInstanceEditorWizard': '@siemens/dashboards-ng',
   'WidgetInstanceEditorWizardState': '@siemens/dashboards-ng',
   'WidgetPositionConfig': '@siemens/dashboards-ng',
-  'SimplDashboardsNgModule': '@siemens/dashboards-ng'
+  'SimplDashboardsNgModule': '@siemens/dashboards-ng',
+  'SiWidgetStorage': '@siemens/dashboards-ng'
 };

--- a/projects/element-ng/schematics/utils/project-utils.ts
+++ b/projects/element-ng/schematics/utils/project-utils.ts
@@ -9,7 +9,7 @@ import {
   allWorkspaceTargets,
   getWorkspace
 } from '@schematics/angular/utility/workspace';
-import { dirname, isAbsolute, resolve } from 'path';
+import { dirname, isAbsolute, resolve } from 'path/posix';
 
 import { parseTsconfigFile } from './ts-utils.js';
 

--- a/projects/element-ng/schematics/utils/schematics-file-system.ts
+++ b/projects/element-ng/schematics/utils/schematics-file-system.ts
@@ -5,7 +5,7 @@
 
 import { normalize } from '@angular-devkit/core';
 import { DirEntry, Tree } from '@angular-devkit/schematics';
-import { relative } from 'path';
+import { relative } from 'path/posix';
 
 export class SchematicsFileSystem {
   private readonly basePath = normalize(process.cwd());

--- a/projects/element-ng/schematics/utils/template-utils.ts
+++ b/projects/element-ng/schematics/utils/template-utils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Tree, UpdateRecorder } from '@angular-devkit/schematics';
-import { join, dirname } from 'path';
+import { join, dirname } from 'path/posix';
 import ts, { NoSubstitutionTemplateLiteral, PropertyAssignment, StringLiteral } from 'typescript';
 
 import { findAttribute, findElement } from './html-utils.js';
@@ -199,7 +199,7 @@ export const renameElementTag = ({
 }: RenameElementTagParams): void => {
   getInlineTemplates(sourceFile).forEach(template =>
     renameElementTagInTemplate({
-      template: template.text,
+      template: sourceFile.text.substring(template.getStart() + 1, template.getEnd() - 1),
       offset: template.getStart() + 1,
       toName,
       fromName,
@@ -231,7 +231,7 @@ export const renameAttribute = ({
 }: RenameElementTagParams): void => {
   getInlineTemplates(sourceFile).forEach(template =>
     renameAttributeInTemplate({
-      template: template.text,
+      template: sourceFile.text.substring(template.getStart() + 1, template.getEnd() - 1),
       offset: template.getStart() + 1,
       toName,
       fromName,
@@ -270,7 +270,7 @@ export const renameApi = ({
 }): void => {
   getInlineTemplates(sourceFile).forEach(template =>
     renameApiInTemplate({
-      template: template.text,
+      template: sourceFile.text.substring(template.getStart() + 1, template.getEnd() - 1),
       offset: template.getStart() + 1,
       elementName,
       recorder,
@@ -311,7 +311,7 @@ export const removeSymbol = ({
 }): void => {
   getInlineTemplates(sourceFile).forEach(template =>
     removeSymbols({
-      template: template.text,
+      template: sourceFile.text.substring(template.getStart() + 1, template.getEnd() - 1),
       offset: template.getStart() + 1,
       elementName,
       attributeSelector,

--- a/projects/element-ng/schematics/utils/ts-utils.ts
+++ b/projects/element-ng/schematics/utils/ts-utils.ts
@@ -4,7 +4,7 @@
  */
 import { normalize } from '@angular-devkit/core';
 import { SchematicsException, Tree } from '@angular-devkit/schematics';
-import { isAbsolute } from 'path';
+import { isAbsolute } from 'path/posix';
 import ts from 'typescript';
 
 import { ComponentNamesInstruction } from '../migrations/data/component-names.js';


### PR DESCRIPTION
Fixes an issue where schematics would fail on Windows when processing template files in component decorators.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SiWidgetStorage support to dashboard migrations.

* **Chores**
  * Updated internal path handling to use standardized POSIX conventions.
  * Refactored template string processing for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->