### PR TITLE
refactor(charts): mark fields readonly

### DIFF
--- a/projects/charts-ng/src/components/si-chart-gauge/si-chart-gauge.component.ts
+++ b/projects/charts-ng/src/components/si-chart-gauge/si-chart-gauge.component.ts
@@ -225,7 +225,7 @@ export class SiChartGaugeComponent extends SiChartComponent implements OnChanges
     return value;
   }
 
-  private axisLabelFormatter = (value: any): string => {
+  private readonly axisLabelFormatter = (value: any): string => {
     const formatted = this.axisNumberFormat().format(Number(value));
     return this.unitsOnSplit() ? `${formatted} ${this.unit()}` : formatted;
   };

--- a/projects/charts-ng/src/components/si-chart-progress-bar/si-chart-progress-bar.component.ts
+++ b/projects/charts-ng/src/components/si-chart-progress-bar/si-chart-progress-bar.component.ts
@@ -35,7 +35,7 @@ export class SiChartProgressBarComponent extends SiChartComponent {
     }
   };
 
-  private formatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
+  private readonly formatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
   private labelPositionOption: BarSeriesOption['label'];
   private labelPositionOptionForValue: BarSeriesOption['label'];
 

--- a/projects/charts-ng/src/components/si-chart/si-chart.component.ts
+++ b/projects/charts-ng/src/components/si-chart/si-chart.component.ts
@@ -280,6 +280,7 @@ export class SiChartComponent implements AfterViewInit, OnChanges, OnInit, OnDes
   private requestedDataZoom?: DataZoomRange;
   private measureCanvas?: CanvasRenderingContext2D;
   private readonly cdRef = inject(ChangeDetectorRef);
+  private readonly ngZone = inject(NgZone);
 
   protected curWidth = 0;
   protected curHeight = 0;
@@ -309,13 +310,13 @@ export class SiChartComponent implements AfterViewInit, OnChanges, OnInit, OnDes
     series: [{ type: 'line', showSymbol: false, lineStyle: { opacity: 0 }, data: [] }]
   };
 
-  private echartMouseDown = (): void => this.handleChartMouseDown();
-  private echartMouseUp = (event: MouseEvent): void => this.handleChartMouseUp(event);
+  private readonly echartMouseDown = (): void => this.handleChartMouseDown();
+  private readonly echartMouseUp = (event: MouseEvent): void => this.handleChartMouseUp(event);
 
-  private echartExtSliderMouseDown = (): void => this.handleExtChartMouseDown();
-  private echartExtSliderMouseUp = (event: MouseEvent): void => this.handleExtChartMouseUp(event);
+  private readonly echartExtSliderMouseDown = (): void => this.handleExtChartMouseDown();
+  private readonly echartExtSliderMouseUp = (event: MouseEvent): void =>
+    this.handleExtChartMouseUp(event);
 
-  private readonly ngZone = inject(NgZone);
   protected readonly shapePaths: Record<string, string> = {
     circle: 'M6 0A6 6 0 1 1 6 12A6 6 0 1 1 6 0Z',
     rect: 'M0 0H12V12H0Z',


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This refactor marks multiple fields as `readonly` across three chart components to improve immutability and type safety:

- **si-chart-gauge.component.ts**: Made `axisLabelFormatter` property readonly
- **si-chart-progress-bar.component.ts**: Made `formatter` field readonly
- **si-chart.component.ts**: 
  - Added `NgZone` injection as a private readonly field
  - Made four chart interaction handlers readonly: `echartMouseDown`, `echartMouseUp`, `echartExtSliderMouseDown`, `echartExtSliderMouseUp`

No behavioral changes or modifications to control flow; purely typing and immutability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->