### PR TITLE
chore(lint): restrict import of TranslatePipe from ngx-translate

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,11 @@ export const tsConfig = defineConfig({
           {
             name: '@siemens/element-ng',
             message: 'Use the secondary entrypoints instead.'
+          },
+          {
+            name: '@ngx-translate/core',
+            importNames: ['TranslatePipe'],
+            message: 'Use `SiTranslatePipe` from `@siemens/element-translate-ng` instead.'
           }
         ]
       }


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linting rules to prevent use of the legacy third‑party translation pipe and guide developers to the recommended internal translation utility, enforcing consistent import practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->