### PR TITLE
test(filtered-search): remove irrelevant test

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
@@ -1997,37 +1997,6 @@ describe('SiFilteredSearchComponent', () => {
       });
     });
 
-    // TODO: this is non-sense. Our interface does not allow empty value for options.
-    // TODO: remove with v47
-    it('should emit criterion with value = label from config', async () => {
-      component.doSearchOnInputChange = true;
-      component.criteria.set([
-        { name: 'company', label: 'Company', options: ['Foo', 'Bar'] },
-        { name: 'Location', label: 'Location', options: ['Munich', 'Zug'] },
-        {
-          name: 'country',
-          label: 'Country',
-          options: [{ value: 'DE', label: 'Germany' }, { label: 'Switzerland' } as any]
-        }
-      ]);
-      component.searchCriteria.set({
-        criteria: [{ name: 'country', value: 'Switzerland' }],
-        value: 'Max'
-      });
-      spyOn(component, 'doSearch');
-
-      const filteredSearch = await loader.getHarness(SiFilteredSearchHarness);
-      const freeTextSearch = await filteredSearch.freeTextSearch();
-      await freeTextSearch.focus();
-      await freeTextSearch.sendKeys(':');
-      await tick();
-
-      expect(component.doSearch).toHaveBeenCalledWith({
-        criteria: jasmine.arrayContaining([{ name: 'country', value: 'Switzerland' }]),
-        value: ''
-      });
-    });
-
     it('should work when only value is defined', async () => {
       component.doSearchOnInputChange = true;
       component.criteria.set([

--- a/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
+++ b/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
@@ -133,8 +133,7 @@ export class SiFilteredSearchTypeaheadComponent
     // We should consider dropping this, but there is currently a unit test checking this behavior.
     const optionValue = this.optionValue();
     if (optionValue) {
-      // TODO: The last ?? optionValue.label is non-sense, but we have a unit test checking this behavior.
-      this.criterionValue().value = optionValue.value ?? optionValue.label;
+      this.criterionValue().value = optionValue.value;
     }
   }
 


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removes a test case titled "should emit criterion with value = label from config" from the filtered-search component spec file. The removed test verified that when selecting a country option with a value-label pair (e.g., `{ label: 'Switzerland' }` without an explicit `value` property), the emitted criterion would use the label as the value. The test was marked as non-sense in TODO comments, noting that the interface does not allow empty values for options and was scheduled for removal in version 47.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->