### PR TITLE
test(element): make tests zoneless ready part 1

### DIFF
--- a/projects/element-ng/accordion/si-accordion.component.spec.ts
+++ b/projects/element-ng/accordion/si-accordion.component.spec.ts
@@ -2,8 +2,14 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  signal,
+  viewChild
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SiAccordionComponent } from './si-accordion.component';
@@ -30,11 +36,12 @@ describe('SiAccordion', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let element: HTMLElement;
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, TestHostComponent]
+      imports: [NoopAnimationsModule, TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
@@ -75,19 +82,17 @@ describe('SiAccordion', () => {
     checkExpanded(true, false, false);
   });
 
-  it('expands a panel and closes others', fakeAsync(() => {
+  it('expands a panel and closes others', () => {
     fixture.detectChanges();
 
     // open second panel
     clickOnHeader(1);
-    flush();
     fixture.detectChanges();
     checkExpanded(false, true, false);
 
     // close second panel
     clickOnHeader(1);
-    flush();
     fixture.detectChanges();
     checkExpanded(false, false, false);
-  }));
+  });
 });

--- a/projects/element-ng/accordion/si-collapsible-panel.component.spec.ts
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -36,11 +36,12 @@ describe('SiCollapsiblePanel', () => {
   const toggleCollapsePanel = (e?: HTMLElement): void =>
     (e ?? element).querySelector<HTMLElement>('.collapsible-header')?.click();
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SiCollapsiblePanelComponent, TestHostComponent]
+      imports: [NoopAnimationsModule, SiCollapsiblePanelComponent, TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
@@ -61,7 +62,7 @@ describe('SiCollapsiblePanel', () => {
     expect(header.innerHTML).toContain('This is the heading');
   });
 
-  it('should collapse/expand on click', fakeAsync(() => {
+  it('should collapse/expand on click', () => {
     component.heading = 'This is the heading';
     fixture.detectChanges();
 
@@ -69,16 +70,15 @@ describe('SiCollapsiblePanel', () => {
     expect(header.classList.contains('open')).toBeFalse();
 
     toggleCollapsePanel();
-    flush();
     fixture.detectChanges();
 
     expect(header.classList.contains('open')).toBeTrue();
 
     const content = element.querySelector('.collapsible-content') as HTMLElement;
     expect(content.innerHTML).toContain('This is the content');
-  }));
+  });
 
-  it('should collapse/expand on #doToggle() API', fakeAsync(() => {
+  it('should collapse/expand on #doToggle() API', () => {
     component.heading = 'This is the heading';
     fixture.detectChanges();
 
@@ -94,12 +94,10 @@ describe('SiCollapsiblePanel', () => {
     expect(content.innerHTML).toContain('This is the content');
 
     toggleCollapsePanel();
-    flush();
     fixture.detectChanges();
 
     expect(header.classList.contains('open')).toBeFalse();
-  }));
-
+  });
   it('should show show custom header selected by si-panel-heading directive', () => {
     component.heading = 'This is the highlighted heading';
     fixture.detectChanges();

--- a/projects/element-ng/action-modal/si-action-dialog.service.spec.ts
+++ b/projects/element-ng/action-modal/si-action-dialog.service.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ApplicationRef } from '@angular/core';
-import { fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { ApplicationRef, provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Subject } from 'rxjs';
 
@@ -16,14 +16,15 @@ describe('SiActionDialogService', () => {
 
   const clickDialogButton = (index: number): void => {
     appRef.tick();
-    flush();
     document.querySelectorAll<HTMLElement>('si-modal button:not(.btn-circle)')[index]?.click();
     appRef.tick();
-    flush();
   };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({ imports: [NoopAnimationsModule] }).compileComponents();
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule],
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
     service = TestBed.inject(SiActionDialogService);
     appRef = TestBed.inject(ApplicationRef);
   });
@@ -32,7 +33,7 @@ describe('SiActionDialogService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should show alert dialog with all options and confirm', fakeAsync(() => {
+  it('should show alert dialog with all options and confirm', () => {
     const observable = service.showActionDialog({
       type: 'alert',
       message: 'This is an alert.',
@@ -44,18 +45,18 @@ describe('SiActionDialogService', () => {
     });
     clickDialogButton(0);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show alert dialog with no options and confirm', fakeAsync(() => {
+  it('should show alert dialog with no options and confirm', () => {
     const observable = service.showActionDialog({ type: 'alert', message: 'This is an alert.' });
     const subscription = observable.subscribe(result => {
       expect(result).toBe('confirm');
     });
     clickDialogButton(0);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show confirmation dialog and confirm', fakeAsync(() => {
+  it('should show confirmation dialog and confirm', () => {
     const observable = service.showActionDialog({
       type: 'confirmation',
       message: 'This is an alert.',
@@ -68,9 +69,9 @@ describe('SiActionDialogService', () => {
 
     clickDialogButton(1);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show confirmation dialog with all options and confirm', fakeAsync(() => {
+  it('should show confirmation dialog with all options and confirm', () => {
     const observable = service.showActionDialog({
       type: 'confirmation',
       message: 'This is an alert.',
@@ -82,9 +83,9 @@ describe('SiActionDialogService', () => {
     });
     clickDialogButton(1);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show confirmation dialog with no options and confirm', fakeAsync(() => {
+  it('should show confirmation dialog with no options and confirm', () => {
     const observable = service.showActionDialog({
       type: 'confirmation',
       message: 'This is an alert.'
@@ -94,9 +95,9 @@ describe('SiActionDialogService', () => {
     });
     clickDialogButton(1);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show confirmation dialog and decline', fakeAsync(() => {
+  it('should show confirmation dialog and decline', () => {
     const observable = service.showActionDialog({
       type: 'confirmation',
       message: 'Question.',
@@ -109,9 +110,9 @@ describe('SiActionDialogService', () => {
     });
     clickDialogButton(0);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show edit-discard dialog with all options and save', fakeAsync(() => {
+  it('should show edit-discard dialog with all options and save', () => {
     const observable = service.showActionDialog({
       type: 'edit-discard',
       disableSave: false,
@@ -127,18 +128,18 @@ describe('SiActionDialogService', () => {
     });
     clickDialogButton(2);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show edit-discard dialog with no options and save', fakeAsync(() => {
+  it('should show edit-discard dialog with no options and save', () => {
     const observable = service.showActionDialog({ type: 'edit-discard' });
     const subscription = observable.subscribe(result => {
       expect(result).toBe('save');
     });
     clickDialogButton(2);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show edit-discard dialog and discard', fakeAsync(() => {
+  it('should show edit-discard dialog and discard', () => {
     const observable = service.showActionDialog({
       type: 'edit-discard',
       disableSave: false,
@@ -153,9 +154,9 @@ describe('SiActionDialogService', () => {
     });
     clickDialogButton(1);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show edit-discard dialog and cancel', fakeAsync(() => {
+  it('should show edit-discard dialog and cancel', () => {
     const observable = service.showActionDialog({
       type: 'edit-discard',
       disableSave: false,
@@ -170,9 +171,9 @@ describe('SiActionDialogService', () => {
     });
     clickDialogButton(0);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show delete confirmation with all options dialog and delete', fakeAsync(() => {
+  it('should show delete confirmation with all options dialog and delete', () => {
     const observable = service.showActionDialog({
       type: 'delete-confirm',
       message: 'This is an alert.',
@@ -185,18 +186,18 @@ describe('SiActionDialogService', () => {
     });
     clickDialogButton(1);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show delete confirmation with no options dialog and delete', fakeAsync(() => {
+  it('should show delete confirmation with no options dialog and delete', () => {
     const observable = service.showActionDialog({ type: 'delete-confirm' });
     const subscription = observable.subscribe(result => {
       expect(result).toBe('delete');
     });
     clickDialogButton(1);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should show delete confirmation dialog and cancel', fakeAsync(() => {
+  it('should show delete confirmation dialog and cancel', () => {
     const observable = service.showActionDialog({
       type: 'delete-confirm',
       message: 'This is an alert.',
@@ -209,9 +210,9 @@ describe('SiActionDialogService', () => {
     });
     clickDialogButton(0);
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should delay closing until delayDismiss() completes', fakeAsync(() => {
+  it('should delay closing until delayDismiss() completes', () => {
     const delaySubject = new Subject<DeleteConfirmationDialogResult>();
     const observable = service.showActionDialog({
       type: 'delete-confirm',
@@ -222,12 +223,9 @@ describe('SiActionDialogService', () => {
     });
     clickDialogButton(1);
 
-    flush();
     expect(document.querySelector('si-modal si-loading-button si-loading-spinner')).toBeTruthy();
     delaySubject.next('delete');
     delaySubject.complete();
-    flush();
-
     subscription.unsubscribe();
-  }));
+  });
 });

--- a/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.spec.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
 
 import { SiAlertDialogComponent } from './si-alert-dialog.component';
@@ -13,13 +14,13 @@ describe('SiAlertDialogComponent', () => {
   let element: HTMLElement;
   let modalRef: ModalRef<any, any>;
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SiAlertDialogComponent],
-      providers: [ModalRef]
+      providers: [ModalRef, provideZonelessChangeDetection()]
     }).compileComponents();
     modalRef = TestBed.inject(ModalRef);
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SiAlertDialogComponent);

--- a/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.spec.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
 
 import { SiConfirmationDialogComponent } from './si-confirmation-dialog.component';
@@ -13,13 +14,13 @@ describe('SiConfirmationDialogComponent', () => {
   let element: HTMLElement;
   let modalRef: ModalRef<any, any>;
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SiConfirmationDialogComponent],
-      providers: [ModalRef]
+      providers: [ModalRef, provideZonelessChangeDetection()]
     }).compileComponents();
     modalRef = TestBed.inject(ModalRef);
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SiConfirmationDialogComponent);

--- a/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
 
@@ -16,7 +17,7 @@ describe('SiDeleteConfirmationDialogComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SiDeleteConfirmationDialogComponent],
-      providers: [ModalRef]
+      providers: [ModalRef, provideZonelessChangeDetection()]
     });
     modalRef = TestBed.inject(ModalRef);
   });

--- a/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.spec.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
 
 import { SiEditDiscardDialogComponent } from './si-edit-discard-dialog.component';
@@ -13,13 +14,13 @@ describe('SiEditDiscardDialogComponent', () => {
   let element: HTMLElement;
   let modalRef: ModalRef<any, any>;
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SiEditDiscardDialogComponent],
-      providers: [ModalRef]
+      providers: [ModalRef, provideZonelessChangeDetection()]
     }).compileComponents();
     modalRef = TestBed.inject(ModalRef);
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SiEditDiscardDialogComponent);

--- a/projects/element-ng/application-header/launchpad/si-launchpad.spec.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component } from '@angular/core';
+import { Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiApplicationHeaderComponent } from '../si-application-header.component';
@@ -33,7 +33,10 @@ describe('SiLaunchpad', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [{ provide: SiApplicationHeaderComponent, useValue: {} }]
+      providers: [
+        { provide: SiApplicationHeaderComponent, useValue: {} },
+        provideZonelessChangeDetection()
+      ]
     }).compileComponents();
   });
 
@@ -58,7 +61,7 @@ describe('SiLaunchpad', () => {
             ]
           }
         ];
-
+        fixture.changeDetectorRef.markForCheck();
         expect(await harness.hasToggle()).toBeTrue();
         expect(await harness.getCategories()).toHaveSize(1);
         await harness.toggleMore();
@@ -80,6 +83,7 @@ describe('SiLaunchpad', () => {
             ]
           }
         ];
+        fixture.changeDetectorRef.markForCheck();
         expect(await harness.getFavoriteCategory().then(category => category.getApps())).toHaveSize(
           1
         );
@@ -104,7 +108,7 @@ describe('SiLaunchpad', () => {
           { name: 'A-1', href: '/a-1', favorite: true },
           { name: 'A-2', href: '/a-2' }
         ];
-
+        fixture.changeDetectorRef.markForCheck();
         await harness.toggleMore();
         const categories = await harness.getCategories();
         expect(categories).toHaveSize(2);
@@ -130,7 +134,7 @@ describe('SiLaunchpad', () => {
             ]
           }
         ];
-
+        fixture.changeDetectorRef.markForCheck();
         expect(await harness.hasToggle()).toBeFalse();
         expect(await harness.getCategories()).toHaveSize(1);
       });
@@ -142,6 +146,7 @@ describe('SiLaunchpad', () => {
           { name: 'A-1', href: '/a-1' },
           { name: 'A-2', href: '/a-2' }
         ];
+        fixture.changeDetectorRef.markForCheck();
         expect(await harness.hasToggle()).toBeFalse();
       });
     });

--- a/projects/element-ng/application-header/si-application-header.component.spec.ts
+++ b/projects/element-ng/application-header/si-application-header.component.spec.ts
@@ -5,7 +5,12 @@
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, Injectable } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Injectable,
+  provideZonelessChangeDetection
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   SiHeaderDropdownComponent,
@@ -97,7 +102,8 @@ describe('SiApplicationHeaderComponent', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [TestHostComponent]
+        imports: [TestHostComponent],
+        providers: [provideZonelessChangeDetection()]
       });
     });
 

--- a/projects/element-ng/avatar/si-avatar.component.spec.ts
+++ b/projects/element-ng/avatar/si-avatar.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EntityStatusType } from '@siemens/element-ng/common';
 
 import { SiAvatarComponent } from './index';
@@ -38,7 +38,8 @@ describe('SiAvatarComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiAvatarComponent, TestHostComponent]
+      imports: [SiAvatarComponent, TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents()
   );
 
@@ -49,78 +50,71 @@ describe('SiAvatarComponent', () => {
     element = fixture.nativeElement.querySelector('si-avatar');
   });
 
-  it('should show image', fakeAsync(() => {
+  it('should show image', () => {
     host.imageUrl = 'testImageUrl';
     fixture.detectChanges();
-    tick();
 
     const img = element.querySelector('img');
     expect(img).toBeTruthy();
     expect(img?.alt).toBe('Test');
-  }));
+  });
 
-  it('should show icon', fakeAsync(() => {
+  it('should show icon', () => {
     host.icon = 'element-user';
     fixture.detectChanges();
-    tick();
 
     const el = element.querySelector<HTMLElement>('.element-user');
     expect(el).toBeTruthy();
     expect(el?.title).toBe('Test');
-  }));
+  });
 
-  it('should show initials', fakeAsync(() => {
+  it('should show initials', () => {
     host.initials = 'JD';
     fixture.detectChanges();
-    tick();
 
     const div = element.querySelector<HTMLElement>('.initials');
     expect(div).toBeTruthy();
     expect(div?.innerText).toBe('JD');
     expect(div?.title).toBe('Test');
-  }));
+  });
 
-  it('should show status icon', fakeAsync(() => {
+  it('should show status icon', () => {
     host.initials = 'JD';
     host.status = 'success';
     fixture.detectChanges();
-    tick();
 
     expect(element.querySelector('.indicator')).toBeTruthy();
-  }));
+  });
 
-  it('should show different color', fakeAsync(() => {
+  it('should show different color', () => {
     host.initials = 'JD';
     host.color = 14;
     fixture.detectChanges();
-    tick();
 
     expect(element.style.getPropertyValue('--background')).toBe('var(--element-data-14)');
-  }));
+  });
 
-  it('should wrap data colors', fakeAsync(() => {
+  it('should wrap data colors', () => {
     host.initials = 'JD';
     host.color = 21;
     fixture.detectChanges();
-    tick();
 
     expect(element.style.getPropertyValue('--background')).toBe('var(--element-data-4)');
-  }));
+  });
 
-  it('should set color automatically', fakeAsync(() => {
+  it('should set color automatically', () => {
     host.initials = 'JD';
     host.autoColor = true;
     fixture.detectChanges();
-    tick();
 
     expect(element.style.getPropertyValue('--background')).toBe('var(--element-data-4)');
 
     host.initials = 'DJ';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    tick();
 
     expect(element.style.getPropertyValue('--background')).toBe('var(--element-data-10)');
-  }));
+  });
 
   describe('auto-calculated initials', () => {
     it('should support account with first and last name', () => {

--- a/projects/element-ng/breadcrumb-router/si-breadcrumb-router.component.spec.ts
+++ b/projects/element-ng/breadcrumb-router/si-breadcrumb-router.component.spec.ts
@@ -2,12 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, ElementRef, viewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
+import { Component, ElementRef, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router, RouterModule, RouterOutlet, Routes } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { BreadcrumbItem } from '@siemens/element-ng/breadcrumb';
 
+import { runOnPushChangeDetection } from '../test-helpers';
 import {
   SI_BREADCRUMB_RESOLVER_SERVICE,
   SiBreadcrumbRouterComponent as TestComponent
@@ -71,7 +72,7 @@ describe('SiBreadcrumbRouterComponent', () => {
     }
   ];
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
         TestComponent,
@@ -83,10 +84,11 @@ describe('SiBreadcrumbRouterComponent', () => {
         {
           provide: SI_BREADCRUMB_RESOLVER_SERVICE,
           useClass: SiBreadcrumbDefaultResolverService
-        }
+        },
+        provideZonelessChangeDetection()
       ]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WrapperComponent);
@@ -96,65 +98,55 @@ describe('SiBreadcrumbRouterComponent', () => {
     router = TestBed.inject(Router);
   });
 
-  it('should display route items using breadcrumb resolver', fakeAsync(() => {
-    fixture.ngZone!.run(() => {
-      router.navigateByUrl('/');
+  it('should display route items using breadcrumb resolver', async () => {
+    router.navigateByUrl('/');
 
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+    await runOnPushChangeDetection(fixture);
 
-      expect(
-        (element.querySelector('.breadcrumb .item') as HTMLElement).querySelector('.icon')
-      ).not.toBeNull();
-      expect(
-        (element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).querySelector('.icon')
-      ).toBeNull();
-      expect((element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).innerText).toBe(
-        routes[0].children![0].data?.title
-      );
-    });
-  }));
+    expect(
+      (element.querySelector('.breadcrumb .item') as HTMLElement).querySelector('.icon')
+    ).not.toBeNull();
+    expect(
+      (element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).querySelector('.icon')
+    ).toBeNull();
+    expect((element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).innerText).toBe(
+      routes[0].children![0].data?.title
+    );
+  });
 
-  it('should change on route change using breadcrumb resolver', fakeAsync(() => {
-    fixture.ngZone!.run(() => {
-      router.navigateByUrl('/');
+  it('should change on route change using breadcrumb resolver', async () => {
+    router.navigateByUrl('/');
 
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+    await runOnPushChangeDetection(fixture);
 
-      expect(
-        (element.querySelector('.breadcrumb .item') as HTMLElement).querySelector('.icon')
-      ).not.toBeNull();
-      expect(
-        (element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).querySelector('.icon')
-      ).toBeNull();
-      expect((element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).innerText).toBe(
-        routes[0].children![0].data?.title
-      );
+    expect(
+      (element.querySelector('.breadcrumb .item') as HTMLElement).querySelector('.icon')
+    ).not.toBeNull();
+    expect(
+      (element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).querySelector('.icon')
+    ).toBeNull();
+    expect((element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).innerText).toBe(
+      routes[0].children![0].data?.title
+    );
 
-      router.navigate(['child']);
+    router.navigate(['child']);
 
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+    await runOnPushChangeDetection(fixture);
 
-      expect(
-        (element.querySelector('.breadcrumb .item') as HTMLElement).querySelector('.icon')
-      ).not.toBeNull();
-      expect(
-        (element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).querySelector('.icon')
-      ).toBeNull();
-      expect(
-        (element.querySelectorAll('.breadcrumb .item')[2] as HTMLElement).querySelector('.icon')
-      ).toBeNull();
-      expect((element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).innerText).toBe(
-        routes[0].children![1].data?.title
-      );
-      expect((element.querySelectorAll('.breadcrumb .item')[2] as HTMLElement).innerText).toBe(
-        routes[0].children![1].children![0].data?.title
-      );
-    });
-  }));
+    expect(
+      (element.querySelector('.breadcrumb .item') as HTMLElement).querySelector('.icon')
+    ).not.toBeNull();
+    expect(
+      (element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).querySelector('.icon')
+    ).toBeNull();
+    expect(
+      (element.querySelectorAll('.breadcrumb .item')[2] as HTMLElement).querySelector('.icon')
+    ).toBeNull();
+    expect((element.querySelectorAll('.breadcrumb .item')[1] as HTMLElement).innerText).toBe(
+      routes[0].children![1].data?.title
+    );
+    expect((element.querySelectorAll('.breadcrumb .item')[2] as HTMLElement).innerText).toBe(
+      routes[0].children![1].children![0].data?.title
+    );
+  });
 });

--- a/projects/element-ng/card/si-card.component.spec.ts
+++ b/projects/element-ng/card/si-card.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
@@ -53,7 +53,8 @@ describe('SiCardComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [RouterModule, NoopAnimationsModule, WrapperComponent]
+      imports: [RouterModule, NoopAnimationsModule, WrapperComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/element-ng/chat-messages/si-ai-message.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-ai-message.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement } from '@angular/core';
+import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By, DomSanitizer } from '@angular/platform-browser';
 import { getMarkdownRenderer } from '@siemens/element-ng/markdown-renderer';
@@ -16,7 +16,8 @@ describe('SiAiMessageComponent', () => {
   let markdownRenderer: (text: string) => string | Node;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestComponent]
+      imports: [TestComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/chat-messages/si-attachment-list.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-attachment-list.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement, TemplateRef } from '@angular/core';
+import { DebugElement, provideZonelessChangeDetection, TemplateRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SiModalService } from '@siemens/element-ng/modal';
@@ -21,7 +21,10 @@ describe('SiAttachmentListComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [TestComponent],
-      providers: [{ provide: SiModalService, useValue: modalServiceSpy }]
+      providers: [
+        { provide: SiModalService, useValue: modalServiceSpy },
+        provideZonelessChangeDetection()
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/chat-messages/si-chat-container.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-chat-container.component.spec.ts
@@ -2,10 +2,11 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement, Component } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { DebugElement, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+import { runOnPushChangeDetection } from '../test-helpers';
 import { SiChatContainerComponent } from './si-chat-container.component';
 
 @Component({
@@ -28,7 +29,8 @@ describe('SiChatContainerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiChatContainerComponent]
+      imports: [SiChatContainerComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(SiChatContainerComponent);
@@ -114,15 +116,16 @@ describe('SiChatContainerComponent', () => {
     expect(debugElement.nativeElement.classList.contains('w-100')).toBe(true);
   });
 
-  it('should handle scroll events', fakeAsync(() => {
+  it('should handle scroll events', async () => {
     const messagesContainer = debugElement.query(By.css('.messages-container'));
     expect(messagesContainer).toBeTruthy();
 
     messagesContainer.nativeElement.dispatchEvent(new Event('scroll'));
-    tick();
+
+    await runOnPushChangeDetection(fixture);
 
     expect(component).toBeTruthy();
-  }));
+  });
 
   it('should project content into input area', () => {
     const hostFixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/chat-messages/si-chat-input.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-chat-input.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement } from '@angular/core';
+import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
@@ -22,7 +22,7 @@ describe('SiChatInputComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestComponent],
-      providers: [provideNoopAnimations()]
+      providers: [provideNoopAnimations(), provideZonelessChangeDetection()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/chat-messages/si-chat-message.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-chat-message.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement } from '@angular/core';
+import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -14,7 +14,8 @@ describe('SiChatMessageComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestComponent]
+      imports: [TestComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/chat-messages/si-user-message.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-user-message.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement } from '@angular/core';
+import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By, DomSanitizer } from '@angular/platform-browser';
 import { getMarkdownRenderer } from '@siemens/element-ng/markdown-renderer';
@@ -18,7 +18,8 @@ describe('SiUserMessageComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestComponent]
+      imports: [TestComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/circle-status/si-circle-status.component.spec.ts
+++ b/projects/element-ng/circle-status/si-circle-status.component.spec.ts
@@ -2,8 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, ComponentRef, SimpleChange } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  ComponentRef,
+  provideZonelessChangeDetection,
+  SimpleChange
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiCircleStatusComponent, SiCircleStatusComponent as TestComponent } from './index';
 
@@ -18,7 +23,8 @@ describe('SiCircleStatusComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestComponent]
+      imports: [TestComponent],
+      providers: [provideZonelessChangeDetection()]
     })
       // because of https://github.com/angular/angular/issues/12313
       .overrideComponent(SiCircleStatusComponent, {
@@ -67,7 +73,7 @@ describe('SiCircleStatusComponent', () => {
     checkAriaLabel('icon description');
   });
 
-  it('set blink to true', fakeAsync(() => {
+  it('set blink to true', async () => {
     componentRef.setInput('blink', true);
     componentRef.setInput('status', 'info');
     component.ngOnChanges({
@@ -77,17 +83,17 @@ describe('SiCircleStatusComponent', () => {
     fixture.detectChanges();
     const statusIndication = element.querySelector('.status-indication .bg') as HTMLElement;
     expect(statusIndication.classList.contains('pulse')).toBeFalse();
-    tick(4 * 1400);
+    await new Promise(r => setTimeout(r, 1400));
     fixture.detectChanges();
     expect(statusIndication.classList.contains('pulse')).toBeTrue();
     component.ngOnDestroy();
-  }));
+  });
 
-  it('should show event out indication', fakeAsync(() => {
+  it('should show event out indication', () => {
     componentRef.setInput('eventOut', true);
     fixture.detectChanges();
 
     const outElement = element.querySelector('.event-out');
     expect(outElement).toBeTruthy();
-  }));
+  });
 });

--- a/projects/element-ng/color-picker/si-color-picker.component.spec.ts
+++ b/projects/element-ng/color-picker/si-color-picker.component.spec.ts
@@ -2,7 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ComponentRef, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ComponentRef,
+  provideZonelessChangeDetection,
+  viewChild
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -21,7 +27,8 @@ class FormHostComponent {
 describe('SiColorPickerComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestComponent, FormHostComponent]
+      imports: [TestComponent, FormHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents()
   );
 

--- a/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.spec.ts
+++ b/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.spec.ts
@@ -2,7 +2,11 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, ComponentRef } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ComponentRef,
+  provideZonelessChangeDetection
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
 
@@ -72,7 +76,7 @@ describe('ColumnDialogComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [ModalRef]
+      providers: [ModalRef, provideZonelessChangeDetection()]
     })
       .overrideComponent(SiColumnSelectionDialogComponent, {
         set: { changeDetection: ChangeDetectionStrategy.Default }
@@ -268,7 +272,10 @@ describe('ColumnDialogComponent', () => {
       'si-column-selection-editor input.form-control'
     )!;
     expect(inputField).toBeTruthy();
+    // Wait for setTimeout in startEdit() to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
     inputField.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await fixture.whenStable();
     expect(
       document.querySelector<HTMLInputElement>('si-column-selection-editor input.form-control')
     ).toBeFalsy();

--- a/projects/element-ng/column-selection-dialog/si-column-selection-dialog.service.spec.ts
+++ b/projects/element-ng/column-selection-dialog/si-column-selection-dialog.service.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ApplicationRef } from '@angular/core';
-import { fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { ApplicationRef, provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 
 import { SiColumnSelectionDialogService } from './si-column-selection-dialog.service';
 import { ColumnSelectionDialogResult } from './si-column-selection-dialog.types';
@@ -14,19 +14,19 @@ describe('SiColumnSelectionDialogService', () => {
 
   const clickSaveButton = (): void => {
     appRef.tick();
-    flush();
     document.querySelector<HTMLElement>('si-modal button.btn-primary')?.click();
     appRef.tick();
-    flush();
   };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({}).compileComponents();
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
     service = TestBed.inject(SiColumnSelectionDialogService);
     appRef = TestBed.inject(ApplicationRef);
   });
 
-  it('should show the column selection dialog', fakeAsync(() => {
+  it('should show the column selection dialog', () => {
     const observable = service.showColumnSelectionDialog({
       heading: 'Column Dialog',
       bodyTitle: 'Select columns',
@@ -39,5 +39,5 @@ describe('SiColumnSelectionDialogService', () => {
     });
     clickSaveButton();
     subscription.unsubscribe();
-  }));
+  });
 });

--- a/projects/element-ng/eslint.config.js
+++ b/projects/element-ng/eslint.config.js
@@ -49,5 +49,12 @@ export default defineConfig(
       '@typescript-eslint/no-deprecated': ['off']
     }
   },
+  // TODO: remove this once upgraded to Angular 21
+  {
+    files: ['**/*.spec.ts'],
+    rules: {
+      '@angular-eslint/no-developer-preview': ['off']
+    }
+  },
   ...templateConfig
 );


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated many component tests to use zoneless change-detection and simplified synchronous/async patterns, reducing reliance on legacy timing helpers and making tests more stable and direct.

* **Chores**
  * Relaxed linter rules for spec files to support current test practices during development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->