### PR TITLE
refactor(dashboards/grid): remove deprecations

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -30,7 +30,6 @@ import { OutputEmitterRef } from '@angular/core';
 import { Provider } from '@angular/core';
 import { SiDashboardComponent } from '@siemens/element-ng/dashboard';
 import * as _siemens_element_translate_ng_translate_types from '@siemens/element-translate-ng/translate-types';
-import { SiLoadingService } from '@siemens/element-ng/loading-spinner';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
@@ -220,8 +219,6 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
     readonly hideProgressIndicator: _angular_core.InputSignal<boolean>;
     readonly isLoading: BehaviorSubject<boolean>;
     readonly isModified: _angular_core.OutputEmitterRef<boolean>;
-    // @deprecated
-    loadingService: SiLoadingService;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)

--- a/projects/dashboards-ng/src/components/grid/si-grid.component.ts
+++ b/projects/dashboards-ng/src/components/grid/si-grid.component.ts
@@ -16,7 +16,7 @@ import {
   Type,
   viewChild
 } from '@angular/core';
-import { SiLoadingService, SiLoadingSpinnerDirective } from '@siemens/element-ng/loading-spinner';
+import { SiLoadingSpinnerDirective } from '@siemens/element-ng/loading-spinner';
 import { ModalOptions, SiModalService } from '@siemens/element-ng/modal';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
@@ -42,7 +42,7 @@ import { SiWidgetInstanceEditorDialogComponent } from '../widget-instance-editor
   imports: [SiGridstackWrapperComponent, SiLoadingSpinnerDirective, AsyncPipe],
   templateUrl: './si-grid.component.html',
   styleUrl: './si-grid.component.scss',
-  providers: [SiGridService, SiLoadingService]
+  providers: [SiGridService]
 })
 export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
   private storeSubscription?: Subscription;
@@ -174,14 +174,6 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
   readonly gridStackWrapper = viewChild.required(SiGridstackWrapperComponent);
 
   /**
-   * Service used to indicate load and save indication.
-   * @deprecated Use `isLoading` instead.
-   *
-   * @defaultValue inject(SiLoadingService)
-   */
-  loadingService = inject(SiLoadingService);
-
-  /**
    * Indication for load and save operations.
    */
   readonly isLoading: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
@@ -220,7 +212,6 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy(): void {
     this.storeSubscription?.unsubscribe();
     this.isLoading.complete();
-    this.loadingService.counter.complete();
   }
 
   /**
@@ -247,7 +238,6 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     this.isLoading.next(true);
-    this.loadingService.counter.next(1);
     // Update position information
     const widgets = this.updateWidgetPositions(this.visibleWidgetInstances$.value);
 
@@ -264,12 +254,10 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
           this.editable.set(false);
           this.gridService.editable$.next(this.editableInternal);
           this.isLoading.next(false);
-          this.loadingService.counter.next(0);
         },
         error: (err: any) => {
           console.error('Saving dashboard configuration failed.', err);
           this.isLoading.next(false);
-          this.loadingService.counter.next(0);
         }
       });
   }
@@ -411,7 +399,6 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
     // subscription. To handle this, we use the boolean marker `initialLoad`.
     this.initialLoad = true;
     this.isLoading.next(true);
-    this.loadingService.counter.next(1);
     this.storeSubscription = this.widgetStorage.load(this.dashboardId()).subscribe({
       next: widgets => {
         this.visibleWidgetInstances$.next(widgets);
@@ -419,13 +406,11 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
         if (this.initialLoad) {
           this.initialLoad = false;
           this.isLoading.next(false);
-          this.loadingService.counter.next(0);
         }
       },
       error: err => {
         console.error('Loading dashboard configuration failed', err);
         this.isLoading.next(false);
-        this.loadingService.counter.next(0);
       }
     });
   }


### PR DESCRIPTION
BREAKING CHANGE: Removed property `SiGridComponent.loadingService`. Use `SiGridComponent.isLoading` instead to indicate load and save operations.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Removes the deprecated SiGridComponent.loadingService and its SiLoadingService provider. The component now uses the existing isLoading BehaviorSubject to indicate load and save operations; all loadingService.counter interactions were removed or replaced with isLoading updates. API goldens were updated to remove the public loadingService member.

### Changes
- Removed SiLoadingService import and component provider (providers now: [SiGridService]).
- Deleted public loadingService field and all counter.next/complete usage.
- Consolidated loading indicator usage to isLoading (used in save(), load paths, ngOnDestroy()).
- Updated api-goldens/dashboards-ng to remove loadingService from public API.

### Breaking change
The component-level provider for SiLoadingService and the public loadingService property were removed. Consumers referencing loadingService must migrate to using SiGridComponent.isLoading to track load/save state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->