### PR TITLE
test(element): make tests zoneless ready

### DIFF
--- a/projects/element-ng/dashboard/si-dashboard-card.component.spec.ts
+++ b/projects/element-ng/dashboard/si-dashboard-card.component.spec.ts
@@ -2,7 +2,12 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  viewChild
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
@@ -36,7 +41,8 @@ describe('SiDashboardCardComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [RouterModule, NoopAnimationsModule, TestHostComponent]
+      imports: [RouterModule, NoopAnimationsModule, TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/element-ng/dashboard/si-dashboard.component.spec.ts
+++ b/projects/element-ng/dashboard/si-dashboard.component.spec.ts
@@ -8,6 +8,7 @@ import {
   ChangeDetectorRef,
   Component,
   inject,
+  provideZonelessChangeDetection,
   signal,
   viewChild,
   viewChildren
@@ -81,7 +82,8 @@ describe('SiDashboardComponent', () => {
         {
           provide: ResizeObserverService,
           useValue: resizeSpy
-        }
+        },
+        provideZonelessChangeDetection()
       ]
     }).compileComponents();
   });

--- a/projects/element-ng/dashboard/si-dashboard.service.spec.ts
+++ b/projects/element-ng/dashboard/si-dashboard.service.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiDashboardCardComponent } from './si-dashboard-card.component';
@@ -12,7 +13,7 @@ describe('SiDashboardService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [{ provide: TestService }]
+      providers: [{ provide: TestService }, provideZonelessChangeDetection()]
     }).compileComponents();
     service = TestBed.inject(TestService);
   });

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-item.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiListWidgetItem, SiListWidgetItemComponent } from './si-list-widget-item.component';
@@ -23,7 +23,8 @@ describe('SiListWidgetItemComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-body.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-body.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiTimelineWidgetBodyComponent } from './si-timeline-widget-body.component';
@@ -32,7 +32,8 @@ describe('SiTimelineWidgetBodyComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {
@@ -27,7 +27,8 @@ describe('SiTimelineWidgetItemComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiTimelineWidgetItem } from './si-timeline-widget-item.component';
@@ -32,7 +32,8 @@ describe('SiTimelineWidgetComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/element-ng/dashboard/widgets/si-value-widget.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-value-widget.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ContentActionBarMainItem } from '@siemens/element-ng/content-action-bar';
 import { MenuItem } from '@siemens/element-ng/menu';
@@ -39,7 +39,8 @@ describe('SiValueWidgetComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestHostComponent]
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Make tests zoneless ready

Updates 8 Angular component test files in the dashboard module to support zoneless change detection by:
- Importing `provideZonelessChangeDetection` from `@angular/core`
- Registering it as a provider in each test's `TestBed.configureTestingModule` configuration

This change prepares the test suite for Angular's zoneless change detection without modifying component logic or public APIs. All updates are isolated to test scaffolding across the following files:
- `si-dashboard-card.component.spec.ts`
- `si-dashboard.component.spec.ts`
- `si-dashboard.service.spec.ts`
- `si-list-widget-item.component.spec.ts`
- `si-timeline-widget-body.component.spec.ts`
- `si-timeline-widget-item.component.spec.ts`
- `si-timeline-widget.component.spec.ts`
- `si-value-widget.component.spec.ts`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->