### PR TITLE
fix(schematics): add symbols in exports as well for NgModule

### DIFF
--- a/projects/element-ng/schematics/ts-import-to-siemens-migration/files/expected.module.export.simpl-element-ng-module.ts
+++ b/projects/element-ng/schematics/ts-import-to-siemens-migration/files/expected.module.export.simpl-element-ng-module.ts
@@ -1,0 +1,170 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SiAboutModule } from '@siemens/element-ng/about';
+import { SiAccordionModule } from '@siemens/element-ng/accordion';
+import { SiBreadcrumbModule } from '@siemens/element-ng/breadcrumb';
+import { SiBreadcrumbRouterModule } from '@siemens/element-ng/breadcrumb-router';
+import { SiCardModule } from '@siemens/element-ng/card';
+import { SiCircleStatusModule } from '@siemens/element-ng/circle-status';
+import { SiConnectionStrengthModule } from '@siemens/element-ng/connection-strength';
+import { SiContentActionBarModule } from '@siemens/element-ng/content-action-bar';
+import { SiCopyrightNoticeModule } from '@siemens/element-ng/copyright-notice';
+import { SiDateRangeFilterModule } from '@siemens/element-ng/date-range-filter';
+import { SiDatepickerModule } from '@siemens/element-ng/datepicker';
+import { SiElectrontitlebarModule } from '@siemens/element-ng/electron-titlebar';
+import { SiEmptyStateModule } from '@siemens/element-ng/empty-state';
+import { SiFileUploaderModule } from '@siemens/element-ng/file-uploader';
+import { SiFilterBarModule } from '@siemens/element-ng/filter-bar';
+import { SiFilteredSearchModule } from '@siemens/element-ng/filtered-search';
+import { SiFooterModule } from '@siemens/element-ng/footer';
+import { SiFormModule } from '@siemens/element-ng/form';
+import { SiIconModule } from '@siemens/element-ng/icon';
+import { SiIconStatusModule } from '@siemens/element-ng/icon-status';
+import { SiInlineNotificationModule } from '@siemens/element-ng/inline-notification';
+import { SiLandingPageModule } from '@siemens/element-ng/landing-page';
+import { SiLanguageSwitcherModule } from '@siemens/element-ng/language-switcher';
+import { SiLinkModule } from '@siemens/element-ng/link';
+import { SiLoadingSpinnerModule } from '@siemens/element-ng/loading-spinner';
+import { SiMainDetailContainerModule } from '@siemens/element-ng/main-detail-container';
+import { SiNavbarModule } from '@siemens/element-ng/navbar';
+import { SiNavbarVerticalModule } from '@siemens/element-ng/navbar-vertical';
+import { SiNumberInputModule } from '@siemens/element-ng/number-input';
+import { SiPaginationModule } from '@siemens/element-ng/pagination';
+import { SiPasswordStrengthModule } from '@siemens/element-ng/password-strength';
+import { SiPasswordToggleModule } from '@siemens/element-ng/password-toggle';
+import { SiPillsInputModule } from '@siemens/element-ng/pills-input';
+import { SiPopoverLegacyModule } from '@siemens/element-ng/popover-legacy';
+import { SiProgressbarModule } from '@siemens/element-ng/progressbar';
+import { SiResizeObserverModule } from '@siemens/element-ng/resize-observer';
+import { SiResultDetailsListModule } from '@siemens/element-ng/result-details-list';
+import { SiSearchBarModule } from '@siemens/element-ng/search-bar';
+import { SiSelectModule } from '@siemens/element-ng/select';
+import { SiSidePanelModule } from '@siemens/element-ng/side-panel';
+import { SiSliderModule } from '@siemens/element-ng/slider';
+import { SiSortBarModule } from '@siemens/element-ng/sort-bar';
+import { SiSplitModule } from '@siemens/element-ng/split';
+import { SiStatusBarModule } from '@siemens/element-ng/status-bar';
+import { SiTabsLegacyModule } from '@siemens/element-ng/tabs-legacy';
+import { SiThresholdModule } from '@siemens/element-ng/threshold';
+import { SiTooltipModule } from '@siemens/element-ng/tooltip';
+import { SiTreeViewModule } from '@siemens/element-ng/tree-view';
+import { SiTypeaheadModule } from '@siemens/element-ng/typeahead';
+import { SiUnauthorizedPageModule } from '@siemens/element-ng/unauthorized-page';
+import { SiWizardModule } from '@siemens/element-ng/wizard';
+import { TranslateModule } from '@ngx-translate/core';
+import { ReactiveFormsModule } from '@angular/forms';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    TranslateModule,
+    ReactiveFormsModule,
+    SiAboutModule,
+    SiAccordionModule,
+    SiBreadcrumbModule,
+    SiBreadcrumbRouterModule,
+    SiCardModule,
+    SiCircleStatusModule,
+    SiConnectionStrengthModule,
+    SiContentActionBarModule,
+    SiCopyrightNoticeModule,
+    SiDatepickerModule,
+    SiDateRangeFilterModule,
+    SiElectrontitlebarModule,
+    SiEmptyStateModule,
+    SiFileUploaderModule,
+    SiFilterBarModule,
+    SiFilteredSearchModule,
+    SiFooterModule,
+    SiFormModule,
+    SiIconModule,
+    SiIconStatusModule,
+    SiInlineNotificationModule,
+    SiLandingPageModule,
+    SiLanguageSwitcherModule,
+    SiLinkModule,
+    SiLoadingSpinnerModule,
+    SiMainDetailContainerModule,
+    SiNavbarModule,
+    SiNavbarVerticalModule,
+    SiNumberInputModule,
+    SiPaginationModule,
+    SiPasswordStrengthModule,
+    SiPasswordToggleModule,
+    SiPillsInputModule,
+    SiPopoverLegacyModule,
+    SiProgressbarModule,
+    SiResizeObserverModule,
+    SiResultDetailsListModule,
+    SiSearchBarModule,
+    SiSelectModule,
+    SiSidePanelModule,
+    SiSliderModule,
+    SiSortBarModule,
+    SiSplitModule,
+    SiStatusBarModule,
+    SiTabsLegacyModule,
+    SiThresholdModule,
+    SiTooltipModule,
+    SiTreeViewModule,
+    SiTypeaheadModule,
+    SiUnauthorizedPageModule,
+    SiWizardModule
+],
+  exports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SiAboutModule,
+    SiAccordionModule,
+    SiBreadcrumbModule,
+    SiBreadcrumbRouterModule,
+    SiCardModule,
+    SiCircleStatusModule,
+    SiConnectionStrengthModule,
+    SiContentActionBarModule,
+    SiCopyrightNoticeModule,
+    SiDatepickerModule,
+    SiDateRangeFilterModule,
+    SiElectrontitlebarModule,
+    SiEmptyStateModule,
+    SiFileUploaderModule,
+    SiFilterBarModule,
+    SiFilteredSearchModule,
+    SiFooterModule,
+    SiFormModule,
+    SiIconModule,
+    SiIconStatusModule,
+    SiInlineNotificationModule,
+    SiLandingPageModule,
+    SiLanguageSwitcherModule,
+    SiLinkModule,
+    SiLoadingSpinnerModule,
+    SiMainDetailContainerModule,
+    SiNavbarModule,
+    SiNavbarVerticalModule,
+    SiNumberInputModule,
+    SiPaginationModule,
+    SiPasswordStrengthModule,
+    SiPasswordToggleModule,
+    SiPillsInputModule,
+    SiPopoverLegacyModule,
+    SiProgressbarModule,
+    SiResizeObserverModule,
+    SiResultDetailsListModule,
+    SiSearchBarModule,
+    SiSelectModule,
+    SiSidePanelModule,
+    SiSliderModule,
+    SiSortBarModule,
+    SiSplitModule,
+    SiStatusBarModule,
+    SiTabsLegacyModule,
+    SiThresholdModule,
+    SiTooltipModule,
+    SiTreeViewModule,
+    SiTypeaheadModule,
+    SiUnauthorizedPageModule,
+    SiWizardModule
+]
+})
+export class MyModule {}

