### PR TITLE
test(element): make tests zoneless ready

### DIFF
--- a/projects/element-ng/breadcrumb-router/si-breadcrumb-default-resolver.service.spec.ts
+++ b/projects/element-ng/breadcrumb-router/si-breadcrumb-default-resolver.service.spec.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { inject, TestBed } from '@angular/core/testing';
 import { UrlSegment } from '@angular/router';
 import { BreadcrumbItem } from '@siemens/element-ng/breadcrumb';
@@ -20,7 +21,11 @@ interface FakeActivatedRouteSnapshot {
 describe('BreadcrumbDefaultResolverService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [SiBreadcrumbDefaultResolverService, provideHttpClientTesting()]
+      providers: [
+        SiBreadcrumbDefaultResolverService,
+        provideHttpClientTesting(),
+        provideZonelessChangeDetection()
+      ]
     });
   });
 

--- a/projects/element-ng/content-action-bar/si-content-action-bar.component.spec.ts
+++ b/projects/element-ng/content-action-bar/si-content-action-bar.component.spec.ts
@@ -4,8 +4,8 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { booleanAttribute, Component, Input } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { booleanAttribute, Component, Input, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { MenuItem } from '@siemens/element-ng/menu';
@@ -42,12 +42,12 @@ describe('SiContentActionBarComponent', () => {
   let loader: HarnessLoader;
   let harness: SiContentActionBarHarness;
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, TestComponent],
-      providers: [provideRouter([])]
+      providers: [provideRouter([]), provideZonelessChangeDetection()]
     }).compileComponents();
-  }));
+  });
 
   beforeEach(async () => {
     fixture = TestBed.createComponent(TestComponent);
@@ -63,7 +63,8 @@ describe('SiContentActionBarComponent', () => {
       { type: 'group', label: 'Save', children: [] },
       { type: 'action', label: 'Delete', action: () => alert('Delete') }
     ];
-
+    fixture.changeDetectorRef.markForCheck();
+    await fixture.whenStable();
     expect(await harness.getPrimaryActionTexts()).toEqual(['Create', 'Route me', 'Save', 'Delete']);
   });
 
@@ -80,6 +81,8 @@ describe('SiContentActionBarComponent', () => {
         ]
       }
     ];
+    fixture.changeDetectorRef.markForCheck();
+    await fixture.whenStable();
 
     await harness.toggleSecondary();
     const secondaryMenu = await harness.getSecondaryMenu();
@@ -108,9 +111,14 @@ describe('SiContentActionBarComponent', () => {
         ]
       }
     ];
+    fixture.changeDetectorRef.markForCheck();
+    await fixture.whenStable();
 
+    // cannot use jasmine.clock here
+    await new Promise(resolve => setTimeout(resolve, 50));
     expect(await harness.isPrimaryExpanded()).toBeFalse();
     await harness.togglePrimary();
+    await fixture.whenStable();
     expect(await harness.isPrimaryExpanded()).toBeTrue();
   });
 
@@ -119,6 +127,8 @@ describe('SiContentActionBarComponent', () => {
     component.primaryActions = [
       { type: 'action', label: 'Item', disabled: true, action: () => {} }
     ];
+    fixture.changeDetectorRef.markForCheck();
+    await fixture.whenStable();
 
     expect(await harness.getPrimaryAction('Item').then(item => item.isDisabled())).toBeTrue();
   });
@@ -127,7 +137,8 @@ describe('SiContentActionBarComponent', () => {
     const actionSpy = jasmine.createSpy('clickSpy');
     component.viewType = 'expanded';
     component.primaryActions = [{ type: 'action', label: 'Item', action: actionSpy }];
-
+    fixture.changeDetectorRef.markForCheck();
+    await fixture.whenStable();
     await harness.getPrimaryAction('Item').then(item => item.click());
     expect(actionSpy).toHaveBeenCalled();
   });
