### PR TITLE
refactor(select): remove deprecations

### DIFF
--- a/projects/element-ng/select/options/si-select-complex-options.directive.ts
+++ b/projects/element-ng/select/options/si-select-complex-options.directive.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 import { computed, Directive, input, OnChanges } from '@angular/core';
-import { buildTrackByIdentity } from '@siemens/element-ng/common';
 
 import { SelectGroup, SelectOption } from '../si-select.types';
 import { SI_SELECT_OPTIONS_STRATEGY } from './si-select-options-strategy';
@@ -32,16 +31,6 @@ export class SiSelectComplexOptionsDirective<T>
 {
   /** Options to be shown in select dropdown. */
   readonly complexOptions = input<T[] | Record<string, T[]> | null>();
-
-  /**
-   * @deprecated Property has no effect and can be removed.
-   *
-   * @defaultValue
-   * ```
-   * buildTrackByIdentity<T>()
-   * ```
-   */
-  readonly trackBy = input(buildTrackByIdentity<T>());
 
   /**
    * By default, values are check on equality by reference. Override to customize the behavior.


### PR DESCRIPTION
BREAKING CHANGE: Removed deprecated input `SiSelectComplexOptionsDirective.trackBy`. The input had no effect.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
