### PR TITLE
test(element): make tests zoneless ready part 2

### DIFF
--- a/projects/element-ng/circle-status/si-circle-status.component.spec.ts
+++ b/projects/element-ng/circle-status/si-circle-status.component.spec.ts
@@ -73,7 +73,8 @@ describe('SiCircleStatusComponent', () => {
     checkAriaLabel('icon description');
   });
 
-  it('set blink to true', async () => {
+  it('set blink to true', () => {
+    jasmine.clock().install();
     componentRef.setInput('blink', true);
     componentRef.setInput('status', 'info');
     component.ngOnChanges({
@@ -83,10 +84,12 @@ describe('SiCircleStatusComponent', () => {
     fixture.detectChanges();
     const statusIndication = element.querySelector('.status-indication .bg') as HTMLElement;
     expect(statusIndication.classList.contains('pulse')).toBeFalse();
-    await new Promise(r => setTimeout(r, 1400));
+    jasmine.clock().tick(4 * 1400);
+
     fixture.detectChanges();
     expect(statusIndication.classList.contains('pulse')).toBeTrue();
     component.ngOnDestroy();
+    jasmine.clock().uninstall();
   });
 
   it('should show event out indication', () => {

--- a/projects/element-ng/common/services/si-uistate.service.spec.ts
+++ b/projects/element-ng/common/services/si-uistate.service.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Injectable } from '@angular/core';
+import { Injectable, provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import {
@@ -30,7 +30,10 @@ describe('SiUIStateService', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        providers: [provideSiUiState({ store: SynchronousMockStore })]
+        providers: [
+          provideSiUiState({ store: SynchronousMockStore }),
+          provideZonelessChangeDetection()
+        ]
       }).compileComponents();
       service = TestBed.inject(SI_UI_STATE_SERVICE);
     });

--- a/projects/element-ng/common/services/text-measure.service.spec.ts
+++ b/projects/element-ng/common/services/text-measure.service.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { TextMeasureService as TestService } from './text-measure.service';
@@ -11,7 +12,7 @@ describe('TextMeasureService', () => {
   let div: HTMLElement | undefined;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({ providers: [TestService] });
+    TestBed.configureTestingModule({ providers: [TestService, provideZonelessChangeDetection()] });
     service = TestBed.inject(TestService);
   });
 

--- a/projects/element-ng/connection-strength/si-connection-strength.component.spec.ts
+++ b/projects/element-ng/connection-strength/si-connection-strength.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef } from '@angular/core';
+import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiConnectionStrengthComponent as TestComponent } from './index';
@@ -14,7 +14,8 @@ describe('SiConnectionStrengthComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestComponent]
+      imports: [TestComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/element-ng/copyright-notice/si-copyright-notice.component.spec.ts
+++ b/projects/element-ng/copyright-notice/si-copyright-notice.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CopyrightDetails, SI_COPYRIGHT_DETAILS } from '@siemens/element-ng/copyright-notice';
 
@@ -30,7 +30,8 @@ describe('SiCopyrightNoticeComponent', () => {
             startYear: 2012,
             lastUpdateYear: 2019
           }
-        }
+        },
+        provideZonelessChangeDetection()
       ]
     }).compileComponents();
 

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.spec.ts
@@ -2,9 +2,10 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
+import { TestScheduler } from 'rxjs/testing';
 
 import { SiListWidgetBodyComponent, SortOrder } from './si-list-widget-body.component';
 import { SiListWidgetItem } from './si-list-widget-item.component';
@@ -32,12 +33,18 @@ describe('SiListWidgetBodyComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let component: TestHostComponent;
   let element: HTMLElement;
+  let testScheduler: TestScheduler;
 
-  beforeEach(() =>
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
-    })
-  );
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
+    });
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
@@ -134,72 +141,76 @@ describe('SiListWidgetBodyComponent', () => {
     expect(items.item(0).textContent).toContain('item_1');
   });
 
