### PR TITLE
test(popover): handle flaky test with jasmine clock

### DIFF
--- a/projects/element-ng/popover/si-popover.directive.spec.ts
+++ b/projects/element-ng/popover/si-popover.directive.spec.ts
@@ -140,6 +140,7 @@ describe('SiPopoverNextDirective', () => {
   });
 
   it('should focus on the popover wrapper', async () => {
+    jasmine.clock().install();
     fixture.detectChanges();
 
     fixture.nativeElement.querySelector('button').click();
@@ -149,9 +150,12 @@ describe('SiPopoverNextDirective', () => {
     expect(popover).toBeTruthy();
     expect(popover.innerHTML).toContain('test popover content');
 
-    await new Promise(r => setTimeout(r, 10)); // wait for focus to settle
+    jasmine.clock().tick(10);
+    await fixture.whenStable();
 
     expect(document.activeElement).toBe(document.querySelector('.popover'));
+
+    jasmine.clock().uninstall();
   });
 });
 


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Replaces Jasmine's fake clock with a native Promise/setTimeout pattern in the "should focus on the popover wrapper" test. The change removes explicit clock installation, ticking, and uninstallation, replacing them with a simple 10ms async wait using `new Promise(r => setTimeout(r, 10))`. This simplifies timing synchronization while maintaining the same focus settlement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->