--- a/projects/element-ng/schematics/ts-import-to-siemens-migration/files/expected.module.no-import-simpl-element-ng-module.ts
+++ b/projects/element-ng/schematics/ts-import-to-siemens-migration/files/expected.module.no-import-simpl-element-ng-module.ts
@@ -1,0 +1,58 @@
+import { NgModule } from '@angular/core';
+import { SiAboutModule } from '@siemens/element-ng/about';
+import { SiAccordionModule } from '@siemens/element-ng/accordion';
+import { SiBreadcrumbModule } from '@siemens/element-ng/breadcrumb';
+import { SiBreadcrumbRouterModule } from '@siemens/element-ng/breadcrumb-router';
+import { SiCardModule } from '@siemens/element-ng/card';
+import { SiCircleStatusModule } from '@siemens/element-ng/circle-status';
+import { SiConnectionStrengthModule } from '@siemens/element-ng/connection-strength';
+import { SiContentActionBarModule } from '@siemens/element-ng/content-action-bar';
+import { SiCopyrightNoticeModule } from '@siemens/element-ng/copyright-notice';
+import { SiDateRangeFilterModule } from '@siemens/element-ng/date-range-filter';
+import { SiDatepickerModule } from '@siemens/element-ng/datepicker';
+import { SiElectrontitlebarModule } from '@siemens/element-ng/electron-titlebar';
+import { SiEmptyStateModule } from '@siemens/element-ng/empty-state';
+import { SiFileUploaderModule } from '@siemens/element-ng/file-uploader';
+import { SiFilterBarModule } from '@siemens/element-ng/filter-bar';
+import { SiFilteredSearchModule } from '@siemens/element-ng/filtered-search';
+import { SiFooterModule } from '@siemens/element-ng/footer';
+import { SiFormModule } from '@siemens/element-ng/form';
+import { SiIconModule } from '@siemens/element-ng/icon';
+import { SiIconStatusModule } from '@siemens/element-ng/icon-status';
+import { SiInlineNotificationModule } from '@siemens/element-ng/inline-notification';
+import { SiLandingPageModule } from '@siemens/element-ng/landing-page';
+import { SiLanguageSwitcherModule } from '@siemens/element-ng/language-switcher';
+import { SiLinkModule } from '@siemens/element-ng/link';
+import { SiLoadingSpinnerModule } from '@siemens/element-ng/loading-spinner';
+import { SiMainDetailContainerModule } from '@siemens/element-ng/main-detail-container';
+import { SiNavbarModule } from '@siemens/element-ng/navbar';
+import { SiNavbarVerticalModule } from '@siemens/element-ng/navbar-vertical';
+import { SiNumberInputModule } from '@siemens/element-ng/number-input';
+import { SiPaginationModule } from '@siemens/element-ng/pagination';
+import { SiPasswordStrengthModule } from '@siemens/element-ng/password-strength';
+import { SiPasswordToggleModule } from '@siemens/element-ng/password-toggle';
+import { SiPillsInputModule } from '@siemens/element-ng/pills-input';
+import { SiPopoverLegacyModule } from '@siemens/element-ng/popover-legacy';
+import { SiProgressbarModule } from '@siemens/element-ng/progressbar';
+import { SiResizeObserverModule } from '@siemens/element-ng/resize-observer';
+import { SiResultDetailsListModule } from '@siemens/element-ng/result-details-list';
+import { SiSearchBarModule } from '@siemens/element-ng/search-bar';
+import { SiSelectModule } from '@siemens/element-ng/select';
+import { SiSidePanelModule } from '@siemens/element-ng/side-panel';
+import { SiSliderModule } from '@siemens/element-ng/slider';
+import { SiSortBarModule } from '@siemens/element-ng/sort-bar';
+import { SiSplitModule } from '@siemens/element-ng/split';
+import { SiStatusBarModule } from '@siemens/element-ng/status-bar';
+import { SiTabsLegacyModule } from '@siemens/element-ng/tabs-legacy';
+import { SiThresholdModule } from '@siemens/element-ng/threshold';
+import { SiTooltipModule } from '@siemens/element-ng/tooltip';
+import { SiTreeViewModule } from '@siemens/element-ng/tree-view';
+import { SiTypeaheadModule } from '@siemens/element-ng/typeahead';
+import { SiUnauthorizedPageModule } from '@siemens/element-ng/unauthorized-page';
+import { SiWizardModule } from '@siemens/element-ng/wizard';
+
+@NgModule({
+  imports: [],
+  exports: []
+})
+export class MyModule {}

