### PR TITLE
refactor(dashboards-ng): remove deprecated module config

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -20,14 +20,12 @@ import { Injector } from '@angular/core';
 import { InputSignal } from '@angular/core';
 import { MenuItem } from '@siemens/element-ng/common';
 import { MenuItem as MenuItem_2 } from '@siemens/element-ng/menu';
-import { ModuleWithProviders } from '@angular/core';
 import { NavigationExtras } from '@angular/router';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { OutputEmitterRef } from '@angular/core';
-import { Provider } from '@angular/core';
 import { SiDashboardComponent } from '@siemens/element-ng/dashboard';
 import * as _siemens_element_translate_ng_translate_types from '@siemens/element-translate-ng/translate-types';
 import { SimpleChanges } from '@angular/core';
@@ -141,13 +139,8 @@ export const SI_WIDGET_ID_PROVIDER: InjectionToken<SiWidgetIdProvider>;
 // @public
 export const SI_WIDGET_STORE: InjectionToken<SiWidgetStorage>;
 
-// @public
+// @public (undocumented)
 class SiDashboardsNgModule {
-    // @deprecated (undocumented)
-    static forRoot({ config, dashboardApi }: {
-        config?: Config;
-        dashboardApi?: Provider;
-    }): ModuleWithProviders<SiDashboardsNgModule>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<SiDashboardsNgModule, never>;
     // (undocumented)

--- a/projects/dashboards-ng/README.md
+++ b/projects/dashboards-ng/README.md
@@ -61,7 +61,7 @@ import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
     BrowserModule,
 
     // Import this library
-    SiDashboardsNgModule.forRoot({})
+    SiDashboardsNgModule
   ],
   providers: [
     provideNgxTranslateForElement()
@@ -244,16 +244,10 @@ providers: [..., { provide: DEFAULT_WIDGET_STORAGE_TOKEN, useValue: localStorage
 
 For persistence in a backend service, you should implement your own
 [SiWidgetStorage](https://github.com/siemens/element/blob/main/projects/dashboards-ng/src/model/si-widget-storage.ts) and provide it in
-the library module definition.
+your module providers or application config.
 
 ```ts
-SiDashboardsNgModule.forRoot({
-  config: {},
-  dashboardApi: {
-    provide: SiWidgetStorage,
-    useClass: CustomWidgetStorage
-  }
-});
+providers: [{ provide: SI_WIDGET_STORE, useClass: CustomWidgetStorage }];
 ```
 
 ### Configuration
@@ -262,8 +256,8 @@ The dashboard is configurable through the Angular inputs of the exposed componen
 the usage of the configuration object `Config`, which includes a `GridConfig` and including
 the [GridStackOptions](https://github.com/siemens/element/blob/main/projects/dashboards-ng/src/model/gridstack.model.ts).
 
-To configure all dashboard instances, you can leverage dependency injection when importing
-the `SiDashboardsNgModule` using `SiDashboardsNgModule.forRoot({...})`.
+To configure all dashboard instances, you can leverage dependency injection by providing
+the `SI_DASHBOARD_CONFIGURATION` token in your providers.
 Alternatively, you have the option to configure individual dashboard instances by setting
 the input property `SiFlexibleDashboardComponent.config = {...}`.
 

--- a/projects/dashboards-ng/src/public-api.module.ts
+++ b/projects/dashboards-ng/src/public-api.module.ts
@@ -2,18 +2,12 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ModuleWithProviders, NgModule, Provider } from '@angular/core';
+import { NgModule } from '@angular/core';
 
 import { SiFlexibleDashboardComponent } from './components/flexible-dashboard/si-flexible-dashboard.component';
 import { SiGridComponent } from './components/grid/si-grid.component';
 import { SiWidgetCatalogComponent } from './components/widget-catalog/si-widget-catalog.component';
 import { SiWidgetInstanceEditorDialogComponent } from './components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component';
-import { Config, SI_DASHBOARD_CONFIGURATION } from './model/configuration';
-import {
-  SI_WIDGET_STORE,
-  SiDefaultWidgetStorage,
-  SiWidgetStorage
-} from './model/si-widget-storage';
 
 @NgModule({
   imports: [
@@ -29,46 +23,6 @@ import {
     SiWidgetInstanceEditorDialogComponent
   ]
 })
-export class SiDashboardsNgModule {
-  /**
-   * @deprecated The module configuration `forRoot` is not needed any more. You can use the injection tokens
-   * `SI_DASHBOARD_CONFIGURATION` and `SI_WIDGET_STORE` direct in your app configuration. We migrated to standalone
-   * components already and will delete this module definition later.
-   */
-  static forRoot({
-    config,
-    dashboardApi
-  }: {
-    config?: Config;
-    /**
-     * Provide a custom widget storage.
-     *
-     * @deprecated Use the provider tokens in your app config instead.
-     *
-     * @example
-     * ```typescript
-     * const appConfig: ApplicationConfig = {
-     *  providers: [{provide: SI_WIDGET_STORE, useClass: YourWidgetStorage}]
-     * }
-     * ```
-     */
-    dashboardApi?: Provider;
-  }): ModuleWithProviders<SiDashboardsNgModule> {
-    return {
-      ngModule: SiDashboardsNgModule,
-      providers: [
-        {
-          provide: SI_DASHBOARD_CONFIGURATION,
-          useValue: config
-        },
-        dashboardApi ?? {
-          provide: SiWidgetStorage,
-          useClass: SiDefaultWidgetStorage
-        },
-        dashboardApi ? { provide: SI_WIDGET_STORE, useExisting: SiWidgetStorage } : []
-      ]
-    };
-  }
-}
+export class SiDashboardsNgModule {}
 
 export { SiDashboardsNgModule as SimplDashboardsNgModule };


### PR DESCRIPTION
BREAKING CHANGE: Removed deprecated module configuration `SiDashboardsNgModule.forRoot`. Use injection tokens `SI_DASHBOARD_CONFIGURATION` and `SI_WIDGET_STORE` directly in your app configuration.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR removes the deprecated SiDashboardsNgModule.forRoot() API. Consumers must now configure dashboards by providing the SI_DASHBOARD_CONFIGURATION and SI_WIDGET_STORE injection tokens directly in application providers.

## Changes

- projects/dashboards-ng/src/public-api.module.ts: Converted SiDashboardsNgModule from an @NgModule with a static forRoot(...) factory to a plain exported class; removed ModuleWithProviders and forRoot implementation.
- projects/dashboards-ng/README.md: Replaced forRoot-based examples with provider-based DI examples and clarified that per-instance config via SiFlexibleDashboardComponent.config remains available.
- api-goldens/dashboards-ng/index.api.md: Removed the static forRoot factory from the public API and adjusted JSDoc visibility.

## Migration (Breaking change)

Before:
imports: [
  SiDashboardsNgModule.forRoot({
    config: {},
    dashboardApi: {
      provide: SiWidgetStorage,
      useClass: CustomWidgetStorage
    }
  })
]

After:
imports: [SiDashboardsNgModule],
providers: [
  { provide: SI_WIDGET_STORE, useClass: AppWidgetStorage },
  { provide: SI_DASHBOARD_CONFIGURATION, useValue: config }
]

Note: The PR checklist item confirming contribution guideline adherence remains unchecked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->