### PR TITLE
fix(charts/cartesian): confine tooltip for cartesian

### DIFF
--- a/projects/charts-ng/src/components/si-chart-cartesian/si-chart-cartesian.component.ts
+++ b/projects/charts-ng/src/components/si-chart-cartesian/si-chart-cartesian.component.ts
@@ -184,7 +184,8 @@ export class SiChartCartesianComponent extends SiChartComponent implements OnCha
         }
       ],
       tooltip: {
-        trigger: 'axis'
+        trigger: 'axis',
+        confine: true
       }
     };
     const tooltipFormatter = this.tooltipFormatter();


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds `confine: true` to the tooltip configuration in the cartesian chart component. This change constrains the tooltip within the chart boundaries while maintaining its axis-triggered behavior, preventing it from being cut off when displayed near the edges of the chart area.

**Key Change:**
- Modified `tooltip` object in `si-chart-cartesian.component.ts` to include `confine: true` alongside the existing `trigger: 'axis'` setting

**Impact:** Improves tooltip visibility and usability in cartesian charts by ensuring tooltips remain fully visible within the chart container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->