### PR TITLE
refactor(resize-observer): remove properties

### DIFF
--- a/api-goldens/element-ng/resize-observer/index.api.md
+++ b/api-goldens/element-ng/resize-observer/index.api.md
@@ -78,18 +78,6 @@ export class SiResizeObserverModule {
 export class SiResponsiveContainerDirective implements OnInit, OnDestroy {
     // (undocumented)
     readonly breakpoints: _angular_core.InputSignal<Breakpoints | undefined>;
-    // @deprecated (undocumented)
-    isLg: boolean;
-    // @deprecated (undocumented)
-    isMd: boolean;
-    // @deprecated (undocumented)
-    isSm: boolean;
-    // @deprecated (undocumented)
-    isXl: boolean;
-    // @deprecated (undocumented)
-    isXs: boolean;
-    // @deprecated (undocumented)
-    isXxl: boolean;
     // (undocumented)
     readonly lg: _angular_core.WritableSignal<boolean>;
     // (undocumented)

--- a/projects/element-ng/resize-observer/si-responsive-container.directive.ts
+++ b/projects/element-ng/resize-observer/si-responsive-container.directive.ts
@@ -43,46 +43,16 @@ export const BOOTSTRAP_BREAKPOINTS: Breakpoints = {
 export class SiResponsiveContainerDirective implements OnInit, OnDestroy {
   /** @defaultValue false */
   readonly xs = signal(false);
-  /**
-   * @deprecated Use {@link xs} instead.
-   * @defaultValue false
-   **/
-  isXs = false;
   /** @defaultValue false */
   readonly sm = signal(false);
-  /**
-   * @deprecated Use {@link sm} instead.
-   * @defaultValue false
-   **/
-  isSm = false;
   /** @defaultValue false */
   readonly md = signal(false);
-  /**
-   * @deprecated Use {@link md} instead.
-   * @defaultValue false
-   **/
-  isMd = false;
   /** @defaultValue false */
   readonly lg = signal(false);
-  /**
-   * @deprecated Use {@link lg} instead.
-   * @defaultValue false
-   **/
-  isLg = false;
   /** @defaultValue false */
   readonly xl = signal(false);
-  /**
-   * @deprecated Use {@link xl} instead.
-   * @defaultValue false
-   **/
-  isXl = false;
   /** @defaultValue false */
   readonly xxl = signal(false);
-  /**
-   * @deprecated Use {@link xxl} instead.
-   * @defaultValue false
-   **/
-  isXxl = false;
 
   /** @defaultValue 100 */
   readonly resizeThrottle = input(100);
@@ -111,16 +81,10 @@ export class SiResponsiveContainerDirective implements OnInit, OnDestroy {
     const breakpoints = this.breakpoints() ?? BOOTSTRAP_BREAKPOINTS;
 
     this.xs.set(width < breakpoints.smMinimum);
-    this.isXs = this.xs();
     this.sm.set(width >= breakpoints.smMinimum && width < breakpoints.mdMinimum);
-    this.isSm = this.sm();
     this.md.set(width >= breakpoints.mdMinimum && width < breakpoints.lgMinimum);
-    this.isMd = this.md();
     this.lg.set(width >= breakpoints.lgMinimum && width < breakpoints.xlMinimum);
-    this.isLg = this.lg();
     this.xl.set(width >= breakpoints.xlMinimum && width < breakpoints.xxlMinimum);
-    this.isXl = this.xl();
     this.xxl.set(width >= breakpoints.xxlMinimum);
-    this.isXxl = this.xxl();
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Removed following deprecated properties from `SiResponsiveContainerDirective` in favor of signal-based properties:

`isXs` -> Use `xs` instead
`isSm` -> Use `sm` instead
`isMd` -> Use `md` instead
`isLg` -> Use `lg` instead
`isXl` -> Use `xl` instead
`isXxl` -> Use `xxl` instead

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

BREAKING CHANGE: Removed six deprecated boolean input properties from SiResponsiveContainerDirective in favor of signal-based properties:

- `isXs`, `isSm`, `isMd`, `isLg`, `isXl`, `isXxl` → `xs`, `sm`, `md`, `lg`, `xl`, `xxl`

### Changes
- Removed deprecated property declarations from the directive class
- Removed assignments in `setResponsiveSize` that updated those properties
- Updated API golden to reflect the reduced public surface

### Impact
Consumers must migrate from the removed boolean inputs to the corresponding signals for responsive breakpoint detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->