### PR TITLE
refactor(dashboards-ng): remove deprecated property

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -325,8 +325,6 @@ export interface WidgetConfig {
     image?: WidgetImage;
     // (undocumented)
     immutable?: boolean;
-    // @deprecated
-    invalid?: boolean;
     // (undocumented)
     isNotRemovable?: boolean;
     minHeight?: number;

--- a/projects/dashboards-demo/webcomponents/src/app/note-widget-editor/note-widget-editor.component.ts
+++ b/projects/dashboards-demo/webcomponents/src/app/note-widget-editor/note-widget-editor.component.ts
@@ -2,9 +2,9 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, EventEmitter, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { WidgetConfig, WidgetInstanceEditor } from '@siemens/dashboards-ng';
+import { WidgetConfig, WidgetConfigStatus, WidgetInstanceEditor } from '@siemens/dashboards-ng';
 
 @Component({
   selector: 'app-note-widget-editor',
@@ -13,7 +13,7 @@ import { WidgetConfig, WidgetInstanceEditor } from '@siemens/dashboards-ng';
 })
 export class NoteWidgetEditorComponent implements WidgetInstanceEditor, OnInit {
   @Input() config!: WidgetConfig | Omit<WidgetConfig, 'id'>;
-  readonly statusChanges = new EventEmitter<Partial<WidgetConfig>>();
+  readonly statusChanges = output<Partial<WidgetConfigStatus>>();
 
   protected heading = '';
   protected message = '';
@@ -26,6 +26,6 @@ export class NoteWidgetEditorComponent implements WidgetInstanceEditor, OnInit {
   onChange(): void {
     this.config!.heading = this.heading ?? '';
     this.config!.payload.message = this.message ?? '';
-    this.statusChanges.emit({ invalid: this.config!.heading.trim().length === 0 });
+    this.statusChanges.emit({ invalid: this.config!.heading.trim().length === 0, modified: true });
   }
 }

--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
@@ -304,7 +304,6 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
           this.subscriptions.push(
             this.widgetInstanceEditor.configChange.subscribe(config => {
               if (!hasStatusChangesEmitter) {
-                this.invalidConfig.set(!!config.invalid);
                 this.widgetConfigModified = true;
               }
             }) as Subscription

--- a/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.ts
@@ -169,7 +169,6 @@ export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy 
         this.subscriptions.push(
           this.widgetInstanceEditor.configChange.subscribe(config => {
             if (!hasStatusChangesEmitter) {
-              this.invalidConfig.set(!!config.invalid);
               this.widgetConfigModified.set(true);
             }
           }) as Subscription

--- a/projects/dashboards-ng/src/model/widgets.model.ts
+++ b/projects/dashboards-ng/src/model/widgets.model.ts
@@ -174,13 +174,6 @@ export interface WidgetConfig {
   isNotRemovable?: boolean;
   immutable?: boolean;
   /**
-   * Widget instance editor components can use this property to indicate an invalid configuration.
-   * True if the config is invalid. False, undefined or null indicate a valid configuration.
-   *
-   * @deprecated Use the statusChanges emitter to notify about configuration status changes.
-   */
-  invalid?: boolean;
-  /**
    * Optional configuration for an image to be displayed on the widget instance.
    */
   image?: WidgetImage;


### PR DESCRIPTION
BREAKING CHANGE: Removed deprecated property `WidgetConfig.invalid`. Use `WidgetInstanceEditor.statusChanges` emitter instead.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Removes deprecated WidgetConfig.invalid and migrates validation/status updates to WidgetInstanceEditor.statusChanges using WidgetConfigStatus.

### Changes

- projects/dashboards-ng/src/model/widgets.model.ts: Removed `invalid?: boolean` from `WidgetConfig`.
- api-goldens/dashboards-ng/index.api.md: Removed `invalid?: boolean` from exported API.
- projects/dashboards-demo/webcomponents/src/app/note-widget-editor/note-widget-editor.component.ts: Switched `statusChanges` to `output<Partial<WidgetConfigStatus>>()` (imported `WidgetConfigStatus` and `output`) and emit `{ invalid, modified: true }`.
- projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts: Removed reading `config.invalid` in `configChange` handler; `invalidConfig` is now updated only via `handleStatusChanges`.
- projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.ts: Removed reading `config.invalid` in `configChange` handler; `widgetConfigModified` still set on config changes.

### Breaking Change

`WidgetConfig.invalid` removed — consumers must use `WidgetInstanceEditor.statusChanges` (emit `WidgetConfigStatus`) for validation/status updates.

Notes: Goldens were requested and updated by the author. The PR template’s contribution-guidelines checkbox remains unchecked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->