### PR TITLE
docs(content-layout): use `rxResource` to load data

### DIFF
--- a/src/app/examples/si-layouts/content-full-layout-full-scroll.html
+++ b/src/app/examples/si-layouts/content-full-layout-full-scroll.html
@@ -55,7 +55,7 @@
       columnMode="force"
       selectionType="single"
       [cssClasses]="tableConfig.cssClasses"
-      [rows]="rows"
+      [rows]="tableData.value().data"
       [columns]="[
         { name: 'Name', sortable: false },
         { name: 'Role', sortable: false },
@@ -65,12 +65,11 @@
       [footerHeight]="tableConfig.footerHeight"
       [rowHeight]="tableConfig.rowHeightSmall"
       [externalPaging]="true"
-      [count]="page.totalElements"
-      [offset]="page.pageNumber"
-      [limit]="page.size"
-      [ghostLoadingIndicator]="isLoading > 0"
+      [count]="tableData.value().page.size"
+      [offset]="tableData.value().page.pageNumber"
+      [ghostLoadingIndicator]="tableData.isLoading()"
       (page)="setPage($event)"
-      (siResizeObserver)="updateTableData($event)"
+      (siResizeObserver)="table.recalculate()"
     >
       <ngx-datatable-footer>
         <ng-template ngx-datatable-footer-template>

--- a/src/app/examples/si-layouts/content-full-layout-full-scroll.ts
+++ b/src/app/examples/si-layouts/content-full-layout-full-scroll.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import {
   SiAccountDetailsComponent,
@@ -22,11 +23,11 @@ import {
 } from '@siemens/element-ng/header-dropdown';
 import { NavbarVerticalItem } from '@siemens/element-ng/navbar-vertical';
 import { SiPaginationComponent } from '@siemens/element-ng/pagination';
-import { ElementDimensions, SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
+import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
-import { NgxDatatableModule } from '@siemens/ngx-datatable';
+import { NgxDatatableModule, PageEvent } from '@siemens/ngx-datatable';
 
-import { CorporateEmployee, DataService, Page, PageRequest } from '../datatable/data.service';
+import { DataService } from '../datatable/data.service';
 
 @Component({
   selector: 'app-sample',
@@ -49,7 +50,7 @@ import { CorporateEmployee, DataService, Page, PageRequest } from '../datatable/
   templateUrl: './content-full-layout-full-scroll.html',
   providers: [DataService]
 })
-export class SampleComponent implements OnInit {
+export class SampleComponent {
   menuItems: NavbarVerticalItem[] = [
     {
       type: 'group',
@@ -74,60 +75,17 @@ export class SampleComponent implements OnInit {
     { type: 'router-link', label: 'Test Coverage', routerLink: 'coverage' }
   ];
   tableConfig = SI_DATATABLE_CONFIG;
-  pageRequest?: PageRequest;
-  page = new Page();
-  rows = new Array<CorporateEmployee>();
-  isLoading = 0;
 
   private dataService = inject(DataService);
+  private readonly pageEvent = signal<PageEvent | undefined>(undefined);
 
-  ngOnInit(): void {
-    // timeout needed to work in the iFrame in the docs
-    setTimeout(() => this.updateTableData(), 500);
-  }
+  readonly tableData = rxResource({
+    params: () => this.pageEvent(),
+    defaultValue: { page: { size: 0, totalElements: 0, totalPages: 0, pageNumber: 0 }, data: [] },
+    stream: ({ params }) => this.dataService.getResults(params)
+  });
 
-  setPage(pageRequest: PageRequest): void {
-    // We cache the latest page request and only fire a new request
-    // if a different page or page size is requested.
-    // For example, the user could click one different pages in the pagination
-    // before the http results actually return.
-    if (
-      this.pageRequest?.offset !== pageRequest.offset ||
-      this.pageRequest?.pageSize !== pageRequest.pageSize
-    ) {
-      this.pageRequest = pageRequest;
-      this.isLoading++;
-      // We reload the data when the page number or page size changes.
-      // During this time, we want to show the ghost loading indicator.
-      // To make sure no data is presented. We set the rows in the table
-      // to an empty array.
-      this.rows = [];
-      this.dataService.getResults(pageRequest).subscribe(pagedData => {
-        this.isLoading--;
-        // Make sure we set the date to the latest page request.
-        if (
-          this.pageRequest?.offset === pageRequest.offset &&
-          this.pageRequest?.pageSize === pageRequest.pageSize
-        ) {
-          this.page = pagedData.page;
-          this.rows = pagedData.data;
-        }
-      });
-    }
-  }
-
-  updateTableData(dimensions?: ElementDimensions): void {
-    if (!dimensions) {
-      return;
-    }
-
-    const bodyHeight =
-      dimensions.height - SI_DATATABLE_CONFIG.headerHeight - SI_DATATABLE_CONFIG.footerHeight;
-    const pageSize = Math.floor(bodyHeight / SI_DATATABLE_CONFIG.rowHeightSmall);
-    this.page.size = pageSize;
-    this.setPage({
-      offset: this.page.pageNumber,
-      pageSize: this.page.size
-    });
+  setPage(pageRequest: PageEvent): void {
+    this.pageEvent.set(pageRequest);
   }
 }


### PR DESCRIPTION
@siemens/siemens-element share your opinions. Should we show / use experimental stuff in our docs?

The resource API allows us to significantly simply the some example code. But even in ng21 it is still experimental.


---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
