### PR TITLE
refactor(icons): always use si-icon for app defined icons

### DIFF
--- a/playwright/snapshots/navbar-vertical-legacy.spec.ts-snapshots/si-navbar-vertical--si-navbar-vertical-legacy--collapsed-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-legacy.spec.ts-snapshots/si-navbar-vertical--si-navbar-vertical-legacy--collapsed-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ddcec955bb3a900f0cbb381c514d554cdaf642a5643300985fe372901e6450ef
-size 14323
+oid sha256:1fa1cedf3321497d7ac92d05e230b3dd3fe7c1d7b24057b904e4265832fcd99d
+size 14344

--- a/playwright/snapshots/navbar-vertical-legacy.spec.ts-snapshots/si-navbar-vertical--si-navbar-vertical-legacy--collapsed-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-legacy.spec.ts-snapshots/si-navbar-vertical--si-navbar-vertical-legacy--collapsed-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25cef555a973fbcee7e5f2b98e8f388bd575f1d3a96c1893120300bc6da46fc0
-size 13839
+oid sha256:10f5c1f9d912647a606017d2a6ba529d38f4684daee2371151d66fef8ccae229
+size 13859

--- a/playwright/snapshots/navbar-vertical-legacy.spec.ts-snapshots/si-navbar-vertical--si-navbar-vertical-legacy--collapsed-flyout-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-legacy.spec.ts-snapshots/si-navbar-vertical--si-navbar-vertical-legacy--collapsed-flyout-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:058108254cd478eb0edb6a1fa7b6036828a458c5d2261aa0e57aabc8a495123f
-size 18788
+oid sha256:c4f3258a71a4ab32c8806999d795bca8bb6099baf63545a18f2869fc5aca2499
+size 18821

--- a/playwright/snapshots/navbar-vertical-legacy.spec.ts-snapshots/si-navbar-vertical--si-navbar-vertical-legacy--collapsed-flyout-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-legacy.spec.ts-snapshots/si-navbar-vertical--si-navbar-vertical-legacy--collapsed-flyout-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:351d04e361cd4b90ccbc0b7aeb07755bf7101d8c7b3e9b30bc806408deb834ab
-size 18450
+oid sha256:6e239e5d254cc5407f257a66df22ea32204b75b888dea4561435ab09cee9e8ef
+size 18461

--- a/playwright/snapshots/si-formly-dynamic-fields.spec.ts-snapshots/si-formly--si-dynamic-form-fields.yaml
+++ b/playwright/snapshots/si-formly-dynamic-fields.spec.ts-snapshots/si-formly--si-dynamic-form-fields.yaml
@@ -8,7 +8,7 @@
 - textbox "Text input*": lorem ipsum
 - text: Icon input
 - textbox "Icon input": Input with icon for additional information tooltip
-- text:  Number input
+- text: Number input
 - spinbutton "Number input"
 - text: Password input*
 - textbox "Password input*"
@@ -25,10 +25,14 @@
   - code: SiDatePickerInputConfig
 - paragraph: The fields are displaying their model value in local time zone
 - text: Date
-- textbox "Date": /1\/1\/\d+/
+- textbox "Date":
+  - /placeholder: ""
+  - text: /1\/1\/\d+/
 - button "Open calendar"
 - text: Datetime*
-- textbox "Datetime*": /8\/\d+\/\d+, 5:\d+:\d+ AM/
+- textbox "Datetime*":
+  - /placeholder: Enter a date
+  - text: /8\/\d+\/\d+, 5:\d+:\d+ AM/
 - button "Open calendar"
 - text: Daterange
 - group:
@@ -42,10 +46,18 @@
 - paragraph: The fields are displaying their model value in local time zone
 - text: Time
 - group:
-  - textbox "Hours"
-  - textbox "Minutes"
-  - textbox "Seconds"
-  - textbox "Milliseconds"
+  - textbox "Hours":
+    - /placeholder: hh
+    - text: ""
+  - textbox "Minutes":
+    - /placeholder: mm
+    - text: ""
+  - textbox "Seconds":
+    - /placeholder: ss
+    - text: ""
+  - textbox "Milliseconds":
+    - /placeholder: ms
+    - text: ""
   - combobox "Period":
     - option "AM" [selected]
     - option "PM"
