### PR TITLE
fix(icon): render font icons when name contains kebab-case with numbers

### DIFF
--- a/projects/element-ng/icon/si-icon.component.spec.ts
+++ b/projects/element-ng/icon/si-icon.component.spec.ts
@@ -50,6 +50,12 @@ describe('SiSvgIconComponent', () => {
         expect(fixture.debugElement.query(By.css('.element-user'))).toBeTruthy();
       });
 
+      it('should use original kebabCase icon as icon font', () => {
+        component.icon.set('element-co2-outdoor');
+        fixture.detectChanges();
+        expect(fixture.debugElement.query(By.css('.element-co2-outdoor'))).toBeTruthy();
+      });
+
       describe('with icon from registry', () => {
         beforeEach(() => {
           component.icon.set('element-2-svg');

--- a/projects/element-ng/icon/si-icon.component.ts
+++ b/projects/element-ng/icon/si-icon.component.ts
@@ -118,10 +118,23 @@ export class SiIconComponent {
     this.svgIcon() ? undefined : this.camelToKebabCase(this.icon())
   );
 
+  private isKebabCase(str: string): boolean {
+    return /^[a-z0-9]+(-[a-z0-9]+)*$/.test(str);
+  }
+
+  /**
+   * Converts a camelCase string to kebab-case.
+   * If the string is already in kebab-case, it returns it unchanged.
+   *
+   * Note: This conversion has limitations with mixed alphanumeric cases.
+   * Complex number-letter combinations may not convert as expected.
+   */
   private camelToKebabCase(str: string): string {
-    return str
-      ?.replace(/([a-z])([A-Z0-9])/g, '$1-$2')
-      .replace(/([0-9])([A-Z])/g, '$1-$2')
-      .toLowerCase();
+    return this.isKebabCase(str)
+      ? str
+      : str
+          ?.replace(/([a-z])([A-Z0-9])/g, '$1-$2')
+          .replace(/([0-9])([A-Z])/g, '$1-$2')
+          .toLowerCase();
   }
 }


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixes icon rendering for kebab-case names containing numbers. Adds a helper method `isKebabCase()` to detect if a string is already in kebab-case format, and modifies `camelToKebabCase()` to return the input unchanged when it's already kebab-case, avoiding unnecessary string transformations. Includes a test case verifying that kebab-case icon names like `element-co2-outdoor` are correctly rendered as icon-font elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->