### PR TITLE
fix(microchart-line): fix gradient ID not unique

### DIFF
--- a/api-goldens/native-charts-ng/microchart-line/index.api.md
+++ b/api-goldens/native-charts-ng/microchart-line/index.api.md
@@ -18,7 +18,7 @@ export class SiMicrochartLineComponent {
     // (undocumented)
     protected readonly areaPath: _angular_core.Signal<string>;
     // (undocumented)
-    protected readonly gradientId = "gradient-line-id";
+    protected readonly gradientId: string;
     // (undocumented)
     readonly height: _angular_core.InputSignal<number>;
     readonly lineWidth: _angular_core.InputSignal<number>;

--- a/projects/native-charts-ng/microchart-line/si-microchart-line.component.ts
+++ b/projects/native-charts-ng/microchart-line/si-microchart-line.component.ts
@@ -100,7 +100,8 @@ export class SiMicrochartLineComponent {
     return path;
   });
 
-  protected readonly gradientId = `gradient-line-id`;
+  private static instanceCounter = 0;
+  protected readonly gradientId = `gradient-line-${SiMicrochartLineComponent.instanceCounter++}`;
 
   private mapToCoordinates(values: number[]): Coordinate[] {
     const max = Math.max(...values);


### PR DESCRIPTION
w/o this:
<img width="258" height="68" alt="Screenshot 2025-11-27 at 16 35 29" src="https://github.com/user-attachments/assets/aa20303a-b983-40af-97cb-dcad990d3e81" />

with this:
<img width="258" height="70" alt="Screenshot 2025-11-27 at 16 35 18" src="https://github.com/user-attachments/assets/65ec9b81-e323-406d-9348-50aa1f80feb0" />

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gradient ID generation in line microcharts to ensure each instance has a unique identifier, preventing potential rendering conflicts when multiple charts are displayed simultaneously.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->