@@ -58,12 +70,18 @@
 - text: "Checkbox #2"
 - separator
 - group "Multi-Checkbox":
+  - text: ""
   - 'checkbox "Option #1" [checked]'
+  - text: ""
   - 'checkbox "Option #2"'
+  - text: ""
   - 'checkbox "Option #3" [checked]'
+  - text: ""
   - 'checkbox "Option #4"'
+  - text: ""
 - separator
 - group "Radio":
+  - text: ""
   - 'radio "Option #1"'
   - text: "Option #1"
   - 'radio "Option #2"'
@@ -85,13 +103,21 @@
   - option "Helsinki"
 - separator
 - text: IPv4 Address*
-- textbox "IPv4 Address*"
+- textbox "IPv4 Address*":
+  - /placeholder: Enter a IPv4 address
+  - text: ""
 - text: IPv4 Address with CIDR*
-- textbox "IPv4 Address with CIDR*"
+- textbox "IPv4 Address with CIDR*":
+  - /placeholder: Enter a IPv4 address with subnet mask
+  - text: ""
 - text: IPv6 Address*
-- textbox "IPv6 Address*": /\d+:0db8:85a3:\d+:\d+:8a2e:\d+:\d+/
+- textbox "IPv6 Address*":
+  - /placeholder: Enter a IPv6 address
+  - text: /\d+:0db8:85a3:\d+:\d+:8a2e:\d+:\d+/
 - text: IPv6 CIDR Address*
-- textbox "IPv6 CIDR Address*": /\d+:0db8:85a3:\d+:\d+:8a2e:\d+:\d+\/\d+/
+- textbox "IPv6 CIDR Address*":
+  - /placeholder: Enter a IPv6 address
+  - text: /\d+:0db8:85a3:\d+:\d+:8a2e:\d+:\d+\/\d+/
 - separator
 - heading "Buttons" [level=2]
 - button "Button function handler"

--- a/playwright/snapshots/static.spec.ts-snapshots/si-avatar--si-avatar.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-avatar--si-avatar.yaml
@@ -1,8 +1,8 @@
 - heading "Styles" [level=4]
 - img "John Doe"
-- text: JD 
+- text: JD
 - 'heading "Status (use only with sizes `regular` or `small`)" [level=4]'
-- text: JD JD JD JD JD  JD JD JD JD JD 
+- text: JD JD JD JD JD JD JD JD JD JD
 - heading "Colors" [level=4]
 - text: JD JD JD JD JD JD JD JD JD JD JD JD JD JD JD JD JD
 - heading "Image sizes" [level=4]

--- a/projects/element-ng/avatar/si-avatar.component.html
+++ b/projects/element-ng/avatar/si-avatar.component.html
@@ -1,7 +1,7 @@
 @if (imageUrl()) {
   <img [src]="imageUrl()" [alt]="altText()" />
 } @else if (icon()) {
-  <i class="icon" [title]="altText()" [ngClass]="icon()"></i>
+  <si-icon class="icon" [title]="altText()" [icon]="icon()!" />
 } @else {
   <div
     class="initials"

--- a/projects/element-ng/avatar/si-avatar.component.spec.ts
+++ b/projects/element-ng/avatar/si-avatar.component.spec.ts
@@ -63,7 +63,7 @@ describe('SiAvatarComponent', () => {
     host.icon = 'element-user';
     fixture.detectChanges();
 
-    const el = element.querySelector<HTMLElement>('.element-user');
+    const el = element.querySelector<HTMLElement>('si-icon');
     expect(el).toBeTruthy();
     expect(el?.title).toBe('Test');
   });

--- a/projects/element-ng/formly/wrapper/si-formly-icon-wrapper.component.html
+++ b/projects/element-ng/formly/wrapper/si-formly-icon-wrapper.component.html
@@ -8,7 +8,7 @@
       [style]="'font-size: ' + (props.iconSize ? props.iconSize : 24) + 'px'"
       [siTooltip]="props.iconTooltip | translate"
     >
-      <i [class]="props.icon"></i>
+      <si-icon [icon]="props.icon" />
     </div>
   }
 </div>

