### PR TITLE
docs(icons): remove outdated information

### DIFF
--- a/docs/fundamentals/icons.md
+++ b/docs/fundamentals/icons.md
@@ -79,10 +79,7 @@ classes such size and color can be used. The CSS class `icon` applies the defaul
 icon size.
 
 There is also a specific [si-icon](../components/status-notifications/icon.md)
-component, which can be used to show icons. It includes a fallback alternative
-text to make icons more accessible.
-
-Some symbols require overlapping of two icons, which is also supported by the
-[si-icon](../components/status-notifications/icon.md) component.
+component, which can be used to show icons. It supports stacking of icons to build
+compositions and also supports SVG-based icons.
 
 <si-docs-component example="icons/icons"></si-docs-component>


### PR DESCRIPTION
Remove the outdated info about a11y handling and make it more concise.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Removes outdated accessibility information from the icons documentation. Replaces references to fallback alternative text and overlapping icon usage with a more concise description stating that the si-icon component supports stacking of icons for compositions and SVG-based icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->