### PR TITLE
test(element): make tests zoneless ready part 6

### DIFF
--- a/projects/element-ng/theme/si-theme.service.spec.ts
+++ b/projects/element-ng/theme/si-theme.service.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
@@ -25,7 +26,11 @@ describe('SiThemeService', () => {
         }) as any
     );
     TestBed.configureTestingModule({
-      providers: [TestService, { provide: SiThemeStore, useValue: store }]
+      providers: [
+        TestService,
+        { provide: SiThemeStore, useValue: store },
+        provideZonelessChangeDetection()
+      ]
     });
     service = TestBed.inject(TestService);
     service.resolvedColorScheme$.subscribe(themeSwitchSpy);

--- a/projects/element-ng/threshold/si-threshold.component.spec.ts
+++ b/projects/element-ng/threshold/si-threshold.component.spec.ts
@@ -4,8 +4,8 @@
  */
 import { HarnessLoader, parallel } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SelectOption, SelectOptionLegacy } from '@siemens/element-ng/select';
 import { SiSelectHarness } from '@siemens/element-ng/select/testing';
@@ -96,11 +96,12 @@ describe('SiThresholdComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 
-  beforeEach(fakeAsync(() => {
+  beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
     component = fixture.componentInstance;
@@ -115,9 +116,7 @@ describe('SiThresholdComponent', () => {
       { value: 30, optionValue: 'poor' }
     ];
     fixture.detectChanges();
-    tick();
-    fixture.detectChanges();
-  }));
+  });
 
   it('should create component', () => {
     expect(component).toBeTruthy();
@@ -167,17 +166,17 @@ describe('SiThresholdComponent', () => {
     expect(element.querySelectorAll<HTMLElement>('.ths-step').length).toBe(4);
   });
 
-  it('should prevent to add/remove steps when disabled', () => {
+  it('should prevent to add/remove steps when disabled', async () => {
     component.canAddRemoveSteps = false;
-    runOnPushChangeDetection(fixture);
+    await runOnPushChangeDetection(fixture);
 
     expect(element.querySelectorAll<HTMLElement>('[aria-label="Add step"]').length).toBe(0);
     expect(element.querySelectorAll<HTMLElement>('[aria-label="Delete step"]').length).toBe(0);
   });
 
-  it('should limit max. number of steps', () => {
+  it('should limit max. number of steps', async () => {
     component.maxSteps = 5;
-    runOnPushChangeDetection(fixture);
+    await runOnPushChangeDetection(fixture);
     const add2 = element.querySelectorAll<HTMLButtonElement>('[aria-label="Add step"]')[1];
     expect(add2.disabled).toBeTruthy();
   });
@@ -212,9 +211,9 @@ describe('SiThresholdComponent', () => {
     ]);
   });
 
-  it('should change threshold options to readonly', () => {
+  it('should change threshold options to readonly', async () => {
     component.readonlyConditions = true;
-    runOnPushChangeDetection(fixture);
+    await runOnPushChangeDetection(fixture);
     const readonlyOptions = fixture.debugElement.queryAll(By.css('si-readonly-threshold-option'));
     expect(readonlyOptions).toHaveSize(component.thresholdSteps.length);
     component.thresholdSteps.forEach((step, index) => {
@@ -227,14 +226,14 @@ describe('SiThresholdComponent', () => {
     });
   });
 
-  it('should still support legacy options', () => {
+  it('should still support legacy options', async () => {
     component.options = [
       { title: 'Good', id: 'good' },
       { title: 'Average', id: 'average' },
       { title: 'Poor', id: 'poor' }
     ];
     component.readonly = true;
-    runOnPushChangeDetection(fixture);
+    await runOnPushChangeDetection(fixture);
     const readonlyOptions = fixture.debugElement
       .queryAll(By.css('si-readonly-threshold-option span'))
       .map(option => option.nativeElement.innerText);

--- a/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Observable, Subject } from 'rxjs';
 
@@ -24,11 +24,12 @@ describe('SiToastNotificationDrawerComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let element: HTMLElement;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, TestHostComponent]
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
@@ -41,7 +42,7 @@ describe('SiToastNotificationDrawerComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('renders toasts', fakeAsync(() => {
+  it('renders toasts', () => {
     const toastSubject = new Subject<SiToast[]>();
     component.toasts = toastSubject;
     fixture.detectChanges();
@@ -52,11 +53,10 @@ describe('SiToastNotificationDrawerComponent', () => {
     ]);
 
     fixture.detectChanges();
-    tick();
 
     const toasts = element.querySelectorAll('si-toast-notification');
     expect(toasts.length).toBe(2);
     expect(toasts[0].innerHTML).toContain('danger message');
     expect(toasts[1].innerHTML).toContain('info message');
-  }));
+  });
 });

--- a/projects/element-ng/toast-notification/si-toast-notification.service.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification.service.spec.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 
 import { SiToastNotificationService } from './si-toast-notification.service';
 
@@ -11,7 +12,7 @@ describe('SiToastNotificationService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [SiToastNotificationService]
+      providers: [SiToastNotificationService, provideZonelessChangeDetection()]
     });
   });
 
@@ -50,7 +51,7 @@ describe('SiToastNotificationService', () => {
     expect(toast.hidden?.next).toHaveBeenCalled();
   });
 
-  it('should queue a maximum of three toasts', fakeAsync(() => {
+  it('should queue a maximum of three toasts', () => {
     service.queueToastNotification('success', 'Toast 1', 'Message 1');
     service.queueToastNotification('success', 'Toast 2', 'Message 2');
     service.queueToastNotification('success', 'Toast 3', 'Message 3');
@@ -58,24 +59,27 @@ describe('SiToastNotificationService', () => {
 
     expect(service.activeToasts.length).toBe(3);
     expect(service.activeToasts[0].message).toBe('Message 2'); // first one is dropped
-    flush();
-  }));
+  });
 
-  it('automatically closes toast after a while', fakeAsync(() => {
+  it('automatically closes toast after a while', () => {
+    jasmine.clock().install();
     service.queueToastNotification('success', 'Toast 1', 'Message 1');
     expect(service.activeToasts.length).toBe(1);
 
-    tick(6000);
+    jasmine.clock().tick(6000);
 
     expect(service.activeToasts.length).toBe(0);
-  }));
+    jasmine.clock().uninstall();
+  });
 
-  it('should respect the disableAutoClose flag', fakeAsync(() => {
+  it('should respect the disableAutoClose flag', () => {
+    jasmine.clock().install();
     service.queueToastNotification('success', 'Toast 1', 'Message 1', true);
     expect(service.activeToasts.length).toBe(1);
 
-    tick(6000);
+    jasmine.clock().tick(6000);
 
     expect(service.activeToasts.length).toBe(1);
-  }));
+    jasmine.clock().uninstall();
+  });
 });

--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.spec.ts
@@ -2,8 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  viewChild
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { STATUS_ICON } from '@siemens/element-ng/common';
 import { Subject } from 'rxjs';
@@ -31,11 +36,12 @@ describe('SiToastNotificationComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let element: HTMLElement;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SiToastNotificationComponent, TestHostComponent]
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, SiToastNotificationComponent, TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
+import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiTooltipModule } from './si-tooltip.module';
 
@@ -28,36 +28,41 @@ describe('SiTooltipDirective', () => {
       triggers: '' | 'focus' = '';
     }
 
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [SiTooltipModule, TestHostComponent]
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [SiTooltipModule, TestHostComponent],
+        providers: [provideZonelessChangeDetection()]
       }).compileComponents();
-    }));
+    });
 
     beforeEach(() => {
+      jasmine.clock().install();
       fixture = TestBed.createComponent(TestHostComponent);
       component = fixture.componentInstance;
       button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
       fixture.detectChanges();
     });
 
