### PR TITLE
fix(password-toggle): hide MS Edge built-in reveal toggle icon

### DIFF
--- a/projects/element-ng/password-toggle/si-password-toggle.component.scss
+++ b/projects/element-ng/password-toggle/si-password-toggle.component.scss
@@ -9,6 +9,11 @@
   &.show-visibility-icon {
     --si-action-icon-offset: #{24px + map.get(variables.$spacers, 2)};
   }
+
+  // this disables the built-in reveal button in MS Edge
+  ::ng-deep input::-ms-reveal {
+    display: none;
+  }
 }
 
 .password-visibility-icon {


### PR DESCRIPTION

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## fix(password-toggle): hide MS Edge built-in reveal toggle icon

Adds CSS rule using `::ng-deep input::-ms-reveal { display: none; }` to hide Microsoft Edge's built-in password reveal button in the password toggle component. This prevents the native Edge reveal icon from appearing alongside the custom visibility toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->