### PR TITLE
feat(typeahead): introduce experimental create option

### DIFF
--- a/api-goldens/element-ng/typeahead/index.api.md
+++ b/api-goldens/element-ng/typeahead/index.api.md
@@ -10,9 +10,9 @@ import * as i1 from '@siemens/element-ng/autocomplete';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
-import * as _siemens_element_translate_ng_translate_types from '@siemens/element-translate-ng/translate-types';
 import { SimpleChanges } from '@angular/core';
 import { TemplateRef } from '@angular/core';
+import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public
 export interface MatchSegment {
@@ -44,15 +44,17 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
     // (undocumented)
     protected static readonly overlayPositions: ConnectionPositionPair[];
     readonly siTypeahead: _angular_core.InputSignal<Typeahead>;
-    readonly typeaheadAutocompleteListLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
+    readonly typeaheadAutocompleteListLabel: _angular_core.InputSignal<TranslatableString>;
     readonly typeaheadAutoSelectIndex: _angular_core.InputSignalWithTransform<number, unknown>;
     readonly typeaheadClearValueOnSelect: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly typeaheadCloseOnEsc: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    readonly typeaheadCreateOption: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly typeaheadFullWidth: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly typeaheadItemTemplate: _angular_core.InputSignal<TemplateRef<TypeaheadOptionItemContext> | undefined>;
     readonly typeaheadMatchAllTokens: _angular_core.InputSignal<"no" | "once" | "separately" | "independently">;
     readonly typeaheadMinLength: _angular_core.InputSignal<number>;
     readonly typeaheadMultiSelect: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    readonly typeaheadOnCreateOption: _angular_core.OutputEmitterRef<string>;
     readonly typeaheadOnFullMatch: _angular_core.OutputEmitterRef<TypeaheadMatch>;
     readonly typeaheadOnInput: _angular_core.OutputEmitterRef<string>;
     readonly typeaheadOnSelect: _angular_core.OutputEmitterRef<TypeaheadMatch>;
@@ -68,7 +70,7 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
     readonly typeaheadTokenize: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly typeaheadWaitMs: _angular_core.InputSignal<number>;
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<SiTypeaheadDirective, "[siTypeahead]", ["si-typeahead"], { "siTypeahead": { "alias": "siTypeahead"; "required": true; "isSignal": true; }; "typeaheadProcess": { "alias": "typeaheadProcess"; "required": false; "isSignal": true; }; "typeaheadScrollable": { "alias": "typeaheadScrollable"; "required": false; "isSignal": true; }; "typeaheadOptionsInScrollableView": { "alias": "typeaheadOptionsInScrollableView"; "required": false; "isSignal": true; }; "typeaheadOptionsLimit": { "alias": "typeaheadOptionsLimit"; "required": false; "isSignal": true; }; "typeaheadScrollableAdditionalHeight": { "alias": "typeaheadScrollableAdditionalHeight"; "required": false; "isSignal": true; }; "typeaheadAutoSelectIndex": { "alias": "typeaheadAutoSelectIndex"; "required": false; "isSignal": true; }; "typeaheadCloseOnEsc": { "alias": "typeaheadCloseOnEsc"; "required": false; "isSignal": true; }; "typeaheadClearValueOnSelect": { "alias": "typeaheadClearValueOnSelect"; "required": false; "isSignal": true; }; "typeaheadWaitMs": { "alias": "typeaheadWaitMs"; "required": false; "isSignal": true; }; "typeaheadMinLength": { "alias": "typeaheadMinLength"; "required": false; "isSignal": true; }; "typeaheadOptionField": { "alias": "typeaheadOptionField"; "required": false; "isSignal": true; }; "typeaheadMultiSelect": { "alias": "typeaheadMultiSelect"; "required": false; "isSignal": true; }; "typeaheadTokenize": { "alias": "typeaheadTokenize"; "required": false; "isSignal": true; }; "typeaheadMatchAllTokens": { "alias": "typeaheadMatchAllTokens"; "required": false; "isSignal": true; }; "typeaheadItemTemplate": { "alias": "typeaheadItemTemplate"; "required": false; "isSignal": true; }; "typeaheadSkipSortingMatches": { "alias": "typeaheadSkipSortingMatches"; "required": false; "isSignal": true; }; "typeaheadAutocompleteListLabel": { "alias": "typeaheadAutocompleteListLabel"; "required": false; "isSignal": true; }; "typeaheadFullWidth": { "alias": "typeaheadFullWidth"; "required": false; "isSignal": true; }; }, { "typeaheadOnInput": "typeaheadOnInput"; "typeaheadOnSelect": "typeaheadOnSelect"; "typeaheadOnFullMatch": "typeaheadOnFullMatch"; "typeaheadOpenChange": "typeaheadOpenChange"; }, never, never, true, [{ directive: typeof i1.SiAutocompleteDirective; inputs: {}; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<SiTypeaheadDirective, "[siTypeahead]", ["si-typeahead"], { "siTypeahead": { "alias": "siTypeahead"; "required": true; "isSignal": true; }; "typeaheadProcess": { "alias": "typeaheadProcess"; "required": false; "isSignal": true; }; "typeaheadScrollable": { "alias": "typeaheadScrollable"; "required": false; "isSignal": true; }; "typeaheadOptionsInScrollableView": { "alias": "typeaheadOptionsInScrollableView"; "required": false; "isSignal": true; }; "typeaheadOptionsLimit": { "alias": "typeaheadOptionsLimit"; "required": false; "isSignal": true; }; "typeaheadScrollableAdditionalHeight": { "alias": "typeaheadScrollableAdditionalHeight"; "required": false; "isSignal": true; }; "typeaheadAutoSelectIndex": { "alias": "typeaheadAutoSelectIndex"; "required": false; "isSignal": true; }; "typeaheadCloseOnEsc": { "alias": "typeaheadCloseOnEsc"; "required": false; "isSignal": true; }; "typeaheadClearValueOnSelect": { "alias": "typeaheadClearValueOnSelect"; "required": false; "isSignal": true; }; "typeaheadWaitMs": { "alias": "typeaheadWaitMs"; "required": false; "isSignal": true; }; "typeaheadMinLength": { "alias": "typeaheadMinLength"; "required": false; "isSignal": true; }; "typeaheadOptionField": { "alias": "typeaheadOptionField"; "required": false; "isSignal": true; }; "typeaheadMultiSelect": { "alias": "typeaheadMultiSelect"; "required": false; "isSignal": true; }; "typeaheadTokenize": { "alias": "typeaheadTokenize"; "required": false; "isSignal": true; }; "typeaheadMatchAllTokens": { "alias": "typeaheadMatchAllTokens"; "required": false; "isSignal": true; }; "typeaheadItemTemplate": { "alias": "typeaheadItemTemplate"; "required": false; "isSignal": true; }; "typeaheadSkipSortingMatches": { "alias": "typeaheadSkipSortingMatches"; "required": false; "isSignal": true; }; "typeaheadAutocompleteListLabel": { "alias": "typeaheadAutocompleteListLabel"; "required": false; "isSignal": true; }; "typeaheadFullWidth": { "alias": "typeaheadFullWidth"; "required": false; "isSignal": true; }; "typeaheadCreateOption": { "alias": "typeaheadCreateOption"; "required": false; "isSignal": true; }; }, { "typeaheadOnInput": "typeaheadOnInput"; "typeaheadOnSelect": "typeaheadOnSelect"; "typeaheadOnFullMatch": "typeaheadOnFullMatch"; "typeaheadOpenChange": "typeaheadOpenChange"; "typeaheadOnCreateOption": "typeaheadOnCreateOption"; }, never, never, true, [{ directive: typeof i1.SiAutocompleteDirective; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<SiTypeaheadDirective, never>;
 }

--- a/projects/element-ng/typeahead/si-typeahead.component.html
+++ b/projects/element-ng/typeahead/si-typeahead.component.html
@@ -13,6 +13,8 @@
   }
 </ng-template>
 
+@let createOption = parent.typeaheadCreateOption();
+
 <!-- Only display the component if there are any matches and set the CSS transform to properly position the typeahead -->
 <ul
   #typeahead
@@ -20,7 +22,6 @@
   [siAutocompleteListboxFor]="autocompleteDirective"
   [siAutocompleteDefaultIndex]="parent.typeaheadAutoSelectIndex()"
   [attr.aria-label]="parent.typeaheadAutocompleteListLabel() | translate"
-  [class.d-none]="!matches().length"
   (siAutocompleteOptionSubmitted)="selectMatch($event)"
 >
   <!-- Loop through every match and bind events, the mousedown prevent default is to prevent the host from losing focus on click -->
@@ -44,6 +45,11 @@
           query: parent.query()
         }"
       />
+    </li>
+  }
+  @if (createOption && parent.query().length) {
+    <li class="dropdown-item" [siAutocompleteOption]="undefined">
+      {{ createOption | translate: { query: parent.query() } }}
     </li>
   }
 </ul>

--- a/projects/element-ng/typeahead/si-typeahead.component.ts
+++ b/projects/element-ng/typeahead/si-typeahead.component.ts
@@ -91,7 +91,11 @@ export class SiTypeaheadComponent implements AfterViewInit {
   }
 
   // Gets called when a match is selected by clicking on it.
-  protected selectMatch(match: TypeaheadMatch): void {
-    this.parent.selectMatch(match);
+  protected selectMatch(match: TypeaheadMatch | undefined): void {
+    if (match) {
+      this.parent.selectMatch(match);
+    } else {
+      this.parent.createOption();
+    }
   }
 }


### PR DESCRIPTION
The idea is to support a similar pattern as in the `si-select`, where apps can add an option in the footer, allowing users to create options on the fly.

We need this ourselves in the filtered-search,
in order to build the planned free-text pills.

This feature is flagged as experimental,
to allow us to remove it in case we decide using
alternative approaches.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

* **New Features**
  * Typeahead keeps the dropdown open when there are matches or a creatable option and appends a "create option" entry that shows the current query and emits it when chosen.
  * New public input/output let host components supply translatable create-option text and receive create events.

* **Tests**
  * Added tests covering create-option rendering, selection behavior, event emission, and clearing the options list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->