### PR TITLE
build(renovate): group all Siemens lint dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,6 +22,11 @@
   rebaseWhen: "conflicted",
   packageRules: [
     {
+      groupName: "Siemens lint dependencies",
+      description: ["Update Siemens lint packages together"],
+      matchSourceUrls: ["https://github.com/siemens/lint"]
+    },
+    {
       description: [
         "Prevent Angular related major and minor updates. Those should be manually done"
       ],


### PR DESCRIPTION
Groups all Siemens Lint packages to prevent seperated PRs.
---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to group Siemens lint package updates together, enabling coordinated dependency updates for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->