### PR TITLE
refactor(element-ng): use --__si- as prefix for internal CSS vars

### DIFF
--- a/docs/architecture/theming.md
+++ b/docs/architecture/theming.md
@@ -49,6 +49,16 @@ and follow these few steps:
 - In some cases using the `$element-ui-*` tokens will fail, e.g. for things
   like `background-color: rgba($element-ui-4, 0.5)`.
 
+## Component customization
+
+Some components offer customization via CSS variables. Also many components use CSS variables
+internally that are not meant for users to override. To distinguish between the two:
+
+- Variables starting with the prefix `--si-` are public and meant for customization
+- Variables starting with the prefix `--__si-` are private/internal. Do not override.
+
+> **Note:** Not all components follow this naming scheme yet. If in doubt, ask.
+
 ## Custom themes
 
 The SiThemeService is responsible for all theming topics.

--- a/projects/element-ng/accordion/si-collapsible-panel.component.scss
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.scss
@@ -3,7 +3,7 @@
 @use '@siemens/element-theme/src/styles/variables';
 
 :host {
-  --__radius: var(--si-accordion-radius, #{variables.$element-button-radius});
+  --__si-radius: var(--si-accordion-radius, #{variables.$element-button-radius});
   display: flex;
   flex-direction: column;
   background: variables.$element-base-0;
@@ -53,7 +53,7 @@
   background: variables.$element-base-1;
   color: variables.$element-text-primary;
   padding-block: map.get(variables.$spacers, 5);
-  border-radius: var(--__radius);
+  border-radius: var(--__si-radius);
 
   &.disabled {
     color: variables.$element-text-disabled;
@@ -89,8 +89,8 @@
   display: flex;
   flex-direction: column;
   background: variables.$element-base-1;
-  border-end-start-radius: var(--__radius);
-  border-end-end-radius: var(--__radius);
+  border-end-start-radius: var(--__si-radius);
+  border-end-end-radius: var(--__si-radius);
 
   &.full-height {
     // cannot use class overflow-auto, as it is using !important which is breaking the animation

--- a/projects/element-ng/datepicker/si-timepicker.component.scss
+++ b/projects/element-ng/datepicker/si-timepicker.component.scss
@@ -14,7 +14,7 @@ $input-max-width: 45px;
   // When individual fields are invalid, they will show their own validation styling instead.
   &.ng-touched.ng-invalid:not(:has(.ng-touched.ng-invalid)) {
     .form-control {
-      --border-color: var(--element-status-danger);
+      --border-color: #{variables.$element-status-danger};
     }
   }
 }

--- a/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.html
+++ b/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.html
@@ -1,6 +1,6 @@
 <div
   class="textarea-grow-wrap text-break"
-  [style.--content-grow]="contentGrowTextarea()"
+  [style.--__si-content-grow]="contentGrowTextarea()"
   [style.max-height]="maxHeightConfiguration()"
 >
   <textarea

--- a/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.scss
+++ b/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.scss
@@ -3,7 +3,7 @@
 }
 
 .textarea-grow-wrap::after {
-  content: var(--content-grow);
+  content: var(--__si-content-grow);
   white-space: pre-wrap;
   visibility: hidden;
   margin-block: 3px;

--- a/projects/element-ng/landing-page/login-basic/si-login-basic.component.scss
+++ b/projects/element-ng/landing-page/login-basic/si-login-basic.component.scss
@@ -3,15 +3,15 @@
 @use '@siemens/element-theme/src/styles/variables';
 
 :host {
-  --animation-duration: #{variables.element-transition-duration(0.25s)};
-  --animation-delay: calc(var(--animation-duration) / 2);
+  --__si-animation-duration: #{variables.element-transition-duration(0.25s)};
+  --__si-animation-delay: calc(var(--__si-animation-duration) / 2);
 }
 
 .login-basic-second-step--container,
 .login-basic-next-button--container {
   display: grid;
   grid-template-rows: 0fr;
-  transition: grid-template-rows var(--animation-duration) ease;
+  transition: grid-template-rows var(--__si-animation-duration) ease;
 
   &.active {
     grid-template-rows: 1fr;
@@ -32,8 +32,8 @@
 .toggle-content-transition {
   min-block-size: 0;
   transition:
-    opacity var(--animation-duration) var(--animation-delay) ease-in,
-    transform var(--animation-duration) var(--animation-delay) ease-out;
+    opacity var(--__si-animation-duration) var(--__si-animation-delay) ease-in,
+    transform var(--__si-animation-duration) var(--__si-animation-delay) ease-out;
   visibility: hidden;
   opacity: 0;
 }
@@ -47,5 +47,5 @@
   @extend .toggle-content-transition;
   margin-block-start: 0;
   transform: translateY(map.get(variables.$spacers, 3));
-  transition: margin var(--animation-duration) ease;
+  transition: margin var(--__si-animation-duration) ease;
 }

--- a/projects/element-ng/loading-spinner/si-loading-spinner.component.scss
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.component.scss
@@ -36,13 +36,13 @@ svg {
 }
 
 path {
-  --spinner-speed: calc(0.2s - 0.1s * var(--element-animations-enabled, 1));
+  --__si-spinner-speed: calc(0.2s - 0.1s * var(--element-animations-enabled, 1));
   fill: var(--loading-spinner-color, variables.$element-ui-2);
   animation: spinner-fade calc(2s - 1s * var(--element-animations-enabled, 1)) infinite linear;
 
   @for $i from 0 through 9 {
     &:nth-child(#{$i + 1}) {
-      animation-delay: calc($i * var(--spinner-speed));
+      animation-delay: calc($i * var(--__si-spinner-speed));
       opacity: 1 - $i * 0.1;
     }
   }

--- a/projects/element-ng/side-panel/si-side-panel-content.component.scss
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.scss
@@ -32,7 +32,7 @@
 
     .rpanel-wrapper {
       gap: 0;
-      inline-size: var(--rpanel-collapsed-width);
+      inline-size: var(--__si-rpanel-collapsed-width);
     }
 
     .rpanel-content {

--- a/projects/element-ng/side-panel/si-side-panel.component.scss
+++ b/projects/element-ng/side-panel/si-side-panel.component.scss
@@ -7,10 +7,10 @@ $rpanel-overlay-bg: rgba(0, 0, 0, 0.4);
 $rpanel-collapsed-width: 48px;
 
 :host {
-  --rpanel-collapsed-padding: 0;
-  --rpanel-size: #{$rpanel-width-regular};
+  --__si-rpanel-collapsed-padding: 0;
+  --__si-rpanel-size: #{$rpanel-width-regular};
   display: block;
-  padding-inline-end: var(--rpanel-size);
+  padding-inline-end: var(--__si-rpanel-size);
 
   &.ready {
     transition: padding-inline-end $rpanel-transition-duration;
@@ -22,16 +22,16 @@ $rpanel-collapsed-width: 48px;
 
   .side-panel,
   .side-panel > .inner {
-    inline-size: var(--rpanel-size);
+    inline-size: var(--__si-rpanel-size);
   }
 
   &.collapsible,
   &.collapsible-temp {
-    --rpanel-collapsed-width: #{$rpanel-collapsed-width};
+    --__si-rpanel-collapsed-width: #{$rpanel-collapsed-width};
   }
 
   &.rpanel-size--wide {
-    --rpanel-size: #{$rpanel-width-wide};
+    --__si-rpanel-size: #{$rpanel-width-wide};
   }
 
   &.rpanel-resize-sm,
@@ -39,7 +39,7 @@ $rpanel-collapsed-width: 48px;
   &.rpanel-resize-lg,
   &.rpanel-resize-xl {
     &.rpanel-mode--over {
-      padding-inline-end: var(--rpanel-collapsed-width);
+      padding-inline-end: var(--__si-rpanel-collapsed-width);
 
       &:not(.rpanel-collapsed) .side-panel {
         box-shadow: all-variables.$element-elevation-2;
@@ -49,14 +49,14 @@ $rpanel-collapsed-width: 48px;
 
   &.rpanel-resize-lg {
     &.rpanel-mode--scroll.rpanel-size--wide {
-      padding-inline-end: var(--rpanel-collapsed-width);
+      padding-inline-end: var(--__si-rpanel-collapsed-width);
     }
   }
 
   &.rpanel-resize-sm,
   &.rpanel-resize-md {
     &.rpanel-mode--scroll {
-      padding-inline-end: var(--rpanel-collapsed-width);
+      padding-inline-end: var(--__si-rpanel-collapsed-width);
 
       &:not(.rpanel-collapsed) .side-panel {
         box-shadow: all-variables.$element-elevation-2;
@@ -67,7 +67,7 @@ $rpanel-collapsed-width: 48px;
   &.rpanel-resize-xs {
     &.rpanel-mode--over,
     &.rpanel-mode--scroll {
-      padding-inline-end: var(--rpanel-collapsed-width);
+      padding-inline-end: var(--__si-rpanel-collapsed-width);
     }
 
     .side-panel {
@@ -87,7 +87,7 @@ $rpanel-collapsed-width: 48px;
   }
 
   &.rpanel-collapsed {
-    padding-inline-end: var(--rpanel-collapsed-width);
+    padding-inline-end: var(--__si-rpanel-collapsed-width);
 
     &:not(.collapsible) {
       .side-panel {
@@ -98,7 +98,7 @@ $rpanel-collapsed-width: 48px;
 
     &.collapsible {
       .side-panel {
-        inline-size: var(--rpanel-collapsed-width);
+        inline-size: var(--__si-rpanel-collapsed-width);
         overflow: hidden;
       }
     }

--- a/projects/element-ng/split/si-split-part.component.scss
+++ b/projects/element-ng/split/si-split-part.component.scss
@@ -76,25 +76,25 @@ $header-height: 40px;
   }
 
   :host-context(.vertical) > :host & {
-    --orientation-rotate: rotate(90deg);
+    --__si-orientation-rotate: rotate(90deg);
   }
 
   :host-context(.horizontal) > :host & {
     @include all-variables.rtl {
-      --orientation-rtl: scaleX(-1);
+      --__si-orientation-rtl: scaleX(-1);
     }
   }
 
   :host(.is-collapsed) & {
-    --collapse-rotate: rotate(180deg);
+    --__si-collapse-rotate: rotate(180deg);
   }
 
   :host(.collapse-start) & {
-    --collapse-direction: rotate(180deg);
+    --__si-collapse-direction: rotate(180deg);
   }
 
   .collapse-icon {
-    transform: var(--orientation-rotate, rotate(0)) var(--collapse-rotate, rotate(0))
-      var(--collapse-direction, rotate(0)) var(--orientation-rtl, scaleX(1));
+    transform: var(--__si-orientation-rotate, rotate(0)) var(--__si-collapse-rotate, rotate(0))
+      var(--__si-collapse-direction, rotate(0)) var(--__si-orientation-rtl, scaleX(1));
   }
 }

--- a/projects/element-ng/threshold/si-threshold.component.scss
+++ b/projects/element-ng/threshold/si-threshold.component.scss
@@ -5,38 +5,38 @@
 $ths-dot-size: 6px;
 
 :host {
-  --direction-main: column;
-  --direction-option: row;
-  --direction-value: row;
-  --input-width: calc(var(--input-base-width, 90px) + var(--buttons-width, 0px));
+  --__si-direction-main: column;
+  --__si-direction-option: row;
+  --__si-direction-value: row;
+  --__si-input-width: calc(var(--input-base-width, 90px) + var(--__si-buttons-width, 0px));
 
   &.horizontal {
-    --direction-main: row;
-    --direction-option: column;
-    --direction-value: column-reverse;
-    --value-margin: #{map.get(variables.$spacers, 8) * -1};
-    padding-inline: calc(var(--value-margin) * -1);
+    --__si-direction-main: row;
+    --__si-direction-option: column;
+    --__si-direction-value: column-reverse;
+    --__si-value-margin: #{map.get(variables.$spacers, 8) * -1};
+    padding-inline: calc(var(--__si-value-margin) * -1);
   }
 
   &.dec-inc-buttons {
-    --buttons-width: 48px;
+    --__si-buttons-width: 48px;
   }
 }
 
 :host,
 .ths-step {
   display: flex;
-  flex-direction: var(--direction-main);
+  flex-direction: var(--__si-direction-main);
 }
 
 .ths-option {
-  flex-direction: var(--direction-option);
-  min-inline-size: var(--option-width, 160px);
+  flex-direction: var(--__si-direction-option);
+  min-inline-size: var(--__si-option-width, 160px);
 }
 
 .ths-value {
-  flex-direction: var(--direction-value);
-  margin-inline: var(--value-margin);
+  flex-direction: var(--__si-direction-value);
+  margin-inline: var(--__si-value-margin);
 }
 
 si-select {
@@ -45,7 +45,7 @@ si-select {
 }
 
 .form-control {
-  inline-size: var(--input-width);
+  inline-size: var(--__si-input-width);
   // This is a weird one. When zooming, it seems like `border-width` and relative `line-height` are scaled differently on inputs
   // Since the threshold needs correct size to keep the lines aligned, setting it to a fixed value here.
   block-size: calc(1rem + (map.get(variables.$spacers, 4) * 2));
@@ -58,7 +58,7 @@ si-select {
   align-self: stretch;
   flex-basis: map.get(variables.$spacers, 6);
   display: flex;
-  flex-direction: var(--direction-main);
+  flex-direction: var(--__si-direction-main);
   align-items: center;
   color: variables.$element-ui-2;
   gap: map.get(variables.$spacers, 2);
@@ -77,5 +77,5 @@ si-select {
 }
 
 .startend {
-  inline-size: calc(var(--input-width) / 2);
+  inline-size: calc(var(--__si-input-width) / 2);
 }

--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.html
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.html
@@ -5,8 +5,8 @@
   @if (autoClose) {
     <div
       class="si-toast-timer-bar"
-      [style.--play-state]="animationMode()"
-      [style.--toast-timer-duration.s]="toastTimeoutInSeconds()"
+      [style.--__si-play-state]="animationMode()"
+      [style.--__si-toast-timer-duration.s]="toastTimeoutInSeconds()"
     ></div>
   }
   <div class="bar" [ngClass]="statusColor()"></div>

--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.scss
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.scss
@@ -74,8 +74,8 @@ $toast-timer-height: 2px;
 }
 
 .si-toast-timer-bar {
-  animation: si-toast-auto-close-animation var(--toast-timer-duration, 4s) linear forwards;
-  animation-play-state: var(--play-state, running);
+  animation: si-toast-auto-close-animation var(--__si-toast-timer-duration, 4s) linear forwards;
+  animation-play-state: var(--__si-play-state, running);
   @extend %si-toast-bottom-bar;
   background-color: all-variables.$element-ui-0;
 }

--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.spec.ts
@@ -75,7 +75,7 @@ describe('SiToastNotificationComponent', () => {
     spyOn(component.siToastComponent().paused, 'emit');
     spyOn(component.siToastComponent().resumed, 'emit');
 
-    expect(timerBar?.style.getPropertyValue('--toast-timer-duration')).toBe(
+    expect(timerBar?.style.getPropertyValue('--__si-toast-timer-duration')).toBe(
       SI_TOAST_AUTO_HIDE_DELAY / 1000 + 's'
     );
     element.querySelector('si-toast-notification')?.dispatchEvent(new MouseEvent('mouseenter'));
@@ -83,12 +83,12 @@ describe('SiToastNotificationComponent', () => {
 
     expect(component.siToastComponent().paused.emit).toHaveBeenCalledTimes(1);
 
-    expect(timerBar?.style.getPropertyValue('--play-state')).toBe('paused');
+    expect(timerBar?.style.getPropertyValue('--__si-play-state')).toBe('paused');
 
     element.querySelector('si-toast-notification')?.dispatchEvent(new MouseEvent('mouseleave'));
     fixture.detectChanges();
 
     expect(component.siToastComponent().resumed.emit).toHaveBeenCalledTimes(1);
-    expect(timerBar?.style.getPropertyValue('--play-state')).toBe('running');
+    expect(timerBar?.style.getPropertyValue('--__si-play-state')).toBe('running');
   });
 });


### PR DESCRIPTION

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
