### PR TITLE
fix(side-panel): should work in zoneless enviroment

### DIFF
--- a/projects/element-ng/side-panel/si-side-panel.component.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel.component.spec.ts
@@ -201,3 +201,43 @@ describe('SiSidePanelComponent', () => {
     });
   });
 });
+
+@Component({
+  imports: [SiSidePanelModule],
+  template: `<si-side-panel [collapsed]="true">
+    <si-side-panel-content heading="Title">
+      <div>Test</div>
+    </si-side-panel-content>
+  </si-side-panel> `,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+class TestWrapperComponent {}
+describe('SiSidePanelComponent without markForChecks', () => {
+  let fixture: ComponentFixture<TestWrapperComponent>;
+  let element: HTMLElement;
+  let service: SiSidePanelService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestWrapperComponent);
+    fixture.detectChanges();
+    element = fixture.nativeElement;
+    service = TestBed.inject(SiSidePanelService);
+  });
+
+  it('should open without doing explicit detect changes', async () => {
+    jasmine.clock().install();
+    service.open();
+    jasmine.clock().tick(500);
+    await fixture.whenStable();
+    const sidePanelContent = element.querySelector('si-side-panel-content');
+
+    expect(sidePanelContent!.classList).toContain('expanded');
+    jasmine.clock().uninstall();
+  });
+});

--- a/projects/element-ng/side-panel/si-side-panel.component.ts
+++ b/projects/element-ng/side-panel/si-side-panel.component.ts
@@ -317,7 +317,10 @@ export class SiSidePanelComponent implements OnInit, OnDestroy, OnChanges {
     if (open) {
       this.isHidden.set(false);
     }
-    setTimeout(() => this.doOpenClose(open));
+    setTimeout(() => {
+      this.doOpenClose(open);
+      this.cdRef.markForCheck();
+    });
   }
 
   private doOpenClose(open: boolean): void {


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## fix(side-panel): should work in zoneless environment

Adds zoneless environment support to the side panel component. Key changes:

- Injects ChangeDetectorRef and calls cdRef.markForCheck() after open/close timeout (ensures change detection runs post-toggle in zoneless setups).
- Calls markForCheck() when attaching content to ensure newly attached content is rendered without zone-based detection.
- Keeps/uses standalone APIs, signal-based inputs/outputs, and DI patterns compatible with zoneless change detection.
- Adds tests: a new TestWrapperComponent and a test suite that verifies the side panel opens correctly in a zoneless (provideZonelessChangeDetection) environment without explicit detectChanges calls.

This fixes cases where async open/close operations didn’t trigger updates in zoneless environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->