### PR TITLE
fix(badges): prevent misaligned icons

### DIFF
--- a/projects/element-theme/src/styles/bootstrap/_badges.scss
+++ b/projects/element-theme/src/styles/bootstrap/_badges.scss
@@ -127,7 +127,8 @@
   .icon {
     font-size: 20px;
     margin-inline-start: -4px;
-    margin-block-start: -2px;
+    vertical-align: top;
+    padding-block: map.get(spacers.$spacers, 1);
   }
 }
 


### PR DESCRIPTION
When using the new brand version, icons are misaligned. With this change, old and new brand version looks correct.

See: https://simpl-element-preview.s3-eu-west-1.amazonaws.com/pr-1037/playwright-report/index.html#?testId=4852420a3ed5ea40b1af-9bbe03284ed10b94043f&q=s:failed

@dr-itz I could imagine this already broken in Safari.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved badge icon vertical alignment and internal spacing for a steadier baseline and cleaner appearance across sizes by replacing a fixed offset with alignment and spacing derived from the design spacing scale.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->