### PR TITLE
fix(loading-spinner): should work in zoneless environment

### DIFF
--- a/projects/element-ng/loading-spinner/si-loading-spinner.component.spec.ts
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef } from '@angular/core';
+import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -14,7 +14,8 @@ describe('SiLoadingSpinnerComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestComponent, NoopAnimationsModule]
+      imports: [TestComponent, NoopAnimationsModule],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 

--- a/projects/element-ng/loading-spinner/si-loading-spinner.directive.ts
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.directive.ts
@@ -5,6 +5,7 @@
 import { ComponentPortal, DomPortalOutlet } from '@angular/cdk/portal';
 import {
   booleanAttribute,
+  ChangeDetectorRef,
   computed,
   Directive,
   ElementRef,
@@ -52,6 +53,7 @@ export class SiLoadingSpinnerDirective implements OnInit, OnChanges, OnDestroy {
 
   private el = inject(ElementRef);
   private readonly viewRef = inject(ViewContainerRef);
+  private cdRef = inject(ChangeDetectorRef);
 
   private sub?: Subscription;
   private progressSubject = new BehaviorSubject(false);
@@ -104,6 +106,7 @@ export class SiLoadingSpinnerDirective implements OnInit, OnChanges, OnDestroy {
       } else if (this.compPortal.isAttached) {
         this.compPortal.detach();
       }
+      this.cdRef.markForCheck();
     });
   }
 


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## fix(loading-spinner): zoneless environment support

Enables the loading-spinner component and directive to work with Angular's zoneless change detection by:

- **Directive** (`si-loading-spinner.directive.ts`): Injects `ChangeDetectorRef` and calls `markForCheck()` after spinner state changes to manually trigger change detection with OnPush strategy in zoneless mode

- **Component tests** (`si-loading-spinner.component.spec.ts`): Adds `provideZonelessChangeDetection()` to TestBed configuration

- **Directive tests** (`si-loading-spinner.directive.spec.ts`): 
  - Configures TestBed with `provideZonelessChangeDetection()`
  - Refactors from `fakeAsync`/`waitForAsync` to async/await pattern with `fixture.whenStable()`
  - Replaces `tick()` with `jasmine.clock()` for timer control
  - Adds `markForCheck()` calls for state changes to ensure DOM updates in zoneless mode
<!-- end of auto-generated comment: release notes by coderabbit.ai -->