### PR TITLE
fix(date-range-filter): update datepicker date-range on preset selection

### DIFF
--- a/api-goldens/element-ng/date-range-filter/index.api.md
+++ b/api-goldens/element-ng/date-range-filter/index.api.md
@@ -104,7 +104,7 @@ export class SiDateRangeFilterComponent implements OnChanges {
     protected readonly datepickerConfigInternal: _angular_core.Signal<DatepickerConfig>;
     readonly datePlaceholder: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
-    protected dateRange: DateRange;
+    protected readonly dateRange: _angular_core.WritableSignal<DateRange>;
     // (undocumented)
     protected readonly dateRangeConfig: _angular_core.Signal<DatepickerConfig>;
     readonly enableTimeSelection: _angular_core.InputSignalWithTransform<boolean, unknown>;
@@ -163,7 +163,7 @@ export class SiDateRangeFilterComponent implements OnChanges {
     // (undocumented)
     protected updateDateRange(range?: DateRangeFilter): void;
     // (undocumented)
-    protected updateFromDateRange(): void;
+    protected updateFromDateRange(dateRange?: DateRange): void;
     // (undocumented)
     protected updateOnModeChange(): void;
     readonly valueLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.html
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.html
@@ -64,8 +64,8 @@
     <si-datepicker
       [config]="dateRangeConfig()"
       [focusedDate]="focusedDate()"
-      [(dateRange)]="dateRange"
-      (dateRangeChange)="updateFromDateRange()"
+      [dateRange]="dateRange()"
+      (dateRangeChange)="updateFromDateRange($event)"
     />
   }
 

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.spec.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.spec.ts
@@ -11,6 +11,7 @@ import {
   viewChild
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { TestScheduler } from 'rxjs/testing';
 
 import { DateRangeFilter, DateRangePreset, SiDateRangeFilterComponent } from './index';
@@ -275,10 +276,11 @@ describe('SiDateRangeFilterComponent', () => {
       point1: new Date('2023-05-13'),
       point2: new Date('2023-08-14')
     };
-
+    fixture.detectChanges();
     await fixture.whenStable();
 
     presetList()[1]?.click();
+    fixture.detectChanges();
     await fixture.whenStable();
 
     const now = new Date();
@@ -288,6 +290,11 @@ describe('SiDateRangeFilterComponent', () => {
     expect(component.range.point1).toEqual(oneWeekAgo);
     expect(component.range.point2).toEqual(today);
     expect(component.range.range).toBeUndefined();
+    expect(
+      fixture.debugElement.query(
+        By.css(`button.si-calendar-date-cell[aria-label="${oneWeekAgo.toDateString()}"]`)
+      )
+    ).toBeTruthy();
   });
 
   it('selecting presets in input mode keeps now', async () => {

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
@@ -302,7 +302,7 @@ export class SiDateRangeFilterComponent implements OnChanges {
 
   protected readonly icons = addIcons({ elementDown2 });
   protected advancedMode = false;
-  protected dateRange: DateRange = { start: undefined, end: undefined };
+  protected readonly dateRange = signal<DateRange>({ start: undefined, end: undefined });
 
   protected point1Now = true;
   protected point2Mode: 'duration' | 'date' = 'duration';
@@ -341,7 +341,8 @@ export class SiDateRangeFilterComponent implements OnChanges {
   });
 
   protected readonly focusedDate = computed(() => {
-    const date = this.dateRange.end ?? this.dateRange.start;
+    const range = this.dateRange();
+    const date = range.end ?? range.start;
     return isValid(date) ? date : undefined;
   });
   protected readonly presetFilter = signal('');
@@ -415,8 +416,7 @@ export class SiDateRangeFilterComponent implements OnChanges {
 
   protected updateDateRange(range = this.range()): void {
     const calculatedRange = this.resolve(range);
-    this.dateRange.start = calculatedRange.start;
-    this.dateRange.end = calculatedRange.end;
+    this.dateRange.set({ start: calculatedRange.start, end: calculatedRange.end });
   }
 
   protected updateOnModeChange(): void {
@@ -459,9 +459,13 @@ export class SiDateRangeFilterComponent implements OnChanges {
     }
   }
 
-  protected updateFromDateRange(): void {
-    const startDate = this.dateRange.start ?? this.getDateNow();
-    const endDate = this.dateRange.end ?? this.getDateNow();
+  protected updateFromDateRange(dateRange?: DateRange): void {
+    if (dateRange) {
+      this.dateRange.set(dateRange);
+    }
+    const range = this.dateRange();
+    const startDate = range.start ?? this.getDateNow();
+    const endDate = range.end ?? this.getDateNow();
     this.point1date = startDate;
     this.point2date = startDate;
     this.range.set({


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Summary**: Fixes datepicker not updating its visible date-range when a preset is selected by switching the component to use a signal-backed dateRange and updating the template to read/write via the signal.

Key changes:
1. Template: si-datepicker binding changed from two-way to one-way: [dateRange]="dateRange()" and (dateRangeChange)="updateFromDateRange($event)".
2. State: dateRange converted from a mutable property to a WritableSignal<DateRange> (protected readonly dateRange = signal<DateRange>({...})); reads use dateRange() and writes use dateRange.set(...).
3. API: updateFromDateRange signature changed to accept an optional DateRange parameter (updateFromDateRange(dateRange?: DateRange)); updateDateRange updated to operate with the signal.
4. Tests: spec updated—imports By, adds fixture.detectChanges() around preset interactions, and asserts the calendar date cell appears for the selected preset.
5. Public API: api-goldens updated to reflect dateRange as a WritableSignal<DateRange> and the updated updateFromDateRange signature.

Impact: Ensures the datepicker UI correctly reflects preset selections by syncing the reactive dateRange signal with the datepicker input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->