### PR TITLE
fix(schematics): remove simpl-element-ng token from scss files and support single and double quotes

### DIFF
--- a/projects/element-ng/schematics/scss-import-to-siemens-migration/index.spec.ts
+++ b/projects/element-ng/schematics/scss-import-to-siemens-migration/index.spec.ts
@@ -39,6 +39,18 @@ describe('scss-import-to-siemens migration', () => {
     expect(actual).not.toContain(`@use '@simpl/element-theme/src/theme';`);
   });
 
+  it(`should remove global style @use '@simpl/element-ng/simpl-element-ng'`, async () => {
+    const originalContent = [`// Import theme`, `@use '@simpl/element-ng/simpl-element-ng';`];
+    const actual = await runFileMigration(globalStyle, originalContent);
+    expect(actual).not.toContain(`@use '@simpl/element-ng/simpl-element-ng';`);
+  });
+
+  it(`should remove global style @use "@simpl/element-ng/simpl-element-ng" if in double quotes`, async () => {
+    const originalContent = [`// Import theme`, `@use "@simpl/element-ng/simpl-element-ng";`];
+    const actual = await runFileMigration(globalStyle, originalContent);
+    expect(actual).not.toContain(`@use "@simpl/element-ng/simpl-element-ng";`);
+  });
+
   it(`should not modify node_modules files';`, async () => {
     const originalContent = [`// Import theme`, `@use '@simpl/element-theme/src/theme';`];
     const actual = await runFileMigration('node_modules/package/styles.scss', originalContent);
@@ -70,6 +82,7 @@ describe('scss-import-to-siemens migration', () => {
       `@use '@simpl/element-icons/dist/style/simpl-element-icons';`
     ];
     const expected = [
+      `// Use Element theme`,
       `@use '@siemens/element-theme/src/theme' with (`,
       `  $element-theme-default: 'siemens-brand',`,
       `  $element-themes: (`,
@@ -77,12 +90,15 @@ describe('scss-import-to-siemens migration', () => {
       `    'element'`,
       `  )`,
       `);`,
+      `// Use Element components`,
       `@use '@siemens/element-ng/element-ng';`,
+      `// Actually build the siemens-brand theme`,
       `@use '@siemens/element-theme/src/styles/themes';`,
       `@use '@simpl/brand/dist/element-theme-siemens-brand-light' as brand-light;`,
       `@use '@simpl/brand/dist/element-theme-siemens-brand-dark' as brand-dark;`,
       `@include themes.make-theme(brand-light.$tokens, 'siemens-brand');`,
       `@include themes.make-theme(brand-dark.$tokens, 'siemens-brand', true);`,
+      `// Load Siemens fonts`,
       `@use '@simpl/brand/assets/fonts/styles/siemens-sans';`,
       `// Load Element icons`,
       `@use '@simpl/element-icons/dist/style/simpl-element-icons';`

--- a/projects/element-ng/schematics/scss-import-to-siemens-migration/style-mappings.ts
+++ b/projects/element-ng/schematics/scss-import-to-siemens-migration/style-mappings.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 export const STYLE_REPLACEMENTS = [
+  // Single quotes
   {
     replace: `@import '@simpl/element-theme/`,
     new: `@import '@siemens/element-theme/`
@@ -10,12 +11,24 @@ export const STYLE_REPLACEMENTS = [
   {
     replace: `@use '@simpl/element-theme/`,
     new: `@use '@siemens/element-theme/`
+  },
+  // Double quotes
+  {
+    replace: `@import "@simpl/element-theme/`,
+    new: `@import "@siemens/element-theme/`
+  },
+  {
+    replace: `@use "@simpl/element-theme/`,
+    new: `@use "@siemens/element-theme/`
   }
 ];
 // Apply theme styles if not already present
 export const THEME_STYLE_ENTRIES = [
+  { insert: `// Load Siemens fonts` },
   { insert: `@use '@simpl/brand/assets/fonts/styles/siemens-sans';` },
+  { insert: `// Load Element icons` },
   { insert: `@use '@simpl/element-icons/dist/style/simpl-element-icons';` },
+  { insert: `// Use Element theme` },
   {
     insert: `@use '@siemens/element-theme/src/theme' with (
   $element-theme-default: 'siemens-brand',
@@ -24,9 +37,11 @@ export const THEME_STYLE_ENTRIES = [
     'element'
   )
 );`,
-    pattern: /@use '@siemens\/element-theme\/src\/theme' with \(([\s\S]*?)\);/g
+    pattern: /@use ['"]@siemens\/element-theme\/src\/theme['"] with \(([\s\S]*?)\);/g
   },
+  { insert: `// Use Element components` },
   { insert: `@use '@siemens/element-ng/element-ng';` },
+  { insert: `// Actually build the siemens-brand theme` },
   { insert: `@use '@siemens/element-theme/src/styles/themes';` },
   { insert: `@use '@simpl/brand/dist/element-theme-siemens-brand-light' as brand-light;` },
   { insert: `@use '@simpl/brand/dist/element-theme-siemens-brand-dark' as brand-dark;` },
@@ -41,7 +56,8 @@ export const THEME_STYLE_ENTRIES = [
 ];
 
 export const SCSS_USE_PATTERNS = [
-  /@use '@simpl\/element-theme\/src\/theme' with \(([\s\S]*?)\);/g,
-  /@use '@simpl\/element-ng\/simpl-element-ng' with \(([\s\S]*?)\);/g,
-  /@use '@simpl\/element-theme\/src\/theme';/g
+  /@use ['"]@simpl\/element-theme\/src\/theme['"] with \(([\s\S]*?)\);/g,
+  /@use ['"]@simpl\/element-ng\/simpl-element-ng['"] with \(([\s\S]*?)\);/g,
+  /@use ['"]@simpl\/element-theme\/src\/theme['"];/g,
+  /@use ['"]@simpl\/element-ng\/simpl-element-ng['"];/g
 ];


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for SCSS migration scenarios including both single and double-quoted import styles.

* **Improvements**
  * Enhanced SCSS migration tool to handle both single and double-quoted imports consistently.
  * Improved migration output with additional guidance comments for better clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->