### PR TITLE
refactor(split): change default collapse others part behavior

### DIFF
--- a/projects/element-ng/split/si-split-part.component.ts
+++ b/projects/element-ng/split/si-split-part.component.ts
@@ -127,11 +127,9 @@ export class SiSplitPartComponent implements OnChanges {
    * If enabled, all split parts between this one and the end of the split in the respective direction will be collapsed if this part is collapsed.
    * If disabled, only this split part will be collapsed.
    *
-   * The default value will change to false in v48.
-   *
-   * @defaultValue true
+   * @defaultValue false
    */
-  @Input({ transform: booleanAttribute }) collapseOthers = true;
+  @Input({ transform: booleanAttribute }) collapseOthers = false;
 
   @Output() readonly collapseChanged = new EventEmitter<boolean>();
   @Output() readonly stateChange = new EventEmitter<PartState>();


### PR DESCRIPTION
BREAKING CHANGE: The default value of `SiSplitPartComponent.collapseOthers` input has been changed from `true` to `false`. Previously, when a split part was collapsed, all split parts between it and the end of the split in the respective direction would also collapse automatically. Now, by default, only the individual split part will collapse.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
