### PR TITLE
refactor(modal): remove deprecations

### DIFF
--- a/api-goldens/element-ng/modal/index.api.md
+++ b/api-goldens/element-ng/modal/index.api.md
@@ -31,8 +31,6 @@ export interface ModalOptions<T = Record<string, any>> extends ModalDependencyIn
     ariaLabelledBy?: string;
     class?: string;
     ignoreBackdropClick?: boolean;
-    // @deprecated
-    initialState?: Partial<T>;
     inputValues?: Record<string, unknown>;
     keyboard?: boolean;
     messageInsteadOfAutoHide?: boolean;

--- a/projects/element-ng/modal/si-modal-service.spec.ts
+++ b/projects/element-ng/modal/si-modal-service.spec.ts
@@ -15,10 +15,9 @@ import { TestBed } from '@angular/core/testing';
 import { SiModalService } from './si-modal.service';
 
 @Component({
-  template: '<div>test component-{{normalProp}}-{{inputProp()}}</div>'
+  template: '<div>test component-{{inputProp()}}</div>'
 })
 class DialogComponent {
-  normalProp?: string;
   readonly inputProp = input<string>();
 }
 
@@ -109,21 +108,6 @@ describe('SiModalService', () => {
       modalRef.setInput('inputProp', 'new input value');
       appRef.tick();
       expect(modal?.innerHTML).toContain('new input value');
-      modalRef.hide();
-      jasmine.clock().tick(500);
-      appRef.tick();
-    });
-
-    it('set input using initialState', () => {
-      const modalRef = service.show(DialogComponent, {
-        initialState: { normalProp: 'prop value' }
-      });
-
-      appRef.tick();
-
-      const modal = document.querySelector('si-modal');
-      expect(modal).toBeTruthy();
-      expect(modal?.innerHTML).toContain('prop value');
       modalRef.hide();
       jasmine.clock().tick(500);
       appRef.tick();

--- a/projects/element-ng/modal/si-modal.service.ts
+++ b/projects/element-ng/modal/si-modal.service.ts
@@ -34,12 +34,6 @@ export interface ModalDependencyInjectionOptions {
 
 export interface ModalOptions<T = Record<string, any>> extends ModalDependencyInjectionOptions {
   /**
-   * Assign all values to the target component using `Object.assign(component, initialState)`.
-   *
-   * @deprecated Use {@link inputValues} instead.
-   */
-  initialState?: Partial<T>;
-  /**
    * Use this to assign values to either `@Input()` or `input()` fields of the provided component.
    * If a template is used, the values are available in the template context.
    */
@@ -148,7 +142,6 @@ export class SiModalService {
     if (modalRef.contentRef instanceof TemplateRef) {
       modalRef.viewRef = modalRef.contentRef.createEmbeddedView({
         modalRef,
-        ...modalRef.data.initialState,
         ...modalRef.data.inputValues
       });
       this.appRef.attachView(modalRef.viewRef);
@@ -159,7 +152,6 @@ export class SiModalService {
       environmentInjector: modalRef.data.environmentInjector ?? this.environmentInjector,
       elementInjector: injector
     });
-    Object.assign(modalRef.componentRef.instance as any, modalRef.data?.initialState);
     // set initial @Input() / input()
     for (const [key, value] of Object.entries(modalRef.data?.inputValues ?? {})) {
       modalRef.componentRef?.setInput(key, value);

--- a/src/app/examples/si-modals/si-modal-service.ts
+++ b/src/app/examples/si-modals/si-modal-service.ts
@@ -49,7 +49,7 @@ export class SampleComponent implements OnDestroy {
     this.parentRef = this.modalService.show(
       template,
       {
-        initialState: { someThing: 'some context' },
+        inputValues: { someThing: 'some context' },
         ignoreBackdropClick: false,
         keyboard: true,
         animated: true,


### PR DESCRIPTION
BREAKING CHANGE: Removed property `ModalOptions.initialState`. Use `ModalOptions.inputValues` instead.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Removed ModalOptions.initialState deprecation

Removed the deprecated `initialState` property from `ModalOptions` and migrated all usages to `inputValues`.

Changes:
- Deleted `initialState?: Partial<T>` and its deprecation comment from `ModalOptions`.
- Removed `Object.assign`-based application of `initialState` to component instances.
- Removed spreading of `initialState` for TemplateRef modal content; only `inputValues` is used.
- Updated tests and example to use `inputValues` instead of `initialState`.
- Removed test component member `normalProp` and the test scenario that exercised `initialState`.

Notes:
- BREAKING CHANGE: Code using `ModalOptions.initialState` must migrate to `ModalOptions.inputValues`. Unlike `initialState` (which used Object.assign and could set arbitrary properties), `inputValues` only binds to component inputs — behavior differs and may require changes in callers.
- PR description still requests more detail and the contribution checklist line remains unchecked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->