-    it('should open on focus', fakeAsync(() => {
-      fixture.detectChanges();
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
 
+    it('should open on focus', () => {
       button.dispatchEvent(new Event('focus'));
-      flush();
+      jasmine.clock().tick(500);
 
       expect(document.querySelector('.tooltip')).toBeTruthy();
       expect(document.querySelector('.tooltip')?.innerHTML).toContain('test tooltip');
 
       button.dispatchEvent(new Event('focusout'));
-      flush();
+      jasmine.clock().tick(500);
 
       expect(document.querySelector('.tooltip')).toBeFalsy();
-    }));
+    });
 
     it('should not show tooltip when disabled', () => {
       component.isDisabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       button.dispatchEvent(new Event('focus'));
@@ -74,6 +79,7 @@ describe('SiTooltipDirective', () => {
 
     it('should not show tooltip on mouse over with focus trigger', () => {
       component.triggers = 'focus';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       ['mouseenter', 'mouseleave'].forEach(e => {
@@ -98,35 +104,45 @@ describe('SiTooltipDirective', () => {
       tooltipContext = {};
     }
 
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [TestHostComponent]
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [TestHostComponent],
+        providers: [provideZonelessChangeDetection()]
       }).compileComponents();
-    }));
+    });
 
     beforeEach(() => {
+      jasmine.clock().install();
       fixture = TestBed.createComponent(TestHostComponent);
       button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
       fixture.detectChanges();
     });
 
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
     it('should render the template', async () => {
-      fixture.detectChanges();
       button.dispatchEvent(new Event('focus'));
+      jasmine.clock().tick(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')?.innerHTML).toContain('Template content');
       button.dispatchEvent(new Event('focusout'));
+      jasmine.clock().tick(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).toBeFalsy();
     });
 
     it('should render the template with context', async () => {
       fixture.componentInstance.tooltipContext = { tooltip: 'test' };
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       button.dispatchEvent(new Event('focus'));
+      jasmine.clock().tick(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')?.innerHTML).toContain('Template content test');
       button.dispatchEvent(new Event('focusout'));
+      jasmine.clock().tick(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).toBeFalsy();
     });

--- a/projects/element-ng/tour/si-tour.service.spec.ts
+++ b/projects/element-ng/tour/si-tour.service.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, inject } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
+import { Component, inject, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiTourService } from './si-tour.service';
 
@@ -18,12 +18,12 @@ describe('SiTourService', () => {
   let component: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
-  }));
-
+  });
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
@@ -34,7 +34,7 @@ describe('SiTourService', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should show/hide modal', fakeAsync(() => {
+  it('should show/hide modal', async () => {
     fixture.detectChanges();
     component.tourService.addSteps([
       {
@@ -52,7 +52,7 @@ describe('SiTourService', () => {
       }
     ]);
     component.tourService.start();
-    flush();
+    await fixture.whenStable();
     fixture.detectChanges();
 
     const tour = document.querySelector('si-tour');
@@ -66,6 +66,5 @@ describe('SiTourService', () => {
     expect(skip?.innerText).toBe('Skip tour');
 
     component.tourService.complete();
-    flush();
-  }));
+  });
 });

