### PR TITLE
fix(datepicker): convert 12 AM to 0 hours for 12-hour clock

### DIFF
--- a/projects/element-ng/datepicker/si-timepicker.component.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.ts
@@ -543,6 +543,8 @@ export class SiTimepickerComponent implements ControlValueAccessor, Validator, S
 
     if (this.isPM() && hour !== 12) {
       hour += 12;
+    } else if (this.use12HourClock() && !this.isPM() && hour === 12) {
+      hour = 0;
     }
 
     if (!date) {


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).

- Corrected 12-hour clock handling for 12:00 AM so midnight times render accurately in 12‑hour mode. Before the datepicker send a Date object with the wrong hours to the date input which means 12 am in the datepicker was display as 12 pm in the input.