@@ -138,7 +149,8 @@ describe('SiContentActionBarComponent', () => {
         { type: 'action', label: 'primaryItem', icon: 'element-user', action: () => {} }
       ];
       component.preventIconsInDropdownMenus = true;
-
+      fixture.changeDetectorRef.markForCheck();
+      await fixture.whenStable();
       expect(
         await harness.getPrimaryAction('primaryItem').then(item => item.hasIcon('element-user'))
       ).toBeTrue();
@@ -149,6 +161,8 @@ describe('SiContentActionBarComponent', () => {
         { type: 'action', label: 'primaryItem', icon: 'element-user', action: () => {} }
       ];
       component.viewType = 'mobile';
+      fixture.changeDetectorRef.markForCheck();
+      await fixture.whenStable();
 
       await harness.toggleMobile();
       expect(
@@ -165,6 +179,8 @@ describe('SiContentActionBarComponent', () => {
       ];
       component.viewType = 'mobile';
       component.preventIconsInDropdownMenus = true;
+      fixture.changeDetectorRef.markForCheck();
+      await fixture.whenStable();
 
       await harness.toggleMobile();
       expect(
@@ -183,6 +199,8 @@ describe('SiContentActionBarComponent', () => {
       component.secondaryActions = [
         { type: 'action', label: 'secondaryItem', icon: 'element-copy', action: () => {} }
       ];
+      fixture.changeDetectorRef.markForCheck();
+      await fixture.whenStable();
 
       await harness.toggleSecondary();
       expect(
@@ -203,6 +221,8 @@ describe('SiContentActionBarComponent', () => {
       ];
       component.preventIconsInDropdownMenus = true;
 
+      fixture.changeDetectorRef.markForCheck();
+      await fixture.whenStable();
       await harness.toggleMobile();
       expect(
         await harness
@@ -217,8 +237,12 @@ describe('SiContentActionBarComponent', () => {
     component.primaryActions = [
       { type: 'action', label: 'primaryItem', icon: 'element-user', action: () => {} }
     ];
+    fixture.changeDetectorRef.markForCheck();
+    await fixture.whenStable();
     expect(await harness.isMobile()).toBeFalse();
     component.primaryActions = [];
+    fixture.changeDetectorRef.markForCheck();
+    await fixture.whenStable();
     expect(await harness.isMobile()).toBeTrue();
   });
 });

--- a/projects/element-ng/datepicker/si-date-input.directive.spec.ts
+++ b/projects/element-ng/datepicker/si-date-input.directive.spec.ts
@@ -2,8 +2,15 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ElementRef, signal, viewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  provideZonelessChangeDetection,
+  signal,
+  viewChild
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl } from '@angular/forms';
 
 import { dispatchEvents, enterValue } from './components/test-helper.spec';
@@ -56,7 +63,8 @@ describe('SiDateInputDirective', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [WrapperComponent]
+      imports: [WrapperComponent],
+      providers: [provideZonelessChangeDetection()]
     })
   );
 
@@ -105,7 +113,8 @@ describe('SiDateInputDirective', () => {
     expect(component.siDateInput().nativeElement.value).toBe('3/12/2022, 5:30:20 AM');
   });
 
-  it('should consider minDate criteria with time', fakeAsync(() => {
+  it('should consider minDate criteria with time', async () => {
+    jasmine.clock().install();
     spyOn(component.siDateInputDirective(), 'validate').and.callThrough();
     component.date = new Date('2020-03-12T13:13:13');
     updateConfig({
@@ -115,16 +124,18 @@ describe('SiDateInputDirective', () => {
     });
     dispatchEvents(dateInput(), ['focus', 'change']);
 
-    tick();
+    jasmine.clock().tick(1);
+    await fixture.whenStable();
 
     expect(component.validation().errors?.minDate).toEqual({
       actual: component.date,
       min: component.config().minDate
     });
-    flush();
-  }));
+    jasmine.clock().uninstall();
+  });
 
-  it('should consider minDate criteria only date', fakeAsync(() => {
+  it('should consider minDate criteria only date', async () => {
+    jasmine.clock().install();
     spyOn(component.siDateInputDirective(), 'validate').and.callThrough();
     component.date = new Date('2020-03-12');
     updateConfig({
@@ -134,16 +145,18 @@ describe('SiDateInputDirective', () => {
     });
     dispatchEvents(dateInput(), ['focus', 'change']);
 
-    tick();
+    jasmine.clock().tick(1);
+    await fixture.whenStable();
 
     expect(component.validation().errors?.minDate).toEqual({
       actual: component.date,
       min: component.config().minDate
     });
-    flush();
-  }));
+    jasmine.clock().uninstall();
+  });
 
-  it('should consider maxDate criteria with time', fakeAsync(() => {
+  it('should consider maxDate criteria with time', async () => {
+    jasmine.clock().install();
     spyOn(component.siDateInputDirective(), 'validate').and.callThrough();
     component.date = new Date('2024-03-12T13:13:13');
     updateConfig({
@@ -153,15 +166,17 @@ describe('SiDateInputDirective', () => {
     });
     dispatchEvents(dateInput(), ['focus', 'change']);
 
-    tick();
+    jasmine.clock().tick(1);
+    await fixture.whenStable();
     expect(component.validation().errors?.maxDate).toEqual({
       actual: component.date,
       max: component.config().maxDate
     });
-    flush();
-  }));
+    jasmine.clock().uninstall();
+  });
 
-  it('should consider maxDate criteria only date', fakeAsync(() => {
+  it('should consider maxDate criteria only date', async () => {
+    jasmine.clock().install();
     spyOn(component.siDateInputDirective(), 'validate').and.callThrough();
     component.date = new Date('2024-03-12');
     updateConfig({
@@ -171,22 +186,23 @@ describe('SiDateInputDirective', () => {
     });
     dispatchEvents(dateInput(), ['focus', 'change']);
 
-    tick();
+    jasmine.clock().tick(1);
+    await fixture.whenStable();
     expect(component.validation().errors?.maxDate).toEqual({
       actual: component.date,
       max: component.config().maxDate
     });
-    flush();
-  }));
+    jasmine.clock().uninstall();
+  });
 
-  it('should disable input element when setting disabled property to true', fakeAsync(() => {
+  it('should disable input element when setting disabled property to true', () => {
     expect(component.siDateInputDirective().disabled()).toBe(false);
     expect(dateInput().disabled).toBe(false);
 
     component.disabled.set(true);
     fixture.detectChanges();
     expect(dateInput().disabled).toBe(true);
-  }));
+  });
 
   it('should trigger modelChange with undefined when input is blank string', async () => {
     // In case user remove the date string this should be reflected in the datepicker

--- a/projects/element-ng/localization/si-locale-id.spec.ts
+++ b/projects/element-ng/localization/si-locale-id.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { LOCALE_ID } from '@angular/core';
+import { LOCALE_ID, provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiLocaleId } from './si-locale-id';
@@ -20,7 +20,8 @@ describe('SiLocaleId', () => {
     TestBed.configureTestingModule({
       providers: [
         { provide: LOCALE_ID, useClass: SiLocaleId, deps: [SiLocaleService] },
-        { provide: SiLocaleService, useClass: SiLocaleServiceMock }
+        { provide: SiLocaleService, useClass: SiLocaleServiceMock },
+        provideZonelessChangeDetection()
       ]
     });
     localeId = TestBed.inject(LOCALE_ID).toString();

--- a/projects/element-ng/localization/si-locale.service.spec.ts
+++ b/projects/element-ng/localization/si-locale.service.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SiTranslateNgxTModule } from '@siemens/element-translate-ng/ngx-translate';
@@ -38,7 +39,7 @@ describe('SiLocaleService', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-        providers: []
+        providers: [provideZonelessChangeDetection()]
       });
       service = TestBed.inject(SiLocaleService);
     });
@@ -80,7 +81,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
     });
     service = TestBed.inject(SiLocaleService);
     expect(service.config.defaultLocale).toBe('fr');
@@ -91,7 +92,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
     });
     service = TestBed.inject(SiLocaleService);
     expect(service.config.defaultLocale).toBe('en');
@@ -104,7 +105,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
     });
     service = TestBed.inject(SiLocaleService);
     expect(service.config.availableLocales![0]).toBe('en');
@@ -117,7 +118,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
     });
     service = TestBed.inject(SiLocaleService);
     const translate = TestBed.inject(TranslateService);
@@ -134,7 +135,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
     });
     service = TestBed.inject(SiLocaleService);
     const translate = TestBed.inject(TranslateService);
@@ -150,7 +151,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
     });
     service = TestBed.inject(SiLocaleService);
     expect(service.locale$.value).toBe('en');
@@ -165,7 +166,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
     });
     service = TestBed.inject(SiLocaleService);
     expect(service.hasLocale('de')).toBeTrue();
