### PR TITLE
test(forms): make tests zoneless ready

### DIFF
--- a/projects/element-ng/form/si-form-container/si-form-container.component.spec.ts
+++ b/projects/element-ng/form/si-form-container/si-form-container.component.spec.ts
@@ -7,9 +7,10 @@ import {
   ChangeDetectorRef,
   Component,
   inject,
+  provideZonelessChangeDetection,
   viewChild
 } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import {
   SiFormContainerComponent,
@@ -71,17 +72,18 @@ describe('SiFormContainerComponent', () => {
     let fixture: ComponentFixture<TestHostComponent>;
     let formContainer: SiFormContainerComponent<TestForm>;
 
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
         imports: [
           ReactiveFormsModule,
           SiFormModule.withConfiguration({
             validationErrorMapper: { minlength: 'custom-length-message' }
           }),
           TestHostComponent
-        ]
+        ],
+        providers: [provideZonelessChangeDetection()]
       }).compileComponents();
-    }));
+    });
 
     beforeEach(() => {
       fixture = TestBed.createComponent(TestHostComponent);
@@ -165,11 +167,12 @@ describe('SiFormContainerComponent', () => {
   describe('with nested form containers', () => {
     let fixture: ComponentFixture<TestHostWithNestingComponent>;
 
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [TestHostWithNestingComponent]
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [TestHostWithNestingComponent],
+        providers: [provideZonelessChangeDetection()]
       }).compileComponents();
-    }));
+    });
 
     beforeEach(() => {
       fixture = TestBed.createComponent(TestHostWithNestingComponent);

--- a/projects/element-ng/form/si-form-item/si-form-item.component.spec.ts
+++ b/projects/element-ng/form/si-form-item/si-form-item.component.spec.ts
@@ -2,8 +2,14 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  signal,
+  viewChild
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiFormItemComponent } from './si-form-item.component';
 
@@ -29,11 +35,12 @@ describe('SiFormItemComponent', () => {
     return fixture.nativeElement.querySelector('label');
   };
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
@@ -41,10 +48,10 @@ describe('SiFormItemComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', fakeAsync(() => {
+  it('should create', () => {
     expect(component).toBeDefined();
     expect(getLabel()).toBeDefined();
-  }));
+  });
 
   it('should display the bound label value', () => {
     component.label.set('Testlabel');

--- a/projects/element-ng/form/si-form.spec.ts
+++ b/projects/element-ng/form/si-form.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   FormControl,
@@ -88,7 +88,8 @@ describe('SiForm', () => {
         imports: [
           TestHostComponent,
           SiFormModule.withConfiguration({ validationErrorMapper: { required: 'required' } })
-        ]
+        ],
+        providers: [provideZonelessChangeDetection()]
       }).compileComponents();
     });
 
@@ -169,7 +170,8 @@ describe('SiForm', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [TestHostComponent]
+        imports: [TestHostComponent],
+        providers: [provideZonelessChangeDetection()]
       }).compileComponents();
     });
 
@@ -195,6 +197,8 @@ describe('SiForm', () => {
 
     it('should update required indicator', async () => {
       fixture.componentInstance.form.controls.input.setValidators([]);
+      fixture.changeDetectorRef.markForCheck();
+      await fixture.whenStable();
       const field = await loader.getHarness(SiFormItemHarness.with({ label: 'Input' }));
       expect(await field.isRequired()).toBeFalse();
     });
@@ -221,7 +225,8 @@ describe('SiForm', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [TestHostComponent]
+        imports: [TestHostComponent],
+        providers: [provideZonelessChangeDetection()]
       }).compileComponents();
     });
 
@@ -238,6 +243,8 @@ describe('SiForm', () => {
       const field = await loader.getHarness(SiFormItemHarness.with({ label: 'Input' }));
       expect(await field.isRequired()).toBeTrue();
       fixture.componentInstance.required = false;
+      fixture.changeDetectorRef.markForCheck();
+      await fixture.whenStable();
       expect(await field.isRequired()).toBeFalse();
     });
   });
