### PR TITLE
test(element): make tests zoneless ready

### DIFF
--- a/projects/element-ng/application-header/si-application-header.component.spec.ts
+++ b/projects/element-ng/application-header/si-application-header.component.spec.ts
@@ -102,7 +102,6 @@ describe('SiApplicationHeaderComponent', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [TestHostComponent],
         providers: [provideZonelessChangeDetection()]
       });
     });
@@ -219,7 +218,7 @@ describe('SiApplicationHeaderComponent', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [TestHostComponent]
+        providers: [provideZonelessChangeDetection()]
       });
     });
 
@@ -305,8 +304,10 @@ describe('SiApplicationHeaderComponent', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [TestHostComponent],
-        providers: [{ provide: BreakpointObserver, useExisting: BreakpointObserverMock }]
+        providers: [
+          { provide: BreakpointObserver, useExisting: BreakpointObserverMock },
+          provideZonelessChangeDetection()
+        ]
       });
     });
 
@@ -355,7 +356,7 @@ describe('SiApplicationHeaderComponent', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [TestHostComponent]
+        providers: [provideZonelessChangeDetection()]
       });
     });
 

--- a/projects/element-ng/autocomplete/si-autocomplete.directive.spec.ts
+++ b/projects/element-ng/autocomplete/si-autocomplete.directive.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { DOWN_ARROW, ENTER, UP_ARROW } from '@angular/cdk/keycodes';
-import { Component, ErrorHandler } from '@angular/core';
+import { Component, ErrorHandler, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -46,6 +46,9 @@ describe('SiAutocompleteDirective', () => {
   let fixture: ComponentFixture<TestHostComponent>;
 
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
     fixture = TestBed.createComponent(TestHostComponent);
     testComponent = fixture.componentInstance;
   });
@@ -118,22 +121,28 @@ describe('SiAutocompleteDirective', () => {
   it('should select an element if default index was changed and none was selected', async () => {
     testComponent.defaultIndex = -1;
     testComponent.showList = true;
-    // needed to detect changes triggered by queueMicrotask
-    fixture.autoDetectChanges(true);
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
     expect(
       fixture.debugElement
         .queryAll(By.directive(SiAutocompleteOptionDirective))
         .filter(option => option.classes.active)
     ).toHaveSize(0);
     testComponent.defaultIndex = 0;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     await fixture.whenStable();
+
+    // cannot use mock timer here
+    await new Promise(resolve => setTimeout(resolve, 0));
     expect(
       fixture.debugElement
         .queryAll(By.directive(SiAutocompleteOptionDirective))
         .filter(option => option.classes.active)
     ).toHaveSize(1);
     testComponent.defaultIndex = 1;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     await fixture.whenStable();
     expect(

--- a/projects/element-ng/card/si-action-card.spec.ts
+++ b/projects/element-ng/card/si-action-card.spec.ts
@@ -5,7 +5,12 @@
 
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  provideZonelessChangeDetection
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 
@@ -39,6 +44,9 @@ describe('SiActionCardComponent', () => {
   let actionCardHarness: SiActionCardHarness;
 
   beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
     fixture = TestBed.createComponent(WrapperComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
     actionCardHarness = await loader.getHarness(SiActionCardHarness);

--- a/projects/element-ng/common/services/si-uistate.service.spec.ts
+++ b/projects/element-ng/common/services/si-uistate.service.spec.ts
@@ -61,7 +61,10 @@ describe('SiUIStateService', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        providers: [provideSiUiState({ store: AsynchronousMockStore })]
+        providers: [
+          provideSiUiState({ store: AsynchronousMockStore }),
+          provideZonelessChangeDetection()
+        ]
       }).compileComponents();
       service = TestBed.inject(SI_UI_STATE_SERVICE);
     });

--- a/projects/element-ng/copyright-notice/si-copyright-notice.component.spec.ts
+++ b/projects/element-ng/copyright-notice/si-copyright-notice.component.spec.ts
@@ -84,7 +84,7 @@ describe('SiCopyrightNoticeComponentWithInput', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WrapperWithInputComponent]
+      providers: [provideZonelessChangeDetection()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(WrapperWithInputComponent);

--- a/projects/element-ng/datepicker/components/si-day-selection.component.spec.ts
+++ b/projects/element-ng/datepicker/components/si-day-selection.component.spec.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 import { DatePipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  signal
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {
@@ -131,6 +136,12 @@ describe('SiDaySelectionComponent', () => {
       ?.dispatchEvent(new Event('mouseover', { bubbles: true }));
     fixture.detectChanges();
   };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
+  });
 
   describe('When Single Select View', () => {
     let wrapperComponent: SingleSelectComponent;

--- a/projects/element-ng/datepicker/components/si-month-selection.component.spec.ts
+++ b/projects/element-ng/datepicker/components/si-month-selection.component.spec.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 import { A11yModule } from '@angular/cdk/a11y';
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  signal
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { getLocaleMonthNames } from '../date-time-helper';
@@ -60,6 +65,9 @@ describe('SiMonthSelectionComponent', () => {
   let helper: CalendarTestHelper;
 
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
     fixture = TestBed.createComponent(WrapperComponent);
     wrapperComponent = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/projects/element-ng/datepicker/components/si-year-selection.component.spec.ts
+++ b/projects/element-ng/datepicker/components/si-year-selection.component.spec.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 import { A11yModule } from '@angular/cdk/a11y';
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  signal
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiDatepickerModule } from '../si-datepicker.module';
@@ -48,6 +53,9 @@ describe('SiYearSelectionComponent', () => {
   let helper: CalendarTestHelper;
 
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
     fixture = TestBed.createComponent(WrapperComponent);
     wrapperComponent = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/projects/element-ng/datepicker/si-timepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.spec.ts
@@ -88,6 +88,9 @@ describe('SiTimepickerComponent', () => {
     let component: WrapperComponent;
 
     beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideZonelessChangeDetection()]
+      }).compileComponents();
       fixture = TestBed.createComponent(WrapperComponent);
       component = fixture.componentInstance;
       element = fixture.nativeElement;

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component } from '@angular/core';
+import { Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -23,6 +23,9 @@ describe('SiFormValidationTooltipDirective', () => {
   let harness: SiFormValidationTooltipHarness;
 
   beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
     fixture = TestBed.createComponent(TestHostComponent);
     harness = await TestbedHarnessEnvironment.loader(fixture).getHarness(
       SiFormValidationTooltipHarness

--- a/projects/element-ng/form/si-form.spec.ts
+++ b/projects/element-ng/form/si-form.spec.ts
@@ -310,6 +310,9 @@ describe('SiForm', () => {
     let loader: HarnessLoader;
 
     beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideZonelessChangeDetection()]
+      }).compileComponents();
       fixture = TestBed.createComponent(TestHostComponent);
       loader = TestbedHarnessEnvironment.loader(fixture);
     });

--- a/projects/element-ng/formly/si-formly.module.spec.ts
+++ b/projects/element-ng/formly/si-formly.module.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
+
 import { SiFormlyModule } from './si-formly.module';
 
 describe('element form module init', () => {

--- a/projects/element-ng/icon/si-icon.component.spec.ts
+++ b/projects/element-ng/icon/si-icon.component.spec.ts
@@ -109,6 +109,9 @@ describe('SiSvgIconComponent', () => {
 
     describe('with disabled svg icons', () => {
       beforeEach(async () => {
+        TestBed.configureTestingModule({
+          providers: [provideZonelessChangeDetection()]
+        }).compileComponents();
         fixture = TestBed.createComponent(TestHostComponent);
         component = fixture.componentInstance;
         fixture.detectChanges();
@@ -165,6 +168,9 @@ describe('SiSvgIconComponent', () => {
     let component: TestHostComponent;
     let iconService: IconService;
     beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideZonelessChangeDetection()]
+      }).compileComponents();
       fixture = TestBed.createComponent(TestHostComponent);
       component = fixture.componentInstance;
       iconService = TestBed.inject(IconService);

--- a/projects/element-ng/notification-item/si-notification-item.component.spec.ts
+++ b/projects/element-ng/notification-item/si-notification-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component } from '@angular/core';
+import { Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -55,6 +55,9 @@ describe('SiNotificationItemComponent', () => {
   let element: HTMLElement;
 
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;
@@ -71,12 +74,14 @@ describe('SiNotificationItemComponent', () => {
 
   it('should display the description', () => {
     component.description = 'Description';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(element.querySelectorAll('span.si-body')[1].innerHTML).toContain('Description');
   });
 
   it('should display the unread state', () => {
     component.unread = true;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(element.querySelector('span.si-h5')).not.toBeTruthy();
     expect(element.querySelector('span.si-h5-bold')).toBeTruthy();
@@ -85,6 +90,7 @@ describe('SiNotificationItemComponent', () => {
 
   it('should link with the item link', () => {
     component.itemLink = { type: 'link', href: '/test' };
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(element.querySelector('a')?.getAttribute('href')).toBe('/test');
   });
@@ -93,6 +99,7 @@ describe('SiNotificationItemComponent', () => {
     const router = TestBed.inject(Router);
     spyOn(router, 'navigateByUrl');
     component.itemLink = { type: 'router-link', routerLink: '/test' };
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     element.querySelector<HTMLElement>('a')?.click();
@@ -110,6 +117,7 @@ describe('SiNotificationItemComponent', () => {
       { type: 'link', href: '/test', ariaLabel: 'Link', icon: 'element-plant' },
       { type: 'router-link', routerLink: '/test', ariaLabel: 'Router Link', icon: 'element-plant' }
     ];
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(element.querySelectorAll('button').length).toBe(1);
     expect(element.querySelectorAll('a').length).toBe(2);
@@ -123,6 +131,7 @@ describe('SiNotificationItemComponent', () => {
         { type: 'action', label: 'Action 2', action: () => {} }
       ]
     };
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(element.querySelector('button si-icon')).toBeTruthy();
   });
@@ -133,6 +142,7 @@ describe('SiNotificationItemComponent', () => {
       label: 'Action',
       action: () => {}
     };
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(element.querySelector('button')?.textContent).toContain('Action');
   });

--- a/projects/element-ng/popover/si-popover.directive.spec.ts
+++ b/projects/element-ng/popover/si-popover.directive.spec.ts
@@ -163,6 +163,9 @@ describe('with custom template', () => {
   let fixture: ComponentFixture<CustomTemplateHostComponent>;
 
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
     fixture = TestBed.createComponent(CustomTemplateHostComponent);
   });
 

--- a/projects/element-ng/search-bar/si-search-bar.component.spec.ts
+++ b/projects/element-ng/search-bar/si-search-bar.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CommonModule } from '@angular/common';
-import { Component, viewChild } from '@angular/core';
+import { Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -41,6 +41,9 @@ describe('SiSearchBarComponent', () => {
     }
 
     beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideZonelessChangeDetection()]
+      }).compileComponents();
       fixture = TestBed.createComponent(TestComponent);
       testComponent = fixture.componentInstance;
       component = fixture.componentInstance.searchBar();
@@ -153,6 +156,10 @@ describe('SiSearchBarComponent', () => {
     }
 
     beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [TestComponent],
+        providers: [provideZonelessChangeDetection()]
+      }).compileComponents();
       fixture = TestBed.createComponent(TestComponent);
       testComponent = fixture.componentInstance;
       component = fixture.componentInstance.searchBar();
@@ -162,11 +169,13 @@ describe('SiSearchBarComponent', () => {
     it('should not emit values when changed via value input', () => {
       spyOn(component.searchChange, 'emit');
       testComponent.value = 'Initial Value';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(element.querySelector('input')!.value).toBe('Initial Value');
       expect(component.searchChange.emit).not.toHaveBeenCalled();
 
       testComponent.value = 'Updated Value';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(element.querySelector('input')!.value).toBe('Updated Value');
       expect(component.searchChange.emit).not.toHaveBeenCalled();
@@ -174,9 +183,11 @@ describe('SiSearchBarComponent', () => {
 
     it('should support disabled input', () => {
       testComponent.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(element.querySelector('input')!.disabled).toBe(true);
       testComponent.disabled = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(element.querySelector('input')!.disabled).toBe(false);
     });

--- a/projects/element-ng/select/si-select.component.spec.ts
+++ b/projects/element-ng/select/si-select.component.spec.ts
@@ -587,6 +587,9 @@ describe('SiSelectComponent', () => {
     let component: TestHostCustomActionComponent;
 
     beforeEach(async () => {
+      TestBed.configureTestingModule({
+        providers: [provideZonelessChangeDetection()]
+      }).compileComponents();
       const typedFixture = TestBed.createComponent(TestHostCustomActionComponent);
       fixture = typedFixture;
       loader = TestbedHarnessEnvironment.loader(fixture);

--- a/projects/element-ng/shadow-root/si-shadow-root.directive.spec.ts
+++ b/projects/element-ng/shadow-root/si-shadow-root.directive.spec.ts
@@ -3,7 +3,13 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
-import { Component, input, signal, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  input,
+  provideZonelessChangeDetection,
+  signal,
+  ViewEncapsulation
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiShadowRootDirective } from './si-shadow-root.directive';
@@ -51,6 +57,9 @@ describe('ShadowRootDirective', () => {
   let fixture: ComponentFixture<TestHostComponent>;
 
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
     fixture = TestBed.createComponent(TestHostComponent);
   });
 


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## test(element): make tests zoneless ready

Updates 19 test files across the element-ng project to enable zoneless change detection by:

- Adding `provideZonelessChangeDetection()` from `@angular/core` to TestBed provider configurations in test modules
- Replacing automatic change detection with explicit manual `markForCheck()` and `detectChanges()` calls where needed
- Adjusting test timing and sequencing to handle asynchronous microtask boundaries without Zone.js

Changes affect test setup only with no modifications to production code or public API signatures. Estimated effort: Medium.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->