### PR TITLE
test(select): use type guards for option discrimination

### DIFF
--- a/api-goldens/element-ng/select/index.api.md
+++ b/api-goldens/element-ng/select/index.api.md
@@ -240,7 +240,7 @@ export class SiSelectOptionTemplateDirective {
 // @public
 export class SiSelectSimpleOptionsDirective<T = string> extends SiSelectOptionsStrategyBase<T> implements OnChanges {
     // (undocumented)
-    readonly allRows: _angular_core.Signal<SelectItem<T>[]>;
+    readonly allRows: _angular_core.Signal<(_siemens_element_ng_select.SelectGroup<T> | SelectOption<T>)[]>;
     // (undocumented)
     ngOnChanges(): void;
     readonly options: _angular_core.InputSignal<(SelectOptionLegacy | SelectItem<T>)[] | null | undefined>;

--- a/projects/element-ng/select/options/si-select-simple-options.directive.ts
+++ b/projects/element-ng/select/options/si-select-simple-options.directive.ts
@@ -4,7 +4,7 @@
  */
 import { computed, Directive, input, OnChanges } from '@angular/core';
 
-import { SelectItem, SelectOption, SelectOptionLegacy } from '../si-select.types';
+import { isSelectItem, SelectItem, SelectOption, SelectOptionLegacy } from '../si-select.types';
 import { SI_SELECT_OPTIONS_STRATEGY } from './si-select-options-strategy';
 import { SiSelectOptionsStrategyBase } from './si-select-options-strategy.base';
 
@@ -46,7 +46,7 @@ export class SiSelectSimpleOptionsDirective<T = string>
     const options = this.options();
     if (options) {
       return options?.map(option =>
-        option.type
+        isSelectItem(option)
           ? option
           : ({
               type: 'option',

--- a/projects/element-ng/select/si-select.types.ts
+++ b/projects/element-ng/select/si-select.types.ts
@@ -70,3 +70,13 @@ export interface SelectOption<T> {
 
 /** Alias for {@link SelectOption} or {@link SelectGroup} */
 export type SelectItem<T> = SelectGroup<T> | SelectOption<T>;
+
+/** @internal */
+export const isSelectOption = (
+  o?: SelectOptionLegacy | SelectOption<unknown>
+): o is SelectOption<unknown> => o != null && 'type' in o && o.type === 'option';
+
+/** @internal */
+export const isSelectItem = (
+  o?: SelectOptionLegacy | SelectItem<unknown>
+): o is SelectItem<unknown> => o != null && (o.type === 'option' || o.type === 'group');

--- a/projects/element-ng/threshold/si-readonly-threshold-option.component.ts
+++ b/projects/element-ng/threshold/si-readonly-threshold-option.component.ts
@@ -5,7 +5,7 @@
 import { NgClass } from '@angular/common';
 import { Component, computed, input } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
-import { SelectOption, SelectOptionLegacy } from '@siemens/element-ng/select';
+import { isSelectOption, SelectOption, SelectOptionLegacy } from '@siemens/element-ng/select';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
@@ -36,7 +36,7 @@ export class SiReadonlyThresholdOptionComponent {
     const options = this.options();
     const value = this.value();
     if (value && options) {
-      return options.find(opt => (opt.type === 'option' ? opt.value === value : opt.id === value));
+      return options.find(opt => (isSelectOption(opt) ? opt.value === value : opt.id === value));
     }
     return undefined;
   });
@@ -45,13 +45,13 @@ export class SiReadonlyThresholdOptionComponent {
     const option = this.option();
     return !option || option.disabled
       ? undefined
-      : option.type === 'option'
+      : isSelectOption(option)
         ? option.iconColor
         : option.color;
   });
 
   protected readonly label = computed(() => {
     const option = this.option();
-    return option?.type === 'option' ? option.label : option?.title;
+    return isSelectOption(option) ? option.label : option?.title;
   });
 }

--- a/projects/element-ng/threshold/si-threshold.component.ts
+++ b/projects/element-ng/threshold/si-threshold.component.ts
@@ -17,6 +17,7 @@ import { FormsModule } from '@angular/forms';
 import { addIcons, elementDelete, elementPlus, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiNumberInputComponent } from '@siemens/element-ng/number-input';
 import {
+  isSelectOption,
   SelectOption,
   SelectOptionLegacy,
   SiSelectComponent,
@@ -183,7 +184,7 @@ export class SiThresholdComponent implements OnChanges {
   protected readonly colors = computed(() => {
     const colorMap = new Map<unknown, string>();
     for (const opt of this.options()) {
-      if (opt.type === 'option') {
+      if (isSelectOption(opt)) {
         colorMap.set(opt.value, opt.iconColor ?? '');
       } else if (!opt.type) {
         colorMap.set(opt.id, opt.color ?? '');


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Improve select item typing with runtime type guards

This PR introduces runtime type-guard utilities and replaces ad-hoc property checks with those guards across select-related code to improve typing, normalization, and runtime safety.

Changes
- Added exported type guards in projects/element-ng/select/si-select.types.ts:
  - isSelectOption(o): narrows to SelectOption<unknown> when o?.type === 'option'
  - isSelectItem(o): narrows to SelectItem<unknown> for option/group discrimination
- Replaced direct shape/type checks with guards:
  - projects/element-ng/select/options/si-select-simple-options.directive.ts: use isSelectItem() when normalizing legacy options into SelectOption<T>
  - projects/element-ng/threshold/si-readonly-threshold-option.component.ts: use isSelectOption() for option lookup, color and label selection
  - projects/element-ng/threshold/si-threshold.component.ts: use isSelectOption() for option discrimination in color mapping
- API golden update: SiSelectSimpleOptionsDirective.allRows signal type updated to Signal<(SelectGroup<T> | SelectOption<T>)[]> to reflect the normalized union shape.

Impact
- Replaces scattered checks like option.type === 'option' with explicit, exported type guards, improving clarity, correctness and maintainability with a small public API shape change for allRows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->