--- a/projects/element-ng/tree-view/si-tree-view-converter.service.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-converter.service.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { inject, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { SiTreeViewConverterService } from './si-tree-view-converter.service';
@@ -11,7 +12,7 @@ export const main = (): void => {
   describe('SiTreeViewConverterService', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        providers: [SiTreeViewService, SiTreeViewConverterService]
+        providers: [SiTreeViewService, SiTreeViewConverterService, provideZonelessChangeDetection()]
       }).compileComponents();
     }));
 

--- a/projects/element-ng/tree-view/si-tree-view-item-height.service.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item-height.service.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { inject, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { SiTreeViewItemHeightService } from './si-tree-view-item-height.service';
@@ -11,7 +12,11 @@ export const main = (): void => {
   describe('SiTreeViewItemHeightService', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        providers: [SiTreeViewService, SiTreeViewItemHeightService]
+        providers: [
+          SiTreeViewService,
+          SiTreeViewItemHeightService,
+          provideZonelessChangeDetection()
+        ]
       }).compileComponents();
     }));
 

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
@@ -3,15 +3,14 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkDragDrop, CdkDropList, DragDropModule } from '@angular/cdk/drag-drop';
-import { ChangeDetectionStrategy, Component, DebugElement, viewChild } from '@angular/core';
 import {
-  ComponentFixture,
-  discardPeriodicTasks,
-  fakeAsync,
-  flush,
-  TestBed,
-  tick
-} from '@angular/core/testing';
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  provideZonelessChangeDetection,
+  viewChild
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
 import {
@@ -128,7 +127,8 @@ describe('SiTreeViewComponentWithDragDrop', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
-      imports: [SiTreeViewModule, DragDropModule, WrapperComponent]
+      imports: [SiTreeViewModule, DragDropModule, WrapperComponent],
+      providers: [provideZonelessChangeDetection()]
     });
   });
 
@@ -153,9 +153,9 @@ describe('SiTreeViewComponentWithDragDrop', () => {
         .nativeElement.textContent
     ).toBe('Company4');
   });