@@ -191,7 +192,8 @@ describe('SiLocaleService', () => {
         imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
         providers: [
           { provide: SI_LOCALE_CONFIG, useValue: config },
-          { provide: SiLocaleStore, useClass: NoLocaleStore }
+          { provide: SiLocaleStore, useClass: NoLocaleStore },
+          provideZonelessChangeDetection()
         ]
       });
 
@@ -255,7 +257,8 @@ describe('SiLocaleService', () => {
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
       providers: [
         { provide: SI_LOCALE_CONFIG, useValue: config },
-        { provide: SiLocaleStore, useClass: DeLocaleStore }
+        { provide: SiLocaleStore, useClass: DeLocaleStore },
+        provideZonelessChangeDetection()
       ]
     });
     service = TestBed.inject(SiLocaleService);
@@ -272,7 +275,8 @@ describe('SiLocaleService', () => {
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
       providers: [
         { provide: SI_LOCALE_CONFIG, useValue: config },
-        { provide: SiLocaleStore, useClass: DeLocaleStore }
+        { provide: SiLocaleStore, useClass: DeLocaleStore },
+        provideZonelessChangeDetection()
       ]
     });
     service = TestBed.inject(SiLocaleService);
@@ -297,7 +301,8 @@ describe('SiLocaleService', () => {
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
       providers: [
         { provide: SI_LOCALE_CONFIG, useValue: config },
-        { provide: SiLocaleStore, useClass: DeLocaleStore }
+        { provide: SiLocaleStore, useClass: DeLocaleStore },
+        provideZonelessChangeDetection()
       ]
     });
     service = TestBed.inject(SiLocaleService);

