### PR TITLE
fix(translate-ng): prevent unwanted import of ngx-translate

### DIFF
--- a/api-goldens/element-ng/application-header/index.api.md
+++ b/api-goldens/element-ng/application-header/index.api.md
@@ -15,7 +15,7 @@ import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import * as rxjs from 'rxjs';
 import * as _siemens_element_ng_application_header from '@siemens/element-ng/application-header';
-import * as _siemens_element_translate_ng from '@siemens/element-translate-ng';
+import * as _siemens_element_translate_ng_translate_types from '@siemens/element-translate-ng/translate-types';
 import { SiHeaderDropdownTriggerDirective } from '@siemens/element-ng/header-dropdown';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
@@ -94,7 +94,7 @@ export class SiApplicationHeaderComponent implements HeaderWithDropdowns, OnDest
     // (undocumented)
     readonly launchpad: _angular_core.InputSignal<TemplateRef<void> | undefined>;
     // (undocumented)
-    readonly launchpadLabel: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
+    readonly launchpadLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
     protected readonly launchpadOpen: _angular_core.WritableSignal<boolean>;
     // (undocumented)
@@ -108,7 +108,7 @@ export class SiApplicationHeaderComponent implements HeaderWithDropdowns, OnDest
     // (undocumented)
     protected toggleMobileNavigationExpanded(): void;
     // (undocumented)
-    protected toggleNavigation: _siemens_element_translate_ng.TranslatableString;
+    protected toggleNavigation: _siemens_element_translate_ng_translate_types.TranslatableString;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiApplicationHeaderComponent, "si-application-header", never, { "expandBreakpoint": { "alias": "expandBreakpoint"; "required": false; "isSignal": true; }; "launchpad": { "alias": "launchpad"; "required": false; "isSignal": true; }; "launchpadLabel": { "alias": "launchpadLabel"; "required": false; "isSignal": true; }; }, {}, never, ["si-header-brand, element-header-brand", "si-header-navigation, element-header-navigation", "si-header-actions, element-header-actions"], true, never>;
     // (undocumented)