--- a/projects/element-ng/schematics/ts-import-to-siemens-migration/files/module.export.simpl-element-ng-module.ts
+++ b/projects/element-ng/schematics/ts-import-to-siemens-migration/files/module.export.simpl-element-ng-module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SimplElementNgModule } from '@simpl/element-ng';
+import { TranslateModule } from '@ngx-translate/core';
+import { ReactiveFormsModule } from '@angular/forms';
+
+@NgModule({
+  imports: [CommonModule, TranslateModule, SimplElementNgModule, ReactiveFormsModule],
+  exports: [CommonModule, SimplElementNgModule, ReactiveFormsModule]
+})
+export class MyModule {}

--- a/projects/element-ng/schematics/ts-import-to-siemens-migration/files/module.no-import-simpl-element-ng-module.ts
+++ b/projects/element-ng/schematics/ts-import-to-siemens-migration/files/module.no-import-simpl-element-ng-module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { SimplElementNgModule } from '@simpl/element-ng';
+
+@NgModule({
+  imports: [],
+  exports: []
+})
+export class MyModule {}

--- a/projects/element-ng/schematics/ts-import-to-siemens-migration/index.spec.ts
+++ b/projects/element-ng/schematics/ts-import-to-siemens-migration/index.spec.ts
@@ -243,4 +243,12 @@ describe('ts-import-to-siemens migration', () => {
   it('should migrate imports correctly if there are multiple imports of the symbol', async () => {
     await checkTemplateMigration(['component.simpl-element-ng-module-multiple-imports.ts']);
   });
+
+  it('should migrate exports from SimplElementNgModule in module', async () => {
+    await checkTemplateMigration(['module.export.simpl-element-ng-module.ts']);
+  });
+
+  it('should not add SimplElementNgModule in module if they are not imported or exported', async () => {
+    await checkTemplateMigration(['module.no-import-simpl-element-ng-module.ts']);
+  });
 });


### PR DESCRIPTION
Currently, when migrating from SimplElementNgModule symbols are added only in imports but if exports are there then it should be added in there too

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration tool now handles module exports in addition to imports for dependency simplification.
  * Extended migration logic to support a broader range of module configurations and patterns.

* **Tests**
  * Added comprehensive test coverage for module export migration scenarios.
  * Added test coverage for edge cases involving unused dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->