### PR TITLE
refactor(angular): remove zone.js test polyfills from charts, maps and dashboard

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -253,7 +253,6 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "projects/charts-ng/tsconfig.spec.json",
             "karmaConfig": "projects/charts-ng/karma.conf.cjs",
             "codeCoverageExclude": ["projects/charts-ng/src/**/*.module.ts"]
@@ -284,7 +283,6 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "projects/native-charts-ng/tsconfig.spec.json",
             "karmaConfig": "projects/native-charts-ng/karma.conf.cjs",
             "codeCoverageExclude": ["projects/native-charts-ng/src/**/*.module.ts"]
@@ -318,7 +316,6 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "projects/maps-ng/tsconfig.spec.json",
             "karmaConfig": "projects/maps-ng/karma.conf.cjs",
             "codeCoverageExclude": ["projects/maps-ng/src/**/*.module.ts"]
@@ -350,7 +347,6 @@
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
             "builderMode": "browser",
-            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "projects/dashboards-ng/tsconfig.spec.json",
             "karmaConfig": "projects/dashboards-ng/karma.conf.cjs",
             "codeCoverageExclude": ["projects/dashboards-ng/src/**/*.module.ts"]


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removes the `polyfills` configuration entry from the Karma test configurations in `angular.json` for four Angular library projects:
- `charts-ng/test`
- `native-charts-ng/test`
- `maps-ng/test`
- `dashboards-ng/test`

The removed polyfills entry previously specified `["zone.js", "zone.js/testing"]`. No other test configuration options were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->