-  it('should support search', fakeAsync(() => {
-    component.items = [
-      { label: { title: 'item_1' } },
-      { label: { title: 'item_2' } },
-      { label: 'item_2' },
-      { label: 'item_3' }
-    ];
-    fixture.detectChanges();
+  it('should support search', () => {
+    testScheduler.run(({ flush }) => {
+      component.items = [
+        { label: { title: 'item_1' } },
+        { label: { title: 'item_2' } },
+        { label: 'item_2' },
+        { label: 'item_3' }
+      ];
+      fixture.detectChanges();
 
-    // No search as default
-    expect(element.querySelector('si-search-bar')).toBeNull();
+      // No search as default
+      expect(element.querySelector('si-search-bar')).toBeNull();
 
-    // Show the search bar
-    component.search = true;
-    runOnPushChangeDetection(fixture);
-    const searchBar = element.querySelector('si-search-bar');
-    expect(searchBar).not.toBeNull();
+      // Show the search bar
+      component.search = true;
+      runOnPushChangeDetection(fixture);
+      const searchBar = element.querySelector('si-search-bar');
+      expect(searchBar).not.toBeNull();
 
-    // Enter text in the search input and search
-    const searchBarInput = element.querySelector('input');
-    searchBarInput!.value = 'item_3';
-    searchBarInput!.dispatchEvent(new Event('input'));
-    tick(500);
-    runOnPushChangeDetection(fixture);
+      // Enter text in the search input and search
+      const searchBarInput = element.querySelector('input');
+      searchBarInput!.value = 'item_3';
+      searchBarInput!.dispatchEvent(new Event('input'));
+      flush();
+      runOnPushChangeDetection(fixture);
 
-    let items = element.querySelectorAll('si-list-widget-item');
-    expect(items.length).toBe(1);
-    expect(items.item(0).textContent).not.toContain('item_1');
-    expect(items.item(0).textContent).toContain('item_3');
+      let items = element.querySelectorAll('si-list-widget-item');
+      expect(items.length).toBe(1);
+      expect(items.item(0).textContent).not.toContain('item_1');
+      expect(items.item(0).textContent).toContain('item_3');
 
-    // Clear search again
-    searchBarInput!.value = '';
-    searchBarInput!.dispatchEvent(new Event('input'));
-    tick(500);
-    runOnPushChangeDetection(fixture);
+      // Clear search again
+      searchBarInput!.value = '';
+      searchBarInput!.dispatchEvent(new Event('input'));
+      flush();
+      runOnPushChangeDetection(fixture);
 
-    items = element.querySelectorAll('si-list-widget-item');
-    expect(items.length).toBe(4);
-  }));
+      items = element.querySelectorAll('si-list-widget-item');
+      expect(items.length).toBe(4);
+    });
+  });
 
-  it('should not fail when searching without value', fakeAsync(() => {
-    component.search = true;
-    runOnPushChangeDetection(fixture);
+  it('should not fail when searching without value', () => {
+    testScheduler.run(({ flush }) => {
+      component.search = true;
+      runOnPushChangeDetection(fixture);
 
-    // Should show 6 skeletons
-    expect(element.querySelector('.si-link-widget-skeleton')).toBeDefined();
+      // Should show 6 skeletons
+      expect(element.querySelector('.si-link-widget-skeleton')).toBeDefined();
 
-    // Enter text in the search input and search
-    const searchBarInput = element.querySelector('input');
-    searchBarInput!.value = 'item_3';
-    searchBarInput!.dispatchEvent(new Event('input'));
-    tick(500);
-    runOnPushChangeDetection(fixture);
+      // Enter text in the search input and search
+      const searchBarInput = element.querySelector('input');
+      searchBarInput!.value = 'item_3';
+      searchBarInput!.dispatchEvent(new Event('input'));
+      flush();
+      runOnPushChangeDetection(fixture);
 
-    // Should show 6 skeletons after search
-    let items = element.querySelectorAll('.si-link-widget-skeleton');
-    expect(items.length).toBe(6);
+      // Should show 6 skeletons after search
+      let items = element.querySelectorAll('.si-link-widget-skeleton');
+      expect(items.length).toBe(6);
 
-    // Clear search again
-    searchBarInput!.value = '';
-    searchBarInput!.dispatchEvent(new Event('input'));
-    tick(500);
-    runOnPushChangeDetection(fixture);
+      // Clear search again
+      searchBarInput!.value = '';
+      searchBarInput!.dispatchEvent(new Event('input'));
+      flush();
+      runOnPushChangeDetection(fixture);
 
-    // Should still show 6 skeletons after clearing search
-    items = element.querySelectorAll('si-list-widget-item');
-    expect(items.length).toBe(6);
-  }));
+      // Should still show 6 skeletons after clearing search
+      items = element.querySelectorAll('si-list-widget-item');
+      expect(items.length).toBe(6);
+    });
+  });
 });