-  it('moves tree items within tree', fakeAsync(() => {
+  it('moves tree items within tree', async () => {
     fixture.detectChanges();
-    runOnPushChangeDetection(fixture);
+    await runOnPushChangeDetection(fixture);
     expect(fixture.componentInstance.items[0].label).toBe('Company1');
     debugElement.query(By.css('si-tree-view')).triggerEventHandler('cdkDropListDropped', {
       currentIndex: 1,
@@ -165,13 +165,11 @@ describe('SiTreeViewComponentWithDragDrop', () => {
     });
     fixture.detectChanges();
     expect(fixture.componentInstance.items[0].label).toBe('Company2');
-    flush();
-    discardPeriodicTasks();
-  }));
+  });
 
-  it('does not move tree item if current and previous index are same', fakeAsync(() => {
+  it('does not move tree item if current and previous index are same', async () => {
     fixture.detectChanges();
-    runOnPushChangeDetection(fixture);
+    await runOnPushChangeDetection(fixture);
     expect(fixture.componentInstance.items[0].label).toBe('Company1');
     debugElement.query(By.css('si-tree-view')).triggerEventHandler('cdkDropListDropped', {
       currentIndex: 0,
@@ -181,13 +179,11 @@ describe('SiTreeViewComponentWithDragDrop', () => {
     });
     fixture.detectChanges();
     expect(fixture.componentInstance.items[0].label).toBe('Company1');
-    flush();
-    discardPeriodicTasks();
-  }));
+  });
 
-  it('moves tree item from one tree to another and removes from source tree', fakeAsync(() => {
+  it('moves tree item from one tree to another and removes from source tree', async () => {
     fixture.detectChanges();
-    runOnPushChangeDetection(fixture);
+    await runOnPushChangeDetection(fixture);
     expect(fixture.componentInstance.items[0].label).toBe('Company1');
     debugElement.query(By.css('si-tree-view')).triggerEventHandler('cdkDropListDropped', {
       currentIndex: 2,
@@ -197,9 +193,7 @@ describe('SiTreeViewComponentWithDragDrop', () => {
     });
     fixture.detectChanges();
     expect(fixture.componentInstance.items[0].label).toBe('Company2');
-    flush();
-    discardPeriodicTasks();
-  }));
+  });
 
   it('renders the updated tree when item is modified', () => {
     fixture.detectChanges();
@@ -255,10 +249,9 @@ describe('SiTreeViewComponentWithDragDrop', () => {
     expect(fixture.componentInstance.items).toEqual(treeItems);
   });
 
-  it('should update index of tree items when item is moved', fakeAsync(() => {
+  it('should update index of tree items when item is moved', async () => {
+    await fixture.whenStable();
     fixture.detectChanges();
-    tick();
-    runOnPushChangeDetection(fixture);
     expect(
       debugElement.query(By.css('si-tree-view-item .si-tree-view-item-object-data div'))
         .nativeElement.textContent
@@ -277,7 +270,5 @@ describe('SiTreeViewComponentWithDragDrop', () => {
         .nativeElement.textContent
     ).toBe('Company2');
     expect(debugElement.query(By.css('si-tree-view-item')).nativeElement.tabIndex).toBe(0);
-    flush();
-    discardPeriodicTasks();
-  }));
+  });
 });

--- a/projects/element-ng/tree-view/si-tree-view-virtualization.service.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-virtualization.service.spec.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { inject, TestBed, waitForAsync } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { SiTreeViewItemHeightService } from './si-tree-view-item-height.service';
 import { SiTreeViewVirtualizationService } from './si-tree-view-virtualization.service';
@@ -90,11 +91,16 @@ export const main = (): void => {
   ];
 
   describe('ListVirtualizationService', () => {
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [SiTreeViewService, SiTreeViewItemHeightService, SiTreeViewVirtualizationService]
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        providers: [
+          SiTreeViewService,
+          SiTreeViewItemHeightService,
+          SiTreeViewVirtualizationService,
+          provideZonelessChangeDetection()
+        ]
       }).compileComponents();
-    }));
+    });
 
     it('should create ListVirtualizationService', inject(
       [SiTreeViewVirtualizationService, SiTreeViewService, SiTreeViewItemHeightService],

--- a/projects/element-ng/tree-view/si-tree-view.service.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view.service.spec.ts
@@ -2,17 +2,18 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { inject, TestBed, waitForAsync } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { SiTreeViewService } from './si-tree-view.service';
 
 export const main = (): void => {
   describe('SiTreeViewService', () => {
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [SiTreeViewService]
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        providers: [SiTreeViewService, provideZonelessChangeDetection()]
       }).compileComponents();
-    }));
+    });
 
     it('should create SiTreeViewService', inject(
       [SiTreeViewService],

--- a/projects/element-ng/unauthorized-page/si-unauthorized-page.component.spec.ts
+++ b/projects/element-ng/unauthorized-page/si-unauthorized-page.component.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router, RouterModule } from '@angular/router';
 import { SiIconModule } from '@siemens/element-ng/icon';
@@ -14,7 +15,8 @@ describe('SiUnauthorizedPageComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiIconModule, TestComponent, RouterModule]
+      imports: [SiIconModule, TestComponent, RouterModule],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR (part 6 of the zoneless change detection migration) modernizes 15 Angular test files by:

- **Enabling zoneless change detection**: Added `provideZonelessChangeDetection()` as a TestBed provider across all modified test suites
- **Replacing zone-dependent async utilities**: Migrated from `waitForAsync`/`fakeAsync`/`flush`/`tick` to `async`/`await` with deterministic Jasmine clock-based timing
- **Improving test determinism**: Explicitly manage clock lifecycle with `install()`/`uninstall()` and `tick()` calls for precise timing control
- **Ensuring proper change detection**: Added `fixture.changeDetectorRef.markForCheck()` calls where needed for zoneless mode compatibility

**Modified test suites**: Tabs, theme service, threshold, toast notification (3 files), tooltip, tour service, tree-view (4 files), unauthorized page, and wizard components

These changes eliminate zone-based timing flakiness, resulting in more reliable and faster test execution while maintaining the same test coverage and semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->