--- a/projects/element-ng/photo-upload/si-photo-upload.component.spec.ts
+++ b/projects/element-ng/photo-upload/si-photo-upload.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef } from '@angular/core';
+import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -59,7 +59,8 @@ describe(`SiPhotoUploadComponent`, () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiPhotoUploadComponent]
+      imports: [SiPhotoUploadComponent],
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(SiPhotoUploadComponent);
@@ -139,12 +140,13 @@ describe(`SiPhotoUploadComponent`, () => {
     mockFileReader(redPng);
 
     fixture.debugElement.query(By.css('button'))!.nativeElement.click();
-
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     await fixture.whenStable();
-
     const modal = document.querySelector('si-modal');
     expect(modal).toBeTruthy();
+    // cannot use jasmine.clock here
+    await new Promise(resolve => setTimeout(resolve, 100)); // Allow cropping lib to process
     expect(modal?.querySelector('img')).toBeTruthy();
   });
 
@@ -164,6 +166,9 @@ describe(`SiPhotoUploadComponent`, () => {
 
     fixture.detectChanges();
     await fixture.whenStable();
+
+    // cannot use jasmine.clock here
+    await new Promise(resolve => setTimeout(resolve, 100)); // Allow cropping lib to process
 
     getButton(document.querySelector('si-modal')!, 'Apply').click();
     fixture.detectChanges();


### PR DESCRIPTION
- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updates 281 test files across the element-ng project to support Angular's zoneless change detection by adding `provideZonelessChangeDetection` to test configurations.

## Key Changes

- **Import additions**: Added `provideZonelessChangeDetection` from `@angular/core` to test files
- **TestBed configuration**: Registered `provideZonelessChangeDetection()` in providers array of `TestBed.configureTestingModule` across all modified test files
- **Async/await patterns**: Replaced `fakeAsync`/`flush`/`tick` patterns with async tests using `fixture.whenStable()` and Jasmine clock for timing control where needed
- **Change detection synchronization**: Added `fixture.changeDetectorRef.markForCheck()` calls to ensure stable change detection before assertions
- **Minor timing adjustments**: Introduced `setTimeout` delays in select tests to accommodate external library processing

## Scope

Comprehensive test updates affecting 281 test files (`.spec.ts`) across multiple components including:
- Core UI components (accordion, cards, buttons, modals, etc.)
- Data visualization (charts, dashboards, grids)
- Form handling (datepicker, inputs, selectors)
- Navigation (breadcrumb, navbar, tabs)
- And many others

All changes maintain test functionality while enabling zoneless change detection support in Angular.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->