--- a/projects/element-ng/formly/wrapper/si-formly-icon-wrapper.component.ts
+++ b/projects/element-ng/formly/wrapper/si-formly-icon-wrapper.component.ts
@@ -4,12 +4,13 @@
  */
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { FieldWrapper } from '@ngx-formly/core';
+import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTooltipDirective } from '@siemens/element-ng/tooltip';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-formly-icon-wrapper',
-  imports: [SiTooltipDirective, SiTranslatePipe],
+  imports: [SiIconComponent, SiTooltipDirective, SiTranslatePipe],
   templateUrl: './si-formly-icon-wrapper.component.html',
   styleUrl: './si-formly-icon-wrapper.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.html
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.html
@@ -1,7 +1,8 @@
-@if (item().icon) {
-  <i class="icon me-n2" aria-hidden="true" [ngClass]="[item().icon]"></i>
+@let icon = item().icon;
+@if (icon) {
+  <si-icon class="icon me-n2" [icon]="icon" />
 }
-@if (item().icon && formattedBadge()) {
+@if (icon && formattedBadge()) {
   <div class="w-100 h-100 position-absolute">
     <span class="badge-text">{{ formattedBadge() }}</span>
   </div>

--- a/projects/element-ng/navbar/si-navbar-item/si-navbar-item.component.html
+++ b/projects/element-ng/navbar/si-navbar-item/si-navbar-item.component.html
@@ -24,7 +24,10 @@
 }
 
 <ng-template #itemContent>
-  <div class="icon" aria-hidden="true" [ngClass]="item().icon"></div>
+  @let icon = item().icon;
+  @if (icon) {
+    <si-icon class="icon" [icon]="icon" />
+  }
   @if (item().badge) {
     <div class="badge-text">{{ item().badge }}</div>
   }

--- a/projects/element-ng/notification-item/si-notification-item.component.html
+++ b/projects/element-ng/notification-item/si-notification-item.component.html
@@ -113,7 +113,7 @@
     [attr.aria-label]="action.ariaLabel"
     (click)="action.action(action)"
   >
-    <i [ngClass]="'icon ' + action.icon"></i>
+    <si-icon class="icon" [icon]="action.icon" />
   </button>
 </ng-template>
 
@@ -131,7 +131,7 @@
     [replaceUrl]="action.extras?.replaceUrl"
     [attr.aria-label]="action.ariaLabel"
   >
-    <i class="icon" [ngClass]="action.icon"></i>
+    <si-icon class="icon" [icon]="action.icon" />
   </a>
 </ng-template>
 
@@ -142,7 +142,7 @@
     [target]="action.target"
     [attr.aria-label]="action.ariaLabel"
   >
-    <i class="icon" [ngClass]="action.icon"></i>
+    <si-icon class="icon" [icon]="action.icon" />
   </a>
 </ng-template>
 


### PR DESCRIPTION
In order to allow apps to use SVG icons, their icon inputs must also be bound to si-icon

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Refactor Icons to Always Use si-icon for App-Defined Inputs

This PR standardizes icon rendering across the component library by replacing inline `<i>` elements with the `si-icon` component in all app-provided icon inputs. This enables applications to use SVG icons through a consistent interface.

**Changes:**
- **Avatar component**: Replaced inline `<i class="icon">` with `<si-icon [icon]="icon()!" />`
- **Formly icon wrapper**: Updated to use `<si-icon [icon]="props.icon" />` with necessary SiIconComponent import
- **Navbar components**: Converted inline icon elements to `<si-icon>` in both vertical and horizontal navbar items, introducing local icon variables and conditional rendering
- **Notification item**: Replaced three instances of inline `<i>` elements with `<si-icon>` in action buttons and links
- **Tests & snapshots**: Updated component tests and Playwright snapshots to reflect the new icon rendering

The refactoring maintains all existing styling and behavior while providing a unified, component-based approach to icon handling that supports SVG icons for app-defined inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->