### PR TITLE
test(charts): make tests zoneless ready

### DIFF
--- a/projects/charts-ng/eslint.config.js
+++ b/projects/charts-ng/eslint.config.js
@@ -36,5 +36,12 @@ export default defineConfig(
       '@typescript-eslint/no-deprecated': ['warn']
     }
   },
+  // TODO: remove this once upgraded to Angular 21
+  {
+    files: ['**/*.spec.ts'],
+    rules: {
+      '@angular-eslint/no-developer-preview': ['off']
+    }
+  },
   ...templateConfig
 );

--- a/projects/charts-ng/src/components/si-chart-cartesian/si-chart-cartesian.component.spec.ts
+++ b/projects/charts-ng/src/components/si-chart-cartesian/si-chart-cartesian.component.spec.ts
@@ -2,7 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, SimpleChange, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  SimpleChange,
+  viewChild
+} from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { EChartOption } from '../../shared/echarts.model';
@@ -39,7 +45,8 @@ class TestHostComponent {
 describe('SiChartBarLineComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/charts-ng/src/components/si-chart-circle/si-chart-circle.component.spec.ts
+++ b/projects/charts-ng/src/components/si-chart-circle/si-chart-circle.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, SimpleChange, viewChild } from '@angular/core';
+import { Component, provideZonelessChangeDetection, SimpleChange, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { CircleChartSeries } from '../si-chart-circle/si-chart-circle.interface';
@@ -30,7 +30,8 @@ class TestHostComponent {
 describe('SiChartCircleComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/charts-ng/src/components/si-chart-gauge/si-chart-gauge.component.spec.ts
+++ b/projects/charts-ng/src/components/si-chart-gauge/si-chart-gauge.component.spec.ts
@@ -2,7 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, SimpleChange, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  SimpleChange,
+  viewChild
+} from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiChartGaugeComponent } from './si-chart-gauge.component';
@@ -31,7 +37,8 @@ class TestHostComponent {
 describe('SiChartGaugeComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/charts-ng/src/components/si-chart-loading-spinner/si-chart-loading-spinner.component.spec.ts
+++ b/projects/charts-ng/src/components/si-chart-loading-spinner/si-chart-loading-spinner.component.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiChartLoadingSpinnerComponent as TestComponent } from './si-chart-loading-spinner.component';
@@ -12,7 +13,8 @@ describe('SiLoadingSpinnerComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestComponent]
+      imports: [TestComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/charts-ng/src/components/si-chart-progress-bar/si-chart-progress-bar.component.spec.ts
+++ b/projects/charts-ng/src/components/si-chart-progress-bar/si-chart-progress-bar.component.spec.ts
@@ -2,7 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, SimpleChange, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  SimpleChange,
+  viewChild
+} from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiChartProgressBarComponent } from './si-chart-progress-bar.component';
@@ -31,7 +37,8 @@ class TestHostComponent {
 describe('SiChartProgressBarComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/charts-ng/src/components/si-chart-progress/si-chart-progress.component.spec.ts
+++ b/projects/charts-ng/src/components/si-chart-progress/si-chart-progress.component.spec.ts
@@ -2,7 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, SimpleChange, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  SimpleChange,
+  viewChild
+} from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiChartProgressComponent } from './si-chart-progress.component';
@@ -29,7 +35,8 @@ class TestHostComponent {
 describe('SiChartProgressComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/charts-ng/src/components/si-chart-sankey/si-chart-sankey.component.spec.ts
+++ b/projects/charts-ng/src/components/si-chart-sankey/si-chart-sankey.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, SimpleChange, viewChild } from '@angular/core';
+import { Component, provideZonelessChangeDetection, SimpleChange, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SankeySeriesOption } from '../../shared/echarts.model';
@@ -28,7 +28,8 @@ class TestHostComponent {
 describe('SiChartSankeyComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/charts-ng/src/components/si-chart-sunburst/si-chart-sunburst.component.spec.ts
+++ b/projects/charts-ng/src/components/si-chart-sunburst/si-chart-sunburst.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, SimpleChange, viewChild } from '@angular/core';
+import { Component, provideZonelessChangeDetection, SimpleChange, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SunburstSeriesOption } from '../../shared/echarts.model';
@@ -29,7 +29,8 @@ class TestHostComponent {
 describe('SiChartSunburstComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });
 

--- a/projects/charts-ng/src/components/si-chart/si-chart.component.spec.ts
+++ b/projects/charts-ng/src/components/si-chart/si-chart.component.spec.ts
@@ -2,8 +2,13 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  viewChild
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { echarts } from '../../shared/echarts.custom';
 import { EChartOption } from '../../shared/echarts.model';
@@ -22,11 +27,12 @@ describe('SiChart', () => {
   let component: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
@@ -34,9 +40,9 @@ describe('SiChart', () => {
   });
 
   describe('initialization', () => {
-    it('should create the chart component', waitForAsync(() => {
+    it('should create the chart component', () => {
       expect(component).toBeTruthy();
-    }));
+    });
   });
 
   describe('data handling', () => {

--- a/projects/charts-ng/src/components/si-custom-legend/si-custom-legend.component.spec.ts
+++ b/projects/charts-ng/src/components/si-custom-legend/si-custom-legend.component.spec.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiCustomLegendComponent } from './si-custom-legend.component';
 import { CustomLegend, CustomLegendItem } from './si-custom-legend.interface';
@@ -30,11 +30,12 @@ describe('SiCustomLegendComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let element: HTMLElement;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);


### PR DESCRIPTION

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the Angular charts test suite to be compatible with zoneless change detection. The changes include:

- **ESLint Configuration**: Added an override in `eslint.config.js` to disable the `@angular-eslint/no-developer-preview` rule for spec files
- **Test Setup Updates**: Added `provideZonelessChangeDetection()` from `@angular/core` to the TestBed providers across all component spec files (si-chart-cartesian, si-chart-circle, si-chart-gauge, si-chart-loading-spinner, si-chart-progress-bar, si-chart-progress, si-chart-sankey, si-chart-sunburst, si-chart, and si-custom-legend)
- **Async Pattern Updates**: Replaced `waitForAsync` with async/await patterns in test setup

These changes enable the tests to run with Angular's zoneless change detection strategy without modifying any component logic or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->