### PR TITLE
test(navbar-vertical): resolve flaky test

### DIFF
--- a/projects/element-ng/navbar-vertical/si-navbar-vertical.spec.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical.spec.ts
@@ -186,7 +186,8 @@ describe('SiNavbarVertical', () => {
       const spySearch = spyOn(component, 'searchEvent');
       await harness.search('test');
       // cannot use jasmine.clock here
-      await new Promise(resolve => setTimeout(resolve, 400));
+      // 400 is the debounceTime and +1 to ensure the timer is executed
+      await new Promise(resolve => setTimeout(resolve, 400 + 1));
       expect(spySearch).toHaveBeenCalledOnceWith('test');
     });
 


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## test(navbar-vertical): resolve flaky test

Fixes a flaky test in the navbar-vertical component by adjusting the debounce wait time from 400ms to 401ms (400 + 1). This ensures the debounce timer completes before the searchEvent assertion is evaluated, eliminating race conditions that caused intermittent test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->