### PR TITLE
test(dashboards): avoid flaky test errors

### DIFF
--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
@@ -66,12 +66,15 @@ describe('SiGridstackWrapperComponent', () => {
       expect(gridStackWrapper!.mount).toHaveBeenCalledWith(TEST_WIDGET_CONFIGS);
     });
 
-    it('should render grid items', () => {
+    it('should render grid items', async () => {
       fixture = TestBed.createComponent(HostComponent);
       host = fixture.componentInstance;
       gridService.widgetCatalog.set([TEST_WIDGET]);
       host.widgets = [TEST_WIDGET_CONFIG_0, TEST_WIDGET_CONFIG_1];
       fixture.detectChanges();
+
+      // to avoid injector destroyed error
+      await new Promise(resolve => setTimeout(resolve, 0));
 
       expect(fixture.debugElement.queryAll(By.css('si-widget-host')).length).toBe(2);
     });
@@ -86,7 +89,7 @@ describe('SiGridstackWrapperComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should mount newly added grid items', () => {
+    it('should mount newly added grid items', async () => {
       host.widgets = [...host.widgets, TEST_WIDGET_CONFIG_2];
 
       const gridStackWrapper = host.gridStackWrapper();
@@ -94,11 +97,14 @@ describe('SiGridstackWrapperComponent', () => {
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
+      // to avoid injector destroyed error
+      await new Promise(resolve => setTimeout(resolve, 0));
+
       expect(gridStackWrapper!.mount).toHaveBeenCalled();
       expect(gridStackWrapper!.mount).toHaveBeenCalledWith([TEST_WIDGET_CONFIG_2]);
     });
 
-    it('should unmount removed grid items', () => {
+    it('should unmount removed grid items', async () => {
       host.widgets = [TEST_WIDGET_CONFIG_1];
       spyOn(host.gridStackWrapper()!, 'unmount').and.callThrough();
       fixture.changeDetectorRef.markForCheck();
@@ -111,18 +117,23 @@ describe('SiGridstackWrapperComponent', () => {
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
+      // to avoid injector destroyed error
+      await new Promise(resolve => setTimeout(resolve, 0));
+
       expect(host.gridStackWrapper()!.unmount).toHaveBeenCalled();
       expect(host.gridStackWrapper()!.unmount).toHaveBeenCalledWith([TEST_WIDGET_CONFIG_1]);
     });
   });
 
   describe('#getLayout()', () => {
-    it('should return layout of grid items', () => {
+    it('should return layout of grid items', async () => {
       fixture = TestBed.createComponent(HostComponent);
       host = fixture.componentInstance;
       gridService.widgetCatalog.set([TEST_WIDGET]);
       host.widgets = TEST_WIDGET_CONFIGS;
       fixture.detectChanges();
+      // to avoid injector destroyed error
+      await new Promise(resolve => setTimeout(resolve, 0));
       const layout = host.gridStackWrapper()!.getLayout();
       expect(layout).toBeDefined();
       expect(layout.length).toBe(TEST_WIDGET_CONFIGS.length);

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
@@ -78,8 +78,12 @@ describe('SiWidgetHostComponent', () => {
     jasmine.clock().uninstall();
   });
 
-  it('#editAction should call onEdit', () => {
+  it('#editAction should call onEdit', async () => {
     fixture.detectChanges();
+    jasmine.clock().install();
+    jasmine.clock().tick(0);
+    await fixture.whenStable();
+    jasmine.clock().uninstall();
     const spy = spyOn(component, 'onEdit');
     ((component.editAction as MenuItemAction).action! as (param?: any) => void)();
 
@@ -96,8 +100,12 @@ describe('SiWidgetHostComponent', () => {
     component.onEdit();
   });
 
-  it('#removeAction should call onRemove', () => {
+  it('#removeAction should call onRemove', async () => {
     fixture.detectChanges();
+    jasmine.clock().install();
+    jasmine.clock().tick(0);
+    await fixture.whenStable();
+    jasmine.clock().uninstall();
     const spy = spyOn(component, 'onRemove');
     ((component.removeAction as MenuItemAction).action! as (param?: any) => void)();
 

--- a/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.spec.ts
@@ -34,7 +34,7 @@ describe('SiWidgetInstanceEditorDialogComponent', () => {
     component = fixture.componentInstance;
   });
 
-  it('should create', () => {
+  it('should create', async () => {
     expect(component).toBeTruthy();
     fixture.componentRef.setInput('widget', TEST_WIDGET);
     fixture.componentRef.setInput('widgetConfig', {
@@ -42,6 +42,8 @@ describe('SiWidgetInstanceEditorDialogComponent', () => {
       id: 'testId'
     });
     fixture.detectChanges();
+    // to avoid injector destroyed error
+    await new Promise(resolve => setTimeout(resolve, 0));
     expect(component.widgetConfig()).toBeDefined();
     expect(component.widget()).toBeDefined();
   });


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes flaky tests in the dashboards-ng component by adding asynchronous handling to stabilize test execution. Three test files were updated to await minimal delays and properly synchronize with async operations:

- **SiGridstackWrapperComponent spec**: Added `await setTimeout(0)` delays before assertions in four tests ("should render grid items", "should mount newly added grid items", "should unmount removed grid items", and "getLayout").
- **SiWidgetHostComponent spec**: Converted two tests to async with Jasmine clock management to ensure asynchronous operations complete before verification.
- **SiWidgetInstanceEditorDialog spec**: Converted "should create" test to async with a zero-timeout await to prevent injector destroyed errors.

These changes address injector lifecycle timing issues without modifying production code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->