### PR TITLE
test(element): make tests zoneless ready part 4

### DIFF
--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
@@ -8,9 +8,10 @@ import {
   Component,
   DebugElement,
   inject,
+  provideZonelessChangeDetection,
   viewChild
 } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Subject } from 'rxjs';
 
@@ -102,7 +103,8 @@ describe('MainDetailContainerComponent', () => {
         {
           provide: ResizeObserverService,
           useValue: resizeSpy
-        }
+        },
+        provideZonelessChangeDetection()
       ]
     }).compileComponents();
 
@@ -113,6 +115,12 @@ describe('MainDetailContainerComponent', () => {
     fixture.detectChanges();
     doAnimationSpy = spyOn<any>(component.mainDetail(), 'doAnimation').and.callThrough();
     resizeObserver.next({ width: 800, height: 500 });
+
+    jasmine.clock().install();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
   });
 
   it('should not contain si-split when #resizableParts is false', () => {
@@ -165,23 +173,24 @@ describe('MainDetailContainerComponent', () => {
       expect(htmlElement.querySelector('si-main-detail-container')?.classList).toContain('animate');
     });
 
-    it('should remove a class indicating to animate the view change after a timeout', fakeAsync(() => {
+    it('should remove a class indicating to animate the view change after a timeout', () => {
       // prepare
       component.detailsActive = true;
       component.cdRef.markForCheck();
       fixture.detectChanges();
       // act
-      tick(animationDurationMilliseconds);
+      jasmine.clock().tick(animationDurationMilliseconds);
       fixture.detectChanges();
       // flush timeout
-      flush();
+      jasmine.clock().tick(0);
+      fixture.detectChanges();
       // expect
       expect(doAnimationSpy).toHaveBeenCalledWith(true);
       expect(htmlElement.querySelector('si-main-detail-container')?.classList).not.toContain(
         'animate'
       );
       expect(htmlElement.classList.contains('animate')).toBeFalse();
-    }));
+    });
   });
 
   describe('responsive behaviour', () => {
@@ -225,45 +234,48 @@ describe('MainDetailContainerComponent', () => {
       expect(getMainDetailContainer()).toBeTruthy();
     });
 
-    it('should only have the main pane in view on small screens when details are inactive', fakeAsync(() => {
+    it('should only have the main pane in view on small screens when details are inactive', () => {
       // prepare
       resizeObserver.next({ width: component.largeLayoutBreakpoint - 1, height: 500 });
       component.detailsActive = false;
       // act
-      tick(animationDurationMilliseconds);
+      jasmine.clock().tick(animationDurationMilliseconds);
       fixture.detectChanges();
       const detailContainer = getDetailContainer();
       // flush timeout
-      flush();
+      jasmine.clock().tick(0);
+      fixture.detectChanges();
       // expect
       expect(getInViewport(detailContainer)).toBeFalse();
-    }));
+    });
 
-    it('should set inert attribute to prevent focus hidden details when details are inactive', fakeAsync(() => {
+    it('should set inert attribute to prevent focus hidden details when details are inactive', () => {
       // prepare
       resizeObserver.next({ width: component.largeLayoutBreakpoint - 1, height: 500 });
       component.detailsActive = false;
       // act
-      tick(animationDurationMilliseconds);
+      jasmine.clock().tick(animationDurationMilliseconds);
       fixture.detectChanges();
       // flush timeout
-      flush();
+      jasmine.clock().tick(0);
+      fixture.detectChanges();
       // expect
       expect(debugElement.query(By.css('.detail-container[inert]'))).toBeTruthy();
-    }));
+    });
 
-    it('should not set inert attribute when details are active', fakeAsync(() => {
+    it('should not set inert attribute when details are active', () => {
       // prepare
       resizeObserver.next({ width: component.largeLayoutBreakpoint - 1, height: 500 });
       component.detailsActive = true;
       // act
-      tick(animationDurationMilliseconds);
+      jasmine.clock().tick(animationDurationMilliseconds);
       fixture.detectChanges();
       // flush timeout
-      flush();
+      jasmine.clock().tick(0);
+      fixture.detectChanges();
       // expect
       expect(debugElement.query(By.css('.detail-container :not([inert])'))).toBeTruthy();
-    }));
+    });
   });
 
   describe('not large size', () => {
@@ -289,17 +301,18 @@ describe('MainDetailContainerComponent', () => {
       expect(htmlElement.querySelector('button')).toBeFalsy();
     });
 
-    it('should only have the detail pane in view on small screens when details are active', fakeAsync(() => {
+    it('should only have the detail pane in view on small screens when details are active', () => {
       // prepare
       component.detailsActive = true;
       // act
-      tick(animationDurationMilliseconds);
+      jasmine.clock().tick(animationDurationMilliseconds);
       fixture.detectChanges();
       const mainContainer = getMainContainer();
       // flush timeout
-      flush();
+      jasmine.clock().tick(0);
+      fixture.detectChanges();
       // expect
       expect(getInViewport(mainContainer)).toBeFalse();
-    }));
+    });
   });
 });

