### PR TITLE
test(maps): make tests zoneless ready

### DIFF
--- a/projects/maps-ng/eslint.config.js
+++ b/projects/maps-ng/eslint.config.js
@@ -35,5 +35,12 @@ export default defineConfig(
       ]
     }
   },
+  // TODO: remove this once upgraded to Angular 21
+  {
+    files: ['**/*.spec.ts'],
+    rules: {
+      '@angular-eslint/no-developer-preview': ['off']
+    }
+  },
   ...templateConfig
 );

--- a/projects/maps-ng/src/components/si-map/components/si-map-popover/si-map-popover.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/components/si-map-popover/si-map-popover.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component } from '@angular/core';
+import { Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MapPointMetaData } from '../../models';
@@ -20,7 +20,8 @@ describe('SiMapPopoverComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiMapPopoverComponent, MockCustomPopoverComponent]
+      imports: [SiMapPopoverComponent, MockCustomPopoverComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -16,7 +17,8 @@ describe('SiMapTooltipComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiMapTooltipComponent]
+      imports: [SiMapTooltipComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/maps-ng/src/components/si-map/services/map.service.spec.ts
+++ b/projects/maps-ng/src/components/si-map/services/map.service.spec.ts
@@ -2,19 +2,20 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 
 import { MapService } from './map.service';
 
 describe('Service: Map', () => {
   let mapService: MapService;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      providers: [MapService]
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [MapService, provideZonelessChangeDetection()]
     }).compileComponents();
     mapService = TestBed.inject(MapService);
-  }));
+  });
 
   it('should create the service', () => {
     expect(mapService).toBeTruthy();

--- a/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef } from '@angular/core';
+import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { TranslateModule } from '@ngx-translate/core';
@@ -50,7 +50,7 @@ describe('SiMapComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [SiMapModule, TranslateModule.forRoot()],
-      providers: [MapService]
+      providers: [MapService, provideZonelessChangeDetection()]
     })
   );
 


### PR DESCRIPTION

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates maps component tests to be zoneless-ready. Changes include:

- **eslint.config.js**: Adds ESLint override for spec files to disable `@angular-eslint/no-developer-preview` (pending Angular version upgrade)
- **Test files** (si-map-popover, si-map-tooltip, map.service, si-map component specs): 
  - Import `provideZonelessChangeDetection` from @angular/core
  - Register it in TestBed providers for all tests
  - Converts map.service.spec.ts from `waitForAsync` to async/await pattern

These changes prepare the test suite for Angular's zoneless change detection feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->