@@ -268,7 +275,8 @@ describe('SiForm', () => {
         providers: [
           provideFormValidationErrorMapper({
             email: emailMapperSpy
-          })
+          }),
+          provideZonelessChangeDetection()
         ]
       }).compileComponents();
       fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/formly/fields/button/si-formly-button.component.spec.ts
+++ b/projects/element-ng/formly/fields/button/si-formly-button.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -63,7 +63,8 @@ describe('formly button type', () => {
         }),
         SiFormlyButtonComponent,
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 
@@ -229,7 +230,7 @@ describe('formly button type', () => {
       spy = jasmine.createSpy();
     });
 
-    it('should trigger the clickListener function', fakeAsync(() => {
+    it('should trigger the clickListener function', () => {
       component.fields = [
         {
           key: 'btn',
@@ -243,9 +244,9 @@ describe('formly button type', () => {
 
       fixture.debugElement.query(By.css('button')).nativeElement.click();
       expect(spy).toHaveBeenCalled();
-    }));
+    });
 
-    it('should trigger the clickListener function with custom params', fakeAsync(() => {
+    it('should trigger the clickListener function with custom params', () => {
       component.fields = [
         {
           key: 'btn',
@@ -260,9 +261,9 @@ describe('formly button type', () => {
 
       fixture.debugElement.query(By.css('button')).nativeElement.click();
       expect(spy).toHaveBeenCalledWith('foo', 42);
-    }));
+    });
 
-    it('should trigger the clickListener function by expression', fakeAsync(() => {
+    it('should trigger the clickListener function by expression', () => {
       component.options = {
         formState: {
           click: () => spy()
@@ -281,9 +282,9 @@ describe('formly button type', () => {
 
       fixture.debugElement.query(By.css('button')).nativeElement.click();
       expect(spy).toHaveBeenCalled();
-    }));
+    });
 
-    it('should trigger the clickListener function with custom params', fakeAsync(() => {
+    it('should trigger the clickListener function with custom params', () => {
       component.options = {
         formState: {
           click: (f: string, s: number) => spy(f, s)
@@ -303,9 +304,9 @@ describe('formly button type', () => {
 
       fixture.debugElement.query(By.css('button')).nativeElement.click();
       expect(spy).toHaveBeenCalledWith('foo', 42);
-    }));
+    });
 
-    it('should trigger the clickListener function with string param', fakeAsync(() => {
+    it('should trigger the clickListener function with string param', () => {
       component.options = {
         formState: {
           click: (f: string) => spy(f)
@@ -325,9 +326,9 @@ describe('formly button type', () => {
 
       fixture.debugElement.query(By.css('button')).nativeElement.click();
       expect(spy).toHaveBeenCalledWith('foo');
-    }));
+    });
 
-    it('should trigger the clickListener function with custom params', fakeAsync(() => {
+    it('should trigger the clickListener function with custom params', () => {
       spyOn(console, 'warn');
       spy.and.throwError('error');
       component.fields = [
@@ -347,7 +348,7 @@ describe('formly button type', () => {
         'Error while executing dyn ui button "btn" direct click listener.',
         new Error('error')
       );
-    }));
+    });
 
     it('should log warning when click listener raised exception', () => {
       spyOn(console, 'warn');

--- a/projects/element-ng/formly/fields/date-range/si-formly-date-range.component.spec.ts
+++ b/projects/element-ng/formly/fields/date-range/si-formly-date-range.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -62,7 +62,8 @@ describe('formly date range type', () => {
         }),
         SiFormlyDateRangeComponent,
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/fields/datetime/si-formly-datetime.component.spec.ts
+++ b/projects/element-ng/formly/fields/datetime/si-formly-datetime.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -66,7 +66,8 @@ describe('formly datetime-type', () => {
         }),
         SiFormlyDateTimeComponent,
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 
@@ -100,7 +101,7 @@ describe('formly datetime-type', () => {
     expect(new Date(inputField.nativeElement.value)).toEqual(new Date(startDateInputVal));
   });
 
-  it('should handle time zone and result into value as short value', fakeAsync(() => {
+  it('should handle time zone and result into value as short value', async () => {
     const componentInstance = fixture.componentInstance;
     componentInstance.fields = [
       {
@@ -122,10 +123,11 @@ describe('formly datetime-type', () => {
     const inputField = fixture.debugElement.query(By.css('input'));
     inputField.nativeElement.value = startDateInputVal;
     inputField.nativeElement.dispatchEvent(new Event('input'));
+    jasmine.clock().tick(200);
     fixture.detectChanges();
-    tick(200);
+    await fixture.whenStable();
     expect(componentInstance.model.name).toEqual(new Date(startDateUTCShort));
-  }));
+  });
 
   it('should have a timezoned display value - as long value', () => {
     const componentInstance = fixture.componentInstance;
@@ -151,7 +153,7 @@ describe('formly datetime-type', () => {
     expect(new Date(inputField.nativeElement.value)).toEqual(new Date(startDateInputVal));
   });
 
-  it('should handle time zone and result into value as long value', fakeAsync(() => {
+  it('should handle time zone and result into value as long value', async () => {
     const componentInstance = fixture.componentInstance;
     componentInstance.fields = [
       {
@@ -175,10 +177,11 @@ describe('formly datetime-type', () => {
     inputField.nativeElement.value = startDateInputVal;
     inputField.nativeElement.dispatchEvent(new Event('input'));
 
+    jasmine.clock().tick(200);
     fixture.detectChanges();
-    tick(200);
+    await fixture.whenStable();
     expect(componentInstance.model.name).toEqual(new Date(startDateUTCSLong));
-  }));
+  });
 
   it('should have a timezoned display value - as data value', () => {
     const componentInstance = fixture.componentInstance;
@@ -204,7 +207,7 @@ describe('formly datetime-type', () => {
     expect(inputField.nativeElement.value).toEqual(startDateInputVal);
   });
 
-  it('should handle time zone and result into value as date', fakeAsync(() => {
+  it('should handle time zone and result into value as date', async () => {
     const componentInstance = fixture.componentInstance;
     componentInstance.fields = [
       {
@@ -226,11 +229,13 @@ describe('formly datetime-type', () => {
     const inputField = fixture.debugElement.query(By.css('input'));
     inputField.nativeElement.value = startDateInputVal;
     inputField.nativeElement.dispatchEvent(new Event('input'));
+
+    jasmine.clock().tick(200);
     fixture.detectChanges();
-    tick(200);
+    await fixture.whenStable();
 
     expect(componentInstance.model.name.getTime()).toEqual(date.getTime());
-  }));
+  });
 
   it('should have calendar-button', async () => {
     const componentInstance = fixture.componentInstance;

--- a/projects/element-ng/formly/fields/email/si-formly-email.component.spec.ts
+++ b/projects/element-ng/formly/fields/email/si-formly-email.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -42,7 +42,8 @@ describe('formly email type', () => {
         }),
         SiFormlyEmailComponent,
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/fields/ip-input/si-formly-ip-input.component.spec.ts
+++ b/projects/element-ng/formly/fields/ip-input/si-formly-ip-input.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
@@ -44,7 +44,8 @@ describe('formly ip', () => {
         }),
         SiFormlyIpInputComponent,
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
     fixture = TestBed.createComponent(FormlyTestComponent);
   });
@@ -65,7 +66,7 @@ describe('formly ip', () => {
     expect(inputField.nativeElement.value).toEqual('192.168.0.1');
   });
 
-  it('should display IPv4 address with CIDR notation - as data value', fakeAsync(() => {
+  it('should display IPv4 address with CIDR notation - as data value', () => {
     const componentInstance = fixture.componentInstance;
     componentInstance.fields = [
       {
@@ -82,7 +83,7 @@ describe('formly ip', () => {
     fixture.detectChanges();
     const inputField = fixture.debugElement.query(By.css('input'));
     expect(inputField.nativeElement.value).toEqual('192.168.0.1/32');
-  }));
+  });
 
   it('should display IPv6 address - as data value', () => {
     const componentInstance = fixture.componentInstance;
@@ -100,7 +101,7 @@ describe('formly ip', () => {
     expect(inputField.nativeElement.value).toEqual('2001:DB8::8:800:200C:417A');
   });
 
-  it('should display IPv6 address with CIDR notation - as data value', fakeAsync(() => {
+  it('should display IPv6 address with CIDR notation - as data value', () => {
     const componentInstance = fixture.componentInstance;
     componentInstance.fields = [
       {
@@ -117,5 +118,5 @@ describe('formly ip', () => {
     fixture.detectChanges();
     const inputField = fixture.debugElement.query(By.css('input'));
     expect(inputField.nativeElement.value).toEqual('2001:DB8::8:800:200C:417A/128');
-  }));
+  });
 });

--- a/projects/element-ng/formly/fields/number/si-formly-number.component.spec.ts
+++ b/projects/element-ng/formly/fields/number/si-formly-number.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -57,7 +57,8 @@ describe('formly number type', () => {
         }),
         SiFormlyNumberComponent,
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 
@@ -65,7 +66,8 @@ describe('formly number type', () => {
     fixture = TestBed.createComponent(FormlyTestComponent);
   });
 
-  it('should display the number input based on props provided', fakeAsync(() => {
+  it('should display the number input based on props provided', async () => {
+    jasmine.clock().install();
     const componentInstance = fixture.componentInstance;
 
     componentInstance.model = {
@@ -86,10 +88,12 @@ describe('formly number type', () => {
 
     inputField.nativeElement.value = 2000;
     inputField.nativeElement.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
-    tick(200);
 
+    jasmine.clock().tick(200);
+    fixture.detectChanges();
+    await fixture.whenStable();
     // Assert if input change reflects the model
     expect(componentInstance.model.cost).toBe(2000);
-  }));
+    jasmine.clock().uninstall();
+  });
 });

--- a/projects/element-ng/formly/fields/select/si-formly-select.component.spec.ts
+++ b/projects/element-ng/formly/fields/select/si-formly-select.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -55,7 +55,8 @@ describe('formly si-select', () => {
           ]
         }),
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
     fixture = TestBed.createComponent(FormlyTestComponent);
   });

--- a/projects/element-ng/formly/fields/text/si-formly-text-display.component.spec.ts
+++ b/projects/element-ng/formly/fields/text/si-formly-text-display.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -57,7 +57,8 @@ describe('formly text-display-type', () => {
           ]
         }),
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.spec.ts
+++ b/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -42,7 +42,8 @@ describe('formly autogrowing textarea type', () => {
           ]
         }),
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/fields/time/si-formly-time.component.spec.ts
+++ b/projects/element-ng/formly/fields/time/si-formly-time.component.spec.ts
@@ -2,7 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  inject,
+  provideZonelessChangeDetection
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -45,7 +51,8 @@ describe('formly time-type', () => {
           ]
         }),
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/si-formly-translate.extension.spec.ts
+++ b/projects/element-ng/formly/si-formly-translate.extension.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { SiTranslateService } from '@siemens/element-ng/translate';
@@ -18,7 +19,10 @@ describe('Formly translations', () => {
     mockTranslationService = jasmine.createSpyObj<SiTranslateService>(['translateAsync']);
     mockTranslationService.translateAsync.and.returnValue(of('translated'));
     TestBed.configureTestingModule({
-      providers: [provideMockTranslateServiceBuilder(() => mockTranslationService)]
+      providers: [
+        provideMockTranslateServiceBuilder(() => mockTranslationService),
+        provideZonelessChangeDetection()
+      ]
     });
     extension = TestBed.runInInjectionContext(() => new SiFormlyTranslateExtension());
   });

--- a/projects/element-ng/formly/si-formly.component.spec.ts
+++ b/projects/element-ng/formly/si-formly.component.spec.ts
@@ -2,8 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  viewChild
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormGroup, FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { FormlyBootstrapModule } from '@ngx-formly/bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
@@ -44,8 +49,8 @@ describe('ElementFormComponent', () => {
   let fixture: ComponentFixture<WrapperComponent>;
   let element: HTMLElement;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [ReactiveFormsModule, FormlyBootstrapModule, SiFormlyModule, WrapperComponent],
       providers: [
         provideMockTranslateServiceBuilder(
@@ -56,10 +61,11 @@ describe('ElementFormComponent', () => {
               translateAsync: (key: string, params: Record<string, any>) =>
                 of(`translated=>${key}-${JSON.stringify(params)}`)
             }) as SiTranslateService
-        )
+        ),
+        provideZonelessChangeDetection()
       ]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(async () => {
     fixture = TestBed.createComponent(WrapperComponent);

--- a/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -96,7 +96,8 @@ describe('formly accordion type', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SiFormlyModule, FormlyTestComponent]
+      imports: [NoopAnimationsModule, SiFormlyModule, FormlyTestComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/structural/si-formly-array/si-formly-array.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-array/si-formly-array.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
@@ -32,8 +32,8 @@ describe('ElementFormComponent', () => {
   let fixture: ComponentFixture<WrapperComponent>;
   let wrapperComponent: WrapperComponent;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         FormlyModule.forRoot({
           types: [
@@ -48,6 +48,7 @@ describe('ElementFormComponent', () => {
         WrapperComponent
       ],
       providers: [
+        provideZonelessChangeDetection(),
         {
           provide: SiTranslateService,
           useValue: {
@@ -59,7 +60,7 @@ describe('ElementFormComponent', () => {
         }
       ]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WrapperComponent);

--- a/projects/element-ng/formly/structural/si-formly-object-grid/si-formly-object-grid.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-object-grid/si-formly-object-grid.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -44,7 +44,8 @@ describe('formly grid  type', () => {
           ]
         }),
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/structural/si-formly-object-plain/si-formly-object-plain.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-object-plain/si-formly-object-plain.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
@@ -32,8 +32,8 @@ describe('ElementFormComponent', () => {
   let fixture: ComponentFixture<WrapperComponent>;
   let wrapperComponent: WrapperComponent;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         FormlyModule.forRoot({
           types: [
@@ -47,6 +47,7 @@ describe('ElementFormComponent', () => {
         WrapperComponent
       ],
       providers: [
+        provideZonelessChangeDetection(),
         provideMockTranslateServiceBuilder(
           () =>
             ({
@@ -58,7 +59,7 @@ describe('ElementFormComponent', () => {
         )
       ]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WrapperComponent);

--- a/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -42,7 +42,8 @@ describe('formly tabset type', () => {
           ]
         }),
         FormlyTestComponent
-      ]
+      ],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates form and formly component test files to support zoneless change detection, preparing them for Angular's new zoneless change detection model.

**Key changes across 25 test spec files:**

- **Added zoneless support:** Import and inject `provideZonelessChangeDetection()` from `@angular/core` in TestBed configurations for all affected test modules
- **Modernized async patterns:** Replaced deprecated `waitForAsync()` with `async/await` semantics in test setup functions where applicable
- **Converted tests:** Changed fakeAsync-wrapped tests to synchronous implementations; added `fixture.whenStable()` and `fixture.changeDetectorRef.markForCheck()` where needed for proper change detection handling

**Files updated:**
- Form components (4): `si-form-container`, `si-form-item`, `si-form`, `si-form-validation-tooltip`
- Formly field types (10): button, date-range, datetime, email, ip-input, number, select, text-display, textarea, time
- Formly structural components (5): accordion, array, object-grid, object-plain, tabset
- Formly extensions/core (3): main component, translate extension, module spec
- Formly utilities (1): utils spec

No public API changes or runtime behavior modifications outside tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->