### PR TITLE
test(element-translate-ng): make tests zoneless ready

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -189,7 +189,6 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "projects/element-translate-ng/tsconfig.spec.json",
             "karmaConfig": "projects/element-translate-ng/karma.conf.cjs",
             "stylePreprocessorOptions": {

--- a/projects/element-translate-ng/eslint.config.js
+++ b/projects/element-translate-ng/eslint.config.js
@@ -33,5 +33,12 @@ export default defineConfig(
       ]
     }
   },
+  // TODO: remove this once upgraded to Angular 21
+  {
+    files: ['**/*.spec.ts'],
+    rules: {
+      '@angular-eslint/no-developer-preview': ['off']
+    }
+  },
   ...templateConfig
 );

--- a/projects/element-translate-ng/ngx-translate/si-translate-ngxt.spec.ts
+++ b/projects/element-translate-ng/ngx-translate/si-translate-ngxt.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, DOCUMENT, Injectable } from '@angular/core';
+import { Component, DOCUMENT, Injectable, provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RouterModule, RouterOutlet } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
@@ -67,15 +67,13 @@ describe('SiTranslateNgxT', () => {
           ]),
           HostComponent
         ],
-        providers: [RootTestService]
+        providers: [RootTestService, provideZonelessChangeDetection()]
       });
     });
 
     it('should use correct translation service', async () => {
-      const fixture = TestBed.createComponent(HostComponent);
-      await RouterTestingHarness.create('/');
-      fixture.detectChanges();
-      expect((fixture.nativeElement as HTMLElement).innerText).toBe('VALUE-MODIFIED');
+      const router = await RouterTestingHarness.create('/');
+      expect((router.routeNativeElement as HTMLElement).innerText).toBe('VALUE-MODIFIED');
       expect(TestBed.inject(RootTestService).siTranslateService.translateSync('KEY-1')).toBe(
         'VALUE-1'
       );
@@ -104,7 +102,8 @@ describe('SiTranslateNgxT', () => {
               } as TranslateLoader
             }
           })
-        ]
+        ],
+        providers: [provideZonelessChangeDetection()]
       });
     });
     beforeEach(() => {

--- a/projects/element-translate-ng/translate/si-no-translate.spec.ts
+++ b/projects/element-translate-ng/translate/si-no-translate.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { injectSiTranslateService } from './si-translate.inject';
@@ -11,6 +12,9 @@ describe('SiNoTranslate', () => {
   let service: SiTranslateService;
 
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    });
     service = TestBed.runInInjectionContext(() => injectSiTranslateService());
   });
 

--- a/projects/element-translate-ng/translate/si-translatable.spec.ts
+++ b/projects/element-translate-ng/translate/si-translatable.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiNoTranslateService } from './si-no-translate.service';
@@ -12,13 +13,20 @@ import { SiTranslateService } from './si-translate.service';
 describe('SiTranslatable', () => {
   let service: SiTranslatableService;
 
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    });
+  });
+
   describe('with SiTranslateService', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         providers: [
           { provide: SiTranslateService, useClass: SiNoTranslateService },
           { provide: SI_TRANSLATABLE_VALUES, useValue: { KEY1: 'value1' }, multi: true },
-          { provide: SI_TRANSLATABLE_VALUES, useValue: { KEY2: 'value2' }, multi: true }
+          { provide: SI_TRANSLATABLE_VALUES, useValue: { KEY2: 'value2' }, multi: true },
+          provideZonelessChangeDetection()
         ]
       });
       service = TestBed.inject(SiTranslatableService);

--- a/projects/element-translate-ng/translate/si-translate.pipe.spec.ts
+++ b/projects/element-translate-ng/translate/si-translate.pipe.spec.ts
@@ -7,7 +7,8 @@ import {
   ChangeDetectorRef,
   Component,
   inject,
-  Injectable
+  Injectable,
+  provideZonelessChangeDetection
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { injectSiTranslateService, t } from '@siemens/element-translate-ng/translate';
@@ -88,7 +89,8 @@ describe('SiTranslatePipe', () => {
       TestBed.configureTestingModule({
         imports: [TestComponent],
         providers: [
-          provideMockTranslateServiceBuilder(injector => injector.get(SiAsyncTranslateService))
+          provideMockTranslateServiceBuilder(injector => injector.get(SiAsyncTranslateService)),
+          provideZonelessChangeDetection()
         ]
       }).compileComponents();
     });
@@ -141,7 +143,8 @@ describe('SiTranslatePipe', () => {
                 translate: (key: string, params: Record<string, any>) =>
                   `translated=>${key}-${JSON.stringify(params)}`
               }) as SiTranslateService
-          )
+          ),
+          provideZonelessChangeDetection()
         ]
       }).compileComponents();
     });
@@ -177,7 +180,8 @@ describe('SiTranslatePipe', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [TestComponent]
+        imports: [TestComponent],
+        providers: [provideZonelessChangeDetection()]
       }).compileComponents();
     });
 


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR makes the element-translate-ng package tests zoneless ready. Changes include:

1. **ESLint Configuration**: Added an override in `eslint.config.js` to disable the `@angular-eslint/no-developer-preview` rule for `*.spec.ts` files (with a TODO note for Angular 21 upgrade).

2. **Test Updates**: Modified test files by importing `provideZonelessChangeDetection` from `@angular/core` and adding it to TestBed provider configurations:
   - `si-translate-ngxt.spec.ts`
   - `si-translatable.spec.ts`
   - `si-translate.pipe.spec.ts`
   - `si-no-translate.spec.ts`

3. **Build Configuration**: Removed the `polyfills` entry (`["zone.js", "zone.js/testing"]`) from the test configuration in `angular.json`.

These changes enable the test suite to run with zoneless change detection enabled, aligning with Angular's modern performance optimization approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->