### PR TITLE
feat(dashboards): add support for primary and secondary toolbar actions via component inputs

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -26,6 +26,7 @@ import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { OutputEmitterRef } from '@angular/core';
+import { Provider } from '@angular/core';
 import { SiDashboardComponent } from '@siemens/element-ng/dashboard';
 import * as _siemens_element_translate_ng_translate from '@siemens/element-translate-ng/translate';
 import { SimpleChanges } from '@angular/core';
@@ -134,6 +135,12 @@ export type LoadRemoteModuleScriptOptions = {
 export type ObjectFit = 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
 
 // @public
+export const provideDashboardToolbarItems: (toolbarItems?: {
+    primary?: DashboardToolbarItem[];
+    secondary?: DashboardToolbarItem[];
+}) => Provider;
+
+// @public
 export type SetupComponentFn = <T>(factory: WidgetComponentFactory, componentName: string, host: ViewContainerRef, injector: Injector, envInjector: EnvironmentInjector) => Observable<ComponentRef<T>>;
 
 // @public (undocumented)
@@ -144,6 +151,12 @@ export const setupWidgetInstance: (widgetComponentFactory: WidgetComponentFactor
 
 // @public
 export const SI_DASHBOARD_CONFIGURATION: InjectionToken<Config>;
+
+// @public
+export const SI_DASHBOARD_TOOLBAR_ITEMS: InjectionToken<{
+    primary: DashboardToolbarItem[];
+    secondary: DashboardToolbarItem[];
+}>;
 
 // @public
 export const SI_WIDGET_ID_PROVIDER: InjectionToken<SiWidgetIdProvider>;
@@ -188,8 +201,10 @@ export class SiFlexibleDashboardComponent implements OnInit, OnChanges, OnDestro
     readonly isModified: _angular_core.OutputEmitterRef<boolean>;
     readonly pageTitle: _angular_core.Signal<string | undefined>;
     readonly primaryEditActions$: BehaviorSubject<(MenuItem | DashboardToolbarItem)[]>;
+    readonly primaryEditActions: _angular_core.InputSignal<DashboardToolbarItem[]>;
     readonly searchPlaceholder: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly secondaryEditActions$: BehaviorSubject<(MenuItem | DashboardToolbarItem)[]>;
+    readonly secondaryEditActions: _angular_core.InputSignal<DashboardToolbarItem[]>;
     readonly showEditButtonLabel: _angular_core.InputSignal<boolean>;
     showWidgetCatalog(): void;
     readonly widgetCatalog: _angular_core.InputSignal<Widget[]>;
@@ -247,6 +262,7 @@ export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy 
 
 // @public
 export abstract class SiWidgetStorage {
+    // @deprecated
     getToolbarMenuItems?: (dashboardId?: string) => {
         primary: Observable<(MenuItem | DashboardToolbarItem)[]>;
         secondary: Observable<(MenuItem | DashboardToolbarItem)[]>;

--- a/projects/dashboards-demo/src/app/app-widget-storage.ts
+++ b/projects/dashboards-demo/src/app/app-widget-storage.ts
@@ -3,117 +3,47 @@
  * SPDX-License-Identifier: MIT
  */
 import {
-  DashboardToolbarItem,
   SiDefaultWidgetStorage,
   SiGridComponent,
   SiWidgetStorage,
   STORAGE_KEY,
   WidgetConfig
 } from '@siemens/dashboards-ng';
-import { BehaviorSubject, delay, Observable, of } from 'rxjs';
+import { delay, Observable } from 'rxjs';
 
 import { FIXED_WIDGETS, WIDGETS } from './widgets/widget-configs.mocks';
 
 const CUSTOM_DEFAULTS = 'app-default-widgets';
 export class AppWidgetStorage extends SiDefaultWidgetStorage implements SiWidgetStorage {
-  private secondaryMenuItems = new BehaviorSubject<DashboardToolbarItem[]>([]);
-  private primaryMenuItems = new BehaviorSubject<DashboardToolbarItem[]>([
-    {
-      type: 'action',
-      label: 'Custom Action',
-      action: (grid: SiGridComponent) =>
-        alert(`Grid has ${grid.visibleWidgetInstances$.value.length} widgets!`)
-    }
-  ]);
-
   constructor() {
     super();
     if (this.storage.getItem(STORAGE_KEY) === null) {
       this.doRestoreDefaults();
     }
-
-    this.secondaryMenuItems.next([
-      {
-        type: 'action',
-        label: 'TOOLBAR.RESTORE_DEFAULTS',
-        action: (grid: SiGridComponent) => this.restoreDefaults(grid)
-      },
-      {
-        type: 'action',
-        label: 'TOOLBAR.SAVE_AS_DEFAULTS',
-        action: (grid: SiGridComponent) => this.saveAsDefaults(grid)
-      }
-    ]);
   }
 
-  restoreDefaults = (grid: SiGridComponent): Observable<void> => this.doRestoreDefaults();
+  restoreDefaults = (dashboardId?: string): void => this.doRestoreDefaults(dashboardId);
 
-  saveAsDefaults = (grid: SiGridComponent): Observable<void> => {
+  saveAsDefaults = (grid: SiGridComponent): void => {
     grid.transientWidgetInstances.forEach(
       widget => (widget.id = Math.random().toString(36).substring(2, 9))
     );
     this.storage.setItem(CUSTOM_DEFAULTS, JSON.stringify(grid.visibleWidgetInstances$.value));
-    return of();
   };
 
-  override getToolbarMenuItems = (
-    dashboardId?: string
-  ): {
-    primary: Observable<DashboardToolbarItem[]>;
-    secondary: Observable<DashboardToolbarItem[]>;
-  } => {
-    if (dashboardId === 'custom-library') {
-      return { primary: this.primaryMenuItems, secondary: this.secondaryMenuItems };
-    } else if (dashboardId === '1') {
-      return {
-        primary: of([
-          {
-            type: 'action',
-            label: 'Dashboard 1',
-            action: (grid: SiGridComponent) =>
-              alert('This message is only for the Demo Dashboard 1')
-          }
-        ]),
-        secondary: of([
-          {
-            type: 'action',
-            label: 'Secondary Action',
-            action: (grid: SiGridComponent) => alert('Action located in the secondary menu items!')
-          }
-        ])
-      };
-    } else if (dashboardId === '2') {
-      return {
-        primary: of([
-          {
-            type: 'action',
-            label: 'Dashboard 2',
-            action: (grid: SiGridComponent) =>
-              alert('This message is only for the Demo Dashboard 1')
-          }
-        ]),
-        secondary: this.secondaryMenuItems
-      };
-    } else {
-      return { primary: of([]), secondary: of([]) };
-    }
-  };
-
-  private doRestoreDefaults(): Observable<void> {
+  private doRestoreDefaults(dashboardId?: string): void {
     const myDefaultsStr = this.storage.getItem(CUSTOM_DEFAULTS);
     let widgets: WidgetConfig[] | undefined;
     if (myDefaultsStr !== null) {
       widgets = JSON.parse(myDefaultsStr);
     }
-    this.update(widgets ?? WIDGETS);
+    this.update(widgets ?? WIDGETS, dashboardId);
 
     const fixedWidgetsDashboard = FIXED_WIDGETS.map(widget => ({
       ...widget,
       isNotRemovable: true
     }));
     this.update(fixedWidgetsDashboard, 'fixed-widgets');
-
-    return of();
   }
 
   override save(

--- a/projects/dashboards-demo/src/app/app.config.ts
+++ b/projects/dashboards-demo/src/app/app.config.ts
@@ -8,6 +8,7 @@ import { provideRouter, withHashLocation } from '@angular/router';
 import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
 import {
   Config,
+  provideDashboardToolbarItems,
   SI_DASHBOARD_CONFIGURATION,
   SI_WIDGET_ID_PROVIDER,
   SI_WIDGET_STORE
@@ -48,6 +49,11 @@ export const appConfig: ApplicationConfig = {
       }
     }),
     provideHttpClient(withInterceptorsFromDi()),
-    provideNgxTranslateForElement()
+    provideNgxTranslateForElement(),
+    provideDashboardToolbarItems({
+      // provide common toolbar action items here
+      primary: [],
+      secondary: []
+    })
   ]
 };

--- a/projects/dashboards-demo/src/app/pages/custom-catalog/custom-catalog.component.html
+++ b/projects/dashboards-demo/src/app/pages/custom-catalog/custom-catalog.component.html
@@ -4,6 +4,8 @@
   dashboardId="custom-library"
   [widgetCatalogComponent]="customWidgetCatalogComponent"
   [widgetCatalog]="widgetCatalog"
+  [primaryEditActions]="primaryMenuItems"
+  [secondaryEditActions]="secondaryMenuItems"
   (editableChange)="onEditableChange($event)"
   (isModified)="appStateService.editable$.next($event)"
 >

--- a/projects/dashboards-demo/src/app/pages/custom-catalog/custom-catalog.component.ts
+++ b/projects/dashboards-demo/src/app/pages/custom-catalog/custom-catalog.component.ts
@@ -3,10 +3,17 @@
  * SPDX-License-Identifier: MIT
  */
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { SiFlexibleDashboardComponent, Widget } from '@siemens/dashboards-ng';
+import {
+  DashboardToolbarItem,
+  SI_WIDGET_STORE,
+  SiFlexibleDashboardComponent,
+  SiGridComponent,
+  Widget
+} from '@siemens/dashboards-ng';
 import { SiEmptyStateComponent } from '@siemens/element-ng/empty-state';
 
 import { AppStateService } from '../../app-state.service';
+import { AppWidgetStorage } from '../../app-widget-storage';
 import { CustomWidgetCatalogComponent } from '../../components/widget-catalog/custom-widget-catalog.component';
 import { HELLO_DESCRIPTOR } from '../../widgets/hello-widget/widget-descriptors';
 
@@ -27,6 +34,29 @@ export class CustomCatalogPageComponent {
   widgetCatalog: Widget[] = [HELLO_DESCRIPTOR];
   emptyIcon = 'element-dashboard';
   emptyText = EMPTY_TEXT;
+
+  protected secondaryMenuItems: DashboardToolbarItem[] = [
+    {
+      type: 'action',
+      label: 'TOOLBAR.RESTORE_DEFAULTS',
+      action: (grid: SiGridComponent) => this.widgetStore.restoreDefaults('custom-library')
+    },
+    {
+      type: 'action',
+      label: 'TOOLBAR.SAVE_AS_DEFAULTS',
+      action: (grid: SiGridComponent) => this.widgetStore.saveAsDefaults(grid)
+    }
+  ];
+  protected primaryMenuItems: DashboardToolbarItem[] = [
+    {
+      type: 'action',
+      label: 'Custom Action',
+      action: (grid: SiGridComponent) =>
+        alert(`Grid has ${grid.visibleWidgetInstances$.value.length} widgets!`)
+    }
+  ];
+
+  private widgetStore = inject<AppWidgetStorage>(SI_WIDGET_STORE);
 
   onEditableChange(editable: boolean): void {
     this.emptyText = editable ? EMPTY_TEXT_EDIT : EMPTY_TEXT;

--- a/projects/dashboards-demo/src/app/pages/routed-dashboard/routed-dashboard.component.html
+++ b/projects/dashboards-demo/src/app/pages/routed-dashboard/routed-dashboard.component.html
@@ -3,6 +3,8 @@
   [heading]="'Demo Dashboard ' + dashboardId"
   [dashboardId]="dashboardId"
   [widgetCatalog]="widgetCatalog"
+  [primaryEditActions]="primaryActions()"
+  [secondaryEditActions]="secondaryActions()"
   (isModified)="appStateService.editable$.next($event)"
 >
   <app-dashboard-filters menubar filters-slot />

--- a/projects/dashboards-ng/src/model/configuration.ts
+++ b/projects/dashboards-ng/src/model/configuration.ts
@@ -2,9 +2,10 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { InjectionToken } from '@angular/core';
+import { InjectionToken, Provider } from '@angular/core';
 
 import { DEFAULT_GRIDSTACK_OPTIONS, GridConfig } from './gridstack.model';
+import { DashboardToolbarItem } from './si-dashboard-toolbar.model';
 
 /**
  * Dashboard configuration object. Inject globally using the {@link SI_DASHBOARD_CONFIGURATION}
@@ -25,3 +26,24 @@ export const SI_DASHBOARD_CONFIGURATION = new InjectionToken<Config>(
     factory: () => ({ grid: { gridStackOptions: DEFAULT_GRIDSTACK_OPTIONS } })
   }
 );
+
+/**
+ * Injection token to configure global toolbar menu items.
+ */
+export const SI_DASHBOARD_TOOLBAR_ITEMS = new InjectionToken<{
+  primary: DashboardToolbarItem[];
+  secondary: DashboardToolbarItem[];
+}>('Injection token to configure global toolbar menu items.');
+
+/**
+ * provider function to configure global toolbar menu items.
+ * @param toolbarItems - primary and secondary edit actions which are common to all
+ * dashboard instances on application.
+ */
+export const provideDashboardToolbarItems = (toolbarItems?: {
+  primary?: DashboardToolbarItem[];
+  secondary?: DashboardToolbarItem[];
+}): Provider => ({
+  provide: SI_DASHBOARD_TOOLBAR_ITEMS,
+  useValue: { primary: toolbarItems?.primary ?? [], secondary: toolbarItems?.secondary ?? [] }
+});

--- a/projects/dashboards-ng/src/model/si-widget-storage.ts
+++ b/projects/dashboards-ng/src/model/si-widget-storage.ts
@@ -6,6 +6,8 @@ import { inject, InjectionToken } from '@angular/core';
 import { MenuItem } from '@siemens/element-ng/common';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 
+import type { SiFlexibleDashboardComponent } from '../components/flexible-dashboard/si-flexible-dashboard.component';
+import type { provideDashboardToolbarItems } from './configuration';
 import { DashboardToolbarItem } from './si-dashboard-toolbar.model';
 import { WidgetConfig } from './widgets.model';
 
@@ -56,6 +58,9 @@ export abstract class SiWidgetStorage {
   /**
    * Optional method to provide primary and secondary toolbar menu items.
    * @param dashboardId - The id of the dashboard if present to allow dashboard specific menu items.
+   *
+   * @deprecated use {@link provideDashboardToolbarItems} to provide common toolbar items.
+   * Additionally configure individual dashboard actions via {@link SiFlexibleDashboardComponent.primaryEditActions} and {@link SiFlexibleDashboardComponent.secondaryEditActions} respectively.
    */
   getToolbarMenuItems?: (dashboardId?: string) => {
     primary: Observable<(MenuItem | DashboardToolbarItem)[]>;


### PR DESCRIPTION
See https://github.com/siemens/element/discussions/1053


Refactor toolbar menu items configuration to support both global and per-dashboard actions. The dashboard now accepts `primaryEditActions` and `secondaryEditActions` as component inputs, which are merged with global actions provided via `provideDashboardToolbarItems()`.

Changes:
- Add `primaryEditActions` and `secondaryEditActions` inputs to `SiFlexibleDashboardComponent`
- Create `provideDashboardToolbarItems` function for configuring global toolbar items
- Add `SI_DASHBOARD_TOOLBAR_ITEMS` injection token for global toolbar configuration
- Update demo app to move toolbar actions from storage to component inputs
- Deprecate `SiWidgetStorage.getToolbarMenuItems` method
- Add comprehensive test coverage for new toolbar action configuration

DEPRECATED: `SiWidgetStorage.getToolbarMenuItems` is deprecated. Use `provideDashboardToolbarItems` in your app configuration for global toolbar items, and/or use the `primaryEditActions` and `secondaryEditActions` inputs on `SiFlexibleDashboardComponent` for dashboard specific toolbar items.

Before (deprecated approach):

```
export class AppWidgetStorage extends SiDefaultWidgetStorage {
  override getToolbarMenuItems = (dashboardId?: string) => ({
    primary: of([{
      type: 'action',
      label: 'Custom Action',
      action: (grid) => alert('Action!')
    }]),
    secondary: of([{
      type: 'action',
      label: 'Settings',
      action: (grid) => this.openSettings()
    }])
  });
}
```

After

```
// For global toolbar items (shared across all dashboards):

// standalone setup
export const appConfig: ApplicationConfig = {
  providers: [
    provideDashboardToolbarItems({
      primary: [{
        type: 'action',
        label: 'Custom Action',
        action: (grid) => alert('Action!')
      }],
      secondary: [{
        type: 'action',
        label: 'Settings',
        action: (grid) => this.openSettings()
      }]
    })
  ]
};

// For module-based apps:
@NgModule({
  providers: [
    provideDashboardToolbarItems({
      primary: [{
        type: 'action',
        label: 'Custom Action',
        action: (grid) => alert('Action!')
      }],
      secondary: [{
        type: 'action',
        label: 'Settings',
        action: (grid) => this.openSettings()
      }]
    })
  ]
})
export class AppModule { }

// For dashboard-specific toolbar items:
<si-flexible-dashboard
  [primaryEditActions]="primaryActions"
  [secondaryEditActions]="secondaryActions"
/>
```



- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR refactors toolbar menu items configuration in dashboards to support both global and per-dashboard actions. It introduces:

- **New injection token** `SI_DASHBOARD_TOOLBAR_ITEMS` and provider function `provideDashboardToolbarItems()` for global toolbar configuration
- **Component inputs** `primaryEditActions` and `secondaryEditActions` on `SiFlexibleDashboardComponent` for dashboard-specific toolbar actions
- **Runtime action merging** of global and dashboard-specific items within the dashboard component
- **API deprecation** of `SiWidgetStorage.getToolbarMenuItems()` in favor of the new provider-based pattern

The demo app is updated to show both configuration approaches: component inputs for per-dashboard actions and the provider pattern for global defaults. `AppWidgetStorage.restoreDefaults()` is simplified to accept an optional `dashboardId` parameter and return void, eliminating internal toolbar state management.

Comprehensive test coverage validates the merged toolbar configuration and demonstrates the new provider-based setup in different scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->