### PR TITLE
feat(schematics): import removal

### DIFF
--- a/projects/element-ng/schematics/migrations/data/import-removals.ts
+++ b/projects/element-ng/schematics/migrations/data/import-removals.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+
+export interface ImportRemovalInstruction {
+  /** Module that the symbol was removed from. */
+  module: RegExp;
+  /** Names of the symbols to be removed from imports. */
+  symbolNames: string[];
+}
+
+/**
+ * List of imports that should be removed during migration.
+ */
+export const IMPORT_REMOVALS_MIGRATION: ImportRemovalInstruction[] = [
+  {
+    module: /@(siemens|simpl)\/element-ng(\/common)?/,
+    symbolNames: ['buildTrackByIdentity', 'buildTrackByIndex']
+  }
+];

--- a/projects/element-ng/schematics/migrations/data/index.ts
+++ b/projects/element-ng/schematics/migrations/data/index.ts
@@ -6,6 +6,7 @@
 import { ATTRIBUTE_SELECTORS_MIGRATION } from './attribute-selectors.js';
 import { COMPONENT_NAMES_MIGRATION } from './component-names.js';
 import { ELEMENT_SELECTORS_MIGRATION } from './element-selectors.js';
+import { IMPORT_REMOVALS_MIGRATION } from './import-removals.js';
 import { OUTPUT_NAMES_MIGRATION } from './output-names.js';
 import { SYMBOL_REMOVALS_MIGRATION } from './symbol-removals.js';
 
@@ -15,5 +16,6 @@ export const getElementMigrationData = () => ({
   componentNameChanges: COMPONENT_NAMES_MIGRATION,
   elementSelectorChanges: ELEMENT_SELECTORS_MIGRATION,
   symbolRemovalChanges: SYMBOL_REMOVALS_MIGRATION,
-  outputNameChanges: OUTPUT_NAMES_MIGRATION
+  outputNameChanges: OUTPUT_NAMES_MIGRATION,
+  importRemovalChanges: IMPORT_REMOVALS_MIGRATION
 });

--- a/projects/element-ng/schematics/migrations/element-migration/element-migration.spec.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/element-migration.spec.ts
@@ -130,4 +130,8 @@ describe('to legacy migration', () => {
   it('should remove the deprecated api from module based accordion', async () => {
     await checkTemplateMigration(['module-based.accordion-inline-template.ts']);
   });
+
+  it('should remove imports of buildTrackByIdentity and buildTrackByIndex', async () => {
+    await checkTemplateMigration(['import-removal-inline.template.ts']);
+  });
 });

--- a/projects/element-ng/schematics/migrations/element-migration/files/expected.import-removal-inline.template.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/expected.import-removal-inline.template.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  template: `<div>Test</div>`,
+  standalone: true
+})
+export class TestComponent {
+  trackByIdentity = buildTrackByIdentity<string>();
+  trackByIndex = buildTrackByIndex<string>();
+}

--- a/projects/element-ng/schematics/migrations/element-migration/files/import-removal-inline.template.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/import-removal-inline.template.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { buildTrackByIdentity, buildTrackByIndex } from '@siemens/element-ng/common';
+
+@Component({
+  selector: 'app-test',
+  template: `<div>Test</div>`,
+  standalone: true
+})
+export class TestComponent {
+  trackByIdentity = buildTrackByIdentity<string>();
+  trackByIndex = buildTrackByIndex<string>();
+}


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Adds import-removal capability to the schematics migration system to remove specific symbols from import statements during migrations.

## Key Changes
- New data: `ImportRemovalInstruction` and `IMPORT_REMOVALS_MIGRATION` in `projects/element-ng/schematics/migrations/data/import-removals.ts` (removes `buildTrackByIdentity` and `buildTrackByIndex` from @siemens|@simpl element-ng imports).
- Migration integration: `element-migration.ts` processes `importRemovalChanges` from migration data, computes and applies import edits, and inserts adjusted import declarations when needed.
- Utility: `removeImportSymbols()` and `ImportRemovalChange` added to `projects/element-ng/schematics/utils/ts-utils.ts` to compute removal edits for full or partial import deletions.
- API/data wiring: `IMPORT_REMOVALS_MIGRATION` exposed via `migrations/data/index.ts` and included in `getElementMigrationData()`.
- Tests & templates: added test case and template files (`import-removal-inline.template.ts`, expected output) validating removal of the two symbols.

## Impact
Allows declarative removal of deprecated/renamed import symbols during migrations, handling both complete and partial import statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->