### PR TITLE
fix(datatable): support compatibility with datatable v22

### DIFF
--- a/api-goldens/element-ng/datatable/index.api.md
+++ b/api-goldens/element-ng/datatable/index.api.md
@@ -5,13 +5,28 @@
 ```ts
 
 import * as i0 from '@angular/core';
-import { NgxDatatableConfig } from '@siemens/ngx-datatable';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Provider } from '@angular/core';
 
 // @public @deprecated (undocumented)
 export interface INgxDatatableConfig extends NgxDatatableConfig {
+}
+
+// @public
+export interface NgxDatatableConfig {
+    // (undocumented)
+    cssClasses?: NgxDatatableCssClasses;
+    // (undocumented)
+    defaultColumnWidth?: number;
+    // (undocumented)
+    footerHeight?: number;
+    // (undocumented)
+    headerHeight?: number;
+    // (undocumented)
+    messages?: NgxDatatableMessages;
+    // (undocumented)
+    rowHeight?: number;
 }
 
 // @public

--- a/projects/element-ng/datatable/si-datatable-providers.ts
+++ b/projects/element-ng/datatable/si-datatable-providers.ts
@@ -3,10 +3,65 @@
  * SPDX-License-Identifier: MIT
  */
 import { Provider } from '@angular/core';
-import { NgxDatatableConfig } from '@siemens/ngx-datatable';
+
+// Copy of NgxDatatableConfig from @siemens/ngx-datatable to maintain compatibility
+// with v22 and earlier where `NgxDatatableConfig` is not defined.
+// See https://github.com/siemens/ngx-datatable/blob/main/projects/ngx-datatable/src/lib/ngx-datatable.config.ts#L50.
+/** Interface for messages to override default table texts. */
+interface NgxDatatableMessages {
+  /** Message to show when the array is present but empty */
+  emptyMessage: string;
+  /** Footer total message */
+  totalMessage: string;
+  /** Footer selected message */
+  selectedMessage: string;
+  /** Pager screen reader message for the first page button */
+  ariaFirstPageMessage: string;
+  /**
+   * Pager screen reader message for the n-th page button.
+   * It will be rendered as: `{{ariaPageNMessage}} {{n}}`.
+   */
+  ariaPageNMessage: string;
+  /** Pager screen reader message for the previous page button */
+  ariaPreviousPageMessage: string;
+  /** Pager screen reader message for the next page button */
+  ariaNextPageMessage: string;
+  /** Pager screen reader message for the last page button */
+  ariaLastPageMessage: string;
+  /** Row checkbox aria label */
+  ariaRowCheckboxMessage: string;
+  /** Header checkbox aria label */
+  ariaHeaderCheckboxMessage: string;
+  /** Group header checkbox aria label */
+  ariaGroupHeaderCheckboxMessage: string;
+}
+/** CSS classes for icons that override the default table icons. */
+interface NgxDatatableCssClasses {
+  sortAscending: string;
+  sortDescending: string;
+  sortUnset: string;
+  pagerLeftArrow: string;
+  pagerRightArrow: string;
+  pagerPrevious: string;
+  pagerNext: string;
+  treeStatusLoading: string;
+  treeStatusExpanded: string;
+  treeStatusCollapsed: string;
+}
+/**
+ * Interface definition for ngx-datatable global configuration
+ */
+export interface NgxDatatableConfig {
+  messages?: NgxDatatableMessages;
+  cssClasses?: NgxDatatableCssClasses;
+  headerHeight?: number;
+  footerHeight?: number;
+  rowHeight?: number;
+  defaultColumnWidth?: number;
+}
 
 /**
- * @deprecated Use NgxDatatableConfig from \@siemens/ngx-datatable instead.
+ * @deprecated Use NgxDatatableConfig from \@siemens/ngx-datatable instead from v23 onward.
  *
  * Configuration interface for the upstream \@siemens/ngx-datatable project.
  * See https://github.com/siemens/ngx-datatable/blob/main/projects/ngx-datatable/src/lib/ngx-datatable.config.ts#L50.


### PR DESCRIPTION
`NgxDatatableConfig` is not part of v22 which makes element v48 with datatable v22 in compatible.

fix by removing direct import of `NgxDatatableConfig` and maintaining local copy.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## fix(datatable): support compatibility with datatable v22

**Problem:** Element v48 is incompatible with datatable v22 due to the removal of `NgxDatatableConfig` from the `@siemens/ngx-datatable` package.

**Solution:** Create a local copy of the `NgxDatatableConfig` interface and related types to eliminate the direct dependency.

**Changes:**
- Added local interfaces: `NgxDatatableMessages` and `NgxDatatableCssClasses` to define datatable configuration structure
- Introduced `NgxDatatableConfig` export with optional configuration fields (messages, cssClasses, headerHeight, footerHeight, rowHeight, defaultColumnWidth)
- Created `SiDatatableConfig` as an extended version with required fields and additional row height variants (rowHeightSmall, rowHeightExtraSmall, rowHeightTiny)
- Exported `SI_DATATABLE_CONFIG` constant with concrete element-specific values
- Updated `provideSiDatatableConfig` to use the local `NgxDatatableConfig` type
- Added deprecation note indicating users should import from upstream starting v23

**Impact:** Restores compatibility with datatable v22 while maintaining full API compatibility for existing consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->