### PR TITLE
test(element-ng): make tests zoneless ready

### DIFF
--- a/projects/element-ng/datepicker/components/test-helper.spec.ts
+++ b/projects/element-ng/datepicker/components/test-helper.spec.ts
@@ -116,7 +116,7 @@ export const generateKeyEvent = (key: string): KeyboardEvent => {
 
 export const backdropClick = async (fixture: any): Promise<void> => {
   const backdrop = document.querySelector('.cdk-overlay-backdrop') as HTMLElement;
-  backdrop.click();
+  await backdrop.click();
   fixture.detectChanges();
   await fixture.whenStable();
 };

--- a/projects/element-ng/datepicker/si-datepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-datepicker.component.spec.ts
@@ -4,7 +4,13 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  signal,
+  viewChild
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiDatepickerComponent, SiDatepickerModule } from '.';
@@ -52,6 +58,10 @@ describe('SiDatepickerComponent', () => {
   };
 
   beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
     jasmine.clock().mockDate(new Date('2023-12-31'));
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;

--- a/projects/element-ng/search-bar/si-search-bar.component.spec.ts
+++ b/projects/element-ng/search-bar/si-search-bar.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { CommonModule } from '@angular/common';
 import { Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 import { SiSearchBarComponent } from './index';
@@ -17,6 +17,15 @@ describe('SiSearchBarComponent', () => {
   };
 
   const getParameterFromSpy = (spy: any): string => (spy as jasmine.Spy).calls.mostRecent().args[0];
+
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
 
   describe('as form control', () => {
     let fixture: ComponentFixture<TestComponent>;
@@ -56,66 +65,67 @@ describe('SiSearchBarComponent', () => {
       expect(element.querySelector('input')!.placeholder).toBe('Users');
     });
 
-    it('should reset search when clicking cancel button', fakeAsync(() => {
+    it('should reset search when clicking cancel button', () => {
       spyOn(component.searchChange, 'emit');
       testComponent.search.setValue('Test1234$');
       fixture.detectChanges();
       element.querySelector<HTMLElement>('button')!.click();
-      tick(1000);
       expect(getParameterFromSpy(component.searchChange.emit)).toBe('');
-    }));
+    });
 
-    it('should trigger the change event on input', fakeAsync(() => {
+    it('should trigger the change event on input', async () => {
       spyOn(component.searchChange, 'emit');
       fixture.detectChanges();
       fakeInput('Test1234$', element);
-      tick(1000);
+      jasmine.clock().tick(400);
+      await fixture.whenStable();
       expect(getParameterFromSpy(component.searchChange.emit)).toEqual('Test1234$');
-    }));
+    });
 
-    it('should trigger the initial change event just once per value', fakeAsync(() => {
+    it('should trigger the initial change event just once per value', async () => {
       fixture.detectChanges();
       spyOn(component.searchChange, 'emit');
       fakeInput('CodeTest1234$', element);
       fixture.detectChanges();
-      tick(400);
+      jasmine.clock().tick(400);
+      await fixture.whenStable();
       expect(component.searchChange.emit).toHaveBeenCalledTimes(1);
-    }));
+    });
 
-    it('should not prohibit characters by default', fakeAsync(() => {
+    it('should not prohibit characters by default', async () => {
       spyOn(component.searchChange, 'emit');
       fixture.detectChanges();
       fakeInput('Test1234$', element);
-      tick(1000);
+      jasmine.clock().tick(400);
+      await fixture.whenStable();
       expect(getParameterFromSpy(component.searchChange.emit)).toEqual('Test1234$');
-    }));
+    });
 
-    it('should not prohibit characters if string is empty', fakeAsync(() => {
+    it('should not prohibit characters if string is empty', () => {
       spyOn(component.searchChange, 'emit');
       testComponent.prohibitedCharacters = '1234$';
       fixture.detectChanges();
       fakeInput('', element);
-      tick(1000);
       expect(component.searchChange.emit).not.toHaveBeenCalled();
-    }));
+    });
 
-    it('should not prohibit characters if string is valid', fakeAsync(() => {
+    it('should not prohibit characters if string is valid', async () => {
       spyOn(component.searchChange, 'emit');
       testComponent.prohibitedCharacters = '1234$';
       fixture.detectChanges();
       fakeInput('Test', element);
-      tick(1000);
+      jasmine.clock().tick(400);
+      await fixture.whenStable();
       expect(getParameterFromSpy(component.searchChange.emit)).toEqual('Test');
-    }));
+    });
 
-    it('should prohibit characters if string is not valid', fakeAsync(() => {
+    it('should prohibit characters if string is not valid', () => {
       spyOn(component.searchChange, 'emit');
       testComponent.prohibitedCharacters = '1234$';
       fixture.detectChanges();
       fakeInput('Test1234$', element);
-      tick(1000);
       expect(component.searchChange.emit).not.toHaveBeenCalled();
-    }));
+    });
 
     it('should support disable state', () => {
       testComponent.search.disable();


### PR DESCRIPTION

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates test files across the `element-ng` datepicker and tabs-legacy modules to be zoneless-ready by adopting Angular's zoneless change detection mode.

**Key Changes:**
- Added `provideZonelessChangeDetection` provider from `@angular/core` to `TestBed.configureTestingModule` in multiple test files
- Converted timing-dependent tests from `fakeAsync`/`tick` to `jasmine.clock()` with explicit `install`/`uninstall` calls
- Enhanced test synchronization by adding `fixture.whenStable()` awaits and explicit `fixture.detectChanges()` calls to ensure proper change detection without NgZone
- Replaced deprecated async/timing utilities with real-time delays and promise-based waits

**Affected Files:**
- `projects/element-ng/datepicker/components/test-helper.spec.ts`
- `projects/element-ng/datepicker/si-date-range.component.spec.ts`
- `projects/element-ng/datepicker/si-datepicker.component.spec.ts`
- `projects/element-ng/datepicker/si-datepicker.directive.spec.ts`
- `projects/element-ng/tabs-legacy/si-tabset/si-tabset-legacy.component.spec.ts`
- `projects/element-ng/search-bar/si-search-bar.component.spec.ts`

No public API changes; all modifications are test-internal updates to ensure compatibility with zoneless change detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->