--- a/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
+++ b/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiMarkdownRendererComponent as TestComponent } from './si-markdown-renderer.component';
@@ -12,7 +13,8 @@ describe('SiMarkdownRendererComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestComponent]
+      imports: [TestComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/menu/si-menu.spec.ts
+++ b/projects/element-ng/menu/si-menu.spec.ts
@@ -5,7 +5,7 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu';
 import { ComponentHarness, HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component } from '@angular/core';
+import { Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MenuItem } from '@siemens/element-ng/common';
 import { SiLinkActionService } from '@siemens/element-ng/link';
@@ -85,7 +85,10 @@ const withObjectType = <ItemType extends MenuItem, ComponentType extends { items
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        providers: [{ provide: SiLinkActionService, useValue: jasmine.createSpyObj(['emit']) }]
+        providers: [
+          { provide: SiLinkActionService, useValue: jasmine.createSpyObj(['emit']) },
+          provideZonelessChangeDetection()
+        ]
       });
       fixture = TestBed.createComponent(componentType);
       loader = TestbedHarnessEnvironment.loader(fixture);
@@ -160,6 +163,7 @@ const withObjectType = <ItemType extends MenuItem, ComponentType extends { items
       expect(await menuItem.isDisabled()).toBeTrue();
       if (!fixture.componentInstance.items[disabledIndex].type) {
         fixture.componentInstance.items[disabledIndex].disabled = false;
+        fixture.changeDetectorRef.markForCheck();
       }
       expect(await menuItem.isDisabled()).toBeFalse();
     });

