### PR TITLE
build(.releaserc.js): disable success comments for releases

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -178,6 +178,11 @@ export default {
             }
           ]
         ]),
-    '@semantic-release/github'
+    [
+      '@semantic-release/github',
+      {
+        successComment: false
+      }
+    ]
   ]
 };


### PR DESCRIPTION
Our release jobs are failing a lot during the "success" step of semantic-release when it tries to comment on the PRs to add the comment about "this PR is inclued in release x.y". I don't know what the issue is exactly, most likely we run into some rate limit issues when there are too many commits. In any case, it's super annoying to see the release build fail and then having to check what the issue is.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Disables success comments in semantic-release by configuring the GitHub plugin in `.releaserc.js` with `successComment: false`. This prevents release job failures that occur when semantic-release attempts to comment on pull requests during the success step, addressing repeated build failures in the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->