### PR TITLE
fix(side-panel): ensure search bar focus outline is visible

### DIFF
--- a/projects/element-ng/side-panel/si-side-panel-content.component.scss
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.scss
@@ -7,7 +7,6 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-  gap: map.get(all-variables.$spacers, 5);
 }
 
 :host-context(.collapsible) {
@@ -24,13 +23,12 @@
   }
 
   :host.collapsed {
-    gap: 0;
-
     .auto-hide {
       display: none;
     }
 
     .rpanel-wrapper {
+      padding-block-start: 0;
       gap: 0;
       inline-size: var(--rpanel-collapsed-width);
     }
@@ -78,6 +76,10 @@
 
 .rpanel-header {
   justify-content: space-between;
+}
+
+.rpanel-wrapper {
+  padding-block-start: map.get(all-variables.$spacers, 5);
 }
 
 .rpanel-wrapper,


### PR DESCRIPTION
Resolves #1204 

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixes issue #1204 — ensures the side-panel search input focus outline is not clipped.

- Modified: projects/element-ng/side-panel/si-side-panel-content.component.scss
  - Moved spacing from a gap-based layout to padding on the wrapper: added padding-block-start: map.get(all-variables.$spacers, 5) to .rpanel-wrapper (default).
  - In :host-context(.collapsible) kept the previous gap on .rpanel-wrapper but reset padding/gap when collapsed (:host.collapsed .rpanel-wrapper sets padding-block-start: 0; gap: 0 and inline-size).
  - Kept/ensured overflow and min-block-size/flex rules on .rpanel-wrapper and .rpanel-content (overflow-x: hidden; overflow-y: auto; min-block-size: 0; flex: 1 0 0) to prevent clipping of the search input focus outline.

No exported/public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->