### PR TITLE
feat(chat-messages): allow asterisk lists and simple images for markdown renderer

### DIFF
--- a/projects/element-ng/markdown-renderer/markdown-renderer.ts
+++ b/projects/element-ng/markdown-renderer/markdown-renderer.ts
@@ -132,6 +132,17 @@ const transformMarkdownText = (
       return codePlaceholder;
     })
 
+    // Images ![alt](url)
+    .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt, url) => {
+      const sanitizedUrl = sanitizeUrl(url, sanitizer);
+      const escapedAlt = alt
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      return `<img src="${sanitizedUrl}" alt="${escapedAlt}">`;
+    })
+
     // Links [text](url)
     .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, text, url) => {
       const sanitizedUrl = sanitizeUrl(url, sanitizer);
@@ -156,7 +167,7 @@ const transformMarkdownText = (
     .replace(/_(.*?)_/g, '<em>$1</em>')
 
     .replace(new RegExp(escapedAsteriskPlaceholder, 'g'), '*')
-    .replace(new RegExp(escapedUnderscorePlaceholder, 'g'), '*')
+    .replace(new RegExp(escapedUnderscorePlaceholder, 'g'), '_')
 
     // Headings #, ##, ###, etc.
     .replace(/^###### (.*$)/gm, '<strong>$1</strong>')
@@ -170,6 +181,7 @@ const transformMarkdownText = (
     // Bullet points - handle each type separately (• gets converted to &#8226; by sanitizer)
     .replace(/^&#8226; (.*$)/gm, '<li class="unordered">$1</li>')
     .replace(/^- (.*$)/gm, '<li class="unordered">$1</li>')
+    .replace(/^\* (.*$)/gm, '<li class="unordered">$1</li>')
 
     // Ordered list items (1., 2., 3., etc.)
     .replace(/^\d+\. (.*$)/gm, '<li class="ordered">$1</li>');

--- a/projects/element-theme/src/styles/components/_markdown.scss
+++ b/projects/element-theme/src/styles/components/_markdown.scss
@@ -124,4 +124,14 @@
     overflow-wrap: break-word;
     word-break: break-word;
   }
+
+  img {
+    max-inline-size: 100%;
+    max-block-size: 400px;
+    block-size: auto;
+    inline-size: auto;
+    object-fit: contain;
+    display: block;
+    margin-block: map.get(variables.$spacers, 4);
+  }
 }


### PR DESCRIPTION
Adds some minor functionality to the markdown renderer

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds support for asterisk-based unordered lists and image rendering to the markdown renderer used in chat messages.

### Changes:

**markdown-renderer.ts**
- Added image markdown syntax support (`![alt](url)`) with URL sanitization, rendering responsive `<img>` tags
- Extended unordered list parsing to recognize asterisk-prefixed lines (`*`) as list items alongside existing dash (`-`) and bullet (`•`) formats
- Fixed underscore placeholder restoration to correctly restore underscores instead of asterisks

**_markdown.scss**
- Added image styling rules constraining images to `max-inline-size: 100%` and `max-block-size: 400px`
- Applied `object-fit: contain` with block-level display and consistent margin spacing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->