### PR TITLE
test(element-ng): replace real timeout with mock

### DIFF
--- a/projects/element-ng/autocomplete/si-autocomplete.directive.spec.ts
+++ b/projects/element-ng/autocomplete/si-autocomplete.directive.spec.ts
@@ -53,6 +53,15 @@ describe('SiAutocompleteDirective', () => {
     testComponent = fixture.componentInstance;
   });
 
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
   it('should be navigable', async () => {
     const input = fixture.debugElement.query(By.css('input'));
     expect(Object.keys(input.attributes)).not.toContain('ariaActiveDescendant');
@@ -134,8 +143,8 @@ describe('SiAutocompleteDirective', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    // cannot use mock timer here
-    await new Promise(resolve => setTimeout(resolve, 0));
+    jasmine.clock().tick(0);
+    await fixture.whenStable();
     expect(
       fixture.debugElement
         .queryAll(By.directive(SiAutocompleteOptionDirective))

--- a/projects/element-ng/datepicker/si-date-range.component.spec.ts
+++ b/projects/element-ng/datepicker/si-date-range.component.spec.ts
@@ -69,6 +69,15 @@ describe('SiDateRangeComponent', () => {
     await fixture.whenStable();
   });
 
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
   it('should create', () => {
     component.siDatepickerConfig.set({
       dateFormat: 'dd-MM-yyyy'
@@ -85,18 +94,15 @@ describe('SiDateRangeComponent', () => {
   });
 
   it('should mark input touched when on datepicker backdrop click', async () => {
-    jasmine.clock().install();
     openCalendarButton()!.click();
     jasmine.clock().tick(0);
     await fixture.whenStable();
     expect(fixture.componentInstance.dateRange.touched).toBeFalse();
     await backdropClick(fixture);
     expect(fixture.componentInstance.dateRange.touched).toBeTrue();
-    jasmine.clock().uninstall();
   });
 
   it('should mark input as touched once the focused is moved outside', async () => {
-    jasmine.clock().install();
     const rangeHarness = await loader.getHarness(SiDateRangeComponentHarness);
     const inputs = await rangeHarness.getInputs();
     const calendarButton = await rangeHarness.getCalendarButton();
@@ -108,7 +114,6 @@ describe('SiDateRangeComponent', () => {
     expect(fixture.componentInstance.dateRange.touched).toBeFalse();
     await calendarButton.blur();
     expect(fixture.componentInstance.dateRange.touched).toBeTruthy();
-    jasmine.clock().uninstall();
   });
 
   describe('with autoClose', () => {
@@ -124,8 +129,8 @@ describe('SiDateRangeComponent', () => {
       helper.getEnabledCellWithText('1')!.click();
       helper.getEnabledCellWithText('3')!.click();
       await fixture.whenStable();
-      // cannot use mock timer here.
-      await new Promise(resolve => setTimeout(resolve, 0));
+      jasmine.clock().tick(0);
+      await fixture.whenStable();
       expect(document.querySelector('si-datepicker-overlay')).toBeFalsy();
     });
   });
@@ -138,7 +143,6 @@ describe('SiDateRangeComponent', () => {
     // - Hovering over a December
     // Then:
     // - April to December should be highlighted
-    jasmine.clock().install();
     fixture.componentInstance.dateRange.setValue({ start: new Date(2023, 2, 1), end: undefined });
     openCalendarButton().click();
     jasmine.clock().tick(1000);
@@ -149,16 +153,14 @@ describe('SiDateRangeComponent', () => {
     helper.getOpenMonthViewLink().click();
     jasmine.clock().tick(1000);
     await fixture.whenStable();
-    jasmine.clock().uninstall();
     helper.getEnabledCellWithText('December')!.dispatchEvent(new Event('mouseover'));
     await fixture.whenStable();
-    // to avoid flakiness we wait a bit here
-    await new Promise(resolve => setTimeout(resolve, 100));
+    jasmine.clock().tick(100);
+    await fixture.whenStable();
     expect(helper.queryAsArray('.range-hover')).toHaveSize(9);
   });
 
   it('should preview month range with second calendar', async () => {
-    jasmine.clock().install();
     // Given:
     // - Start date selected 01.03.2023
     // - Month view opened
@@ -176,7 +178,6 @@ describe('SiDateRangeComponent', () => {
     jasmine.clock().tick(1000);
     // In case the small screen media query match we need to wait for the dialog animation
     await fixture.whenStable();
-    jasmine.clock().uninstall();
 
     const helper = new CalendarTestHelper(
       document.querySelectorAll<HTMLElement>('si-datepicker')[1]
@@ -187,7 +188,6 @@ describe('SiDateRangeComponent', () => {
   });
 
   it('should not overlap month view with enableTwoMonthDateRange when pressing previous year button', async () => {
-    jasmine.clock().install();
     // Given:
     // - config enableTwoMonthDateRange = true and onlyMonthSelection = true
     // - Selected range 03/2023 - 04/2024
@@ -207,7 +207,6 @@ describe('SiDateRangeComponent', () => {
     openCalendarButton().click();
     jasmine.clock().tick(1000);
     await fixture.whenStable();
-    jasmine.clock().uninstall();
 
     const calendars = document.querySelectorAll<HTMLElement>('si-datepicker');
     const firstCalendar = new CalendarTestHelper(calendars[0]);

--- a/projects/element-ng/list-details/si-list-details.component.spec.ts
+++ b/projects/element-ng/list-details/si-list-details.component.spec.ts
@@ -466,6 +466,15 @@ describe('ListDetailsComponent', () => {
       });
     });
 
+    beforeEach(() => {
+      jasmine.clock().install();
+      jasmine.clock().mockDate();
+    });
+
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
     it('should navigate back and forward in mobile mode by clicking', async () => {
       spyOn(ResizeObserverService.prototype, 'observe').and.returnValue(
         of({ width: 100, height: 100 })
@@ -483,8 +492,8 @@ describe('ListDetailsComponent', () => {
       debugElement.query(By.css('.si-details-header-back')).nativeElement.click();
       routerHarness.detectChanges();
       await routerHarness.fixture.whenStable();
-      // cannot use jasmine.clock here
-      await new Promise(resolve => setTimeout(resolve, 10));
+      jasmine.clock().tick(10);
+      await routerHarness.fixture.whenStable();
       expect(debugElement.query(By.css('si-empty'))).toBeTruthy();
       expect(debugElement.query(By.css('.list-details')).classes['details-active']).toBeFalsy();
     });

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical.spec.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical.spec.ts
@@ -118,6 +118,15 @@ describe('SiNavbarVertical', () => {
     let harness: SiNavbarVerticalHarness;
     beforeEach(async () => (harness = await harnessLoader.getHarness(SiNavbarVerticalHarness)));
 
+    beforeEach(() => {
+      jasmine.clock().install();
+      jasmine.clock().mockDate();
+    });
+
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
     it('should expand/collapse navbar with click', async () => {
       component.collapsed = true;
       fixture.changeDetectorRef.markForCheck();
@@ -185,9 +194,8 @@ describe('SiNavbarVertical', () => {
 
       const spySearch = spyOn(component, 'searchEvent');
       await harness.search('test');
-      // cannot use jasmine.clock here
-      // 400 is the debounceTime and +1 to ensure the timer is executed
-      await new Promise(resolve => setTimeout(resolve, 400 + 1));
+      jasmine.clock().tick(400);
+      await fixture.whenStable();
       expect(spySearch).toHaveBeenCalledOnceWith('test');
     });
 

--- a/projects/element-ng/popover/si-popover.directive.spec.ts
+++ b/projects/element-ng/popover/si-popover.directive.spec.ts
@@ -52,9 +52,11 @@ describe('SiPopoverNextDirective', () => {
   });
 
   it('should open/close on click', async () => {
+    jasmine.clock().install();
     fixture.detectChanges();
 
     fixture.nativeElement.querySelector('button').click();
+    jasmine.clock().tick(10);
     await fixture.whenStable();
 
     const popover = document.querySelector('.popover')!;
@@ -66,6 +68,7 @@ describe('SiPopoverNextDirective', () => {
     await fixture.whenStable();
 
     expect(document.querySelector('.popover')).toBeFalsy();
+    jasmine.clock().uninstall();
   });
 
   it('should not emit hidden event if popover overlay is closed', () => {
@@ -78,9 +81,11 @@ describe('SiPopoverNextDirective', () => {
   });
 
   it('should close on ESC press', async () => {
+    jasmine.clock().install();
     fixture.detectChanges();
 
     fixture.nativeElement.querySelector('button').click();
+    jasmine.clock().tick(10);
     await fixture.whenStable();
     const popover = document.querySelector('.popover')!;
     expect(popover).toBeTruthy();
@@ -90,12 +95,15 @@ describe('SiPopoverNextDirective', () => {
     await fixture.whenStable();
 
     expect(document.querySelector('.popover')).toBeFalsy();
+    jasmine.clock().uninstall();
   });
 
   it('should close on outside click', async () => {
+    jasmine.clock().install();
     fixture.detectChanges();
 
     fixture.nativeElement.querySelector('button').click();
+    jasmine.clock().tick(10);
     await fixture.whenStable();
     const popover = document.querySelector('.popover')!;
     expect(popover).toBeTruthy();
@@ -105,9 +113,11 @@ describe('SiPopoverNextDirective', () => {
     await fixture.whenStable();
 
     expect(document.querySelector('.popover')).toBeFalsy();
+    jasmine.clock().uninstall();
   });
 
   it('should not close if click starts on the popover', async () => {
+    jasmine.clock().install();
     fixture.detectChanges();
 
     fixture.nativeElement.querySelector('button').click();
@@ -118,12 +128,15 @@ describe('SiPopoverNextDirective', () => {
 
     popover.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, cancelable: true }));
     document.body.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, cancelable: true }));
+    jasmine.clock().tick(10);
     await fixture.whenStable();
 
     expect(document.querySelector('.popover')).toBeTruthy();
+    jasmine.clock().uninstall();
   });
 
   it('should not close if click ends on the popover', async () => {
+    jasmine.clock().install();
     fixture.detectChanges();
 
     fixture.nativeElement.querySelector('button').click();
@@ -134,9 +147,11 @@ describe('SiPopoverNextDirective', () => {
 
     document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, cancelable: true }));
     popover.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, cancelable: true }));
+    jasmine.clock().tick(10);
     await fixture.whenStable();
 
     expect(document.querySelector('.popover')).toBeTruthy();
+    jasmine.clock().uninstall();
   });
 
   it('should focus on the popover wrapper', async () => {
@@ -170,6 +185,7 @@ describe('with custom template', () => {
   });
 
   it('should focus on the first interactive element', async () => {
+    jasmine.clock().install();
     fixture.detectChanges();
 
     fixture.nativeElement.querySelector('button').click();
@@ -177,8 +193,10 @@ describe('with custom template', () => {
     const popover = document.querySelector('.popover')!;
     expect(popover).toBeTruthy();
 
-    await new Promise(r => setTimeout(r, 10)); // wait for focus to settle
+    jasmine.clock().tick(10);
+    await fixture.whenStable();
 
     expect(document.activeElement).toBe(document.querySelector('#input-1'));
+    jasmine.clock().uninstall();
   });
 });

--- a/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
+++ b/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
@@ -57,6 +57,15 @@ describe('SelectLazyOptionsDirective', () => {
     component = fixture.componentInstance;
   });
 
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
   it('should render initial value', async () => {
     component.control.setValue(['value']);
 
@@ -72,13 +81,14 @@ describe('SelectLazyOptionsDirective', () => {
 
     const harness = await loader.getHarness(SiSelectHarness);
     await harness.open();
-    // cannot jasmine.clock for debounceTime, so use real wait
-    await new Promise(resolve => setTimeout(resolve, 200));
+    jasmine.clock().tick(200);
+    await fixture.whenStable();
     const list = (await harness.getList())!;
 
     await list.sendKeys('search');
     expect(component.optionSource.getOptionsForSearch).not.toHaveBeenCalled();
-    await new Promise(resolve => setTimeout(resolve, 100));
+    jasmine.clock().tick(200);
+    await fixture.whenStable();
 
     expect(component.optionSource.getOptionsForSearch).toHaveBeenCalled();
     expect(await list.getAllItemTexts()).toEqual(['label: result']);
@@ -95,12 +105,14 @@ describe('SelectLazyOptionsDirective', () => {
     const harness = await loader.getHarness(SiSelectHarness);
     await harness.open();
 
-    // cannot jasmine.clock for debounceTime, so use real wait
-    await new Promise(resolve => setTimeout(resolve, 200));
+    jasmine.clock().tick(200);
+    await fixture.whenStable();
+
     const list = (await harness.getList())!;
     await list.sendKeys('result');
 
-    await new Promise(resolve => setTimeout(resolve, 100));
+    jasmine.clock().tick(200);
+    await fixture.whenStable();
 
     await list.getItemByText('label: result-2').then(item => item.click());
     await list.getItemByText('label: result-0').then(item => item.click());
@@ -116,7 +128,8 @@ describe('SelectLazyOptionsDirective', () => {
 
     const harness = await loader.getHarness(SiSelectHarness);
     await harness.open();
-    await new Promise(resolve => setTimeout(resolve, 200));
+    jasmine.clock().tick(200);
+    await fixture.whenStable();
     const list = (await harness.getList())!;
     expect(await list.getAllItemTexts()).toEqual(['label: value-0', 'label: value-1']);
   });
@@ -130,7 +143,7 @@ describe('SelectLazyOptionsDirective', () => {
 
     await harness.open();
 
-    await new Promise(resolve => setTimeout(resolve, 200));
+    jasmine.clock().tick(200);
     await fixture.whenStable();
 
     const list = (await harness.getList())!;

--- a/projects/element-ng/tree-view/si-tree-view.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.spec.ts
@@ -141,9 +141,12 @@ describe('SiTreeViewComponent', () => {
 
   beforeEach(() => {
     originalRequestAnimationFrame = window.requestAnimationFrame;
+    jasmine.clock().install();
+    jasmine.clock().mockDate();
   });
 
   afterEach(() => {
+    jasmine.clock().uninstall();
     window.requestAnimationFrame = originalRequestAnimationFrame;
   });
 
@@ -650,7 +653,8 @@ describe('SiTreeViewComponent', () => {
           shiftKey: true
         })
       );
-      await new Promise(resolve => setTimeout(resolve, 0));
+      jasmine.clock().tick(0);
+      await fixture.whenStable();
       fixture.detectChanges();
       await fixture.whenStable();
       expect(document.querySelector<HTMLElement>('si-menu si-menu-item')?.innerText).toBe(
@@ -666,7 +670,7 @@ describe('SiTreeViewComponent', () => {
           key: 'ContextMenu'
         })
       );
-      await new Promise(resolve => setTimeout(resolve, 0));
+      jasmine.clock().tick(0);
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
@@ -678,8 +682,9 @@ describe('SiTreeViewComponent', () => {
     it('should open on context-menu event', async () => {
       fixture.detectChanges();
       element.querySelectorAll('si-tree-view-item')[0].dispatchEvent(new Event('contextmenu'));
-      await new Promise(resolve => setTimeout(resolve, 0));
+      jasmine.clock().tick(0);
       fixture.detectChanges();
+      await fixture.whenStable();
       expect(document.querySelector<HTMLElement>('si-menu si-menu-item')?.innerText).toBe(
         'Item One'
       );
@@ -693,7 +698,7 @@ describe('SiTreeViewComponent', () => {
 
       for (const i of Array.from(items)) {
         i.dispatchEvent(new Event('contextmenu'));
-        await new Promise(resolve => setTimeout(resolve, 0));
+        jasmine.clock().tick(0);
         fixture.detectChanges();
         await fixture.whenStable();
       }
@@ -893,7 +898,8 @@ describe('SiTreeViewComponent', () => {
       [lastVisibleNode].triggerEventHandler('click', null);
     fixture.detectChanges();
     nextNode.triggerEventHandler('click', null);
-    await new Promise(resolve => setTimeout(resolve, 0));
+    jasmine.clock().tick(0);
+    await fixture.whenStable();
     expect(scrollObserver).toHaveBeenCalled();
   });
 
@@ -918,10 +924,12 @@ describe('SiTreeViewComponent', () => {
     component.smallSize = true;
     component.cdRef.markForCheck();
     fixture.detectChanges();
-    // cannot use jasmine.clock here
-    await new Promise(resolve => setTimeout(resolve, 0));
+    jasmine.clock().uninstall();
+    // cannot use mock timer here
+    await new Promise(r => setTimeout(r, 0));
     // Changing the class require a second cycle to call ngAfterViewChecked
     fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(getHeightService().itemHeight).toBe(24);
   });
@@ -942,7 +950,6 @@ describe('SiTreeViewComponent', () => {
     });
 
     it('should select multiple items', async () => {
-      jasmine.clock().install();
       component.selectedItem = [component.items[0], component.items[1], component.items[2]];
       component.cdRef.markForCheck();
       jasmine.clock().tick(100);
@@ -951,17 +958,14 @@ describe('SiTreeViewComponent', () => {
       expect(
         debugElement.queryAll(By.css('.si-tree-view-li-item.si-tree-view-item-selected')).length
       ).toBe(3);
-      jasmine.clock().uninstall();
     });
 
     it('should handle selectedItem changes', async () => {
-      jasmine.clock().install();
       component.selectedItem = [component.items[0], component.items[1], component.items[2]];
       component.cdRef.markForCheck();
       jasmine.clock().tick(100);
       fixture.detectChanges();
       await fixture.whenStable();
-      jasmine.clock().uninstall();
       expect(
         debugElement.queryAll(By.css('.si-tree-view-li-item.si-tree-view-item-selected')).length
       ).toBe(3);
@@ -1363,9 +1367,9 @@ describe('SiTreeViewComponent', () => {
             bubbles: true
           })
         );
-        // cannot use jasmine.clock here
-        await new Promise(resolve => setTimeout(resolve, 0));
+        jasmine.clock().tick(0);
         fixture.detectChanges();
+        await fixture.whenStable();
 
         document.activeElement?.dispatchEvent(
           new KeyboardEvent('keydown', {
@@ -1373,9 +1377,9 @@ describe('SiTreeViewComponent', () => {
             bubbles: true
           })
         );
-        // cannot use jasmine.clock here
-        await new Promise(resolve => setTimeout(resolve, 0));
+        jasmine.clock().tick(0);
         fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(treeViewComponent.treeItemsSelected.emit).toHaveBeenCalledWith([
           component.items[0].children![0]
@@ -1393,9 +1397,9 @@ describe('SiTreeViewComponent', () => {
             bubbles: true
           })
         );
-        // cannot use jasmine.clock here
-        await new Promise(resolve => setTimeout(resolve, 0));
+        jasmine.clock().tick(0);
         fixture.detectChanges();
+        await fixture.whenStable();
 
         document.activeElement?.dispatchEvent(
           new KeyboardEvent('keydown', {
@@ -1403,9 +1407,9 @@ describe('SiTreeViewComponent', () => {
             bubbles: true
           })
         );
-        // cannot use jasmine.clock here
-        await new Promise(resolve => setTimeout(resolve, 0));
+        jasmine.clock().tick(0);
         fixture.detectChanges();
+        await fixture.whenStable();
 
         document.activeElement?.closest('si-tree-view-item')?.dispatchEvent(
           new KeyboardEvent('keydown', {
@@ -1413,9 +1417,9 @@ describe('SiTreeViewComponent', () => {
             bubbles: true
           })
         );
-        // cannot use jasmine.clock here
-        await new Promise(resolve => setTimeout(resolve, 0));
+        jasmine.clock().tick(0);
         fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(treeViewComponent.treeItemsSelected.emit).toHaveBeenCalledWith([component.items[0]]);
       });


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Replace real timeouts with Jasmine mock timers across 7 test spec files in element-ng components (autocomplete, datepicker, list-details, navbar-vertical, popover, select, and tree-view). Centralizes clock setup/teardown using beforeEach/afterEach hooks and replaces asynchronous delays (setTimeout) with synchronous clock.tick() calls followed by fixture.whenStable() for deterministic, faster test execution. No changes to component logic or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->