--- a/projects/element-ng/modal/si-modal-service.spec.ts
+++ b/projects/element-ng/modal/si-modal-service.spec.ts
@@ -2,8 +2,15 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ApplicationRef, Component, input, TemplateRef, viewChild } from '@angular/core';
-import { fakeAsync, flush, TestBed } from '@angular/core/testing';
+import {
+  ApplicationRef,
+  Component,
+  input,
+  provideZonelessChangeDetection,
+  TemplateRef,
+  viewChild
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 
 import { SiModalService } from './si-modal.service';
 
@@ -31,12 +38,18 @@ describe('SiModalService', () => {
   let appRef!: ApplicationRef;
 
   beforeEach(() => {
+    jasmine.clock().install();
     TestBed.configureTestingModule({
-      imports: [DialogComponent, DialogTemplateComponent]
+      imports: [DialogComponent, DialogTemplateComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
 
     service = TestBed.inject(SiModalService);
     appRef = TestBed.inject(ApplicationRef);
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
   });
 
   describe('with template', () => {
@@ -48,12 +61,11 @@ describe('SiModalService', () => {
       templateRef = comp.componentInstance.templateRef();
     });
 
-    it('shows and hides the dialog', fakeAsync(() => {
+    it('shows and hides the dialog', () => {
       const modalRef = service.show(templateRef, {});
       const bodyStyle = getComputedStyle(document.body);
 
       appRef.tick();
-      flush();
 
       const modal = document.querySelector('si-modal');
       expect(modal).toBeTruthy();
@@ -61,39 +73,35 @@ describe('SiModalService', () => {
       expect(bodyStyle.overflow).toBe('hidden');
 
       modalRef.hide();
-
+      jasmine.clock().tick(500);
       appRef.tick();
-      flush();
 
       expect(document.querySelector('si-modal')).toBeFalsy();
       expect(bodyStyle.overflow).not.toBe('hidden');
-    }));
+    });
   });
 
   describe('with component', () => {
-    it('shows and hides the dialog', fakeAsync(() => {
+    it('shows and hides the dialog', () => {
       const modalRef = service.show(DialogComponent, {});
 
       appRef.tick();
-      flush();
 
       const modal = document.querySelector('si-modal');
       expect(modal).toBeTruthy();
       expect(modal?.innerHTML).toContain('test component');
 
       modalRef.hide();
-
+      jasmine.clock().tick(500);
       appRef.tick();
-      flush();
 
       expect(document.querySelector('si-modal')).toBeFalsy();
-    }));
+    });
 
-    it('set input using setInputs', fakeAsync(() => {
+    it('set input using setInputs', () => {
       const modalRef = service.show(DialogComponent, { inputValues: { inputProp: 'input value' } });
 
       appRef.tick();
-      flush();
 
       const modal = document.querySelector('si-modal');
       expect(modal).toBeTruthy();
@@ -102,24 +110,23 @@ describe('SiModalService', () => {
       appRef.tick();
       expect(modal?.innerHTML).toContain('new input value');
       modalRef.hide();
+      jasmine.clock().tick(500);
       appRef.tick();
-      flush();
-    }));
+    });
 
-    it('set input using initialState', fakeAsync(() => {
+    it('set input using initialState', () => {
       const modalRef = service.show(DialogComponent, {
         initialState: { normalProp: 'prop value' }
       });
 
       appRef.tick();
-      flush();
 
       const modal = document.querySelector('si-modal');
       expect(modal).toBeTruthy();
       expect(modal?.innerHTML).toContain('prop value');
       modalRef.hide();
+      jasmine.clock().tick(500);
       appRef.tick();
-      flush();
-    }));
+    });
   });
 });

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.spec.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, signal } from '@angular/core';
+import { Component, provideZonelessChangeDetection, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiNavbarVerticalItemComponent } from './si-navbar-vertical-item.component';
@@ -33,7 +33,10 @@ describe('SiNavbarVerticalItemComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [{ provide: SI_NAVBAR_VERTICAL, useValue: mockNavbar }]
+      providers: [
+        { provide: SI_NAVBAR_VERTICAL, useValue: mockNavbar },
+        provideZonelessChangeDetection()
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/navbar/si-navbar-item/si-navbar-item.component.spec.ts
+++ b/projects/element-ng/navbar/si-navbar-item/si-navbar-item.component.spec.ts
@@ -2,7 +2,14 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ElementRef, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  provideZonelessChangeDetection,
+  signal,
+  viewChild
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MenuItem } from '@siemens/element-ng/common';
 import { SiNavbarPrimaryComponent } from '@siemens/element-ng/navbar';
@@ -38,7 +45,8 @@ describe('SiNavbarItemComponent', () => {
             header: signal({ closeMobileMenus: NEVER }),
             navItemCount: signal(0)
           }
-        }
+        },
+        provideZonelessChangeDetection()
       ]
     })
   );

--- a/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.spec.ts
+++ b/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.spec.ts
@@ -4,7 +4,13 @@
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideLocationMocks } from '@angular/common/testing';
-import { ChangeDetectionStrategy, Component, HostBinding, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  provideZonelessChangeDetection,
+  viewChild
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { SiApplicationHeaderHarness } from '@siemens/element-ng/application-header/testing/si-application-header.harness';
@@ -41,7 +47,7 @@ describe('SiNavbarPrimaryComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [provideRouter([]), provideLocationMocks()]
+      providers: [provideRouter([]), provideLocationMocks(), provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/element-ng/pagination/si-pagination.component.spec.ts
+++ b/projects/element-ng/pagination/si-pagination.component.spec.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 import { CommonModule } from '@angular/common';
-import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiPaginationComponent as TestComponent } from '.';
 
@@ -20,11 +21,12 @@ describe('SiPaginationComponent', () => {
   const getCurrentItem = (): HTMLElement =>
     element.querySelector('.page-item.active') as HTMLElement;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [CommonModule, TestComponent]
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CommonModule, TestComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);
@@ -81,7 +83,7 @@ describe('SiPaginationComponent', () => {
     expect(getCurrentItem().innerHTML).toContain('9');
   });
 
-  it('should enable/disable buttons', fakeAsync(() => {
+  it('should enable/disable buttons', () => {
     fixture.componentRef.setInput('totalPages', 3);
     fixture.componentRef.setInput('currentPage', 1);
 
@@ -95,7 +97,6 @@ describe('SiPaginationComponent', () => {
 
     (buttons.item(1) as HTMLElement).click();
     fixture.detectChanges();
-    tick();
 
     buttons = getNavButtons();
     expect(buttons.item(0).disabled).toBeFalse();
@@ -104,11 +105,10 @@ describe('SiPaginationComponent', () => {
 
     (buttons.item(1) as HTMLElement).click();
     fixture.detectChanges();
-    tick();
 
     buttons = getNavButtons();
     expect(buttons.item(0).disabled).toBeFalse();
     expect(buttons.item(1).disabled).toBeTrue();
     expect(getCurrentItem().innerHTML).toContain('3');
-  }));
+  });
 });

--- a/projects/element-ng/password-strength/si-password-strength.component.spec.ts
+++ b/projects/element-ng/password-strength/si-password-strength.component.spec.ts
@@ -2,8 +2,14 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ElementRef, viewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  provideZonelessChangeDetection,
+  viewChild
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
 import {
@@ -64,7 +70,8 @@ describe('SiPasswordStrengthDirective', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiPasswordStrengthModule, FormsModule, WrapperComponent]
+      imports: [SiPasswordStrengthModule, FormsModule, WrapperComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 
@@ -187,7 +194,7 @@ describe('SiPasswordStrengthDirective', () => {
     expect(element.classList.contains('strong')).toBeTrue();
   });
 
-  it('should show the icon, toggle', fakeAsync(() => {
+  it('should show the icon, toggle', () => {
     fixture.detectChanges();
 
     const icon = element.querySelector('button')!;
@@ -198,9 +205,8 @@ describe('SiPasswordStrengthDirective', () => {
     expect(element.querySelector<HTMLElement>('input')?.getAttribute('type')).toBe('password');
 
     element.querySelector('button')?.click();
-    tick();
     fixture.detectChanges();
 
     expect(element.querySelector<HTMLElement>('input')?.getAttribute('type')).toBe('text');
-  }));
+  });
 });

--- a/projects/element-ng/password-toggle/si-password-toggle.component.spec.ts
+++ b/projects/element-ng/password-toggle/si-password-toggle.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, input } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Component, input, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
 import { SiPasswordToggleModule } from './si-password-toggle.module';
@@ -26,7 +26,8 @@ describe('SiPasswordToggleComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule, SiPasswordToggleModule, TestHostComponent]
+      imports: [FormsModule, SiPasswordToggleModule, TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     });
   });
 
@@ -36,7 +37,7 @@ describe('SiPasswordToggleComponent', () => {
     element = fixture.nativeElement;
   });
 
-  it('should show the icon, toggle', fakeAsync(() => {
+  it('should show the icon, toggle', () => {
     fixture.detectChanges();
 
     const icon = element.querySelector('button')!;
@@ -47,11 +48,11 @@ describe('SiPasswordToggleComponent', () => {
     expect(element.querySelector<HTMLElement>('input')?.getAttribute('type')).toBe('password');
 
     element.querySelector('button')?.click();
-    tick();
+
     fixture.detectChanges();
 
     expect(element.querySelector<HTMLElement>('input')?.getAttribute('type')).toBe('text');
-  }));
+  });
 
   it('should hide the icon when disabled', () => {
     fixture.componentRef.setInput('showVisibilityIcon', false);

--- a/projects/element-ng/phone-number/si-phone-number-input.component.spec.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.spec.ts
@@ -4,8 +4,8 @@
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
@@ -70,7 +70,8 @@ describe('SiPhoneNumberInputComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiPhoneNumberInputComponent, CommonModule, ReactiveFormsModule, WrapperComponent]
+      imports: [SiPhoneNumberInputComponent, CommonModule, ReactiveFormsModule, WrapperComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 
@@ -157,7 +158,7 @@ describe('SiPhoneNumberInputComponent', () => {
     expect(component.form.controls.workPhone.value).toEqual('+49 30 123456');
   });
 
-  it('should update the country code and phone number on setting it from the form control', fakeAsync(() => {
+  it('should update the country code and phone number on setting it from the form control', () => {
     fixture.componentInstance.form.controls.workPhone.setValue('+911234567890');
     fixture.detectChanges();
     const displaySelectedCountry = element.querySelector(
@@ -165,9 +166,9 @@ describe('SiPhoneNumberInputComponent', () => {
     ) as HTMLElement;
     expect(displaySelectedCountry.textContent).toContain('+91');
     expect(inputElement.value).toEqual('1234 567 890');
-  }));
+  });
 
-  it('should remove input value on form-control reset', fakeAsync(() => {
+  it('should remove input value on form-control reset', () => {
     component.form.controls.workPhone.setValue('+911234567890');
     fixture.detectChanges();
 
@@ -175,9 +176,9 @@ describe('SiPhoneNumberInputComponent', () => {
     component.form.reset();
     fixture.detectChanges();
     expect(inputElement.value).toEqual('');
-  }));
+  });
 
-  it('should set selected country to defaultCountry on form-control reset', fakeAsync(() => {
+  it('should set selected country to defaultCountry on form-control reset', () => {
     component.defaultCountry = 'CH';
     component.form.controls.workPhone.setValue('+911234567890');
     fixture.detectChanges();
@@ -189,7 +190,7 @@ describe('SiPhoneNumberInputComponent', () => {
     component.form.reset();
     fixture.detectChanges();
     expect(countryButton.textContent).toContain('+41');
-  }));
+  });
 
   it('should update both the country code and phone number when manually entering a valid country code and phone number in the input', () => {
     typePhoneNumber('+911234567890');
@@ -222,6 +223,7 @@ describe('SiPhoneNumberInputComponent', () => {
 
   it('should reflect initialCountry changes after view init', () => {
     component.country = 'US';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     const countryCode = element.querySelector<HTMLElement>('span.si-body');
@@ -230,6 +232,7 @@ describe('SiPhoneNumberInputComponent', () => {
 
   it('should reflect country when not part of supportedCountries', () => {
     component.country = 'AU';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     const countryCode = element.querySelector<HTMLElement>('span.si-body');
@@ -254,6 +257,7 @@ describe('SiPhoneNumberInputComponent', () => {
   it('should not show error when the supportedCountries list change after country selection', () => {
     // The country is pre initialized and we are changing the supported country list
     component.supportedCountries = null;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     typePhoneNumber('211111111');
@@ -296,6 +300,7 @@ describe('SiPhoneNumberInputComponent', () => {
 
     beforeEach(async () => {
       component.readonly = '';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       await fixture.whenStable();
       phoneInput = element.querySelector<HTMLElement>('si-phone-number-input')!;


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Modernized many component tests to use zoneless change detection and updated timing control (Jasmine clock, async/await or synchronous flows) with explicit change-detection triggers for more reliable, deterministic test execution; no runtime or user-facing behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->