### PR TITLE
refactor(element-ng): remove zone polyfills from element test config

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -140,7 +140,6 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "projects/element-ng/tsconfig.spec.json",
             "karmaConfig": "projects/element-ng/karma.conf.cjs",
             "exclude": ["projects/element-ng/schematics/**"],


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removes zone polyfills from the element-ng test configuration in angular.json. The polyfills array for Karma tests is changed from `["zone.js", "zone.js/testing"]` to an empty array `[]`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->