--- a/projects/element-ng/date-range-filter/si-date-range-calculation.service.spec.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-calculation.service.spec.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { formatDate } from '@angular/common';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiDateRangeCalculationService } from './si-date-range-calculation.service';
@@ -18,7 +19,9 @@ describe('SiDateRangeCalculationService', () => {
     expect(formatDate(d1, 'dateShort', 'en')).toEqual(formatDate(d2, 'dateShort', 'en'));
 
   beforeEach(() => {
-    TestBed.configureTestingModule({ providers: [SiDateRangeCalculationService] });
+    TestBed.configureTestingModule({
+      providers: [SiDateRangeCalculationService, provideZonelessChangeDetection()]
+    });
     service = TestBed.inject(SiDateRangeCalculationService);
   });
 

--- a/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
@@ -2,8 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  signal
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { t } from '@siemens/element-translate-ng/translate';
 
 import { SiRelativeDateComponent } from './si-relative-date.component';
@@ -43,17 +48,10 @@ describe('SiRelativeDateComponent', () => {
     btn?.dispatchEvent(new Event('mouseup'));
   };
 
-  const updateView = (): void => {
-    // twice because of si-number-input
-    fixture.detectChanges();
-    flush();
-    fixture.detectChanges();
-    flush();
-  };
-
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiRelativeDateComponent, TestHostComponent]
+      imports: [SiRelativeDateComponent, TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 
@@ -63,69 +61,68 @@ describe('SiRelativeDateComponent', () => {
     element = fixture.nativeElement;
   });
 
-  it('pre-selects matching offset', fakeAsync(() => {
+  it('pre-selects matching offset', async () => {
     component.value.set(2 * ONE_DAY);
-    updateView();
+    await fixture.whenStable();
 
     expect(inputValue()).toBe(2);
     expect(selectContent()).toBe('Days');
 
     component.value.set(88 * ONE_DAY);
-    updateView();
+    await fixture.whenStable();
 
     expect(inputValue()).toBe(88);
     expect(selectContent()).toBe('Days');
-  }));
+  });
 
-  it('falls back to smallest unit', fakeAsync(() => {
+  it('falls back to smallest unit', async () => {
     component.value.set(7 * ONE_DAY);
-    updateView();
+    await fixture.whenStable();
 
     expect(inputValue()).toBe(1);
     expect(selectContent()).toBe('Weeks');
 
     component.value.set(0);
-    updateView();
+    await fixture.whenStable();
 
     expect(inputValue()).toBe(1);
     expect(selectContent()).toBe('Days');
-  }));
+  });
 
-  it('updates input values', fakeAsync(() => {
+  it('updates input values', async () => {
     component.value.set(2 * ONE_DAY);
-    updateView();
+    await fixture.whenStable();
 
     component.value.set(7 * ONE_DAY);
-    updateView();
+    await fixture.whenStable();
 
     expect(inputValue()).toBe(1);
     expect(selectContent()).toBe('Weeks');
-  }));
+  });
 
-  it('calculates and emits value/unit changes', fakeAsync(() => {
+  it('calculates and emits value/unit changes', async () => {
     component.value.set(7 * ONE_DAY);
-    updateView();
+    await fixture.whenStable();
 
     element.querySelector<HTMLElement>('si-select .select')?.click();
-    tick();
-    fixture.detectChanges();
+    await fixture.whenStable();
     document.querySelector<HTMLElement>('.dropdown-menu [data-id=weeks]')?.click();
-    updateView();
+    await fixture.whenStable();
 
     inputAction('.inc');
-    updateView();
+    await fixture.whenStable();
 
     expect(inputValue()).toBe(2);
     expect(component.value()).toBe(14 * ONE_DAY);
-  }));
+  });
 
-  it('handles time selection', fakeAsync(() => {
+  it('handles time selection', async () => {
     component.enableTimeSelection = true;
-    updateView();
+    await fixture.whenStable();
 
     element.querySelector<HTMLElement>('si-select .select')?.click();
-    updateView();
+    await fixture.whenStable();
 
     expect(document.querySelector<HTMLElement>('.dropdown-menu [data-id=minutes]')).toBeTruthy();
-  }));
+  });
 });

--- a/projects/element-ng/datepicker/components/si-day-selection.component.spec.ts
+++ b/projects/element-ng/datepicker/components/si-day-selection.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { DatePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {
   addDays,
@@ -16,6 +16,7 @@ import {
   isSameYear,
   daysInMonth
 } from '../date-time-helper';
+import { runOnPushChangeDetection } from './../../test-helpers/change-detection.helper';
 import { SiDaySelectionComponent as TestComponent } from './si-day-selection.component';
 import { CalendarTestHelper, generateKeyEvent } from './test-helper.spec';
 
@@ -153,13 +154,13 @@ describe('SiDaySelectionComponent', () => {
       expect(selectedElement.innerHTML.trim()).toBe('25');
     });
 
-    it('does not show selected date if in different month', fakeAsync(() => {
+    it('does not show selected date if in different month', async () => {
       wrapperComponent.startDate.set(new Date('2022-05-15'));
-      fixture.detectChanges();
+      await runOnPushChangeDetection(fixture);
 
       const selectedElement = element.querySelector('.selected');
       expect(selectedElement).toBeNull();
-    }));
+    });
 
     it('select cell on cell clicked', () => {
       selectDate(31);
@@ -194,21 +195,19 @@ describe('SiDaySelectionComponent', () => {
     });
 
     ['PageUp', 'PageDown'].forEach(key => {
-      it(`should emit activeMonthChange on ${key} press`, fakeAsync(() => {
+      it(`should emit activeMonthChange on ${key} press`, async () => {
         helper.getCalendarBody().dispatchEvent(generateKeyEvent('PageDown'));
-        fixture.detectChanges();
-        flush();
+        await fixture.whenStable();
         expect(wrapperComponent.activeMonth).toBeTruthy();
-      }));
+      });
     });
 
     ['Previous Month', 'Next Month'].forEach(label => {
-      it(`should emit activeMonthChange on button '${label}' click`, fakeAsync(() => {
+      it(`should emit activeMonthChange on button '${label}' click`, async () => {
         element.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)!.click();
-        fixture.detectChanges();
-        flush();
+        await fixture.whenStable();
         expect(wrapperComponent.activeMonth).toBeTruthy();
-      }));
+      });
     });
 
     it('should emit viewChange when clicking on month', () => {
@@ -326,14 +325,14 @@ describe('SiDaySelectionComponent', () => {
         });
       });
 
-      it('should set aria-current to today', fakeAsync(() => {
+      it('should set aria-current to today', async () => {
         wrapperComponent.focusedDate.set(getToday());
-        fixture.detectChanges();
+        await runOnPushChangeDetection(fixture);
 
         const actual = helper.queryAsArray('[aria-current]');
         expect(actual.length).toBe(1);
         expect(actual[0].getAttribute('aria-current')).toBe('date');
-      }));
+      });
     });
 
     describe('calendar body navigation', () => {

--- a/projects/element-ng/datepicker/date-time-helper.spec.ts
+++ b/projects/element-ng/datepicker/date-time-helper.spec.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { DatePipe } from '@angular/common';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import {
@@ -27,7 +28,7 @@ describe('date time helper', () => {
   let dtPipe: DatePipe;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [DatePipe]
+      providers: [DatePipe, provideZonelessChangeDetection()]
     });
     dtPipe = TestBed.inject(DatePipe);
   });

--- a/projects/element-ng/datepicker/si-calendar-button.component.spec.ts
+++ b/projects/element-ng/datepicker/si-calendar-button.component.spec.ts
@@ -2,8 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  signal
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SiDatepickerDirective } from '@siemens/element-ng/datepicker';
 
 import { SiCalendarButtonComponent } from './si-calendar-button.component';
@@ -36,7 +41,8 @@ describe('SiCalendarButtonComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [WrapperComponent]
+      imports: [WrapperComponent],
+      providers: [provideZonelessChangeDetection()]
     });
     fixture = TestBed.createComponent(WrapperComponent);
     component = fixture.componentInstance;
@@ -63,14 +69,16 @@ describe('SiCalendarButtonComponent', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('should mark as touched if button is blurred', fakeAsync(() => {
+  it('should mark as touched if button is blurred', () => {
+    jasmine.clock().install();
     const touchSpy = spyOn(SiDatepickerDirective.prototype, 'touch');
     const button = calendarToggleButton();
     button.focus();
     button.blur();
-    tick();
+    jasmine.clock().tick(0);
     expect(touchSpy).toHaveBeenCalled();
-  }));
+    jasmine.clock().uninstall();
+  });
 
   it('should use default aria label', () => {
     expect(calendarToggleButton().getAttribute('aria-label')).toBe('Open calendar');

--- a/projects/element-ng/datepicker/si-datepicker-overlay.directive.spec.ts
+++ b/projects/element-ng/datepicker/si-datepicker-overlay.directive.spec.ts
@@ -8,6 +8,7 @@ import {
   ComponentRef,
   HostListener,
   inject,
+  provideZonelessChangeDetection,
   signal
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -84,7 +85,8 @@ describe('SiDatepickerOverlayDirective', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [WrapperComponent]
+      imports: [WrapperComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/element-ng/datepicker/si-timepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, signal, viewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { Component, provideZonelessChangeDetection, signal, viewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 import { SiTimepickerComponent as TestComponent } from './index';
@@ -67,7 +67,8 @@ describe('SiTimepickerComponent', () => {
 
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        imports: [TestComponent]
+        imports: [TestComponent],
+        providers: [provideZonelessChangeDetection()]
       }).compileComponents();
       fixture = TestBed.createComponent(TestComponent);
       element = fixture.nativeElement;
@@ -93,16 +94,17 @@ describe('SiTimepickerComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should display seconds and milliseconds input', fakeAsync(() => {
+    it('should display seconds and milliseconds input', () => {
       component.showSeconds.set(true);
       component.showMilliseconds.set(true);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(getHours().value).toEqual('');
       expect(getMinutes().value).toEqual('');
       expect(getSeconds().value).toEqual('');
       expect(getMilliseconds().value).toEqual('');
-    }));
+    });
 
     it('should display time components in input elements', () => {
       component.showSeconds.set(true);
@@ -116,33 +118,37 @@ describe('SiTimepickerComponent', () => {
       expect(getMilliseconds().value).toEqual('000');
     });
 
-    it('should display time in 24 hours mode with date object input', fakeAsync(() => {
+    it('should display time in 24 hours mode with date object input', () => {
       component.showSeconds.set(true);
       component.showMilliseconds.set(true);
       component.showMeridian.set(false);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       component.time.setValue(new Date('2022-01-12 16:23:59.435'));
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(getHours().value).toEqual('16');
       expect(getMinutes().value).toEqual('23');
       expect(getSeconds().value).toEqual('59');
       expect(getMilliseconds().value).toEqual('435');
-    }));
+    });
 
-    it('should display time in 24 hours mode with string object input', fakeAsync(() => {
+    it('should display time in 24 hours mode with string object input', () => {
       component.showSeconds.set(true);
       component.showMilliseconds.set(true);
       component.showMeridian.set(false);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       component.time.setValue('2022-01-12 16:23:59.435');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(getHours().value).toEqual('16');
       expect(getMinutes().value).toEqual('23');
       expect(getSeconds().value).toEqual('59');
       expect(getMilliseconds().value).toEqual('435');
-    }));
+    });
 
     it('should remove time components when setting undefined time', () => {
       component.time.setValue('2022-01-12 16:23:59.435');
@@ -275,14 +281,16 @@ describe('SiTimepickerComponent', () => {
       });
     });
 
-    it('should disable component', fakeAsync(() => {
+    it('should disable component', () => {
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       component.time.setValue('2021-01-12 18:23:58.435');
       component.disabled.set(true);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(getHours().disabled).toBeTruthy();
       expect(getMinutes().disabled).toBeTruthy();
-    }));
+    });
 
     it('should toggle meridian', () => {
       component.time.setValue('2021-01-12 18:23:58.435');

--- a/projects/element-ng/electron-titlebar/si-electron-titlebar.component.spec.ts
+++ b/projects/element-ng/electron-titlebar/si-electron-titlebar.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MenuItem } from '@siemens/element-ng/menu';
 
@@ -45,7 +45,8 @@ describe('SiElectrontitlebarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/element-ng/empty-state/si-empty-state.component.spec.ts
+++ b/projects/element-ng/empty-state/si-empty-state.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef } from '@angular/core';
+import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiEmptyStateComponent as TestComponent } from '.';
@@ -14,7 +14,8 @@ describe('SiEmptyStateComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestComponent]
+      imports: [TestComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/element-ng/file-uploader/si-file-dropzone.component.spec.ts
+++ b/projects/element-ng/file-uploader/si-file-dropzone.component.spec.ts
@@ -2,8 +2,14 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  signal,
+  viewChild
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { SiFileDropzoneComponent, UploadFile } from './index';
@@ -48,7 +54,8 @@ describe('SiFileDropzoneComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot(), TestHostComponent]
+      imports: [TranslateModule.forRoot(), TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);
@@ -292,7 +299,7 @@ describe('SiFileDropzoneComponent', () => {
     expect(files[0].status).toBe('added');
   });
 
-  it('should display max allowed file size with abbreviation', fakeAsync(() => {
+  it('should display max allowed file size with abbreviation', () => {
     component.maxFileSize.set(1_572_864); // 1.5mb
     fixture.detectChanges();
     expect(element.querySelector('.allowed')!.innerHTML).toContain('1.5MB');
@@ -301,7 +308,7 @@ describe('SiFileDropzoneComponent', () => {
     fixture.detectChanges();
 
     expect(element.querySelector('.allowed')!.innerHTML).toContain('1.5GB');
-  }));
+  });
 
   it('should allow directory upload when using drag and drop', () => {
     component.directoryUpload = true;


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added zoneless change detection to many test modules.
  * Replaced fakeAsync/tick/flush patterns with async/await, fixture.whenStable, and run-on-push helpers.
  * Introduced TestScheduler-driven flows for RxJS timing and Jasmine clock for specific timing-sensitive tests.
  * Consolidated timing control to scheduler/clock where appropriate, improving determinism, stability, and reducing flakiness while preserving behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->