@@ -159,7 +159,7 @@ export class SiHeaderCollapsibleActionsComponent implements OnDestroy {
     protected readonly icons: Record<"elementOptionsVertical", string>;
     // (undocumented)
     protected readonly id: string;
-    readonly mobileToggleLabel: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
+    readonly mobileToggleLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -235,11 +235,11 @@ export class SiLaunchpadFactoryComponent {
     protected readonly categories: _angular_core.Signal<AppCategory[]>;
     // (undocumented)
     protected closeLaunchpad(): void;
-    readonly closeText: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
+    readonly closeText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly enableFavorites: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     protected escape(): void;
-    readonly favoriteAppsText: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
+    readonly favoriteAppsText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
     readonly favoriteChange: _angular_core.OutputEmitterRef<FavoriteChangeEvent>;
     // (undocumented)
@@ -252,10 +252,10 @@ export class SiLaunchpadFactoryComponent {
     protected isCategories(items: App[] | AppCategory[]): items is AppCategory[];
     // (undocumented)
     protected showAllApps: boolean;
-    readonly showLessAppsText: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
-    readonly showMoreAppsText: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
-    readonly subtitleText: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
-    readonly titleText: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
+    readonly showLessAppsText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
+    readonly showMoreAppsText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
+    readonly subtitleText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
+    readonly titleText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
     protected toggleFavorite(app: App, favorite: boolean): void;
     // (undocumented)

--- a/api-goldens/element-ng/navbar/index.api.md
+++ b/api-goldens/element-ng/navbar/index.api.md
@@ -18,7 +18,7 @@ import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import * as rxjs from 'rxjs';
 import { SiApplicationHeaderComponent } from '@siemens/element-ng/application-header';
-import * as _siemens_element_translate_ng from '@siemens/element-translate-ng';
+import * as _siemens_element_translate_ng_translate_types from '@siemens/element-translate-ng/translate-types';
 import { SiHeaderCollapsibleActionsComponent } from '@siemens/element-ng/application-header';
 import { SiHeaderDropdownTriggerDirective } from '@siemens/element-ng/header-dropdown';
 import { SimpleChanges } from '@angular/core';
@@ -95,14 +95,14 @@ export class SiNavbarPrimaryComponent implements OnChanges, HeaderWithDropdowns 
     readonly appItemFavoriteChanged: _angular_core.OutputEmitterRef<[AppItem, boolean]>;
     readonly appItems: _angular_core.InputSignal<AppItem[] | undefined>;
     readonly appItemsFavorites: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly appSwitcherSubTitle: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
-    readonly appSwitcherTitle: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
+    readonly appSwitcherSubTitle: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
+    readonly appSwitcherTitle: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly appTitle: _angular_core.InputSignal<string | undefined>;
     readonly ariaLabelMainMenu: _angular_core.InputSignal<string>;
     readonly ariaLabelSecondaryMenu: _angular_core.InputSignal<string>;
-    readonly closeAppSwitcherText: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
-    readonly defaultAppsTitle: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
-    readonly favoriteAppsTitle: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
+    readonly closeAppSwitcherText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
+    readonly defaultAppsTitle: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
+    readonly favoriteAppsTitle: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly focusOnLoad: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly home: _angular_core.InputSignal<Link | undefined>;
     readonly logoUrl: _angular_core.InputSignal<string | undefined>;
@@ -111,11 +111,11 @@ export class SiNavbarPrimaryComponent implements OnChanges, HeaderWithDropdowns 
     protected newAppItems?: App[] | AppCategory[];
     // (undocumented)
     protected onFavoriteChange({ app, favorite }: FavoriteChangeEvent): void;
-    readonly openAppSwitcherText: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
+    readonly openAppSwitcherText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly primaryItems: _angular_core.InputSignal<MenuItem[]>;
-    readonly showLessAppsTitle: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
-    readonly showMoreAppsTitle: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
-    readonly toggleNavigationText: _angular_core.InputSignal<_siemens_element_translate_ng.TranslatableString>;
+    readonly showLessAppsTitle: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
+    readonly showMoreAppsTitle: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
+    readonly toggleNavigationText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiNavbarPrimaryComponent, "si-navbar-primary", never, { "primaryItems": { "alias": "primaryItems"; "required": false; "isSignal": true; }; "accountItems": { "alias": "accountItems"; "required": false; "isSignal": true; }; "account": { "alias": "account"; "required": false; "isSignal": true; }; "logoUrl": { "alias": "logoUrl"; "required": false; "isSignal": true; }; "appTitle": { "alias": "appTitle"; "required": false; "isSignal": true; }; "home": { "alias": "home"; "required": false; "isSignal": true; }; "appSwitcherTitle": { "alias": "appSwitcherTitle"; "required": false; "isSignal": true; }; "appSwitcherSubTitle": { "alias": "appSwitcherSubTitle"; "required": false; "isSignal": true; }; "favoriteAppsTitle": { "alias": "favoriteAppsTitle"; "required": false; "isSignal": true; }; "defaultAppsTitle": { "alias": "defaultAppsTitle"; "required": false; "isSignal": true; }; "showMoreAppsTitle": { "alias": "showMoreAppsTitle"; "required": false; "isSignal": true; }; "showLessAppsTitle": { "alias": "showLessAppsTitle"; "required": false; "isSignal": true; }; "appItems": { "alias": "appItems"; "required": false; "isSignal": true; }; "appCategoryItems": { "alias": "appCategoryItems"; "required": false; "isSignal": true; }; "appItemsFavorites": { "alias": "appItemsFavorites"; "required": false; "isSignal": true; }; "allAppsLink": { "alias": "allAppsLink"; "required": false; "isSignal": true; }; "focusOnLoad": { "alias": "focusOnLoad"; "required": false; "isSignal": true; }; "navAriaLabel": { "alias": "navAriaLabel"; "required": false; "isSignal": true; }; "closeAppSwitcherText": { "alias": "closeAppSwitcherText"; "required": false; "isSignal": true; }; "openAppSwitcherText": { "alias": "openAppSwitcherText"; "required": false; "isSignal": true; }; "toggleNavigationText": { "alias": "toggleNavigationText"; "required": false; "isSignal": true; }; "ariaLabelMainMenu": { "alias": "ariaLabelMainMenu"; "required": false; "isSignal": true; }; "ariaLabelSecondaryMenu": { "alias": "ariaLabelSecondaryMenu"; "required": false; "isSignal": true; }; }, { "appItemFavoriteChanged": "appItemFavoriteChanged"; }, never, ["*", "si-navbar-item[quickAction], element-navbar-item[quickAction='true']"], true, never>;
     // (undocumented)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,7 +74,12 @@ export const tsConfig = defineConfig({
           {
             name: '@ngx-translate/core',
             importNames: ['TranslatePipe'],
-            message: 'Use `SiTranslatePipe` from `@siemens/element-translate-ng` instead.'
+            message: 'Use `SiTranslatePipe` from `@siemens/element-translate-ng/translate` instead.'
+          },
+          {
+            name: '@siemens/element-translate-ng',
+            message:
+              'Always use a dedicated secondary entrypoint, e.g. `@siemens/element-translate-ng/translate`.'
           }
         ]
       }

--- a/projects/element-ng/application-header/si-account-details.component.ts
+++ b/projects/element-ng/application-header/si-account-details.component.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { SiTranslatePipe } from '@siemens/element-translate-ng';
-import { TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-account-details',

--- a/projects/maps-ng/src/components/si-map/si-map.component.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.ts
@@ -23,7 +23,11 @@ import {
   Type,
   viewChild
 } from '@angular/core';
-import { SiNoTranslateService, SiTranslateServiceBuilder, t } from '@siemens/element-translate-ng';
+import {
+  SiNoTranslateService,
+  SiTranslateServiceBuilder,
+  t
+} from '@siemens/element-translate-ng/translate';
 import { apply as applyMapboxStyle } from 'ol-mapbox-style';
 import Control from 'ol/control/Control';
 import { defaults as defaultControls } from 'ol/control/defaults';

--- a/src/app/examples/si-chat-messages/si-chat-message.ts
+++ b/src/app/examples/si-chat-messages/si-chat-message.ts
@@ -15,7 +15,7 @@ import {
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiMarkdownRendererComponent } from '@siemens/element-ng/markdown-renderer';
 import { MenuItemAction, SiMenuFactoryComponent } from '@siemens/element-ng/menu';
-import { SiTranslatePipe } from '@siemens/element-translate-ng';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { LOG_EVENT } from '@siemens/live-preview';
 
 @Component({


### PR DESCRIPTION
The `@siemens/element-translate-ng` should
have never existed, as it imports all framework specific
translation layers.

So when importing something from that entrypoint,
an app automatically loads all translation frameworks
we support.

This entrypoint should be dropped with v49.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated translation imports to the dedicated secondary entrypoint (@siemens/element-translate-ng/translate).
  * Updated lint messages to encourage using the dedicated translation entrypoint.
* **Documentation**
  * Aligned public API/type references for translatable text properties to the translate-types module and updated API docs accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->