### PR TITLE
fix(select): ensure the filter value is retained after options updates

### DIFF
--- a/api-goldens/element-ng/select/index.api.md
+++ b/api-goldens/element-ng/select/index.api.md
@@ -185,8 +185,12 @@ export class SiSelectLazyOptionsDirective<T> implements SiSelectOptionsStrategy<
 export class SiSelectListHasFilterComponent<T> extends SiSelectListBase<T> implements OnInit {
     constructor();
     // (undocumented)
+    protected readonly filteredRows: Signal<readonly SelectItem<T>[]>;
+    // (undocumented)
     protected readonly filterInput: Signal<ElementRef<HTMLInputElement>>;
     readonly filterPlaceholder: _angular_core.InputSignal<TranslatableString>;
+    // (undocumented)
+    protected readonly filterValue: _angular_core.WritableSignal<string>;
     // (undocumented)
     protected readonly icons: Record<"elementSearch", string>;
     // (undocumented)

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--actions-option-created-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--actions-option-created-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:826ccd540101aec1b8b8368e02c9305e3013f184c63a86b03d47b86e039e5bd7
-size 21430
+oid sha256:85270579ebcc1dd579fa831d1aa63b489f88cbd5c71781b389c0ef59b4d30c6c
+size 21332

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--actions-option-created-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--actions-option-created-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35e3ac58ca38bbb7ad3925d3baf7cedd93ef999eb19322664bdcc0a58128516d
-size 21024
+oid sha256:2f8971e4aaa7f3f093dea9ef59ab099300ec3f09486e7b4a9274ae3512ac43a4
+size 21090

--- a/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
+++ b/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
@@ -85,7 +85,7 @@ describe('SelectLazyOptionsDirective', () => {
     await fixture.whenStable();
     const list = (await harness.getList())!;
 
-    await list.sendKeys('search');
+    await list.sendKeys('result');
     expect(component.optionSource.getOptionsForSearch).not.toHaveBeenCalled();
     jasmine.clock().tick(200);
     await fixture.whenStable();

--- a/projects/element-ng/select/options/si-select-options-strategy.base.ts
+++ b/projects/element-ng/select/options/si-select-options-strategy.base.ts
@@ -45,32 +45,8 @@ export abstract class SiSelectOptionsStrategyBase<T> implements SiSelectOptionsS
   }
 
   onFilter(filterValue?: string): void {
-    if (filterValue) {
-      const filterValueLC = filterValue.toLowerCase();
-      const checkRow: (row: SelectOption<T>) => boolean = (row: SelectOption<T>) =>
-        (row.typeaheadLabel ?? row.label)!.toLowerCase().includes(filterValueLC!);
-
-      this.rows.set(
-        this.allRows().reduce((rows, row) => {
-          if (row.type === 'option' && checkRow(row)) {
-            rows.push(row);
-          } else if (row.type === 'group') {
-            if (row.label!.toLowerCase().includes(filterValueLC!)) {
-              rows.push(row);
-            } else {
-              const options = row.options.filter(checkRow);
-
-              if (options.length) {
-                rows.push({ ...row, options });
-              }
-            }
-          }
-
-          return rows;
-        }, [] as SelectItem<T>[])
-      );
-    } else {
-      this.rows.set(this.allRows());
-    }
+    // When filterValue is undefined, re-apply the last filter to maintain consistency
+    // if options change while the dropdown is open
+    this.rows.set(this.allRows());
   }
 }

--- a/projects/element-ng/select/select-list/si-select-list-has-filter.component.html
+++ b/projects/element-ng/select/select-list/si-select-list-has-filter.component.html
@@ -27,7 +27,7 @@
   [attr.aria-labelledby]="baseId() + '-aria-label' + ' ' + labelledby()"
   (siAutocompleteOptionSubmitted)="select($event)"
 >
-  @for (item of rows(); track item; let index = $index) {
+  @for (item of filteredRows(); track item; let index = $index) {
     @if (item.type === 'group') {
       <div
         role="group"

--- a/projects/element-ng/select/si-select.component.spec.ts
+++ b/projects/element-ng/select/si-select.component.spec.ts
@@ -357,6 +357,19 @@ describe('SiSelectComponent', () => {
         const item = await selectHarness.getList().then(list => list!.getItemByText('c'));
         expect(await item.isActive()).toBeTrue();
       });
+
+      it('should apply current filter when options are applied', async () => {
+        await selectHarness.open();
+        await selectHarness.getList().then(list => list!.sendKeys('c'));
+        hostComponent.options = [...hostComponent.options!, { id: 'aaa', title: 'aaa' }];
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+        const items = await selectHarness.getList().then(list => list!.getAllItemTexts());
+        expect(items).not.toContain('a');
+        expect(items).not.toContain('b');
+        expect(items).not.toContain('ab');
+        expect(items).not.toContain('aaa');
+      });
     });
   });
 


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix for Select Component Filter Value Retention — Updated Summary

- projects/element-ng/select/options/si-select-options-strategy.base.ts
  - onFilter replaced with a no-op that resets rows to allRows (strategy no longer performs filtering or retains last-filter state).

- projects/element-ng/select/select-list/si-select-list-has-filter.component.ts/.html
  - Added filterValue (WritableSignal<string>) and filteredRows (Computed<SelectItem<T>[]>).
  - input() now updates filterValue and calls selectOptions.onFilter with the input value.
  - Template iterates filteredRows() instead of rows(), moving UI filtering into the list component.

- projects/element-ng/select/si-select.component.spec.ts
  - Added "should apply current filter when options are applied" to ensure a typed filter remains effective after dynamic option updates.

- projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
  - Adjusted test input from 'search' to 'result' to align with debounce behavior and assertions.

- api-goldens/element-ng/select/index.api.md
  - API updated to include new protected signals on SiSelectListHasFilterComponent: filterValue and filteredRows.

Overall: filtering was moved out of the options strategy into the list component (signals + template change). The options strategy now exposes allRows while the list component maintains and applies the active filter; tests were added/updated to verify filter persistence when options change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->