### PR TITLE
docs(ux-text-style-guide): use new dos and donts style everywhere

### DIFF
--- a/docs/_src/dos-and-donts.css
+++ b/docs/_src/dos-and-donts.css
@@ -64,6 +64,7 @@
   gap: 8px;
   margin-block-end: 18px;
   line-height: 1.4;
+  min-block-size: round(up, 1.4em, 1px);
   color: var(--md-footer-fg-color);
 }
 
@@ -73,8 +74,8 @@
 }
 
 /* Icons (Shared Base) */
-.dos li::before,
-.donts li::before {
+.dos li:not(:empty)::before,
+.donts li:not(:empty)::before {
   content: '';
   display: inline-block;
   flex-shrink: 0;
@@ -94,7 +95,7 @@
   border-block-start-color: var(--md-admonition-success-color);
 }
 
-.dos li::before {
+.dos li:not(:empty)::before {
   background-color: var(--md-admonition-success-color);
   -webkit-mask-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjU2IDY0QzE1MC4xMyA2NCA2NCAxNTAuMTMgNjQgMjU2czg2LjEzIDE5MiAxOTIgMTkyIDE5Mi04Ni4xMyAxOTItMTkyUzM2MS44NyA2NCAyNTYgNjRabTEwOC40OSAxMzEuNzRMMjI3IDMzMy4yNGExMiAxMiAwIDAgMS0xNyAwbC02Mi41LTYyLjVhMTIgMTIgMCAwIDEgMTctMTdsNTQgNTQgMTI5LTEyOWExMiAxMiAwIDAgMSAxNyAxN1oiPjwvcGF0aD48L3N2Zz4=');
   mask-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjU2IDY0QzE1MC4xMyA2NCA2NCAxNTAuMTMgNjQgMjU2czg2LjEzIDE5MiAxOTIgMTkyIDE5Mi04Ni4xMyAxOTItMTkyUzM2MS44NyA2NCAyNTYgNjRabTEwOC40OSAxMzEuNzRMMjI3IDMzMy4yNGExMiAxMiAwIDAgMS0xNyAwbC02Mi41LTYyLjVhMTIgMTIgMCAwIDEgMTctMTdsNTQgNTQgMTI5LTEyOWExMiAxMiAwIDAgMSAxNyAxN1oiPjwvcGF0aD48L3N2Zz4=');
@@ -105,7 +106,7 @@
   border-block-start-color: var(--md-admonition-failure-color);
 }
 
-.donts li::before {
+.donts li:not(:empty)::before {
   background-color: var(--md-admonition-failure-color);
   -webkit-mask-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjU2IDY0QzE1MC4xMyA2NCA2NCAxNTAuMTMgNjQgMjU2czg2LjEzIDE5MiAxOTIgMTkyIDE5Mi04Ni4xMyAxOTItMTkyUzM2MS44NyA2NCAyNTYgNjRabTEwNC40OSAyNzkuNTFhMTIgMTIgMCAwIDEtMTcgMTdMMjU2IDI3M2wtODcuNTEgODcuNTJhMTIgMTIgMCAwIDEtMTctMTdMMjM5IDI1NmwtODcuNTItODcuNTFhMTIgMTIgMCAwIDEgMTctMTdMMjU2IDIzOWw4Ny41MS04Ny41MmExMiAxMiAwIDAgMSAxNyAxN0wyNzMgMjU2WiI+PC9wYXRoPjwvc3ZnPg==');
   mask-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjU2IDY0QzE1MC4xMyA2NCA2NCAxNTAuMTMgNjQgMjU2czg2LjEzIDE5MiAxOTIgMTkyIDE5Mi04Ni4xMyAxOTItMTkyUzM2MS44NyA2NCAyNTYgNjRabTEwNC40OSAyNzkuNTFhMTIgMTIgMCAwIDEtMTcgMTdMMjU2IDI3M2wtODcuNTEgODcuNTJhMTIgMTIgMCAwIDEtMTctMTdMMjM5IDI1NmwtODcuNTItODcuNTFhMTIgMTIgMCAwIDEgMTctMTdMMjU2IDIzOWw4Ny41MS04Ny41MmExMiAxMiAwIDAgMSAxNyAxN0wyNzMgMjU2WiI+PC9wYXRoPjwvc3ZnPg==');

--- a/docs/fundamentals/ux-text-style-guide/basics.md
+++ b/docs/fundamentals/ux-text-style-guide/basics.md
@@ -21,7 +21,6 @@ writing errors to avoid when creating industrial products and experiences.
 - Use positive instead of negative framing
 - Avoid using contractions in general
 
-<!-- markdownlint-disable MD033 -->
 <div class="dos-and-donts" markdown>
 <div class="dos" markdown>
 
@@ -48,7 +47,6 @@ writing errors to avoid when creating industrial products and experiences.
 
 </div>
 </div>
-<!-- markdownlint-enable MD033 -->
 
 ## Length
 
@@ -66,33 +64,70 @@ writing errors to avoid when creating industrial products and experiences.
 - Capitalize proper nouns, i.e. places, organizations, tools, languages, products and things according the [proper nouns](proper-nouns.md) chapter
 - Capitalize named app functions and UI elements: Go to Settings, Allocate users in User management, Press OK
 
-| Dos                                                        | Don'ts                                                     |
-| ---------------------------------------------------------- | ---------------------------------------------------------- |
-| Go to Settings                                             | Go To Settings                                             |
-| Press OK                                                   | Press Ok                                                   |
-| Log in                                                     | LOG IN                                                     |
-| For more information, see Siemens Industry Online Support. | For more information, see Siemens industry online support. |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Go to Settings
+- Press OK
+- Log in
+- For more information, see Siemens Industry Online Support.
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Go To Settings
+- Press Ok
+- LOG IN
+- For more information, see Siemens industry online support.
+
+</div>
+</div>
 
 ## Common UX wording mistakes
 
 The following table contains frequently discovered UX writing mistakes.
 
-<!-- markdownlint-disable MD033 -->
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
 
-| Dos                                                                       | Don'ts                  |
-| ------------------------------------------------------------------------- | ----------------------- |
-| time zone                                                                 | timezone                |
-| log file                                                                  | logfile                 |
-| log in (as an action)                                                     | login                   |
-| login (as a noun)                                                         | log in                  |
-| equipment                                                                 | equipments              |
-| feedback                                                                  | feedbacks               |
-| training                                                                  | trainings               |
-| current<br>_Avoid misunderstandings with current (electricity)_           | actual                  |
-| present<br>_If misunderstandings with current (electricity) are possible_ | actual                  |
-| avoid "shall"                                                             | user shall manage users |
-| Siemens has                                                               | Siemens have            |
-| 34 million / 35 billion                                                   | 34 / 35                 |
-| 34 million                                                                | 34 millions             |
+#### Do's
 
-<!-- markdownlint-enable MD033 -->
+- time zone
+- log file
+- log in (as an action)
+- login (as a noun)
+- equipment
+- feedback
+- training
+- current<br>_Avoid misunderstandings with current (electricity)_
+- present<br>_If misunderstandings with current (electricity) are possible_
+- avoid "shall"
+- Siemens has
+- 34 million / 35 billion
+- 34 million
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- timezone
+- logfile
+- login
+- log in
+- equipments
+- feedbacks
+- trainings
+- actual
+- actual
+- user shall manage users
+- Siemens have
+- 34 / 35
+- 34 millions
+
+</div>
+</div>

--- a/docs/fundamentals/ux-text-style-guide/best-practices.md
+++ b/docs/fundamentals/ux-text-style-guide/best-practices.md
@@ -6,12 +6,28 @@
 - Do not use informal, transitional wording
 - Confirmation messages: Use the same verb as the transitional text
 
-| Dos                                 | Don'ts                               |
-| ----------------------------------- | ------------------------------------ |
-| Updating user roles...              | Getting ready...                     |
-| Submitting log files...             | Getting ready...                     |
-| Saving project... > Project saved   | Saving project... > Project uploaded |
-| Training models... > Models trained | Training models... > Training done   |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Updating user roles...
+- Submitting log files...
+- Saving project... > Project saved
+- Training models... > Models trained
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Getting ready...
+- Getting ready...
+- Saving project... > Project uploaded
+- Training models... > Training done
+
+</div>
+</div>
 
 ## Empty-state
 
@@ -22,12 +38,8 @@
 - Do not over communicate
 - Use wording to show users how to resolve the empty state, e.g. with an action, click, etc.
 
-<!-- markdownlint-disable MD033 -->
-
 | Dos                                                                                                        | Don'ts             |
 | ---------------------------------------------------------------------------------------------------------- | ------------------ |
 | _(Title)_ No users<br>_(Explanation)_ Add users to current site<br>_(Action)_ Add users                    | No allocated users |
 | _(Title)_ Nothing to display<br>_(Explanation)_ Select a project to see users<br>_(Action)_ Select project | No rows to show    |
 | _(Title)_ No projects<br>_(Explanation)_ Create a project to use the app<br>_(Action)_ Create project      | No projects saved  |
-
-<!-- markdownlint-enable MD033 -->

--- a/docs/fundamentals/ux-text-style-guide/dialogs-and-buttons.md
+++ b/docs/fundamentals/ux-text-style-guide/dialogs-and-buttons.md
@@ -12,26 +12,52 @@
 - Avoid using ‘Yes’ and ‘No’ as buttons, but instead use suitable verbs to make the action directly understandable
 - Only use ‘OK’ as an option if you cannot find an appropriate verb
 
-<!-- markdownlint-disable MD033 -->
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
 
-| Dos                                              | Don'ts                                         |
-| ------------------------------------------------ | ---------------------------------------------- |
-| Title: Add user<br>Buttons: Cancel, Add          | Title: Add user<br>Buttons: Cancel, OK         |
-| Title: Delete file<br>Buttons: Cancel, Delete    | Title: Are you sure<br>Buttons: Cancel, Delete |
-| Title: Edit details<br>Buttons: Cancel, Save     | Title: Edit details<br>Buttons: Cancel, Edit   |
-| Title: Unsaved changes<br>Buttons: Cancel, Save  | Title: Unsaved changes<br>Buttons: No, Yes     |
-| Title: Delete devices<br>Buttons: Cancel, Delete | Title: Delete items<br>Buttons: Cancel, Delete |
+#### Do's
 
-<!-- markdownlint-enable MD033 -->
+- Title: Add user<br>Buttons: Cancel, Add
+- Title: Delete file<br>Buttons: Cancel, Delete
+- Title: Edit details<br>Buttons: Cancel, Save
+- Title: Unsaved changes<br>Buttons: Cancel, Save
+- Title: Delete devices<br>Buttons: Cancel, Delete
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Title: Add user<br>Buttons: Cancel, OK
+- Title: Are you sure<br>Buttons: Cancel, Delete
+- Title: Edit details<br>Buttons: Cancel, Edit
+- Title: Unsaved changes<br>Buttons: No, Yes
+- Title: Delete items<br>Buttons: Cancel, Delete
+
+</div>
+</div>
 
 ## Primary and secondary actions
 
 - Primary on the right, secondary left (Cancel, OK) not (OK, Cancel)
 - Primary actions can either be positive (Send, Save) or negative (Delete)
 
-| Dos          | Don'ts       |
-| ------------ | ------------ |
-| Cancel, Save | Save, Cancel |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Cancel, Save
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Save, Cancel
+
+</div>
+</div>
 
 ## Clear content
 
@@ -42,13 +68,25 @@
 - Check whether a disclaimer can be prevented by a different interaction
 - Only use ‘this action’ in disclaimers
 
-<!-- markdownlint-disable MD033 -->
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
 
-| Dos                                | Don'ts                                                                 |
-| ---------------------------------- | ---------------------------------------------------------------------- |
-| Delete Wittelsbacherplatz München? | Do you really want to delete Wittelsbacherplatz München?               |
-| Delete Wittelsbacherplatz München? | Delete Building?                                                       |
-| Delete Wittelsbacherplatz München? | Delete Wittelsbacherplatz München?<br><br>This action cannot be undone |
-| Delete Wittelsbacherplatz München? | Delete Wittelsbacherplatz München permanently?                         |
+#### Do's
 
-<!-- markdownlint-enable MD033 -->
+- Delete Wittelsbacherplatz München?
+- Delete Wittelsbacherplatz München?
+- Delete Wittelsbacherplatz München?
+- Delete Wittelsbacherplatz München?
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Do you really want to delete Wittelsbacherplatz München?
+- Delete Building?
+- Delete Wittelsbacherplatz München?<br><br>This action cannot be undone
+- Delete Wittelsbacherplatz München permanently?
+
+</div>
+</div>

--- a/docs/fundamentals/ux-text-style-guide/error-messages.md
+++ b/docs/fundamentals/ux-text-style-guide/error-messages.md
@@ -22,34 +22,60 @@
 - An error message alerts user of a problem that exists and must be addressed
 - Avoid using `error` or `warning`, as these words are superfluous in most cases
 
-<!-- markdownlint-disable MD013 MD033 -->
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
 
-| Dos                                                                                        | Don'ts                                                                                                                       |
-| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| Form incomplete: Fill in all mandatory fields                                              | What did you do!?                                                                                                            |
-| _(Input field validation)_ Invalid email address                                           | The email address you entered does not match the required format. Please enter your email address using the standard format. |
-| Failed to delete device. Device still in use                                               | You have failed to delete the device.                                                                                        |
-| Insufficient access rights: No access rights to delete {{fileName}}. Contact administrator | Permission error: To carry out this task, you need more permissions. Contact admin to change permissions.                    |
-| Page not found: Check address                                                              | Error 404                                                                                                                    |
-| _(Input field validation)_ Max. 255<br>_(Input field validation)_ Min. 0                   | Value out of range.                                                                                                          |
-| No Internet connection: Check connection and try again                                     | System error: You’re offline. Check your connection and try again.                                                           |
-| Failed to upload file: Check source file and try again                                     | File error: We cannot upload this file. Try uploading again.                                                                 |
-| File not found: Check if file is moved                                                     | File not found.                                                                                                              |
-| _(Skip title)_                                                                             | _(Title)_ Input error                                                                                                        |
-| _(Input field validation)_ Max. 30 characters                                              | _(Explanation)_ Input error detected.                                                                                        |
-| _(Skip action)_                                                                            | _(Action)_ Try again.                                                                                                        |
+#### Do's
 
-<!-- markdownlint-enable MD013 MD033 -->
+- Form incomplete: Fill in all mandatory fields
+- _(Input field validation)_ Invalid email address
+- Failed to delete device. Device still in use
+- Insufficient access rights: No access rights to delete {{fileName}}. Contact administrator
+- Page not found: Check address
+- _(Input field validation)_ Max. 255<br>_(Input field validation)_ Min. 0
+- No Internet connection: Check connection and try again
+- Failed to upload file: Check source file and try again
+- File not found: Check if file is moved
+- _(Skip title)_
+- _(Input field validation)_ Max. 30 characters
+- _(Skip action)_
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- What did you do!?
+- The email address you entered does not match the required format. Please enter your email address using the standard format.
+- You have failed to delete the device.
+- Permission error: To carry out this task, you need more permissions. Contact admin to change permissions.
+- Error 404
+- Value out of range.
+- System error: You're offline. Check your connection and try again.
+- File error: We cannot upload this file. Try uploading again.
+- File not found.
+- _(Title)_ Input error
+- _(Explanation)_ Input error detected.
+- _(Action)_ Try again.
+
+</div>
+</div>
 
 ## Warning messages
 
 - A warning message alerts users of a condition that may cause a problem in the future
 
-| Dos                                                    |
-| ------------------------------------------------------ |
-| Title: Unsaved documents                               |
-| Explanation: Save all documents before leaving the app |
-| Action: Save all _(button)_                            |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Title: Unsaved documents
+- Explanation: Save all documents before leaving the app
+- Action: Save all _(button)_
+
+</div>
+</div>
 
 ## Notifications
 
@@ -57,8 +83,23 @@
 - Avoid using `success`, `successful`, or `successfully`, as these words are superfluous in most cases
 - Avoid using `information` as a title, as it does not provide an additional value to the user
 
-| Dos                         | Don'ts                                    |
-| --------------------------- | ----------------------------------------- |
-| Access point 2 connected    | Access point connection failed. Try again |
-| Changes saved automatically | No rows to show                           |
-| Email sent                  | Email sent successfully                   |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Access point 2 connected
+- Changes saved automatically
+- Email sent
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Access point connection failed. Try again
+- No rows to show
+- Email sent successfully
+
+</div>
+</div>

--- a/docs/fundamentals/ux-text-style-guide/frequent-app-functions.md
+++ b/docs/fundamentals/ux-text-style-guide/frequent-app-functions.md
@@ -4,8 +4,6 @@
 
 Many applications share common actions and associated icons. For example for actions triggered by buttons, action links or menu entries.
 
-<!-- markdownlint-disable MD013 MD033 -->
-
 | Action    | Icon                                          | Description                                                                                                                                                                                                                                  |
 | --------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Create    | <i class="icon-large element-plus"></i>       | Creates a new object or entity, which gets persisted on completion. For example, create a new user account. Use `Duplicate` when a user wants to start using an existing similar object.                                                     |
@@ -24,8 +22,6 @@ Many applications share common actions and associated icons. For example for act
 | Refresh   | <i class="icon-large element-refresh"></i>    | Reloads a view of an object, list, or data set.                                                                                                                                                                                              |
 | Close     | <i class="icon-large element-cancel"></i>     | Exits the current context (without saving) ([see Modals](../../components/layout-navigation/modals.md)).                                                                                                                                     |
 
-<!-- markdownlint-enable MD013 MD033 -->
-
 ### Best practices for actions
 
 - Assign the most important or likely action to the [primary button](../../components/buttons-menus/buttons.md), but use only one per screen
@@ -42,94 +38,191 @@ Many applications share common actions and associated icons. For example for act
 - Add goes hand in hand with Remove, it usually means it can be restored
 - Do not use Delete and Remove as synonym
 
-| Dos                                                    | Don'ts                             |
-| ------------------------------------------------------ | ---------------------------------- |
-| Create a chart and delete a chart                      | Create a chart and remove it       |
-| Add a sensor to a chart and remove a sensor from chart | Add a sensor and delete the sensor |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Create a chart and delete a chart
+- Add a sensor to a chart and remove a sensor from chart
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Create a chart and remove it
+- Add a sensor and delete the sensor
+
+</div>
+</div>
 
 ## Overview
 
-| Dos       |
-| --------- |
-| Dashboard |
-| Overview  |
-| Cockpit   |
-| Home      |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
 
-| Don'ts        |
-| ------------- |
-| Console       |
-| Dash          |
-| Control panel |
+#### Do's
+
+- Dashboard
+- Overview
+- Cockpit
+- Home
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Console
+- Dash
+- Control panel
+
+</div>
+</div>
 
 ## Analytics
 
-| Dos               |
-| ----------------- |
-| Analysis          |
-| Analysis          |
-| Anomaly detection |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
 
-| Don'ts      |
-| ----------- |
-| Assessment  |
-| Examination |
+#### Do's
+
+- Analysis
+- Analysis
+- Anomaly detection
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Assessment
+- Examination
+
+</div>
+</div>
 
 ## Detail view
 
-| Dos            | Don'ts    |
-| -------------- | --------- |
-| Details        | Facts     |
-| Details        | Specifics |
-| Device details |           |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Details
+- Details
+- Device details
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Facts
+- Specifics
+
+</div>
+</div>
 
 ### Device properties
 
-| Dos               |
-| ----------------- |
-| Product name      |
-| Tag               |
-| Manufacturer      |
-| Type              |
-| State             |
-| Article number    |
-| Serial number     |
-| Installation date |
-| HW version        |
-| FW version        |
-| SW version        |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Product name
+- Tag
+- Manufacturer
+- Type
+- State
+- Article number
+- Serial number
+- Installation date
+- HW version
+- FW version
+- SW version
+
+</div>
+</div>
 
 ## Upload
 
-| Dos                               | Don'ts                       |
-| --------------------------------- | ---------------------------- |
-| Drag a file here or select a file | Drag and drop here or browse |
-| Drag files here or select files   |                              |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Drag a file here or select a file
+- Drag files here or select files
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Drag and drop here or browse
+
+</div>
+</div>
 
 ## Comments
 
-| Dos                       | Don'ts          |
-| ------------------------- | --------------- |
-| Write comment             | Write a comment |
-| Write comment and approve |                 |
-| Write comment and reject  |                 |
-| Write your comments here  |                 |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Write comment
+- Write comment and approve
+- Write comment and reject
+- Write your comments here
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Write a comment
+
+</div>
+</div>
 
 ## Grid and list actions
 
-| Dos          | Don'ts |
-| ------------ | ------ |
-| Group        |        |
-| Sort         |        |
-| Filter       |        |
-| Edit columns |        |
-| Search by XY |        |
+<div class="dos" markdown>
+
+#### Do's
+
+- Group
+- Sort
+- Filter
+- Edit columns
+- Search by XY
+
+</div>
 
 ## Notifications
 
-| Dos                     | Don'ts  |
-| ----------------------- | ------- |
-| Events                  | Error   |
-| Notifications           | Issue   |
-| Anomalies               | Problem |
-| Notify me when X occurs |         |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Events
+- Notifications
+- Anomalies
+- Notify me when X occurs
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Error
+- Issue
+- Problem
+
+</div>
+</div>

--- a/docs/fundamentals/ux-text-style-guide/grammar-and-vocabulary.md
+++ b/docs/fundamentals/ux-text-style-guide/grammar-and-vocabulary.md
@@ -6,24 +6,51 @@
 - Use present participle tense with an ellipsis (…) at the end to describe an ongoing progress
 - Only use simple verb forms in the past or future when necessary
 
-| Dos                     | Don'ts                                           |
-| ----------------------- | ------------------------------------------------ |
-| click, browse, upload   | clicking, being clicked, was clicking            |
-| file loads, file loaded | file is going to be loaded, file has been loaded |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- click, browse, upload
+- file loads, file loaded
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- clicking, being clicked, was clicking
+- file is going to be loaded, file has been loaded
+
+</div>
+</div>
 
 ## Active voice
 
-<!-- markdownlint-disable MD033 -->
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
 
-| Dos                                                     | Don'ts                                 |
-| ------------------------------------------------------- | -------------------------------------- |
-| Configuration file opens<br>Opening configuration file… | The configuration file is opened.      |
-| Admin provides read-only access                         | Read-only access is provided by Admin. |
-| Measure performance                                     | Performance is measured.               |
-| Click Submit                                            | Submit is clicked by user.             |
-| Calculate the data<br>Calculating the data…             | The data is calculated by application. |
+#### Do's
 
-<!-- markdownlint-enable MD033 -->
+- Configuration file opens<br>Opening configuration file…
+- Admin provides read-only access
+- Measure performance
+- Click Submit
+- Calculate the data<br>Calculating the data…
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- The configuration file is opened.
+- Read-only access is provided by Admin.
+- Performance is measured.
+- Submit is clicked by user.
+- The data is calculated by application.
+
+</div>
+</div>
 
 ## UI terminology
 
@@ -31,10 +58,24 @@
 - Touchscreen gestures: tap, drag, flick, touch and hold, double-tap, swipe, pinch, spread
 - Basic terminology: checkbox, drop-down, field, icon, menu, link, radio button, window
 
-| Dos   | Don'ts     |
-| ----- | ---------- |
-| click | press      |
-| hover | mouse over |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- click
+- hover
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- press
+- mouse over
+
+</div>
+</div>
 
 ## Idioms and phrasal verbs
 
@@ -42,12 +83,28 @@
 - Avoid idiomatic expressions
 - Avoid cultural references
 
-| Dos           | Don'ts                          |
-| ------------- | ------------------------------- |
-| remove        | get rid of                      |
-| calculate     | add up                          |
-| retrieve data | fetch data                      |
-| mobile device | Apple, Android, iOS, smartphone |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- remove
+- calculate
+- retrieve data
+- mobile device
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- get rid of
+- add up
+- fetch data
+- Apple, Android, iOS, smartphone
+
+</div>
+</div>
 
 ## Jargon, buzz words and terms
 
@@ -63,14 +120,32 @@
 - No periods in abbreviations or acronyms
 - Never make up your own acronyms: <https://www.acronymfinder.com>
 
-| Dos                                 | Don'ts                             |
-| ----------------------------------- | ---------------------------------- |
-| light emitting diodes (LEDs)        | Light Emitting Diodes (LEDS)       |
-| APS                                 | A.P.S.                             |
-| EU                                  | E.U.                               |
-| I/O component, I/O list, I/O module | IO component, i/o list, I-O module |
-| min.                                | minimum                            |
-| max.                                | maximum                            |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- light emitting diodes (LEDs)
+- APS
+- EU
+- I/O component, I/O list, I/O module
+- min.
+- max.
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Light Emitting Diodes (LEDS)
+- A.P.S.
+- E.U.
+- IO component, i/o list, I-O module
+- minimum
+- maximum
+
+</div>
+</div>
 
 ## Time based vocabulary: Last, latest and recent
 
@@ -79,13 +154,25 @@
 - Recent is more time focused and is similar to latest. It means that it happened a short time ago.
 - Avoid the adjectives last, latest and recent if the verb relates to a time stamp (e.g., column header).
 
-<!-- markdownlint-disable MD033 -->
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
 
-| Dos                           | Don'ts                             |
-| ----------------------------- | ---------------------------------- |
-| Latest update                 | Last update                        |
-| Latest summary                | Last summary                       |
-| Recent events                 | Last events                        |
-| Saved<br>01.Jan 2025 08:32 am | Last saved<br>01.Jan 2025 08:32 am |
+#### Do's
 
-<!-- markdownlint-enable MD033 -->
+- Latest update
+- Latest summary
+- Recent events
+- Saved<br>01.Jan 2025 08:32 am
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- Last update
+- Last summary
+- Last events
+- Last saved<br>01.Jan 2025 08:32 am
+
+</div>
+</div>

--- a/docs/fundamentals/ux-text-style-guide/main-menu-functions.md
+++ b/docs/fundamentals/ux-text-style-guide/main-menu-functions.md
@@ -2,29 +2,68 @@
 
 ## Welcome page
 
-| Dos                | Don'ts                              |
-| ------------------ | ----------------------------------- |
-| User name or email |                                     |
-| Log in / Sign up   | Sign in / Sign up                   |
-| Log in             | Login (as it is a noun, not a verb) |
-| Forgot password?   |                                     |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- User name or email
+- Log in / Sign up
+- Log in
+- Forgot password?
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- <!-- Skip -->
+- Sign in / Sign up
+- Login (as it is a noun, not a verb)
+
+</div>
+</div>
 
 ## User management
 
-| Dos                                                     | Don'ts                                      |
-| ------------------------------------------------------- | ------------------------------------------- |
-| Username                                                |                                             |
-| Profile / User profile                                  |                                             |
-| Account / My account                                    |                                             |
-| ID                                                      | id / identification                         |
-| Email address                                           | E-mail                                      |
-| Last name                                               | Surname                                     |
-| First name                                              | Initial name / Given name                   |
-| Add user / Delete user                                  | Add a user / Delete a user / Add permission |
-| Add permissions / Revoke permissions / Edit permissions |                                             |
-| Edit account                                            |                                             |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Username
+- Profile / User profile
+- Account / My account
+- ID
+- Email address
+- Last name
+- First name
+- Add user / Delete user
+- Add permissions / Revoke permissions / Edit permissions
+- Edit account
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- <!-- Skip -->
+- <!-- Skip -->
+- <!-- Skip -->
+- id / identification
+- E-mail
+- Surname
+- Initial name / Given name
+- Add a user / Delete a user / Add permission
+
+</div>
+</div>
 
 ## Password
+
+<div class="dos" markdown>
+
+#### Do's
 
 - Change password
 - Current password
@@ -32,57 +71,129 @@
 - Confirm password
 - Confirm new password
 
+</div>
+
 ## License management
+
+<div class="dos" markdown>
+
+#### Do's
 
 - Used licenses
 - Free licenses
 - Available licenses
 
+</div>
+
 ## License status
 
-| Dos                         | Don'ts  |
-| --------------------------- | ------- |
-| License                     | licence |
-| License start / License end |         |
-| Purchased licenses          |         |
-| License type                |         |
-| Activated licenses          |         |
-| Used licenses               |         |
-| Expired licenses            |         |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- License
+- License start / License end
+- Purchased licenses
+- License type
+- Activated licenses
+- Used licenses
+- Expired licenses
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- licence
+
+</div>
+</div>
 
 ## Subscription status
 
-| Dos                                | Don'ts  |
-| ---------------------------------- | ------- |
-| Subscription                       | License |
-| Activate subscription              |         |
-| Deactivate subscription            |         |
-| Available subscriptions            |         |
-| Subscription type                  |         |
-| Active subscriptions               |         |
-| Subscription expires on `{{date}}` |         |
-| Expired subscriptions              |         |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Subscription
+- Activate subscription
+- Deactivate subscription
+- Available subscriptions
+- Subscription type
+- Active subscriptions
+- Subscription expires on `{{date}}`
+- Expired subscriptions
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- License
+
+</div>
+</div>
 
 ## Service & Support
 
-| Dos                                     | Don'ts        |
-| --------------------------------------- | ------------- |
-| Contact support: <support@mail.com>     |               |
-| Feedback: What do you think of our app? |               |
-| Manual                                  | Documentation |
-| User guide                              | User manual   |
-| FAQ                                     |               |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Contact support: <support@mail.com>
+- Feedback: What do you think of our app?
+- Manual
+- User guide
+- FAQ
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- <!-- Skip -->
+- <!-- Skip -->
+- Documentation
+- User manual
+
+</div>
+</div>
 
 ## Workspace
 
-| Dos                | Don'ts         |
-| ------------------ | -------------- |
-| Application status |                |
-| KPI settings       | KPI's settings |
-| KPI settings       | KPIS settings  |
-| KPIs               | KPI's          |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- Application status
+- KPI settings
+- KPI settings
+- KPIs
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- <!-- Skip -->
+- KPI's settings
+- KPIS settings
+- KPI's
+
+</div>
+</div>
 
 ## Resetting
 
+<div class="dos" markdown>
+
+#### Do's
+
 - Factory reset
-- Reseting may take a while
+- Resetting may take a while
+
+</div>

--- a/docs/fundamentals/ux-text-style-guide/punctuation.md
+++ b/docs/fundamentals/ux-text-style-guide/punctuation.md
@@ -68,13 +68,30 @@ Use internalization libraries to reuse common standards if applicable.
 - Hyphen for ranges: 10-40%
 - Numbers: Use No. as an abbreviation for number, no spacing between abbreviated No. and number: No.8
 
-| Dos      | Don'ts |
-| -------- | ------ |
-| 30 mm    | 30 mms |
-| 10 oz    | 10 oz. |
-| 10-40%   | 10–40% |
-| No.7     | #7     |
-| Number 7 | Num 7  |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- 30 mm
+- 10 oz
+- 10-40%
+- No.7
+- Number 7
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- 30 mms
+- 10 oz.
+- 10–40%
+- \#7
+- Num 7
+
+</div>
+</div>
 
 ## Spacing
 
@@ -85,12 +102,28 @@ Use internalization libraries to reuse common standards if applicable.
 - No space before and after hyphens and em dashes
 - Add a space before unit of measurement
 
-| Dos              | Don'ts          |
-| ---------------- | --------------- |
-| 50%              | 50 %            |
-| 11am             | 11 am           |
-| Tuesday: no data | Tuesday:no data |
-| Calculating…     | Calculating …   |
+<div class="dos-and-donts" markdown>
+<div class="dos" markdown>
+
+#### Do's
+
+- 50%
+- 11am
+- Tuesday: no data
+- Calculating…
+
+</div>
+<div class="donts" markdown>
+
+#### Don'ts
+
+- 50 %
+- 11 am
+- Tuesday:no data
+- Calculating …
+
+</div>
+</div>
 
 ## Lists
 


### PR DESCRIPTION
Uses the new style everywhere

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR applies the new HTML-based "dos and donts" styling consistently across the UX Text Style Guide documentation.

**Documentation Changes:**
- Replaces all Markdown table-based Do's/Don'ts sections with HTML div blocks (`<div class="dos-and-donts">`) containing nested `<div class="dos">` and `<div class="donts">` sections across 8 documentation files (basics, best-practices, dialogs-and-buttons, error-messages, frequent-app-functions, grammar-and-vocabulary, main-menu-functions, and punctuation)
- Removes markdownlint disable/enable comments (MD033) to ease copy & paste between Element and iX

**CSS Changes:**
- Updates `dos-and-donts.css` to render icons only for non-empty list items using the `:not(:empty)` pseudo-selector on `.dos li` and `.donts li` elements
- Adds `min-block-size: round(up, 1.4em, 1px)` to `.dos li` for consistent item height

**Impact:**
- Documentation presentation is updated to use the new HTML-based style guide format consistently
- All Do's/Don'ts content remains semantically identical; only the markup structure changes from tables to HTML blocks
- Note: Flex layout used in the new structure causes a minor visual layout adjustment compared to the previous table-based rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->