### PR TITLE
refactor(dashboards-ng): remove `initCompleted` output event

### DIFF
--- a/projects/dashboards-ng/src/components/grid/si-grid.component.spec.ts
+++ b/projects/dashboards-ng/src/components/grid/si-grid.component.spec.ts
@@ -219,7 +219,7 @@ describe('SiGridComponent', () => {
       fixture.componentRef.setInput('widgetCatalog', [TEST_WIDGET]);
       fixture.detectChanges();
       await fixture.whenStable();
-      component.addWidgetInstance({ widgetId: TEST_WIDGET.id });
+      component.addWidgetInstance({ widgetId: TEST_WIDGET.id, payload: TEST_WIDGET.payload });
       component.save();
       await fixture.whenStable();
       const widgetConfig = component.visibleWidgetInstances$.value[0];

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
@@ -60,21 +60,22 @@ describe('SiWidgetHostComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should instantiate and attach widget instance', (done: DoneFn) => {
-    component.initCompleted.subscribe(_ => {
-      expect(component.widgetHost().length).toBe(1);
-      done();
-    });
+  it('should instantiate and attach widget instance', async () => {
     fixture.detectChanges();
+    jasmine.clock().install();
+    jasmine.clock().tick(0);
+    await fixture.whenStable();
+    expect(component.widgetHost().length).toBe(1);
+    jasmine.clock().uninstall();
   });
 
-  it('should not create widget instance without widget', (done: DoneFn) => {
+  it('should not create widget instance without widget', async () => {
     gridService.widgetCatalog.set([]);
-    component.initCompleted.subscribe(_ => {
-      expect(component.widgetHost().length).toBe(0);
-      done();
-    });
-    fixture.detectChanges();
+    jasmine.clock().install();
+    jasmine.clock().tick(0);
+    await fixture.whenStable();
+    expect(component.widgetHost().length).toBe(0);
+    jasmine.clock().uninstall();
   });
 
   it('#editAction should call onEdit', () => {
@@ -118,34 +119,35 @@ describe('SiWidgetHostComponent', () => {
   });
 
   describe('#setupEditable()', () => {
-    it('should setup default edit actions with widgets edit actions', (done: DoneFn) => {
-      component.initCompleted.subscribe(_ => {
-        expect(component.primaryActions.length).toBe(0);
-
-        component.setupEditable(true);
-        expect(component.primaryActions.length).toBe(3);
-        expect((component.primaryActions[0] as MenuItem).title).toBe('Hello User');
-        expect(component.primaryActions[1]).toBe(component.editAction);
-        expect(component.primaryActions[2]).toBe(component.removeAction);
-        expect(component.widgetInstance!.editable).toBeTrue();
-        done();
-      });
+    it('should setup default edit actions with widgets edit actions', async () => {
+      jasmine.clock().install();
+      jasmine.clock().tick(0);
+      await fixture.whenStable();
+      expect(component.primaryActions.length).toBe(0);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
+      component.setupEditable(true);
+      expect(component.primaryActions.length).toBe(3);
+      expect((component.primaryActions[0] as MenuItem).title).toBe('Hello User');
+      expect(component.primaryActions[1]).toBe(component.editAction);
+      expect(component.primaryActions[2]).toBe(component.removeAction);
+      expect(component.widgetInstance!.editable).toBeTrue();
+      jasmine.clock().uninstall();
     });
 
-    it('should setup default edit actions without widgets edit actions', (done: DoneFn) => {
-      component.initCompleted.subscribe(_ => {
-        component.widgetInstance!.primaryEditActions = undefined;
-        expect(component.primaryActions.length).toBe(0);
+    it('should setup default edit actions without widgets edit actions', async () => {
+      jasmine.clock().install();
+      jasmine.clock().tick(0);
+      await fixture.whenStable();
+      component.widgetInstance!.primaryEditActions = undefined;
+      expect(component.primaryActions.length).toBe(0);
 
-        component.setupEditable(true);
-        expect(component.primaryActions.length).toBe(2);
-        expect(component.primaryActions[0]).toBe(component.editAction);
-        expect(component.primaryActions[1]).toBe(component.removeAction);
-        expect(component.widgetInstance!.editable).toBeTrue();
-        done();
-      });
-      fixture.detectChanges();
+      component.setupEditable(true);
+      expect(component.primaryActions.length).toBe(2);
+      expect(component.primaryActions[0]).toBe(component.editAction);
+      expect(component.primaryActions[1]).toBe(component.removeAction);
+      expect(component.widgetInstance!.editable).toBeTrue();
+      jasmine.clock().uninstall();
     });
   });
 });

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
@@ -55,7 +55,6 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
 
   readonly remove = output<string>();
   readonly edit = output<WidgetConfig>();
-  readonly initCompleted = output<void>();
 
   readonly card = viewChild.required<SiDashboardCardComponent>('card');
 
@@ -187,14 +186,11 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
           }
           this.widgetInstanceFooter = this.widgetInstance.footer;
           this.setupEditable(this.gridService.editable$.value);
-
-          this.initCompleted.emit();
         },
         error: error => console.error('Error: ', error)
       });
     } else {
       console.error(`Cannot find widget with id ${this.widgetConfig().widgetId}`);
-      this.initCompleted.emit();
     }
   }
 

--- a/projects/dashboards-ng/test/test-widget/test-widget.ts
+++ b/projects/dashboards-ng/test/test-widget/test-widget.ts
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 import { Widget, WidgetConfig } from '@siemens/dashboards-ng';
+import * as testWidgetModule from 'projects/dashboards-ng/test/test-widget/index';
 
 const loaderFunction = (name: string): Promise<any> => {
   if (name === 'TestWidgetComponent' || name === 'TestWidgetEditorComponent') {
-    return import('projects/dashboards-ng/test/test-widget/index');
+    // immediately resolve so we don't have to deal with timers in tests
+    return Promise.resolve(testWidgetModule);
   } else {
     throw new Error(`Unknown component to be loaded ${name}`);
   }


### PR DESCRIPTION
`initCompleted` has no functional use but it was used just for handling tests. adjusted tests with immediate promise resolver so we don't have to rely on explicit `initCompleted` event subscriptions.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Refactor: Remove `initCompleted` output event

Removes the unused `initCompleted` output event from `SiWidgetHostComponent` that served no functional purpose and was only used for testing. Tests have been refactored to eliminate their dependency on this event by using Jasmine clock ticks, `fixture.whenStable()`, and Promise-based control flow instead of event subscriptions.

**Changes:**
- Removed `initCompleted` output declaration and its two emission sites from `SiWidgetHostComponent`
- Refactored widget host tests to use Jasmine clock installation/ticking, `fixture.whenStable()`, and explicit change detection instead of subscribing to initialization events
- Refactored grid tests to use async/await patterns with `fixture.whenStable()` for better control flow
- Updated test widget module loader to use `Promise.resolve()` for synchronous immediate resolution instead of dynamic imports
<!-- end of auto-generated comment: release notes by coderabbit.ai -->