### PR TITLE
build(api-goldens): exclude protected members

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -74,6 +74,8 @@ npm run lint:scss
 We guard our APIs against unintentional changes using API goldens based on [API Extractor](https://api-extractor.com/).
 Whenever the public API is changed, the corresponding golden must be updated.
 
+`protected` members are considered internal and are excluded from the public API report.
+
 ```shell
 # Build and updates the API goldens. This is the main command needed for local development.
 npm run api-goldens:build-accept

--- a/api-goldens/charts-ng/index.api.md
+++ b/api-goldens/charts-ng/index.api.md
@@ -419,25 +419,13 @@ export { SiCandlestickSeriesOption as SimplCandlestickSeriesOption }
 export class SiChartCartesianComponent extends SiChartComponent implements OnChanges {
     addData(index: number, data: CartesianChartData): void;
     addDataMulti(series: SeriesUpdate<CartesianChartData>[]): void;
-    // (undocumented)
-    protected afterChartInit(skipZoom?: boolean): void;
-    // (undocumented)
-    protected applyOptions(): void;
     getSeriesMarker(seriesName: string): string;
     getSeriesMarkerSvg(seriesName: string): string;
-    // (undocumented)
-    protected getValidXAxis(): Set<number>;
-    // (undocumented)
-    protected handleSelectionChanged(event: any): void;
-    // (undocumented)
-    protected hasData(): boolean;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     refreshSeries(isLive?: boolean, dzToSet?: DataZoomRange): void;
     readonly series: _angular_core.InputSignal<CartesianChartSeries[] | undefined>;
-    // (undocumented)
-    protected setZoomMode(): void;
     readonly stacked: _angular_core.InputSignal<boolean>;
     // (undocumented)
     readonly subChartGrids: _angular_core.InputSignal<SubchartGrid[] | undefined>;
@@ -453,10 +441,6 @@ export class SiChartCartesianComponent extends SiChartComponent implements OnCha
 
 // @public (undocumented)
 export class SiChartCircleComponent extends SiChartComponent {
-    // (undocumented)
-    protected applyDataZoom(): void;
-    // (undocumented)
-    protected applyOptions(): void;
     changeMultiValues(updateValues: CircleValueUpdate[]): void;
     changeSingleValue(index: number, valueIndex: number, value: number): void;
     readonly series: _angular_core.InputSignal<CircleChartSeries[] | undefined>;
@@ -468,47 +452,12 @@ export class SiChartCircleComponent extends SiChartComponent {
 
 // @public (undocumented)
 export class SiChartComponent implements AfterViewInit, OnChanges, OnInit, OnDestroy {
-    // (undocumented)
-    protected activeTheme: any;
-    protected actualOptions: EChartOption;
-    // (undocumented)
-    protected addDataInternal(series: SeriesUpdate<any>[]): void;
     readonly additionalOptions: _angular_core.InputSignal<EChartOption | undefined>;
-    // (undocumented)
-    protected addLegendItem(name: string, visible?: boolean | null, index?: number, gridIndex?: number, customLegendProp?: CustomLegendProps, seriesSymbol?: string): void;
-    // (undocumented)
-    protected afterChartInit(skipZoom?: boolean): void;
-    // (undocumented)
-    protected afterChartResize(): void;
-    // (undocumented)
-    protected applyCustomLegendPosition(): void;
-    // (undocumented)
-    protected applyDataZoom(): void;
-    // (undocumented)
-    protected applyOptions(): void;
-    // (undocumented)
-    protected applyStyles(): void;
-    // (undocumented)
-    protected applyTitles(): void;
     readonly autoZoomSeriesIndex: _angular_core.InputSignal<number>;
-    // (undocumented)
-    protected autoZoomUpdate: boolean;
     readonly axisPointer: _angular_core.InputSignal<string | boolean | undefined>;
-    // (undocumented)
-    protected readonly backgroundColor: _angular_core.WritableSignal<string>;
-    // (undocumented)
-    protected readonly chartContainer: _angular_core.Signal<ElementRef<any> | undefined>;
     readonly chartContainerWrapper: _angular_core.Signal<ElementRef<any>>;
     readonly chartGridResized: _angular_core.OutputEmitterRef<GridRectCoordinate>;
     readonly chartSeriesClick: _angular_core.OutputEmitterRef<LegendItem>;
-    // (undocumented)
-    protected readonly containerHeight: _angular_core.WritableSignal<number | null>;
-    // (undocumented)
-    protected curHeight: number;
-    // (undocumented)
-    protected curWidth: number;
-    // (undocumented)
-    protected customLegend: CustomLegend[];
     readonly customLegendAction: _angular_core.InputSignal<boolean | undefined>;
     readonly customLegendMultiLineInfoEvent: _angular_core.OutputEmitterRef<CustomLegendMultiLineInfo[]>;
     readonly dataZoom: _angular_core.OutputEmitterRef<DataZoomEvent>;
@@ -520,36 +469,9 @@ export class SiChartComponent implements AfterViewInit, OnChanges, OnInit, OnDes
     readonly eChartContainerHeight: _angular_core.InputSignal<string | null | undefined>;
     readonly externalXAxisFormatter: _angular_core.InputSignal<((value: any, visibleRange: number) => string) | undefined>;
     readonly externalZoomSlider: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected readonly externalZoomSliderContainer: _angular_core.Signal<ElementRef<any> | undefined>;
-    // (undocumented)
-    protected extZoomSliderOptions: EChartOption;
-    protected fetchSeriesColors(colorsToBeUSed?: any): void;
     getOptionNoClone(): any;
     getSeriesColorBySeriesName(seriesName: string): string | undefined;
-    // (undocumented)
-    protected getThemeCustomValue(props: string[], defaultValue: any): any;
-    // (undocumented)
-    protected getThemeValue(props: string[], defaultValue: any, ns?: string): any;
-    // (undocumented)
-    protected getValidXAxis(): Set<number> | undefined;
     getVisibleRange(): DataZoomEvent | undefined;
-    protected handleClickOnChart(event: any, toggleVisibility: boolean): void;
-    // (undocumented)
-    protected handleLegendClick(legend: CustomLegendItem): void;
-    // (undocumented)
-    protected handleLegendHover(legend: CustomLegendItem, start: boolean): void;
-    // (undocumented)
-    protected handleSelectionChanged(event: any): void;
-    protected handleSelectionChangedCustom(event: any): void;
-    // (undocumented)
-    protected hasData(): boolean;
-    // (undocumented)
-    protected hasDataZoom(): boolean;
-    // (undocumented)
-    protected readonly inProgress: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected internalGetModel(): any;
     readonly maxEntries: _angular_core.InputSignal<number>;
     // (undocumented)
     ngAfterViewInit(skipZoom?: boolean): void;
@@ -561,8 +483,6 @@ export class SiChartComponent implements AfterViewInit, OnChanges, OnInit, OnDes
     ngOnInit(): void;
     readonly options: _angular_core.InputSignal<EChartOption | undefined>;
     readonly palette: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected parsePercent(percent: string | number, all: number): number;
     readonly pointer: _angular_core.OutputEmitterRef<AxisPointerEvent>;
     refreshSeries(isLive?: boolean, dzToSet?: DataZoomRange): void;
     readonly renderer: _angular_core.InputSignal<"canvas" | "svg">;
@@ -570,51 +490,19 @@ export class SiChartComponent implements AfterViewInit, OnChanges, OnInit, OnDes
     resize(): void;
     readonly selectedItem: _angular_core.InputSignal<SelectedLegendItem>;
     readonly selectionChanged: _angular_core.OutputEmitterRef<any>;
-    protected selectSeries(element: any, emit: boolean, seriesDataIndex: number): any;
     setTimeRange(range: number): void;
-    // (undocumented)
-    protected setZoomMode(): void;
-    // (undocumented)
-    protected readonly shapePaths: Record<string, string>;
     readonly showCustomLegend: _angular_core.InputSignal<boolean>;
     readonly showLegend: _angular_core.ModelSignal<boolean>;
     // @deprecated
     readonly showTimeRangeBar: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected readonly siCustomLegend: _angular_core.Signal<readonly SiCustomLegendComponent[]>;
     startProgressIndication(): void;
     stopProgressIndication(): void;
-    protected styleSelectedSeries(seriesName: string, emit: boolean, seriesDataIndex: number): any;
     readonly subTitle: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly subTitleColor: _angular_core.WritableSignal<string>;
-    // (undocumented)
-    protected readonly textColor: _angular_core.WritableSignal<string>;
     readonly theme: _angular_core.InputSignal<any>;
-    // (undocumented)
-    protected themeChanged(): void;
     readonly themeCustomization: _angular_core.InputSignal<any>;
-    // (undocumented)
-    protected readonly timeBarBottom: _angular_core.WritableSignal<number>;
-    // (undocumented)
-    protected readonly timeBarHeight: _angular_core.WritableSignal<number>;
-    // (undocumented)
-    protected readonly timeBarLeft: _angular_core.WritableSignal<number>;
-    // (undocumented)
-    protected readonly timeBarRight: _angular_core.WritableSignal<number>;
     readonly timeRangeChange: _angular_core.OutputEmitterRef<number>;
     readonly title: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly titleColor: _angular_core.WritableSignal<string>;
     toggleSeriesVisibility(name: string, visible: boolean): void;
-    protected unselectSeries(element: any, emit: boolean, seriesDataIndex: number): {
-        color: any;
-        series: (EChartSeries | undefined)[];
-    };
-    // (undocumented)
-    protected updateAxisAndDataZoom(inOptions?: EChartOption): boolean;
-    // (undocumented)
-    protected updateEChart(force?: boolean, options?: EChartOption): void;
     readonly visibleEntries: _angular_core.ModelSignal<number>;
     readonly visibleRange: _angular_core.ModelSignal<number>;
     readonly zoomInside: _angular_core.InputSignal<boolean>;
@@ -630,14 +518,6 @@ export class SiChartComponent implements AfterViewInit, OnChanges, OnInit, OnDes
 
 // @public (undocumented)
 export class SiChartGaugeComponent extends SiChartComponent implements OnChanges {
-    // (undocumented)
-    protected afterChartInit(): void;
-    // (undocumented)
-    protected afterChartResize(): void;
-    // (undocumented)
-    protected applyDataZoom(): void;
-    // (undocumented)
-    protected applyOptions(): void;
     readonly axisNumberOfDecimals: _angular_core.InputSignal<number>;
     readonly colors: _angular_core.InputSignal<string[] | undefined>;
     // (undocumented)
@@ -674,16 +554,10 @@ export class SiChartGaugeComponent extends SiChartComponent implements OnChanges
 
 // @public (undocumented)
 export class SiChartProgressBarComponent extends SiChartComponent {
-    // (undocumented)
-    protected applyDataZoom(): void;
-    // (undocumented)
-    protected applyOptions(): void;
     changeMultiValues(updateValues: ProgressBarValueUpdate[]): void;
     changeSingleValue(valueIndex: number, value: number): void;
     readonly labelPosition: _angular_core.InputSignal<string | undefined>;
     readonly series: _angular_core.InputSignal<ProgressBarChartSeries[] | undefined>;
-    // (undocumented)
-    protected themeChanged(): void;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiChartProgressBarComponent, "si-chart-progress-bar", never, { "series": { "alias": "series"; "required": false; "isSignal": true; }; "labelPosition": { "alias": "labelPosition"; "required": false; "isSignal": true; }; }, {}, never, ["[slot=timeRangeBar]"], true, never>;
     // (undocumented)
@@ -692,20 +566,10 @@ export class SiChartProgressBarComponent extends SiChartComponent {
 
 // @public (undocumented)
 export class SiChartProgressComponent extends SiChartComponent {
-    // (undocumented)
-    protected afterChartInit(): void;
-    // (undocumented)
-    protected applyDataZoom(): void;
-    // (undocumented)
-    protected applyOptions(): void;
     changeMultiValues(updateValues: ProgressValueUpdate[]): void;
     changeSingleValue(index: number, percent: number): void;
     readonly dataAngle: _angular_core.InputSignal<number>;
-    // (undocumented)
-    protected handleSelectionChanged(event: any): void;
     readonly series: _angular_core.InputSignal<ProgressChartSeries[] | undefined>;
-    // (undocumented)
-    protected themeChanged(): void;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiChartProgressComponent, "si-chart-progress", never, { "series": { "alias": "series"; "required": false; "isSignal": true; }; "dataAngle": { "alias": "dataAngle"; "required": false; "isSignal": true; }; }, {}, never, ["[slot=timeRangeBar]"], true, never>;
     // (undocumented)
@@ -714,8 +578,6 @@ export class SiChartProgressComponent extends SiChartComponent {
 
 // @public (undocumented)
 export class SiChartSankeyComponent extends SiChartComponent {
-    // (undocumented)
-    protected applyOptions(): void;
     readonly series: _angular_core.InputSignal<SankeySeriesOption | undefined>;
     // @deprecated (undocumented)
     readonly toolTip: _angular_core.InputSignal<boolean>;
@@ -741,8 +603,6 @@ export { SiChartsNgModule as SimplChartsNgModule }
 
 // @public (undocumented)
 export class SiChartSunburstComponent extends SiChartComponent {
-    // (undocumented)
-    protected applyOptions(): void;
     readonly series: _angular_core.InputSignal<SunburstSeriesOption | undefined>;
     // @deprecated (undocumented)
     readonly toolTip: _angular_core.InputSignal<boolean>;
@@ -758,13 +618,9 @@ export class SiChartSunburstComponent extends SiChartComponent {
 export class SiCustomLegendComponent {
     // (undocumented)
     readonly customLegend: _angular_core.InputSignal<CustomLegend | undefined>;
-    // (undocumented)
-    protected legendClick(legend: CustomLegendItem): void;
     readonly legendClickEvent: _angular_core.OutputEmitterRef<CustomLegendItem>;
     readonly legendHoverEndEvent: _angular_core.OutputEmitterRef<CustomLegendItem>;
     readonly legendHoverStartEvent: _angular_core.OutputEmitterRef<CustomLegendItem>;
-    // (undocumented)
-    protected legendIconClick(legend: CustomLegendItem): void;
     readonly legendIconClickEvent: _angular_core.OutputEmitterRef<CustomLegendItem>;
     readonly subTitle: _angular_core.InputSignal<string | undefined>;
     readonly subTitleColor: _angular_core.InputSignal<string | undefined>;

--- a/api-goldens/element-ng/about/index.api.md
+++ b/api-goldens/element-ng/about/index.api.md
@@ -37,24 +37,14 @@ export class SiAboutComponent implements OnInit {
     readonly copyrightDetails: _angular_core.InputSignal<CopyrightDetails | undefined>;
     readonly icon: _angular_core.InputSignal<string | undefined>;
     readonly iconName: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly icons: Record<"elementDocument", string>;
     readonly imprintLink: _angular_core.InputSignal<Link | undefined>;
-    // (undocumented)
-    protected readonly licenseApi: _angular_core.WritableSignal<ApiInfo[]>;
     readonly licenseInfo: _angular_core.InputSignal<LicenseInfo>;
     readonly links: _angular_core.InputSignal<Link[]>;
     // (undocumented)
     ngOnInit(): void;
     readonly privacyLink: _angular_core.InputSignal<Link | undefined>;
-    // (undocumented)
-    protected readonly sanitizedUrl: _angular_core.Signal<_angular_platform_browser.SafeResourceUrl | undefined>;
     readonly subheading: _angular_core.InputSignal<string[] | undefined>;
     readonly termsLink: _angular_core.InputSignal<Link | undefined>;
-    // (undocumented)
-    protected toggleLoadLicenseApi(apiInfo: ApiInfo): void;
-    // (undocumented)
-    protected toggleLoadLicenseContent(apiInfo: ApiInfo): void;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiAboutComponent, "si-about", never, { "aboutTitle": { "alias": "aboutTitle"; "required": true; "isSignal": true; }; "licenseInfo": { "alias": "licenseInfo"; "required": true; "isSignal": true; }; "icon": { "alias": "icon"; "required": false; "isSignal": true; }; "iconName": { "alias": "iconName"; "required": false; "isSignal": true; }; "appName": { "alias": "appName"; "required": true; "isSignal": true; }; "subheading": { "alias": "subheading"; "required": false; "isSignal": true; }; "acceptableUsePolicyLink": { "alias": "acceptableUsePolicyLink"; "required": false; "isSignal": true; }; "imprintLink": { "alias": "imprintLink"; "required": false; "isSignal": true; }; "privacyLink": { "alias": "privacyLink"; "required": false; "isSignal": true; }; "cookieNoticeLink": { "alias": "cookieNoticeLink"; "required": false; "isSignal": true; }; "termsLink": { "alias": "termsLink"; "required": false; "isSignal": true; }; "links": { "alias": "links"; "required": false; "isSignal": true; }; "copyrightDetails": { "alias": "copyrightDetails"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/accordion/index.api.md
+++ b/api-goldens/element-ng/accordion/index.api.md
@@ -48,31 +48,13 @@ export class SiCollapsiblePanelComponent {
     readonly colorVariant: _angular_core.InputSignal<BackgroundColorVariant | undefined>;
     readonly contentBgClasses: _angular_core.InputSignal<string>;
     readonly contentCssClasses: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected controlId: string;
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected doToggle(event?: Event): void;
-    // (undocumented)
-    protected readonly fullHeight: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly hcollapsed: _angular_core.Signal<boolean>;
     readonly headerCssClasses: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected headerId: string;
     readonly heading: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly icon: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly icons: Record<"elementDown2", string>;
-    // (undocumented)
-    protected isHCollapsible: boolean;
-    // (undocumented)
-    protected keydown(event: KeyboardEvent): void;
     openClose(open: boolean, enableAnimation?: boolean): void;
     readonly opened: _angular_core.ModelSignal<boolean>;
     readonly panelToggle: _angular_core.OutputEmitterRef<boolean>;
-    // (undocumented)
-    protected get showHide(): string;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiCollapsiblePanelComponent, "si-collapsible-panel", never, { "heading": { "alias": "heading"; "required": false; "isSignal": true; }; "headerCssClasses": { "alias": "headerCssClasses"; "required": false; "isSignal": true; }; "contentBgClasses": { "alias": "contentBgClasses"; "required": false; "isSignal": true; }; "contentCssClasses": { "alias": "contentCssClasses"; "required": false; "isSignal": true; }; "opened": { "alias": "opened"; "required": false; "isSignal": true; }; "icon": { "alias": "icon"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "colorVariant": { "alias": "colorVariant"; "required": false; "isSignal": true; }; "badge": { "alias": "badge"; "required": false; "isSignal": true; }; "badgeColor": { "alias": "badgeColor"; "required": false; "isSignal": true; }; }, { "opened": "openedChange"; "panelToggle": "panelToggle"; }, never, ["[si-panel-heading]", "*"], true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/application-header/index.api.md
+++ b/api-goldens/element-ng/application-header/index.api.md
@@ -82,33 +82,13 @@ export class SiAccountDetailsComponent {
 
 // @public
 export class SiApplicationHeaderComponent implements HeaderWithDropdowns, OnDestroy {
-    // (undocumented)
-    protected backdropClicked(): void;
     readonly expandBreakpoint: _angular_core.InputSignal<"sm" | "md" | "lg" | "xl" | "xxl" | "never">;
-    // (undocumented)
-    protected readonly icons: Record<"elementThumbnails" | "elementMenu", string>;
-    // (undocumented)
-    protected readonly id: string;
-    // (undocumented)
-    protected injector: Injector;
     // (undocumented)
     readonly launchpad: _angular_core.InputSignal<TemplateRef<void> | undefined>;
     // (undocumented)
     readonly launchpadLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
-    protected readonly launchpadOpen: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected navigationEscapePressed(): void;
-    // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
-    protected readonly openDropdownCount: _angular_core.WritableSignal<number>;
-    // (undocumented)
-    protected toggleLaunchpad(): void;
-    // (undocumented)
-    protected toggleMobileNavigationExpanded(): void;
-    // (undocumented)
-    protected toggleNavigation: _siemens_element_translate_ng_translate_types.TranslatableString;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiApplicationHeaderComponent, "si-application-header", never, { "expandBreakpoint": { "alias": "expandBreakpoint"; "required": false; "isSignal": true; }; "launchpad": { "alias": "launchpad"; "required": false; "isSignal": true; }; "launchpadLabel": { "alias": "launchpadLabel"; "required": false; "isSignal": true; }; }, {}, never, ["si-header-brand, element-header-brand", "si-header-navigation, element-header-navigation", "si-header-actions, element-header-actions"], true, never>;
     // (undocumented)
@@ -153,17 +133,9 @@ export class SiHeaderBrandDirective {
 
 // @public
 export class SiHeaderCollapsibleActionsComponent implements OnDestroy {
-    // (undocumented)
-    protected escapePressed(): void;
-    // (undocumented)
-    protected readonly icons: Record<"elementOptionsVertical", string>;
-    // (undocumented)
-    protected readonly id: string;
     readonly mobileToggleLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
-    protected toggleMobileExpanded(): void;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiHeaderCollapsibleActionsComponent, "si-header-collapsible-actions", never, { "mobileToggleLabel": { "alias": "mobileToggleLabel"; "required": false; "isSignal": true; }; }, {}, never, ["*"], true, never>;
     // (undocumented)
@@ -173,11 +145,7 @@ export class SiHeaderCollapsibleActionsComponent implements OnDestroy {
 // @public
 export class SiHeaderLogoDirective implements OnInit {
     // (undocumented)
-    protected readonly logoText: _angular_core.WritableSignal<string | undefined>;
-    // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected updateLogoText(): void;
     // (undocumented)
     static ɵdir: _angular_core.ɵɵDirectiveDeclaration<SiHeaderLogoDirective, "si-header-logo, [siHeaderLogo]", never, {}, {}, never, never, true, never>;
     // (undocumented)
@@ -188,10 +156,6 @@ export class SiHeaderLogoDirective implements OnInit {
 export class SiHeaderNavigationComponent implements OnDestroy {
     constructor();
     // (undocumented)
-    protected header: SiApplicationHeaderComponent;
-    // (undocumented)
-    protected readonly icons: Record<"elementThumbnails", string>;
-    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiHeaderNavigationComponent, "si-header-navigation", never, {}, {}, never, ["*"], true, never>;
@@ -201,8 +165,6 @@ export class SiHeaderNavigationComponent implements OnDestroy {
 
 // @public
 export class SiHeaderNavigationItemComponent {
-    // (undocumented)
-    protected readonly icons: Record<"elementDown2", string>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiHeaderNavigationItemComponent, "button[si-header-navigation-item], a[si-header-navigation-item]", never, {}, {}, never, ["*"], true, never>;
     // (undocumented)
@@ -228,36 +190,16 @@ export class SiHeaderSiemensLogoComponent extends SiHeaderLogoDirective {
 
 // @public (undocumented)
 export class SiLaunchpadFactoryComponent {
-    // (undocumented)
-    protected readonly activatedRoute: ActivatedRoute | null;
     readonly apps: _angular_core.InputSignal<App[] | AppCategory[]>;
-    // (undocumented)
-    protected readonly categories: _angular_core.Signal<AppCategory[]>;
-    // (undocumented)
-    protected closeLaunchpad(): void;
     readonly closeText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly enableFavorites: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected escape(): void;
     readonly favoriteAppsText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
     readonly favoriteChange: _angular_core.OutputEmitterRef<FavoriteChangeEvent>;
-    // (undocumented)
-    protected readonly favorites: _angular_core.Signal<(_siemens_element_ng_application_header.AppLink | _siemens_element_ng_application_header.AppRouterLink)[]>;
-    // (undocumented)
-    protected readonly hasFavorites: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly icons: Record<"elementDown2" | "elementCancel", string>;
-    // (undocumented)
-    protected isCategories(items: App[] | AppCategory[]): items is AppCategory[];
-    // (undocumented)
-    protected showAllApps: boolean;
     readonly showLessAppsText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly showMoreAppsText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly subtitleText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly titleText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected toggleFavorite(app: App, favorite: boolean): void;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiLaunchpadFactoryComponent, "si-launchpad-factory", never, { "closeText": { "alias": "closeText"; "required": false; "isSignal": true; }; "titleText": { "alias": "titleText"; "required": false; "isSignal": true; }; "subtitleText": { "alias": "subtitleText"; "required": false; "isSignal": true; }; "apps": { "alias": "apps"; "required": true; "isSignal": true; }; "enableFavorites": { "alias": "enableFavorites"; "required": false; "isSignal": true; }; "favoriteAppsText": { "alias": "favoriteAppsText"; "required": false; "isSignal": true; }; "showMoreAppsText": { "alias": "showMoreAppsText"; "required": false; "isSignal": true; }; "showLessAppsText": { "alias": "showLessAppsText"; "required": false; "isSignal": true; }; }, { "favoriteChange": "favoriteChange"; }, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/auto-collapsable-list/index.api.md
+++ b/api-goldens/element-ng/auto-collapsable-list/index.api.md
@@ -54,8 +54,6 @@ export class SiAutoCollapsableListItemDirective extends SiAutoCollapsableListMea
 
 // @public (undocumented)
 export class SiAutoCollapsableListMeasurable {
-    // (undocumented)
-    protected readonly elementRef: ElementRef<any>;
     size$: rxjs.Observable<number>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<SiAutoCollapsableListMeasurable, never, never, {}, {}, never, never, true, never>;

--- a/api-goldens/element-ng/autocomplete/index.api.md
+++ b/api-goldens/element-ng/autocomplete/index.api.md
@@ -13,14 +13,6 @@ export class SiAutocompleteDirective<T> {
     // (undocumented)
     get active(): SiAutocompleteOptionDirective<T> | undefined | null;
     // (undocumented)
-    protected get activeDescendant(): string;
-    // (undocumented)
-    protected get ariaControls(): string | undefined;
-    // (undocumented)
-    protected get expanded(): boolean;
-    // (undocumented)
-    protected keydown(event: KeyboardEvent): void;
-    // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<SiAutocompleteDirective<any>, "input[siAutocomplete]", ["siAutocomplete"], {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SiAutocompleteDirective<any>, never>;
@@ -59,10 +51,6 @@ export class SiAutocompleteModule {
 
 // @public (undocumented)
 export class SiAutocompleteOptionDirective<T = unknown> implements Highlightable {
-    // (undocumented)
-    protected active?: boolean;
-    // (undocumented)
-    protected click(): void;
     // (undocumented)
     get disabled(): boolean;
     // (undocumented)

--- a/api-goldens/element-ng/avatar/index.api.md
+++ b/api-goldens/element-ng/avatar/index.api.md
@@ -17,8 +17,6 @@ export type AvatarSize = 'tiny' | 'xsmall' | 'small' | 'regular' | 'large' | 'xl
 // @public
 export class SiAvatarBackgroundColorDirective implements OnChanges {
     readonly autoColor: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly backgroundStyle: _angular_core.WritableSignal<string | undefined>;
     calculateColorFromInitials(displayInitials?: string): void;
     readonly color: _angular_core.InputSignalWithTransform<number | undefined, unknown>;
     // (undocumented)
@@ -34,16 +32,12 @@ export class SiAvatarComponent {
     constructor();
     readonly altText: _angular_core.InputSignal<string>;
     readonly color: _angular_core.InputSignalWithTransform<number | undefined, unknown>;
-    // (undocumented)
-    protected readonly displayInitials: _angular_core.Signal<string>;
     readonly icon: _angular_core.InputSignal<string | undefined>;
     readonly imageUrl: _angular_core.InputSignal<string | undefined>;
     readonly initials: _angular_core.InputSignal<string | undefined>;
     readonly size: _angular_core.InputSignal<AvatarSize>;
     readonly status: _angular_core.InputSignal<EntityStatusType | undefined>;
     readonly statusAriaLabel: _angular_core.InputSignal<TranslatableString | undefined>;
-    // (undocumented)
-    protected readonly statusIcon: _angular_core.Signal<_siemens_element_ng_common.StatusIcon | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiAvatarComponent, "si-avatar", never, { "size": { "alias": "size"; "required": false; "isSignal": true; }; "imageUrl": { "alias": "imageUrl"; "required": false; "isSignal": true; }; "icon": { "alias": "icon"; "required": false; "isSignal": true; }; "initials": { "alias": "initials"; "required": false; "isSignal": true; }; "color": { "alias": "color"; "required": false; "isSignal": true; }; "altText": { "alias": "altText"; "required": true; "isSignal": true; }; "status": { "alias": "status"; "required": false; "isSignal": true; }; "statusAriaLabel": { "alias": "statusAriaLabel"; "required": false; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof SiAvatarBackgroundColorDirective; inputs: { "color": "color"; "autoColor": "autoColor"; }; outputs: {}; }]>;
     // (undocumented)

--- a/api-goldens/element-ng/breadcrumb-router/index.api.md
+++ b/api-goldens/element-ng/breadcrumb-router/index.api.md
@@ -41,8 +41,6 @@ export interface SiBreadcrumbResolverService {
 export class SiBreadcrumbRouterComponent implements OnInit, OnDestroy {
     readonly ariaLabel: i0.InputSignal<string>;
     // (undocumented)
-    protected readonly items: i0.WritableSignal<BreadcrumbItem[]>;
-    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;

--- a/api-goldens/element-ng/breadcrumb/index.api.md
+++ b/api-goldens/element-ng/breadcrumb/index.api.md
@@ -26,35 +26,13 @@ export interface EnumeratedBreadcrumbItem extends BreadcrumbItem {
 
 // @public (undocumented)
 export class SiBreadcrumbComponent implements OnChanges, OnDestroy {
-    // (undocumented)
-    protected addExpandDropdown: boolean;
     readonly ariaLabel: i0.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected breadcrumbDropdownOpen: number | undefined;
-    // (undocumented)
-    protected breadcrumbShortened: boolean;
-    // (undocumented)
-    protected controlId: string;
-    // (undocumented)
-    protected documentClick(targetElement: any): void;
-    // (undocumented)
-    protected ellipsesLevel: number;
-    // (undocumented)
-    protected readonly icons: Record<"elementBreadcrumbRoot" | "elementRight2", string>;
     readonly items: i0.InputSignal<BreadcrumbItem[]>;
-    // (undocumented)
-    protected itemsHidden: EnumeratedBreadcrumbItem[];
-    // (undocumented)
-    protected itemsShown: EnumeratedBreadcrumbItem[];
     // (undocumented)
     ngOnChanges(): void;
     // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
-    protected resetBreadcrumb(): void;
     readonly showRootAsText: i0.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected toggleBreadcrumbDropdown(itemLevel: number): void;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiBreadcrumbComponent, "si-breadcrumb", never, { "items": { "alias": "items"; "required": true; "isSignal": true; }; "showRootAsText": { "alias": "showRootAsText"; "required": false; "isSignal": true; }; "ariaLabel": { "alias": "ariaLabel"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/card/index.api.md
+++ b/api-goldens/element-ng/card/index.api.md
@@ -13,14 +13,8 @@ import { ViewType } from '@siemens/element-ng/content-action-bar';
 
 // @public
 export class SiActionCardComponent extends SiCardBaseDirective {
-    // (undocumented)
-    protected contentId: string;
-    // (undocumented)
-    protected headingId: string;
     readonly selectable: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly selected: _angular_core.ModelSignal<boolean>;
-    // (undocumented)
-    protected subHeadingId: string;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiActionCardComponent, "button[si-action-card]", never, { "selectable": { "alias": "selectable"; "required": false; "isSignal": true; }; "selected": { "alias": "selected"; "required": false; "isSignal": true; }; }, { "selected": "selectedChange"; }, never, ["[headerIcon]", "[body]", "[footer]"], true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/chat-messages/index.api.md
+++ b/api-goldens/element-ng/chat-messages/index.api.md
@@ -47,13 +47,9 @@ export class SiAiMessageComponent {
     readonly actions: _angular_core.InputSignal<MessageAction[]>;
     readonly content: _angular_core.InputSignal<string>;
     readonly contentFormatter: _angular_core.InputSignal<((text: string) => string | Node) | undefined>;
-    // (undocumented)
-    protected readonly formattedContent: _angular_core.Signal<ElementRef<HTMLDivElement> | undefined>;
     readonly loading: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly secondaryActions: _angular_core.InputSignal<MenuItem[]>;
     readonly secondaryActionsLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly textContent: _angular_core.WritableSignal<string | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiAiMessageComponent, "si-ai-message", never, { "content": { "alias": "content"; "required": false; "isSignal": true; }; "contentFormatter": { "alias": "contentFormatter"; "required": false; "isSignal": true; }; "loading": { "alias": "loading"; "required": false; "isSignal": true; }; "actions": { "alias": "actions"; "required": false; "isSignal": true; }; "secondaryActions": { "alias": "secondaryActions"; "required": false; "isSignal": true; }; "actionParam": { "alias": "actionParam"; "required": false; "isSignal": true; }; "secondaryActionsLabel": { "alias": "secondaryActionsLabel"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)
@@ -64,12 +60,6 @@ export class SiAiMessageComponent {
 export class SiAttachmentListComponent {
     readonly alignment: _angular_core.InputSignal<"start" | "end">;
     readonly attachments: _angular_core.InputSignal<Attachment[]>;
-    // (undocumented)
-    protected getFileIcon(name: string): string;
-    // (undocumented)
-    protected modalService: SiModalService;
-    // (undocumented)
-    protected openPreview(event: Event, attachment: Attachment): void;
     readonly removable: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly remove: _angular_core.OutputEmitterRef<Attachment>;
     readonly removeLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
@@ -90,8 +80,6 @@ export class SiChatContainerComponent implements AfterContentInit, OnDestroy {
     ngOnDestroy(): void;
     readonly noAutoScroll: _angular_core.InputSignalWithTransform<boolean, string | boolean>;
     // (undocumented)
-    protected onScroll(): void;
-    // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiChatContainerComponent, "si-chat-container", never, { "colorVariant": { "alias": "colorVariant"; "required": false; "isSignal": true; }; "noAutoScroll": { "alias": "noAutoScroll"; "required": false; "isSignal": true; }; }, {}, never, ["*", "si-inline-notification", "si-chat-input,[siChatContainerInput]"], true, never>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<SiChatContainerComponent, never>;
@@ -110,42 +98,14 @@ export class SiChatInputComponent implements AfterViewInit {
     readonly accept: _angular_core.InputSignal<string | undefined>;
     readonly actionParam: _angular_core.InputSignal<any>;
     readonly actions: _angular_core.InputSignal<MessageAction[]>;
-    // (undocumented)
-    protected adjustTextareaHeight(event: Event): void;
     readonly allowAttachments: _angular_core.InputSignal<boolean>;
     readonly attachFileLabel: _angular_core.InputSignal<TranslatableString_2>;
-    // (undocumented)
-    protected get attachmentList(): Attachment[];
     readonly attachments: _angular_core.ModelSignal<ChatInputAttachment[]>;
     readonly autoFocus: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly buttonDisabled: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly buttonIcon: _angular_core.Signal<string>;
-    // (undocumented)
-    protected readonly buttonLabel: _angular_core.Signal<TranslatableString_2>;
-    // (undocumented)
-    protected readonly canSend: _angular_core.Signal<boolean>;
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly disclaimer: _angular_core.InputSignal<TranslatableString_2 | undefined>;
-    // (undocumented)
-    protected dragOver: boolean;
-    // (undocumented)
-    protected dragOverHandler(event: DragEvent): void;
-    // (undocumented)
-    protected dropHandler(event: DragEvent): void;
     readonly fileError: _angular_core.OutputEmitterRef<FileUploadError>;
     focus(): void;
-    // (undocumented)
-    protected readonly hasActions: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly hasAttachments: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly hasContent: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly hasSecondaryActions: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly id: string;
     readonly interrupt: _angular_core.OutputEmitterRef<void>;
     readonly interruptButtonLabel: _angular_core.InputSignal<TranslatableString_2>;
     readonly interruptible: _angular_core.InputSignalWithTransform<boolean, unknown>;
@@ -154,23 +114,7 @@ export class SiChatInputComponent implements AfterViewInit {
     readonly maxLength: _angular_core.InputSignal<number | undefined>;
     // (undocumented)
     ngAfterViewInit(): void;
-    // (undocumented)
-    protected onButtonClick(): void;
-    // (undocumented)
-    protected onContainerClick(event: Event): void;
-    // (undocumented)
-    protected onFileError(error: FileUploadError): void;
-    // (undocumented)
-    protected onFilesAdded(uploadFiles: UploadFile[]): void;
-    // (undocumented)
-    protected onInputChange(value: string): void;
-    // (undocumented)
-    protected onKeyDown(event: KeyboardEvent): void;
-    // (undocumented)
-    protected onSend(): void;
     readonly placeholder: _angular_core.InputSignal<TranslatableString_2>;
-    // (undocumented)
-    protected removeAttachment(attachment: Attachment): void;
     readonly removeAttachmentLabel: _angular_core.InputSignal<TranslatableString_2>;
     readonly secondaryActions: _angular_core.InputSignal<MenuItem[]>;
     readonly secondaryActionsLabel: _angular_core.InputSignal<TranslatableString_2>;
@@ -181,8 +125,6 @@ export class SiChatInputComponent implements AfterViewInit {
     readonly sendButtonIcon: _angular_core.InputSignal<string>;
     readonly sendButtonLabel: _angular_core.InputSignal<TranslatableString_2>;
     readonly sending: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly showInterruptButton: _angular_core.Signal<boolean>;
     readonly value: _angular_core.ModelSignal<string>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiChatInputComponent, "si-chat-input", never, { "value": { "alias": "value"; "required": false; "isSignal": true; }; "placeholder": { "alias": "placeholder"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "sending": { "alias": "sending"; "required": false; "isSignal": true; }; "interruptible": { "alias": "interruptible"; "required": false; "isSignal": true; }; "maxLength": { "alias": "maxLength"; "required": false; "isSignal": true; }; "disclaimer": { "alias": "disclaimer"; "required": false; "isSignal": true; }; "actions": { "alias": "actions"; "required": false; "isSignal": true; }; "secondaryActions": { "alias": "secondaryActions"; "required": false; "isSignal": true; }; "allowAttachments": { "alias": "allowAttachments"; "required": false; "isSignal": true; }; "accept": { "alias": "accept"; "required": false; "isSignal": true; }; "maxFileSize": { "alias": "maxFileSize"; "required": false; "isSignal": true; }; "attachments": { "alias": "attachments"; "required": false; "isSignal": true; }; "label": { "alias": "label"; "required": false; "isSignal": true; }; "actionParam": { "alias": "actionParam"; "required": false; "isSignal": true; }; "sendButtonLabel": { "alias": "sendButtonLabel"; "required": false; "isSignal": true; }; "sendButtonIcon": { "alias": "sendButtonIcon"; "required": false; "isSignal": true; }; "interruptButtonLabel": { "alias": "interruptButtonLabel"; "required": false; "isSignal": true; }; "autoFocus": { "alias": "autoFocus"; "required": false; "isSignal": true; }; "attachFileLabel": { "alias": "attachFileLabel"; "required": false; "isSignal": true; }; "removeAttachmentLabel": { "alias": "removeAttachmentLabel"; "required": false; "isSignal": true; }; "secondaryActionsLabel": { "alias": "secondaryActionsLabel"; "required": false; "isSignal": true; }; }, { "value": "valueChange"; "attachments": "attachmentsChange"; "send": "send"; "interrupt": "interrupt"; "fileError": "fileError"; }, never, ["*", "[siChatInputDisclaimer]"], true, never>;
@@ -225,14 +167,8 @@ export class SiUserMessageComponent {
     readonly attachments: _angular_core.InputSignal<Attachment[]>;
     readonly content: _angular_core.InputSignal<string>;
     readonly contentFormatter: _angular_core.InputSignal<((text: string) => string | Node) | undefined>;
-    // (undocumented)
-    protected readonly formattedContent: _angular_core.Signal<ElementRef<HTMLDivElement> | undefined>;
-    // (undocumented)
-    protected readonly hasAttachments: _angular_core.Signal<boolean>;
     readonly secondaryActions: _angular_core.InputSignal<MenuItem[]>;
     readonly secondaryActionsLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly textContent: _angular_core.WritableSignal<string | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiUserMessageComponent, "si-user-message", never, { "content": { "alias": "content"; "required": false; "isSignal": true; }; "contentFormatter": { "alias": "contentFormatter"; "required": false; "isSignal": true; }; "actions": { "alias": "actions"; "required": false; "isSignal": true; }; "secondaryActions": { "alias": "secondaryActions"; "required": false; "isSignal": true; }; "attachments": { "alias": "attachments"; "required": false; "isSignal": true; }; "actionParam": { "alias": "actionParam"; "required": false; "isSignal": true; }; "secondaryActionsLabel": { "alias": "secondaryActionsLabel"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/circle-status/index.api.md
+++ b/api-goldens/element-ng/circle-status/index.api.md
@@ -16,33 +16,19 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 // @public (undocumented)
 export class SiCircleStatusComponent implements OnChanges, OnDestroy {
     readonly ariaLabel: _angular_core.InputSignal<TranslatableString | undefined>;
-    // (undocumented)
-    protected readonly autoLabel: _angular_core.Signal<string>;
-    // (undocumented)
-    protected readonly backgroundClass: _angular_core.Signal<string>;
     readonly blink: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly blinkOn: _angular_core.WritableSignal<boolean>;
     readonly blinkPulse: _angular_core.InputSignal<Observable<boolean> | undefined>;
     // @deprecated
     readonly color: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly contrastFix: _angular_core.WritableSignal<boolean>;
     readonly eventIcon: _angular_core.InputSignal<string | undefined>;
     readonly eventOut: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly icon: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly icons: Record<"elementRight4", string>;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnDestroy(): void;
     readonly size: _angular_core.InputSignal<"regular" | "small">;
     readonly status: _angular_core.InputSignal<EntityStatusType | undefined>;
-    // (undocumented)
-    protected readonly statusIcon: _angular_core.Signal<StatusIcon | undefined>;
-    // (undocumented)
-    protected readonly theAriaLabel: _angular_core.Signal<string>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiCircleStatusComponent, "si-circle-status", never, { "status": { "alias": "status"; "required": false; "isSignal": true; }; "color": { "alias": "color"; "required": false; "isSignal": true; }; "icon": { "alias": "icon"; "required": false; "isSignal": true; }; "size": { "alias": "size"; "required": false; "isSignal": true; }; "eventOut": { "alias": "eventOut"; "required": false; "isSignal": true; }; "eventIcon": { "alias": "eventIcon"; "required": false; "isSignal": true; }; "blink": { "alias": "blink"; "required": false; "isSignal": true; }; "blinkPulse": { "alias": "blinkPulse"; "required": false; "isSignal": true; }; "ariaLabel": { "alias": "ariaLabel"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/color-picker/index.api.md
+++ b/api-goldens/element-ng/color-picker/index.api.md
@@ -11,36 +11,14 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 // @public (undocumented)
 export class SiColorPickerComponent implements ControlValueAccessor {
     readonly ariaLabel: _angular_core.InputSignal<TranslatableString | undefined>;
-    // (undocumented)
-    protected arrowDown(index: number, event: Event): void;
-    // (undocumented)
-    protected arrowLeft(index: number, event: Event): void;
-    // (undocumented)
-    protected arrowRight(index: number, event: Event): void;
-    // (undocumented)
-    protected arrowUp(index: number, event: Event): void;
     readonly autoClose: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected blur(): void;
     readonly color: _angular_core.ModelSignal<string | undefined>;
     readonly colorPalette: _angular_core.InputSignal<string[]>;
-    // (undocumented)
-    protected readonly disabled: _angular_core.Signal<boolean>;
     readonly disabledInput: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected readonly icons: Record<"elementOk", string>;
-    // (undocumented)
-    protected readonly isOverlayOpen: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected openOverlay(): void;
-    // (undocumented)
-    protected overlayDetach(): void;
     // (undocumented)
     registerOnChange(fn: (value: string) => void): void;
     // (undocumented)
     registerOnTouched(fn: () => void): void;
-    // (undocumented)
-    protected selectColor(color: string): void;
     // (undocumented)
     setDisabledState(isDisabled: boolean): void;
     // (undocumented)

--- a/api-goldens/element-ng/connection-strength/index.api.md
+++ b/api-goldens/element-ng/connection-strength/index.api.md
@@ -11,8 +11,6 @@ export type ConnectionStrength = 'none' | 'low' | 'medium' | 'strong';
 
 // @public (undocumented)
 export class SiConnectionStrengthComponent {
-    // (undocumented)
-    protected readonly numberValue: i0.Signal<number>;
     readonly value: i0.InputSignal<ConnectionStrength>;
     readonly wlan: i0.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)

--- a/api-goldens/element-ng/content-action-bar/index.api.md
+++ b/api-goldens/element-ng/content-action-bar/index.api.md
@@ -24,30 +24,12 @@ export type ContentActionBarMainItem = (MenuItemAction | MenuItemCheckbox | Menu
 // @public (undocumented)
 export class SiContentActionBarComponent implements AfterViewInit {
     readonly actionParam: _angular_core.InputSignal<any>;
-    // (undocumented)
-    protected collapse(): void;
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
-    protected expand(): void;
-    // (undocumented)
-    protected readonly expanded: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly icons: Record<"elementCancel" | "elementOptionsVertical", string>;
-    // (undocumented)
-    protected isNewItemStyle(item: MenuItem | ContentActionBarMainItem): item is ContentActionBarMainItem;
-    // (undocumented)
-    protected readonly mobileActions: _angular_core.Signal<readonly (MenuItem | MenuItem_2)[]>;
-    // (undocumented)
     ngAfterViewInit(): void;
-    // (undocumented)
-    protected parentElement?: HTMLElement | null;
     readonly preventIconsInDropdownMenus: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly primaryActions: _angular_core.InputSignal<readonly (MenuItem | ContentActionBarMainItem)[] | undefined>;
-    // (undocumented)
-    protected runAction(item: MenuItemAction | MenuItemRadio | MenuItemCheckbox): void;
     readonly secondaryActions: _angular_core.InputSignal<readonly (MenuItem | MenuItem_2)[] | undefined>;
-    // (undocumented)
-    protected readonly secondaryActionsInternal: _angular_core.Signal<readonly (MenuItem | MenuItem_2)[] | undefined>;
     readonly toggleItemLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly viewType: _angular_core.InputSignal<ViewType>;
     // (undocumented)

--- a/api-goldens/element-ng/copyright-notice/index.api.md
+++ b/api-goldens/element-ng/copyright-notice/index.api.md
@@ -19,15 +19,7 @@ export const SI_COPYRIGHT_DETAILS: InjectionToken<CopyrightDetails>;
 
 // @public (undocumented)
 export class SiCopyrightNoticeComponent {
-    // (undocumented)
-    protected readonly company: _angular_core.Signal<string | undefined>;
     readonly copyright: _angular_core.InputSignal<CopyrightDetails | undefined>;
-    // (undocumented)
-    protected readonly copyrightInfo: _angular_core.Signal<string>;
-    // (undocumented)
-    protected readonly lastUpdateYear: _angular_core.Signal<number | undefined>;
-    // (undocumented)
-    protected readonly startYear: _angular_core.Signal<number>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiCopyrightNoticeComponent, "si-copyright-notice", never, { "copyright": { "alias": "copyright"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/dashboard/index.api.md
+++ b/api-goldens/element-ng/dashboard/index.api.md
@@ -30,10 +30,6 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 export class SiDashboardCardComponent extends SiCardComponent implements OnDestroy {
     constructor();
     // (undocumented)
-    protected readonly actionBarTitleComputed: _angular_core.Signal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly actionBarViewTypeComputed: _angular_core.Signal<_siemens_element_ng_content_action_bar.ViewType>;
-    // (undocumented)
     readonly displayContentActionBar: _angular_core.Signal<boolean>;
     readonly enableExpandInteraction: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
@@ -44,8 +40,6 @@ export class SiDashboardCardComponent extends SiCardComponent implements OnDestr
     readonly isExpanded: _angular_core.WritableSignal<boolean>;
     // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
-    protected readonly primaryActionsComputed: _angular_core.Signal<(MenuItem | ContentActionBarMainItem)[]>;
     restore(): void;
     readonly restoreText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly showMenubar: _angular_core.InputSignalWithTransform<boolean, unknown>;
@@ -58,14 +52,10 @@ export class SiDashboardCardComponent extends SiCardComponent implements OnDestr
 // @public (undocumented)
 export class SiDashboardComponent implements OnChanges, AfterViewInit {
     constructor();
-    // (undocumented)
-    protected dashboardFrameEndPadding: number | null;
     readonly enableExpandInteractions: _angular_core.InputSignalWithTransform<boolean, unknown>;
     expand(card: SiDashboardCardComponent): void;
     readonly heading: _angular_core.InputSignal<string | undefined>;
     readonly hideMenubar: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly hideMenubarComputed: _angular_core.Signal<boolean>;
     get isExpanded(): boolean;
     // (undocumented)
     ngAfterViewInit(): void;
@@ -102,10 +92,6 @@ export class SiDashboardService {
 
 // @public
 export class SiLinkWidgetComponent extends SiWidgetBaseComponent<Link[]> {
-    // (undocumented)
-    protected readonly ghosts: _angular_core.Signal<any[]>;
-    // (undocumented)
-    protected readonly icons: Record<"elementRight2", string>;
     readonly numberOfLinks: _angular_core.InputSignal<number>;
     readonly showLinkIcons: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
@@ -117,15 +103,11 @@ export class SiLinkWidgetComponent extends SiWidgetBaseComponent<Link[]> {
 // @public
 export class SiListWidgetBodyComponent extends SiWidgetBaseComponent<SiListWidgetItem[]> implements OnChanges {
     readonly compareFn: _angular_core.InputSignal<(a: SiListWidgetItem, b: SiListWidgetItem) => number | undefined>;
-    protected readonly filteredListWidgetItems: _angular_core.Signal<SiListWidgetItem[] | undefined>;
     readonly filterFn: _angular_core.InputSignal<(item: SiListWidgetItem, searchTerm: string) => boolean | undefined>;
-    protected readonly ghosts: _angular_core.Signal<any[]>;
     readonly link: _angular_core.InputSignal<Link | undefined>;
     readonly numberOfLinks: _angular_core.InputSignal<number>;
     readonly search: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly searchPlaceholderLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly searchText: _angular_core.ModelSignal<string>;
     readonly sort: _angular_core.InputSignal<SortOrder | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiListWidgetBodyComponent, "si-list-widget-body", never, { "link": { "alias": "link"; "required": false; "isSignal": true; }; "searchPlaceholderLabel": { "alias": "searchPlaceholderLabel"; "required": false; "isSignal": true; }; "sort": { "alias": "sort"; "required": false; "isSignal": true; }; "search": { "alias": "search"; "required": false; "isSignal": true; }; "compareFn": { "alias": "compareFn"; "required": false; "isSignal": true; }; "filterFn": { "alias": "filterFn"; "required": false; "isSignal": true; }; "numberOfLinks": { "alias": "numberOfLinks"; "required": false; "isSignal": true; }; "searchText": { "alias": "searchText"; "required": false; "isSignal": true; }; }, { "searchText": "searchTextChange"; }, never, ["[empty-state]"], true, never>;
@@ -135,20 +117,15 @@ export class SiListWidgetBodyComponent extends SiWidgetBaseComponent<SiListWidge
 
 // @public
 export class SiListWidgetComponent extends SiWidgetBaseComponent<SiListWidgetItem[]> implements OnChanges {
-    // (undocumented)
-    protected readonly accentClass: _angular_core.Signal<string>;
     readonly accentLine: _angular_core.InputSignal<AccentLineType | undefined>;
     readonly compareFn: _angular_core.InputSignal<(a: SiListWidgetItem, b: SiListWidgetItem) => number | undefined>;
     readonly filterFn: _angular_core.InputSignal<(item: SiListWidgetItem, searchTerm: string) => boolean | undefined>;
     readonly heading: _angular_core.InputSignal<TranslatableString | undefined>;
-    // (undocumented)
-    protected readonly icons: Record<"elementRight2" | "elementSortDown" | "elementSortUp", string>;
     readonly link: _angular_core.InputSignal<Link | undefined>;
     readonly numberOfLinks: _angular_core.InputSignal<number>;
     readonly search: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly searchPlaceholderLabel: _angular_core.InputSignal<TranslatableString>;
     readonly sort: _angular_core.ModelSignal<SortOrder | undefined>;
-    protected readonly sortAction: _angular_core.Signal<ContentActionBarMainItem[]>;
     // (undocumented)
     readonly sortAscendingLabel: _angular_core.InputSignal<TranslatableString>;
     // (undocumented)
@@ -173,16 +150,6 @@ export interface SiListWidgetItem {
 // @public
 export class SiListWidgetItemComponent extends SiWidgetBaseComponent<SiListWidgetItem> {
     // (undocumented)
-    protected readonly badgeColor: _angular_core.Signal<string>;
-    // (undocumented)
-    protected readonly icons: Record<"elementRight2", string>;
-    // (undocumented)
-    protected readonly isLink: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly label: _angular_core.Signal<string>;
-    // (undocumented)
-    protected readonly link: _angular_core.Signal<Link>;
-    // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiListWidgetItemComponent, "si-list-widget-item", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<SiListWidgetItemComponent, never>;
@@ -190,7 +157,6 @@ export class SiListWidgetItemComponent extends SiWidgetBaseComponent<SiListWidge
 
 // @public (undocumented)
 export class SiTimelineWidgetBodyComponent extends SiWidgetBaseComponent<SiTimelineWidgetItem[]> {
-    protected readonly ghosts: _angular_core.Signal<any[]>;
     readonly numberOfItems: _angular_core.InputSignal<number>;
     readonly showDescription: _angular_core.InputSignal<boolean>;
     // (undocumented)
@@ -201,12 +167,8 @@ export class SiTimelineWidgetBodyComponent extends SiWidgetBaseComponent<SiTimel
 
 // @public (undocumented)
 export class SiTimelineWidgetComponent extends SiWidgetBaseComponent<SiTimelineWidgetItem[]> implements OnChanges {
-    // (undocumented)
-    protected readonly accentClass: _angular_core.Signal<string>;
     readonly accentLine: _angular_core.InputSignal<AccentLineType | undefined>;
     readonly heading: _angular_core.InputSignal<TranslatableString | undefined>;
-    // (undocumented)
-    protected readonly icons: Record<"elementRight2", string>;
     readonly link: _angular_core.InputSignal<Link | undefined>;
     readonly numberOfItems: _angular_core.InputSignal<number>;
     readonly primaryActions: _angular_core.InputSignal<(MenuItem | ContentActionBarMainItem)[]>;
@@ -233,8 +195,6 @@ export interface SiTimelineWidgetItem {
 
 // @public
 export class SiTimelineWidgetItemComponent extends SiWidgetBaseComponent<SiTimelineWidgetItem> implements OnInit, OnChanges {
-    // (undocumented)
-    protected readonly activatedRoute: ActivatedRoute | null;
     readonly ariaLabelDropdown: TranslatableString;
     readonly showDescription: _angular_core.InputSignal<boolean>;
     // (undocumented)
@@ -257,8 +217,6 @@ export class SiValueWidgetBodyComponent extends SiWidgetBaseComponent<Translatab
 
 // @public
 export class SiValueWidgetComponent {
-    // (undocumented)
-    protected readonly accentClass: _angular_core.Signal<string>;
     readonly accentLine: _angular_core.InputSignal<AccentLineType | undefined>;
     readonly description: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly disableAutoLoadingIndicator: _angular_core.InputSignalWithTransform<boolean, unknown>;

--- a/api-goldens/element-ng/datatable/index.api.md
+++ b/api-goldens/element-ng/datatable/index.api.md
@@ -43,16 +43,6 @@ export class SiDatatableInteractionDirective implements OnDestroy, OnInit {
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)
-    protected onFocusin(event: FocusEvent): void;
-    // (undocumented)
-    protected onKeydown(event: KeyboardEvent): void;
-    // (undocumented)
-    protected onMousedown(event: MouseEvent): void;
-    // (undocumented)
-    protected onMouseup(event: MouseEvent): void;
-    // (undocumented)
-    protected tabIndex: string;
-    // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<SiDatatableInteractionDirective, "ngx-datatable[siDatatableInteraction]", ["si-datatable-interaction"], { "datatableInteractionAutoSelect": { "alias": "datatableInteractionAutoSelect"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SiDatatableInteractionDirective, never>;

--- a/api-goldens/element-ng/date-range-filter/index.api.md
+++ b/api-goldens/element-ng/date-range-filter/index.api.md
@@ -89,62 +89,22 @@ export class SiDateRangeCalculationService {
 // @public (undocumented)
 export class SiDateRangeFilterComponent implements OnChanges {
     readonly advancedLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected advancedMode: boolean;
     readonly afterLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly applyClicked: _angular_core.OutputEmitterRef<void>;
     readonly applyLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly basicMode: _angular_core.InputSignal<"input" | "calendar">;
     readonly beforeLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly calculatedRange: _angular_core.Signal<ResolvedDateRange>;
     readonly dateLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly datepickerConfig: _angular_core.InputSignal<DatepickerInputConfig | undefined>;
-    // (undocumented)
-    protected readonly datepickerConfigInternal: _angular_core.Signal<DatepickerConfig>;
     readonly datePlaceholder: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly dateRange: _angular_core.WritableSignal<DateRange>;
-    // (undocumented)
-    protected readonly dateRangeConfig: _angular_core.Signal<DatepickerConfig>;
     readonly enableTimeSelection: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly filteredPresetList: _angular_core.Signal<DateRangePreset[]>;
-    // (undocumented)
-    protected readonly focusedDate: _angular_core.Signal<Date | undefined>;
     readonly fromLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly hideAdvancedMode: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
-    protected readonly icons: Record<"elementDown2", string>;
-    // (undocumented)
-    protected readonly inputMode: _angular_core.Signal<boolean>;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     readonly nowLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly pipeFormat: _angular_core.Signal<string>;
-    // (undocumented)
-    protected point1Changed(): void;
-    // (undocumented)
-    protected point1date: Date;
-    // (undocumented)
-    protected point1Now: boolean;
-    // (undocumented)
-    protected point2Changed(): void;
-    // (undocumented)
-    protected point2date: Date;
-    // (undocumented)
-    protected point2Mode: 'duration' | 'date';
-    // (undocumented)
-    protected point2offset: number;
-    // (undocumented)
-    protected point2range: 'before' | 'after' | 'within';
-    // (undocumented)
-    protected readonly presetFilter: _angular_core.WritableSignal<string>;
     readonly presetLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly presetList: _angular_core.InputSignal<DateRangePreset[] | undefined>;
-    // (undocumented)
-    protected readonly presetOpen: _angular_core.WritableSignal<boolean>;
     readonly presetSearch: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly previewLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly range: _angular_core.ModelSignal<DateRangeFilter>;
@@ -152,20 +112,10 @@ export class SiDateRangeFilterComponent implements OnChanges {
     readonly refLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly reverseInputFields: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly searchLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected selectPresetItem(event: Event, item: DateRangePreset): void;
     readonly showApplyButton: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly smallScreen: boolean;
     readonly todayLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly toLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly unitLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected updateDateRange(range?: DateRangeFilter): void;
-    // (undocumented)
-    protected updateFromDateRange(dateRange?: DateRange): void;
-    // (undocumented)
-    protected updateOnModeChange(): void;
     readonly valueLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly withinLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)

--- a/api-goldens/element-ng/datepicker/index.api.md
+++ b/api-goldens/element-ng/datepicker/index.api.md
@@ -300,26 +300,11 @@ export type RangeType = 'START' | 'END' | undefined;
 export class SiCalendarButtonComponent implements OnInit, AfterContentInit, DoCheck {
     readonly ariaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
-    protected readonly button: _angular_core.Signal<ElementRef<HTMLButtonElement>>;
-    protected readonly datepicker: _angular_core.Signal<SiDatepickerDirective>;
-    // (undocumented)
-    protected readonly datepickerOverlay: _angular_core.Signal<SiDatepickerOverlayDirective>;
-    // (undocumented)
-    protected readonly disabled: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly icons: Record<"elementCalendar", string>;
-    // (undocumented)
     ngAfterContentInit(): void;
-    // (undocumented)
-    protected readonly ngControl: _angular_core.Signal<NgControl | undefined>;
     // (undocumented)
     ngDoCheck(): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected show(): void;
-    // (undocumented)
-    protected readonly showValidationMessages: _angular_core.WritableSignal<boolean>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiCalendarButtonComponent, "si-calendar-button", never, { "ariaLabel": { "alias": "ariaLabel"; "required": false; "isSignal": true; }; }, {}, ["datepicker", "datepickerOverlay", "ngControl"], ["*"], true, never>;
     // (undocumented)
@@ -328,27 +313,12 @@ export class SiCalendarButtonComponent implements OnInit, AfterContentInit, DoCh
 
 // @public
 export class SiDateInputDirective implements ControlValueAccessor, OnChanges, Validator, SiFormItemControl {
-    // (undocumented)
-    protected date?: Date;
-    protected readonly dateChange: _angular_core.OutputEmitterRef<Date | undefined>;
-    // (undocumented)
-    protected readonly dateString: _angular_core.WritableSignal<string>;
     readonly disabledInput: _angular_core.InputSignal<boolean>;
     readonly errormessageId: _angular_core.InputSignal<string>;
     // (undocumented)
     readonly id: _angular_core.InputSignal<string>;
     // (undocumented)
-    protected readonly locale: string;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
-    protected onBlur(event: FocusEvent): void;
-    protected onDateChanged(date?: Date): void;
-    protected onInput(event: Event): void;
-    // (undocumented)
-    protected onModelChange: (value: any) => void;
-    // (undocumented)
-    protected onTouched: () => void;
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     registerOnChange(fn: any): void;
@@ -363,7 +333,6 @@ export class SiDateInputDirective implements ControlValueAccessor, OnChanges, Va
     readonly stateChange: _angular_core.OutputEmitterRef<void>;
     // (undocumented)
     validate(c: AbstractControl): ValidationErrors | null;
-    protected validator: _angular_forms.ValidatorFn;
     // (undocumented)
     writeValue(value?: Date | string): void;
     // (undocumented)
@@ -375,34 +344,17 @@ export class SiDateInputDirective implements ControlValueAccessor, OnChanges, Va
 // @public (undocumented)
 export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
     constructor();
-    protected activeMonthChange(selection: Date | null): void;
-    protected activeYearChange(selection: Date | null): void;
-    // (undocumented)
-    protected readonly actualFocusedDate: _angular_core.Signal<Date>;
     readonly calendarWeekLabel: _angular_core.InputSignal<TranslatableString>;
     // @deprecated
     readonly calenderWeekLabel: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly config: _angular_core.ModelSignal<DatepickerConfig>;
     readonly date: _angular_core.ModelSignal<Date | undefined>;
     readonly dateRange: _angular_core.ModelSignal<DateRange | undefined>;
-    // (undocumented)
-    protected readonly derivedWeekLabel: _angular_core.Signal<TranslatableString>;
     readonly disabledTime: _angular_core.ModelSignal<boolean>;
-    // (undocumented)
-    protected get endDate(): Date | undefined;
     focusActiveCell(): void;
     readonly focusedDate: _angular_core.ModelSignal<Date | undefined>;
-    protected readonly forceFocus: _angular_core.Signal<boolean>;
     readonly hideTimeToggle: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected get hideWeekNumbers(): boolean;
-    // (undocumented)
-    protected readonly includeTimeLabel: _angular_core.Signal<TranslatableString>;
     readonly initialFocus: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected months: string[];
-    // (undocumented)
-    protected monthViewSwitchTo: 'month' | 'week';
     readonly nextLabel: _angular_core.InputSignal<TranslatableString>;
     // (undocumented)
     ngAfterViewInit(): void;
@@ -410,30 +362,10 @@ export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected onActiveHoverChange(event?: Cell): void;
     readonly previousLabel: _angular_core.InputSignal<TranslatableString>;
     readonly rangeType: _angular_core.ModelSignal<RangeType>;
-    // (undocumented)
-    protected readonly requireFocus: _angular_core.WritableSignal<boolean>;
-    protected selectionChange(selection: Date): void;
-    // (undocumented)
-    protected get startDate(): Date | undefined;
-    // (undocumented)
-    protected switchId: string;
-    protected time: FormControl<Date | undefined>;
     readonly time12h: _angular_core.InputSignalWithTransform<boolean | undefined, unknown>;
-    // (undocumented)
-    protected timepickerId: string;
     readonly timepickerLabel: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected timeSelected(newTime?: Date): void;
-    // (undocumented)
-    protected toggleDisabledTime(): void;
-    protected readonly view: _angular_core.WritableSignal<ViewType>;
-    // (undocumented)
-    protected get weekStartDay(): WeekStart;
-    protected yearViewSwitchTo: 'month' | 'week';
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiDatepickerComponent, "si-datepicker", never, { "focusedDate": { "alias": "focusedDate"; "required": false; "isSignal": true; }; "date": { "alias": "date"; "required": false; "isSignal": true; }; "dateRange": { "alias": "dateRange"; "required": false; "isSignal": true; }; "dateRangeRole": { "alias": "dateRangeRole"; "required": false; "isSignal": true; }; "initialFocus": { "alias": "initialFocus"; "required": false; "isSignal": true; }; "disabledTime": { "alias": "disabledTime"; "required": false; "isSignal": true; }; "config": { "alias": "config"; "required": false; "isSignal": true; }; "previousLabel": { "alias": "previousLabel"; "required": false; "isSignal": true; }; "nextLabel": { "alias": "nextLabel"; "required": false; "isSignal": true; }; "calenderWeekLabel": { "alias": "calenderWeekLabel"; "required": false; "isSignal": true; }; "calendarWeekLabel": { "alias": "calendarWeekLabel"; "required": false; "isSignal": true; }; "time12h": { "alias": "time12h"; "required": false; "isSignal": true; }; "rangeType": { "alias": "rangeType"; "required": false; "isSignal": true; }; "minMonth": { "alias": "minMonth"; "required": false; "isSignal": true; }; "maxMonth": { "alias": "maxMonth"; "required": false; "isSignal": true; }; "hideTimeToggle": { "alias": "hideTimeToggle"; "required": false; "isSignal": true; }; "hideCalendar": { "alias": "hideCalendar"; "required": false; "isSignal": true; }; "timepickerLabel": { "alias": "timepickerLabel"; "required": false; "isSignal": true; }; "activeHover": { "alias": "activeHover"; "required": false; "isSignal": true; }; }, { "focusedDate": "focusedDateChange"; "date": "dateChange"; "dateRange": "dateRangeChange"; "disabledTime": "disabledTimeChange"; "config": "configChange"; "rangeType": "rangeTypeChange"; "activeHover": "activeHoverChange"; }, never, never, true, never>;
     // (undocumented)
@@ -444,14 +376,7 @@ export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
 export class SiDatepickerDirective extends SiDateInputDirective implements AfterViewInit {
     readonly autoClose: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
-    protected focusChange(): void;
-    // (undocumented)
     ngAfterViewInit(): void;
-    protected onBlur(event: FocusEvent): void;
-    protected onClick(): void;
-    protected onDateChanged(date?: Date): void;
-    // (undocumented)
-    protected onTab(): void;
     // (undocumented)
     static ɵdir: _angular_core.ɵɵDirectiveDeclaration<SiDatepickerDirective, "[siDatepicker]", ["siDatepicker"], { "autoClose": { "alias": "autoClose"; "required": false; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof SiDatepickerOverlayDirective; inputs: {}; outputs: { "siDatepickerClose": "siDatepickerClose"; }; }]>;
     // (undocumented)
@@ -470,31 +395,13 @@ export class SiDatepickerModule {
 
 // @public (undocumented)
 export class SiDatepickerOverlayComponent implements OnChanges, OnInit, OnDestroy {
-    // (undocumented)
-    protected activeHover?: Cell;
-    // (undocumented)
-    protected readonly completeAnimation: _angular_core.WritableSignal<boolean>;
     readonly config: _angular_core.InputSignal<DatepickerConfig>;
     readonly date: _angular_core.ModelSignal<Date | undefined>;
-    // (undocumented)
-    protected readonly datepicker: _angular_core.Signal<SiDatepickerComponent>;
     readonly dateRange: _angular_core.ModelSignal<DateRange | undefined>;
     readonly disabledTimeChange: _angular_core.OutputEmitterRef<boolean>;
-    // (undocumented)
-    protected disableTime: boolean;
-    // (undocumented)
-    protected readonly firstDatepickerConfig: _angular_core.WritableSignal<DatepickerConfig>;
-    // (undocumented)
-    protected firstDatepickerFocusDateChange(newFocusedDate?: Date): void;
     focusActiveCell(): void;
     readonly initialFocus: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly isMobile: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected readonly isTwoMonthDateRange: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly maxMonth: _angular_core.WritableSignal<Date | undefined>;
-    // (undocumented)
-    protected readonly minMonth: _angular_core.WritableSignal<Date | undefined>;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
@@ -502,10 +409,6 @@ export class SiDatepickerOverlayComponent implements OnChanges, OnInit, OnDestro
     // (undocumented)
     ngOnInit(): void;
     readonly rangeType: _angular_core.ModelSignal<"START" | "END" | undefined>;
-    // (undocumented)
-    protected readonly secondDatepickerConfig: _angular_core.WritableSignal<DatepickerConfig>;
-    // (undocumented)
-    protected secondDatepickerFocusDateChange(newFocusedDate?: Date): void;
     readonly time12h: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiDatepickerOverlayComponent, "si-datepicker-overlay", never, { "initialFocus": { "alias": "initialFocus"; "required": false; "isSignal": true; }; "config": { "alias": "config"; "required": false; "isSignal": true; }; "date": { "alias": "date"; "required": false; "isSignal": true; }; "dateRange": { "alias": "dateRange"; "required": false; "isSignal": true; }; "rangeType": { "alias": "rangeType"; "required": false; "isSignal": true; }; "time12h": { "alias": "time12h"; "required": false; "isSignal": true; }; "isMobile": { "alias": "isMobile"; "required": false; "isSignal": true; }; }, { "date": "dateChange"; "dateRange": "dateRangeChange"; "rangeType": "rangeTypeChange"; "disabledTimeChange": "disabledTimeChange"; }, never, never, true, never>;
@@ -518,10 +421,6 @@ export class SiDatepickerOverlayDirective implements OnDestroy {
     closeAfterSelection(): void;
     closeOverlay(): undefined;
     contains(element: HTMLElement): boolean;
-    // (undocumented)
-    protected createDesktopOverlay(): void;
-    // (undocumented)
-    protected createMobileOverlay(): void;
     focus(focus?: boolean): this;
     isShown(): ComponentRef<SiDatepickerOverlayComponent> | undefined;
     // (undocumented)
@@ -539,15 +438,11 @@ export class SiDatepickerOverlayDirective implements OnDestroy {
 export class SiDateRangeComponent implements ControlValueAccessor, Validator, AfterViewInit, OnChanges, SiFormItemControl {
     readonly ariaLabelCalendarButton: _angular_core.InputSignal<TranslatableString>;
     readonly autoClose: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly disabled: _angular_core.Signal<boolean>;
     readonly disabledInput: _angular_core.InputSignal<boolean>;
     readonly disabledTimeChange: _angular_core.OutputEmitterRef<boolean>;
     readonly endDatePlaceholder: _angular_core.InputSignal<TranslatableString>;
     readonly endTimeLabel: _angular_core.InputSignal<TranslatableString>;
     readonly errormessageId: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected readonly icons: Record<"elementCalendar", string>;
     // (undocumented)
     readonly id: _angular_core.InputSignal<string>;
     // (undocumented)
@@ -556,8 +451,6 @@ export class SiDateRangeComponent implements ControlValueAccessor, Validator, Af
     ngAfterViewInit(): void;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    protected onFocusOut(event: FocusEvent): void;
-    protected onInputChanged(dateRange: DateRange): void;
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     registerOnChange(fn: any): void;
@@ -565,8 +458,6 @@ export class SiDateRangeComponent implements ControlValueAccessor, Validator, Af
     registerOnTouched(fn: () => void): void;
     // (undocumented)
     setDisabledState(isDisabled: boolean): void;
-    // (undocumented)
-    protected show(): void;
     readonly siDatepickerConfig: _angular_core.ModelSignal<DatepickerInputConfig>;
     readonly siDatepickerRangeChange: _angular_core.OutputEmitterRef<DateRange | undefined>;
     readonly startDatePlaceholder: _angular_core.InputSignal<TranslatableString>;
@@ -585,15 +476,8 @@ export class SiDateRangeComponent implements ControlValueAccessor, Validator, Af
 // @public (undocumented)
 export class SiTimepickerComponent implements ControlValueAccessor, Validator, SiFormItemControl {
     constructor();
-    // (undocumented)
-    protected readonly disabled: _angular_core.Signal<boolean>;
     readonly disabledInput: _angular_core.InputSignal<boolean>;
     readonly errormessageId: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected focusChange(event: FocusOrigin): void;
-    protected focusNext(event: Event): void;
-    protected handleKeyPressEvent(event: KeyboardEvent): void;
-    protected hasInvalidUnit(): boolean;
     readonly hideLabels: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     readonly hoursAriaLabel: _angular_core.InputSignal<TranslatableString>;
@@ -610,8 +494,6 @@ export class SiTimepickerComponent implements ControlValueAccessor, Validator, S
     // (undocumented)
     readonly labelledby: string;
     readonly max: _angular_core.InputSignal<Date | undefined>;
-    // (undocumented)
-    protected readonly meridian: _angular_core.WritableSignal<"" | "am" | "pm">;
     // (undocumented)
     readonly meridianChange: _angular_core.OutputEmitterRef<string>;
     // (undocumented)
@@ -634,8 +516,6 @@ export class SiTimepickerComponent implements ControlValueAccessor, Validator, S
     // (undocumented)
     readonly minutesPlaceholder: _angular_core.InputSignal<string>;
     // (undocumented)
-    protected readonly periods: _angular_core.Signal<string[]>;
-    // (undocumented)
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     registerOnChange(fn: any): void;
@@ -656,29 +536,6 @@ export class SiTimepickerComponent implements ControlValueAccessor, Validator, S
     readonly showMinutes: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     readonly showSeconds: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly timeControls: _angular_forms.FormGroup<{
-        hours: _angular_forms.FormControl<string>;
-        minutes: _angular_forms.FormControl<string>;
-        seconds: _angular_forms.FormControl<string>;
-        milliseconds: _angular_forms.FormControl<string>;
-    }>;
-    // (undocumented)
-    protected toggleMeridian(): void;
-    // (undocumented)
-    protected toHtmlInputElement: (target?: EventTarget | null) => HTMLInputElement;
-    // (undocumented)
-    protected readonly units: _angular_core.Signal<Config[]>;
-    // (undocumented)
-    protected updateField(name: keyof Value, value: string): void;
-    // (undocumented)
-    protected readonly use12HourClock: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected validateMax(control: AbstractControl): ValidationErrors | null;
-    // (undocumented)
-    protected validateMin(control: AbstractControl): ValidationErrors | null;
-    // (undocumented)
-    protected validateTime(name: string): ValidatorFn;
     // (undocumented)
     writeValue(obj?: Date | string): void;
     // (undocumented)

--- a/api-goldens/element-ng/electron-titlebar/index.api.md
+++ b/api-goldens/element-ng/electron-titlebar/index.api.md
@@ -23,8 +23,6 @@ export class SiElectrontitlebarComponent {
     readonly canGoForward: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly forward: _angular_core.OutputEmitterRef<void>;
     readonly hasFocus: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly icons: Record<"elementLeft4" | "elementRight4" | "elementOptionsVertical", string>;
     readonly menuItems: _angular_core.InputSignal<(MenuItem | MenuItem_2)[]>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiElectrontitlebarComponent, "si-electron-titlebar", never, { "appTitle": { "alias": "appTitle"; "required": true; "isSignal": true; }; "canGoBack": { "alias": "canGoBack"; "required": false; "isSignal": true; }; "canGoForward": { "alias": "canGoForward"; "required": false; "isSignal": true; }; "hasFocus": { "alias": "hasFocus"; "required": false; "isSignal": true; }; "menuItems": { "alias": "menuItems"; "required": false; "isSignal": true; }; "ariaLabelForward": { "alias": "ariaLabelForward"; "required": false; "isSignal": true; }; "ariaLabelBack": { "alias": "ariaLabelBack"; "required": false; "isSignal": true; }; "ariaLabelMenu": { "alias": "ariaLabelMenu"; "required": false; "isSignal": true; }; }, { "forward": "forward"; "back": "back"; }, never, never, true, never>;

--- a/api-goldens/element-ng/file-uploader/index.api.md
+++ b/api-goldens/element-ng/file-uploader/index.api.md
@@ -54,29 +54,13 @@ export class SiFileDropzoneComponent {
     readonly accept: _angular_core.InputSignal<string | undefined>;
     readonly acceptText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly directoryUpload: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected dragOver: boolean;
-    // (undocumented)
-    protected dragOverHandler(event: DragEvent): void;
-    // (undocumented)
-    protected dropHandler(event: DragEvent): void;
     readonly errorTextFileMaxSize: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly errorTextFileType: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly fileError: _angular_core.OutputEmitterRef<FileUploadError>;
     readonly filesAdded: _angular_core.OutputEmitterRef<UploadFile[]>;
-    // (undocumented)
-    protected readonly icons: Record<"elementUpload", string>;
-    // (undocumented)
-    protected inputEnterHandler(): void;
     readonly maxFileSize: _angular_core.InputSignal<number | undefined>;
-    // (undocumented)
-    protected readonly maxFileSizeString: _angular_core.Signal<string>;
     readonly maxFileSizeText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly multiple: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected onFileError(error: FileUploadError): void;
-    // (undocumented)
-    protected onFilesAdded(files: UploadFile[]): void;
     reset(): void;
     readonly uploadDropText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly uploadTextFileSelect: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
@@ -102,8 +86,6 @@ export class SiFileUploadDirective {
     handleItems(items: DataTransferItemList): void;
     readonly maxFileSize: _angular_core.InputSignal<number | undefined>;
     readonly multiple: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected onInputChange(event: Event): void;
     reset(): void;
     triggerClick(): void;
     readonly validFiles: _angular_core.OutputEmitterRef<UploadFile[]>;
@@ -119,40 +101,24 @@ export class SiFileUploaderComponent implements OnChanges {
     readonly acceptText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly autoUpload: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly cancelButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected cancelUpload(file: ExtUploadFile): void;
     readonly clearButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly directoryUpload: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly disableUpload: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly errorTextFileMaxSize: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly errorTextFileType: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly errorUploadFailed: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected files: ExtUploadFile[];
     readonly filesChanges: _angular_core.OutputEmitterRef<UploadFile[]>;
     fileUpload(doRetry?: boolean): void;
-    // (undocumented)
-    protected handleFiles(files: UploadFile[]): void;
-    // (undocumented)
-    protected readonly icons: Record<"elementCancel" | "elementDelete" | "elementDocument" | "elementRedo", string>;
     readonly maxConcurrentUploads: _angular_core.InputSignalWithTransform<number, unknown>;
     readonly maxFiles: _angular_core.InputSignalWithTransform<number, unknown>;
     readonly maxFileSize: _angular_core.InputSignalWithTransform<number | undefined, unknown>;
     readonly maxFileSizeText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected maxFilesReached: boolean;
     readonly maxFilesReachedText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
-    protected pending: number;
     readonly removeButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected removeFile(index: number): void;
     reset(emit?: boolean): void;
     readonly retries: _angular_core.InputSignalWithTransform<number, unknown>;
-    // (undocumented)
-    protected retryUpload(file: UploadFile): void;
     readonly showHttpError: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly successTextTitle: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly uploadButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
@@ -160,10 +126,6 @@ export class SiFileUploaderComponent implements OnChanges {
     readonly uploadCompleted: _angular_core.OutputEmitterRef<FileUploadResult>;
     readonly uploadConfig: _angular_core.InputSignal<FileUploadConfig>;
     readonly uploadDropText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected uploadEnabled: boolean;
-    // (undocumented)
-    protected uploading: number;
     readonly uploadingText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly uploadTextFileSelect: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)

--- a/api-goldens/element-ng/filter-bar/index.api.md
+++ b/api-goldens/element-ng/filter-bar/index.api.md
@@ -26,15 +26,9 @@ export class SiFilterBarComponent {
     readonly allowReset: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly collapsedFiltersDescription: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly colorVariant: _angular_core.InputSignal<BackgroundColorVariant>;
-    // (undocumented)
-    protected deleteFilters(deletedPill: Filter): void;
-    // (undocumented)
-    protected deleteOverflowFilter(): void;
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly filterDefaultText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly filters: _angular_core.ModelSignal<Filter[]>;
-    // (undocumented)
-    protected onResetFilters(): void;
     readonly resetFilters: _angular_core.OutputEmitterRef<void>;
     readonly resetText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
@@ -55,8 +49,6 @@ export class SiFilterBarModule {
 
 // @public (undocumented)
 export class SiFilterPillComponent {
-    // (undocumented)
-    protected deleteClicked(): void;
     readonly deleteFilters: _angular_core.OutputEmitterRef<Filter>;
     // (undocumented)
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;

--- a/api-goldens/element-ng/filtered-search/index.api.md
+++ b/api-goldens/element-ng/filtered-search/index.api.md
@@ -65,47 +65,18 @@ export interface SearchCriteria {
 // @public (undocumented)
 export class SiFilteredSearchComponent implements OnInit, OnChanges {
     constructor();
-    // (undocumented)
-    protected readonly allowFreeTextCache: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected autoEditCriteria: boolean;
     readonly clearButtonLabel: _angular_core.InputSignal<TranslatableString>;
     readonly colorVariant: _angular_core.InputSignal<BackgroundColorVariant>;
-    // (undocumented)
-    protected createFreeTextPill(query: string): void;
     readonly criteria: _angular_core.InputSignal<Criterion[] | CriterionDefinition[]>;
-    // (undocumented)
-    protected dataSource: Observable<InternalCriterionDefinition[]>;
     deleteAllCriteria(event?: MouseEvent): void;
-    // (undocumented)
-    protected deleteCriterion(criterion: CriterionValue, index: number, event: {
-        triggerSearch: boolean;
-    } | void): void;
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly disableFreeTextSearch: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly disableSelectionByColonAndSemicolon: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly doSearch: _angular_core.OutputEmitterRef<SearchCriteria>;
     readonly doSearchOnInputChange: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly exclusiveCriteria: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected focusNext(index: number, event: {
-        freeText: string;
-    } | void): void;
-    // (undocumented)
-    protected freeTextBackspace(event: Event): void;
-    // (undocumented)
-    protected freeTextBlur(): void;
     readonly freeTextCriterion: _angular_core.InputSignal<CriterionDefinition | undefined>;
-    // (undocumented)
-    protected freeTextFocus(): void;
-    // (undocumented)
-    protected freeTextInput(event: Event): void;
-    // (undocumented)
-    protected readonly icons: Record<"elementCancel" | "elementSearch", string>;
     readonly interceptDisplayedCriteria: _angular_core.OutputEmitterRef<DisplayedCriteriaEventArgs>;
-    protected internalCriterionDefinitions: InternalCriterionDefinition[];
-    // (undocumented)
-    protected readonly isStrictOrOnlySelectValue: _angular_core.Signal<boolean>;
     readonly itemCountText: _angular_core.InputSignal<TranslatableString>;
     readonly lazyCriterionProvider: _angular_core.InputSignal<((typed: string, searchCriteria?: SearchCriteria) => Observable<Criterion[] | CriterionDefinition[]>) | undefined>;
     readonly lazyLoadingDebounceTime: _angular_core.InputSignal<number>;
@@ -125,28 +96,10 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     readonly searchDebounceTime: _angular_core.InputSignal<number>;
     readonly searchForFreeTextLabel: _angular_core.InputSignal<TranslatableString>;
     readonly searchLabel: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected searchValue: string;
     readonly strictCriterion: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly strictValue: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected submit(): void;
     readonly submitButtonLabel: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected typeaheadOnSelectCriterion(event: TypeaheadOption): void;
     readonly typeaheadOptionsLimit: _angular_core.InputSignal<number>;
-    // (undocumented)
-    protected validateCriterionLabel(criterion: InternalCriterionDefinition): boolean;
-    // (undocumented)
-    protected valueChange(value: CriterionValue, criterion: {
-        config: InternalCriterionDefinition;
-        value: CriterionValue;
-    }): void;
-    // (undocumented)
-    protected values: {
-        config: InternalCriterionDefinition;
-        value: CriterionValue;
-    }[];
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiFilteredSearchComponent, "si-filtered-search", never, { "doSearchOnInputChange": { "alias": "doSearchOnInputChange"; "required": false; "isSignal": true; }; "lazyCriterionProvider": { "alias": "lazyCriterionProvider"; "required": false; "isSignal": true; }; "lazyValueProvider": { "alias": "lazyValueProvider"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "readonly": { "alias": "readonly"; "required": false; "isSignal": true; }; "strictCriterion": { "alias": "strictCriterion"; "required": false; "isSignal": true; }; "strictValue": { "alias": "strictValue"; "required": false; "isSignal": true; }; "onlySelectValue": { "alias": "onlySelectValue"; "required": false; "isSignal": true; }; "lazyLoadingDebounceTime": { "alias": "lazyLoadingDebounceTime"; "required": false; "isSignal": true; }; "searchDebounceTime": { "alias": "searchDebounceTime"; "required": false; "isSignal": true; }; "placeholder": { "alias": "placeholder"; "required": false; "isSignal": true; }; "optionsInScrollableView": { "alias": "optionsInScrollableView"; "required": false; "isSignal": true; }; "searchCriteria": { "alias": "searchCriteria"; "required": false; "isSignal": true; }; "criteria": { "alias": "criteria"; "required": false; "isSignal": true; }; "exclusiveCriteria": { "alias": "exclusiveCriteria"; "required": false; "isSignal": true; }; "maxCriteria": { "alias": "maxCriteria"; "required": false; "isSignal": true; }; "maxCriteriaOptions": { "alias": "maxCriteriaOptions"; "required": false; "isSignal": true; }; "searchLabel": { "alias": "searchLabel"; "required": false; "isSignal": true; }; "clearButtonLabel": { "alias": "clearButtonLabel"; "required": false; "isSignal": true; }; "submitButtonLabel": { "alias": "submitButtonLabel"; "required": false; "isSignal": true; }; "itemCountText": { "alias": "itemCountText"; "required": false; "isSignal": true; }; "colorVariant": { "alias": "colorVariant"; "required": false; "isSignal": true; }; "disableFreeTextSearch": { "alias": "disableFreeTextSearch"; "required": false; "isSignal": true; }; "typeaheadOptionsLimit": { "alias": "typeaheadOptionsLimit"; "required": false; "isSignal": true; }; "disableSelectionByColonAndSemicolon": { "alias": "disableSelectionByColonAndSemicolon"; "required": false; "isSignal": true; }; "freeTextCriterion": { "alias": "freeTextCriterion"; "required": false; "isSignal": true; }; "searchForFreeTextLabel": { "alias": "searchForFreeTextLabel"; "required": false; "isSignal": true; }; }, { "doSearch": "doSearch"; "searchCriteria": "searchCriteriaChange"; "interceptDisplayedCriteria": "interceptDisplayedCriteria"; }, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/form/index.api.md
+++ b/api-goldens/element-ng/form/index.api.md
@@ -42,10 +42,6 @@ export class SiFormContainerComponent<TControl extends {
     readonly disableErrorPrinting: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly errorCodeTranslateKeyMap: _angular_core.InputSignal<SiFormValidationErrorMapper | Map<string, string> | undefined>;
     readonly form: _angular_core.InputSignal<FormGroup<TControl> | undefined>;
-    // (undocumented)
-    protected getControlNameTranslateKey(controlName: string): string | undefined;
-    // (undocumented)
-    protected hasParentContainer: boolean;
     get invalidFormContainerMessage(): boolean;
     readonly labelWidth: _angular_core.InputSignal<string | undefined>;
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
@@ -59,20 +55,12 @@ export class SiFormContainerComponent<TControl extends {
 
 // @public (undocumented)
 export class SiFormFieldsetComponent implements DoCheck {
-    // (undocumented)
-    protected readonly errors: _angular_core.Signal<_siemens_element_ng_form.SiFormError[]>;
     readonly inline: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly isRequired: _angular_core.Signal<boolean>;
     readonly label: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected labelId: string;
     readonly labelWidth: _angular_core.InputSignal<string | undefined>;
     // (undocumented)
     ngDoCheck(): void;
     readonly required: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly touched: _angular_core.WritableSignal<boolean>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiFormFieldsetComponent, "si-form-fieldset", never, { "label": { "alias": "label"; "required": true; "isSignal": true; }; "labelWidth": { "alias": "labelWidth"; "required": false; "isSignal": true; }; "required": { "alias": "required"; "required": false; "isSignal": true; }; "inline": { "alias": "inline"; "required": false; "isSignal": true; }; }, {}, never, ["[si-help-button]", "*"], true, never>;
     // (undocumented)
@@ -81,31 +69,11 @@ export class SiFormFieldsetComponent implements DoCheck {
 
 // @public (undocumented)
 export class SiFormItemComponent implements AfterContentInit, AfterContentChecked, OnChanges, OnInit, OnDestroy {
-    // (undocumented)
-    protected container: SiFormContainerComponent<{
-        [x: string]: _angular_forms.AbstractControl<any, any>;
-    }> | null;
-    // (undocumented)
-    protected readonly controlElementRef: _angular_core.Signal<ElementRef<HTMLElement> | undefined>;
     readonly disableErrorPrinting: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
-    protected readonly fieldControl: _angular_core.Signal<SiFormItemControl | undefined>;
-    // (undocumented)
-    protected readonly fieldControlQuery: _angular_core.Signal<SiFormItemControl | undefined>;
-    // (undocumented)
-    protected fieldset: SiFormFieldsetComponent | null;
-    // (undocumented)
     readonly formErrorMapper: _angular_core.InputSignal<SiFormValidationErrorMapper | undefined>;
-    // (undocumented)
-    protected get formItemErrormessageId(): string | null;
-    // (undocumented)
-    protected get formItemId(): string | null;
-    // (undocumented)
-    protected get formItemLabelledBy(): string | null;
     readonly label: _angular_core.InputSignal<TranslatableString | null | undefined>;
     readonly labelWidth: _angular_core.InputSignal<string | number | undefined>;
-    // (undocumented)
-    protected readonly labelWidthCssVar: _angular_core.Signal<string | undefined>;
     // (undocumented)
     ngAfterContentChecked(): void;
     // (undocumented)
@@ -116,11 +84,7 @@ export class SiFormItemComponent implements AfterContentInit, AfterContentChecke
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected readonly printErrors: _angular_core.Signal<boolean>;
     readonly requiredInput: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly requiredValidator: _angular_core.Signal<RequiredValidator | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiFormItemComponent, "si-form-item", never, { "label": { "alias": "label"; "required": false; "isSignal": true; }; "labelWidth": { "alias": "labelWidth"; "required": false; "isSignal": true; }; "disableErrorPrinting": { "alias": "disableErrorPrinting"; "required": false; "isSignal": true; }; "formErrorMapper": { "alias": "formErrorMapper"; "required": false; "isSignal": true; }; "requiredInput": { "alias": "required"; "required": false; "isSignal": true; }; }, {}, ["fieldControlQuery", "ngControl", "controlElementRef", "requiredValidator"], ["[si-help-button]", ".warning-feedback, .info-feedback, .invalid-feedback", "*"], true, never>;
     // (undocumented)
@@ -225,13 +189,7 @@ export interface SiFormValidationErrorMapper {
 // @public
 export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
     // (undocumented)
-    protected decreaseActivation(): void;
-    // (undocumented)
-    protected readonly describedBy: string;
-    // (undocumented)
     readonly formErrorMapper: _angular_core.InputSignal<SiFormValidationErrorMapper | undefined>;
-    // (undocumented)
-    protected increaseActivation(): void;
     // (undocumented)
     ngDoCheck(): void;
     // (undocumented)

--- a/api-goldens/element-ng/formly/index.api.md
+++ b/api-goldens/element-ng/formly/index.api.md
@@ -29,10 +29,6 @@ import { OnInit } from '@angular/core';
 export class SiFormlyComponent<TControl extends {
     [K in keyof TControl]: AbstractControl;
 }> implements OnInit {
-    // (undocumented)
-    protected readonly fieldConfig: i0.Signal<FormlyFieldConfig<_ngx_formly_core.FormlyFieldProps & {
-        [additionalProperties: string]: any;
-    }>[]>;
     readonly fields: i0.InputSignal<FormlyFieldConfig<_ngx_formly_core.FormlyFieldProps & {
         [additionalProperties: string]: any;
     }>[]>;
@@ -48,8 +44,6 @@ export class SiFormlyComponent<TControl extends {
     // (undocumented)
     ngOnInit(): void;
     readonly options: i0.InputSignal<FormlyFormOptions>;
-    // (undocumented)
-    protected ownForm: boolean;
     readonly schema: i0.ModelSignal<JSONSchema7 | undefined>;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiFormlyComponent<any>, "si-formly", never, { "form": { "alias": "form"; "required": false; "isSignal": true; }; "model": { "alias": "model"; "required": false; "isSignal": true; }; "options": { "alias": "options"; "required": false; "isSignal": true; }; "schema": { "alias": "schema"; "required": false; "isSignal": true; }; "fields": { "alias": "fields"; "required": false; "isSignal": true; }; "labelWidth": { "alias": "labelWidth"; "required": false; "isSignal": true; }; }, { "form": "formChange"; "model": "modelChange"; "schema": "schemaChange"; "fieldsChange": "fieldsChange"; }, never, never, false, never>;

--- a/api-goldens/element-ng/header-dropdown/index.api.md
+++ b/api-goldens/element-ng/header-dropdown/index.api.md
@@ -29,18 +29,8 @@ export class SiHeaderDropdownItemComponent {
     readonly badge: _angular_core.InputSignal<string | number | undefined>;
     readonly badgeColor: _angular_core.InputSignal<string | undefined>;
     readonly checked: _angular_core.InputSignal<"" | "check" | "radio" | undefined>;
-    // (undocumented)
-    protected click(): void;
     readonly icon: _angular_core.InputSignal<string | undefined>;
     readonly iconBadge: _angular_core.InputSignal<string | number | undefined>;
-    // (undocumented)
-    protected readonly icons: Record<"elementDown2" | "elementOk" | "elementRecordFilled", string>;
-    // (undocumented)
-    protected readonly navbar: _siemens_element_ng_header_dropdown.HeaderWithDropdowns | null;
-    // (undocumented)
-    protected readonly ownTrigger: SiHeaderDropdownTriggerDirective | null;
-    // (undocumented)
-    protected readonly parentTrigger: SiHeaderDropdownTriggerDirective;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiHeaderDropdownItemComponent, "si-header-dropdown-item, a[si-header-dropdown-item], button[si-header-dropdown-item]", never, { "icon": { "alias": "icon"; "required": false; "isSignal": true; }; "badge": { "alias": "badge"; "required": false; "isSignal": true; }; "iconBadge": { "alias": "iconBadge"; "required": false; "isSignal": true; }; "badgeColor": { "alias": "badgeColor"; "required": false; "isSignal": true; }; "checked": { "alias": "checked"; "required": false; "isSignal": true; }; }, {}, never, ["*"], true, never>;
     // (undocumented)
@@ -49,16 +39,12 @@ export class SiHeaderDropdownItemComponent {
 
 // @public
 export class SiHeaderDropdownTriggerDirective implements OnChanges, OnInit, OnDestroy {
-    // (undocumented)
-    protected click(): void;
     close(options?: {
         all?: boolean;
     }): void;
     readonly dropdown: _angular_core.InputSignal<TemplateRef<unknown>>;
     readonly dropdownData: _angular_core.InputSignal<unknown>;
     get isOpen(): boolean;
-    // (undocumented)
-    protected _isOpen: boolean;
     // (undocumented)
     ngOnChanges(): void;
     // (undocumented)

--- a/api-goldens/element-ng/help-button/index.api.md
+++ b/api-goldens/element-ng/help-button/index.api.md
@@ -10,8 +10,6 @@ import * as i1 from '@siemens/element-ng/popover';
 // @public
 export class SiHelpButtonComponent {
     // (undocumented)
-    protected icons: Record<"elementHelp", string>;
-    // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiHelpButtonComponent, "button[si-help-button]", never, {}, {}, never, ["*"], true, [{ directive: typeof i1.SiPopoverDirective; inputs: { "siPopoverTitle": "siHelpTitle"; "siPopover": "siHelpContent"; "siPopoverContext": "siHelpContext"; "siPopoverPlacement": "siHelpPlacement"; }; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SiHelpButtonComponent, never>;

--- a/api-goldens/element-ng/icon/index.api.md
+++ b/api-goldens/element-ng/icon/index.api.md
@@ -206,10 +206,7 @@ export const provideIconConfig: (config: IconConfig) => Provider;
 
 // @public
 export class SiIconComponent {
-    protected readonly fontIcon: _angular_core.Signal<string | undefined>;
     readonly icon: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected readonly svgIcon: _angular_core.Signal<_angular_platform_browser.SafeHtml | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiIconComponent, "si-icon", never, { "icon": { "alias": "icon"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)
@@ -219,8 +216,6 @@ export class SiIconComponent {
 // @public @deprecated (undocumented)
 export class SiIconLegacyComponent {
     readonly alt: _angular_core.InputSignal<TranslatableString | undefined>;
-    // (undocumented)
-    protected readonly altText: _angular_core.Signal<string>;
     readonly color: _angular_core.InputSignal<string | undefined>;
     readonly icon: _angular_core.InputSignal<string | undefined>;
     readonly size: _angular_core.InputSignal<string>;
@@ -246,8 +241,6 @@ export class SiIconModule {
 export class SiStatusIconComponent {
     // (undocumented)
     readonly status: _angular_core.InputSignal<EntityStatusType>;
-    // (undocumented)
-    protected readonly statusIcon: _angular_core.Signal<_siemens_element_ng_common.StatusIcon>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiStatusIconComponent, "si-status-icon", never, { "status": { "alias": "status"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/ip-input/index.api.md
+++ b/api-goldens/element-ng/ip-input/index.api.md
@@ -28,7 +28,6 @@ export const ipV6Validator: (options: {
 
 // @public
 export class SiIp4InputDirective extends SiIpInputDirective implements ControlValueAccessor, Validator {
-    protected leaveInput(): void;
     // (undocumented)
     validate(control: AbstractControl): ValidationErrors | null;
     // (undocumented)
@@ -40,11 +39,7 @@ export class SiIp4InputDirective extends SiIpInputDirective implements ControlVa
 // @public
 export class SiIp6InputDirective extends SiIpInputDirective implements ControlValueAccessor, Validator {
     // (undocumented)
-    protected maskInput(e: AddrInputEvent): void;
-    // (undocumented)
     validate(control: AbstractControl): ValidationErrors | null;
-    // (undocumented)
-    protected readonly validatorFn: i0.Signal<_angular_forms.ValidatorFn>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<SiIp6InputDirective, "input[siIpV6]", ["siIpV6"], {}, {}, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/landing-page/index.api.md
+++ b/api-goldens/element-ng/landing-page/index.api.md
@@ -56,40 +56,20 @@ export class SiChangePasswordComponent implements OnInit, OnDestroy {
     readonly backButtonLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly changeButtonLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly changePasswordAlert: _angular_core.InputSignal<AlertConfig | undefined>;
-    // (undocumented)
-    protected changePasswordForm: FormGroup<{
-        newPassword: FormControl<string | null>;
-        confirmPassword: FormControl<string | null>;
-    }>;
     readonly changePasswordRequested: _angular_core.OutputEmitterRef<ChangePassword>;
-    // (undocumented)
-    protected confirmPasswordId: string;
     readonly confirmPasswordLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly disableChange: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected handleBackClick(): void;
-    // (undocumented)
-    protected handlePasswordStrengthChanged(data: number | void): void;
-    // (undocumented)
-    protected handleValueChanges(): void;
     readonly heading: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    protected landingPage: SiLandingPageComponent | null;
-    // (undocumented)
-    protected newPasswordId: string;
     readonly newPasswordLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
     readonly passwordPolicyContent: _angular_core.InputSignal<string | TemplateRef<unknown>>;
-    // (undocumented)
-    protected passwordPolicyContentTemplate: TemplateRef<any> | null;
     readonly passwordPolicyTitle: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly passwordStrength: _angular_core.InputSignal<PasswordPolicy>;
     readonly passwordStrengthChanged: _angular_core.OutputEmitterRef<number | void>;
     readonly subheading: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected submit(): void;
     readonly valueChanged: _angular_core.OutputEmitterRef<ChangePassword>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiChangePasswordComponent, "si-change-password", never, { "heading": { "alias": "heading"; "required": false; "isSignal": true; }; "subheading": { "alias": "subheading"; "required": false; "isSignal": true; }; "newPasswordLabel": { "alias": "newPasswordLabel"; "required": false; "isSignal": true; }; "confirmPasswordLabel": { "alias": "confirmPasswordLabel"; "required": false; "isSignal": true; }; "changeButtonLabel": { "alias": "changeButtonLabel"; "required": false; "isSignal": true; }; "backButtonLabel": { "alias": "backButtonLabel"; "required": false; "isSignal": true; }; "disableChange": { "alias": "disableChange"; "required": false; "isSignal": true; }; "passwordPolicyTitle": { "alias": "passwordPolicyTitle"; "required": false; "isSignal": true; }; "passwordPolicyContent": { "alias": "passwordPolicyContent"; "required": true; "isSignal": true; }; "passwordStrength": { "alias": "passwordStrength"; "required": true; "isSignal": true; }; "changePasswordAlert": { "alias": "changePasswordAlert"; "required": false; "isSignal": true; }; }, { "valueChanged": "valueChanged"; "changePasswordRequested": "changePasswordRequested"; "passwordStrengthChanged": "passwordStrengthChanged"; "back": "back"; }, never, never, true, never>;
@@ -104,12 +84,7 @@ export class SiExplicitLegalAcknowledgeComponent implements OnInit, OnDestroy {
     readonly back: _angular_core.OutputEmitterRef<void>;
     readonly backButtonLabel: _angular_core.InputSignal<TranslatableString>;
     readonly disableAcceptance: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected handleAccept(): void;
-    // (undocumented)
-    protected handleBack(): void;
     readonly heading: _angular_core.InputSignal<TranslatableString>;
-    protected landingPage: SiLandingPageComponent | null;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -160,39 +135,18 @@ export class SiLoginBasicComponent implements OnInit {
     readonly backButtonLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly disableLogin: _angular_core.InputSignal<boolean>;
     readonly forgotPasswordLink: _angular_core.InputSignal<Link | undefined>;
-    // (undocumented)
-    protected goBack(): void;
-    // (undocumented)
-    protected handleValueChanges(): void;
     readonly loading: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected readonly loadingNext: _angular_core.WritableSignal<boolean>;
     readonly login: _angular_core.OutputEmitterRef<UsernamePassword>;
     readonly loginButtonLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected loginCredentials: FormGroup<{
-        username: FormControl<string | null>;
-        password: FormControl<string | null>;
-    }>;
     readonly nextButtonLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected passwordId: string;
     readonly passwordLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly registerNowIntroText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly registerNowLink: _angular_core.InputSignal<Link | undefined>;
-    // (undocumented)
-    protected readonly secondStepVisible: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected submit(): void;
     readonly twoStep: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected usernameId: string;
     readonly usernameLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly usernameValidation: _angular_core.OutputEmitterRef<UsernameValidationPayload>;
-    // (undocumented)
-    protected validateUsername(): void;
     readonly valueChanged: _angular_core.OutputEmitterRef<UsernamePassword>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiLoginBasicComponent, "si-login-basic", never, { "usernameLabel": { "alias": "usernameLabel"; "required": false; "isSignal": true; }; "passwordLabel": { "alias": "passwordLabel"; "required": false; "isSignal": true; }; "forgotPasswordLink": { "alias": "forgotPasswordLink"; "required": false; "isSignal": true; }; "registerNowIntroText": { "alias": "registerNowIntroText"; "required": false; "isSignal": true; }; "registerNowLink": { "alias": "registerNowLink"; "required": false; "isSignal": true; }; "loginButtonLabel": { "alias": "loginButtonLabel"; "required": false; "isSignal": true; }; "disableLogin": { "alias": "disableLogin"; "required": false; "isSignal": true; }; "twoStep": { "alias": "twoStep"; "required": false; "isSignal": true; }; "loading": { "alias": "loading"; "required": false; "isSignal": true; }; "backButtonLabel": { "alias": "backButtonLabel"; "required": false; "isSignal": true; }; "nextButtonLabel": { "alias": "nextButtonLabel"; "required": false; "isSignal": true; }; }, { "usernameValidation": "usernameValidation"; "valueChanged": "valueChanged"; "login": "login"; }, never, never, true, never>;
@@ -204,8 +158,6 @@ export class SiLoginBasicComponent implements OnInit {
 export class SiLoginSingleSignOnComponent {
     readonly disableSso: _angular_core.InputSignal<boolean>;
     readonly ssoButtonLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected ssoClick(): void;
     readonly ssoEvent: _angular_core.OutputEmitterRef<void>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiLoginSingleSignOnComponent, "si-login-single-sign-on", never, { "ssoButtonLabel": { "alias": "ssoButtonLabel"; "required": false; "isSignal": true; }; "disableSso": { "alias": "disableSso"; "required": false; "isSignal": true; }; }, { "ssoEvent": "ssoEvent"; }, never, never, true, never>;

--- a/api-goldens/element-ng/language-switcher/index.api.md
+++ b/api-goldens/element-ng/language-switcher/index.api.md
@@ -17,14 +17,8 @@ export interface IsoLanguageValue {
 
 // @public (undocumented)
 export class SiLanguageSwitcherComponent {
-    // (undocumented)
-    protected readonly availableIsoLanguages: i0.Signal<IsoLanguageValue[]>;
     readonly availableLanguages: i0.InputSignal<(string | IsoLanguageValue)[] | null>;
     readonly languageSwitcherLabel: i0.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected switchLanguage(target: EventTarget | null): void;
-    // (undocumented)
-    protected readonly translate: _siemens_element_translate_ng_translate.SiTranslateService;
     readonly translationKey: i0.InputSignal<string>;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiLanguageSwitcherComponent, "si-language-switcher", never, { "translationKey": { "alias": "translationKey"; "required": false; "isSignal": true; }; "languageSwitcherLabel": { "alias": "languageSwitcherLabel"; "required": false; "isSignal": true; }; "availableLanguages": { "alias": "availableLanguages"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;

--- a/api-goldens/element-ng/link/index.api.md
+++ b/api-goldens/element-ng/link/index.api.md
@@ -61,10 +61,6 @@ export class SiLinkDirective implements DoCheck, OnChanges, OnDestroy {
     // (undocumented)
     readonly exactMatch: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
-    protected readonly href: _angular_core.WritableSignal<string | undefined>;
-    // (undocumented)
-    protected readonly isAriaCurrent: _angular_core.Signal<AriaCurrentType | undefined>;
-    // (undocumented)
     ngDoCheck(): void;
     // (undocumented)
     ngOnChanges(): void;
@@ -76,10 +72,6 @@ export class SiLinkDirective implements DoCheck, OnChanges, OnDestroy {
     readonly siLink: _angular_core.InputSignal<Link | undefined>;
     // (undocumented)
     readonly siLinkDefaultTarget: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly target: _angular_core.WritableSignal<string | undefined>;
-    // (undocumented)
-    protected readonly title: _angular_core.WritableSignal<string | undefined>;
     // (undocumented)
     static ɵdir: _angular_core.ɵɵDirectiveDeclaration<SiLinkDirective, "[siLink]", ["siLink"], { "siLink": { "alias": "siLink"; "required": false; "isSignal": true; }; "siLinkDefaultTarget": { "alias": "siLinkDefaultTarget"; "required": false; "isSignal": true; }; "actionParam": { "alias": "actionParam"; "required": false; "isSignal": true; }; "activeClass": { "alias": "activeClass"; "required": false; "isSignal": true; }; "exactMatch": { "alias": "exactMatch"; "required": false; "isSignal": true; }; "ariaCurrent": { "alias": "ariaCurrent"; "required": false; "isSignal": true; }; }, { "activeChange": "activeChange"; }, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/list-details/index.api.md
+++ b/api-goldens/element-ng/list-details/index.api.md
@@ -26,8 +26,6 @@ export class SiDetailsPaneBodyComponent {
 export class SiDetailsPaneComponent {
     constructor();
     // (undocumented)
-    protected parent: SiListDetailsComponent;
-    // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiDetailsPaneComponent, "si-details-pane", never, {}, {}, ["routerOutlet"], ["*"], true, never>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<SiDetailsPaneComponent, never>;
@@ -46,13 +44,7 @@ export class SiDetailsPaneHeaderComponent {
     constructor();
     readonly backButtonText: _angular_core.InputSignal<TranslatableString>;
     readonly backButtonUrl: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected backClicked(): void;
-    // (undocumented)
-    protected get hasLargeSize(): Signal<boolean>;
     readonly hideBackButton: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly icons: Record<"elementBack", string>;
     readonly title: _angular_core.InputSignal<TranslatableString | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiDetailsPaneHeaderComponent, "si-details-pane-header", never, { "title": { "alias": "title"; "required": false; "isSignal": true; }; "hideBackButton": { "alias": "hideBackButton"; "required": false; "isSignal": true; }; "backButtonText": { "alias": "backButtonText"; "required": false; "isSignal": true; }; "backButtonUrl": { "alias": "backButtonUrl"; "required": false; "isSignal": true; }; }, {}, never, ["*"], true, never>;
@@ -63,16 +55,10 @@ export class SiDetailsPaneHeaderComponent {
 // @public (undocumented)
 export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
     readonly detailsActive: _angular_core.ModelSignal<boolean>;
-    // (undocumented)
-    protected detailsExpandedAnimationDone(): void;
-    // (undocumented)
-    protected readonly detailsStateId: _angular_core.Signal<string | undefined>;
     readonly disableResizing: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly expandBreakpoint: _angular_core.InputSignal<number>;
     // (undocumented)
     readonly hasLargeSize: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly listStateId: _angular_core.Signal<string | undefined>;
     readonly listWidth: _angular_core.ModelSignal<number>;
     readonly minDetailsSize: _angular_core.InputSignal<number>;
     readonly minListSize: _angular_core.InputSignal<number>;
@@ -82,12 +68,6 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected onSplitSizesChange(sizes: number[]): void;
-    // (undocumented)
-    protected readonly opacity: _angular_core.Signal<"" | "0">;
-    // (undocumented)
-    protected readonly splitSizes: _angular_core.Signal<[number, number]>;
     readonly stateId: _angular_core.InputSignal<string | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiListDetailsComponent, "si-list-details", never, { "expandBreakpoint": { "alias": "expandBreakpoint"; "required": false; "isSignal": true; }; "detailsActive": { "alias": "detailsActive"; "required": false; "isSignal": true; }; "disableResizing": { "alias": "disableResizing"; "required": false; "isSignal": true; }; "listWidth": { "alias": "listWidth"; "required": false; "isSignal": true; }; "minListSize": { "alias": "minListSize"; "required": false; "isSignal": true; }; "minDetailsSize": { "alias": "minDetailsSize"; "required": false; "isSignal": true; }; "stateId": { "alias": "stateId"; "required": false; "isSignal": true; }; }, { "detailsActive": "detailsActiveChange"; "listWidth": "listWidthChange"; }, never, ["si-list-pane", "si-details-pane"], true, never>;
@@ -106,8 +86,6 @@ export class SiListPaneBodyComponent {
 // @public (undocumented)
 export class SiListPaneComponent {
     constructor();
-    // (undocumented)
-    protected parent: SiListDetailsComponent;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiListPaneComponent, "si-list-pane", never, {}, {}, never, ["*"], true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/loading-spinner/index.api.md
+++ b/api-goldens/element-ng/loading-spinner/index.api.md
@@ -26,8 +26,6 @@ export class SiLoadingButtonComponent {
     readonly ariaLabelledBy: _angular_core.InputSignal<string | undefined>;
     readonly buttonClass: _angular_core.InputSignal<string>;
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected handleClick(event: Event): void;
     readonly loading: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly type: _angular_core.InputSignal<"button" | "submit" | "reset">;
     // (undocumented)
@@ -51,8 +49,6 @@ export class SiLoadingService {
 export class SiLoadingSpinnerComponent {
     readonly ariaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
-    protected fadeAnimation: string;
-    // (undocumented)
     readonly isBlockingSpinner: _angular_core.InputSignal<boolean | null>;
     // (undocumented)
     readonly isSpinnerOverlay: _angular_core.InputSignal<boolean | null>;
@@ -73,8 +69,6 @@ export class SiLoadingSpinnerDirective implements OnInit, OnChanges, OnDestroy {
     // (undocumented)
     ngOnInit(): void;
     readonly siLoading: _angular_core.InputSignal<number | boolean>;
-    // (undocumented)
-    protected readonly spinner$: rxjs.Observable<boolean>;
     // (undocumented)
     static ɵdir: _angular_core.ɵɵDirectiveDeclaration<SiLoadingSpinnerDirective, "[siLoading]", never, { "siLoading": { "alias": "siLoading"; "required": true; "isSignal": true; }; "blocking": { "alias": "blocking"; "required": false; "isSignal": true; }; "initialDelay": { "alias": "initialDelay"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/localization/index.api.md
+++ b/api-goldens/element-ng/localization/index.api.md
@@ -58,8 +58,6 @@ export interface SiLocaleConfig {
 export class SiLocaleId extends String {
     constructor();
     // (undocumented)
-    protected service: SiLocaleService;
-    // (undocumented)
     toLowerCase(): string;
     toString(): string;
     // (undocumented)

--- a/api-goldens/element-ng/main-detail-container/index.api.md
+++ b/api-goldens/element-ng/main-detail-container/index.api.md
@@ -13,32 +13,18 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public (undocumented)
 export class SiMainDetailContainerComponent implements OnInit, OnChanges, OnDestroy {
-    // (undocumented)
-    protected animate: boolean;
     readonly containerClass: _angular_core.InputSignal<string>;
     readonly detailContainerClass: _angular_core.InputSignal<string>;
     readonly detailsActive: _angular_core.ModelSignal<boolean>;
     readonly detailsBackButtonText: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected detailsBackClicked(): void;
     readonly detailsHeading: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected readonly detailStateId: _angular_core.Signal<string | undefined>;
     hasLargeSize: boolean;
     readonly hasLargeSizeChange: _angular_core.OutputEmitterRef<boolean>;
     readonly heading: _angular_core.InputSignal<TranslatableString>;
     readonly hideBackButton: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly icons: Record<"elementBack", string>;
     readonly largeLayoutBreakpoint: _angular_core.InputSignal<number>;
     readonly mainContainerClass: _angular_core.InputSignal<string>;
     readonly mainContainerWidth: _angular_core.ModelSignal<number | "default">;
-    // (undocumented)
-    protected readonly mainStateId: _angular_core.Signal<string | undefined>;
-    // (undocumented)
-    protected maxDetailSize: string;
-    // (undocumented)
-    protected maxMainSize: string;
     readonly minDetailSize: _angular_core.InputSignal<number>;
     readonly minMainSize: _angular_core.InputSignal<number>;
     // (undocumented)
@@ -47,14 +33,7 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges, OnDest
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected onSplitSizesChange(sizes: number[]): void;
-    // (undocumented)
-    protected opacity: string;
-    protected preventFocusDetails: boolean;
     readonly resizableParts: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected splitSizes: [number, number];
     readonly stateId: _angular_core.InputSignal<string | undefined>;
     readonly truncateHeading: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)

--- a/api-goldens/element-ng/menu/index.api.md
+++ b/api-goldens/element-ng/menu/index.api.md
@@ -99,8 +99,6 @@ export abstract class SiMenuActionService {
 export class SiMenuBarDirective {
     readonly disabled: i0.InputSignal<boolean | undefined>;
     // (undocumented)
-    protected get tabIndex(): 0 | -1 | null;
-    // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<SiMenuBarDirective, "si-menu-bar", never, { "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof i1.CdkMenuBar; inputs: {}; outputs: {}; }, { directive: typeof i1.CdkTargetMenuAim; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SiMenuBarDirective, never>;
@@ -127,15 +125,7 @@ export class SiMenuFactoryComponent {
     // (undocumented)
     readonly actionParam: i0.InputSignal<unknown>;
     // (undocumented)
-    protected isLegacyItemStyle(item: MenuItem_2 | MenuItem): item is MenuItem_2;
-    // (undocumented)
-    protected isNewItemStyle(item: MenuItem_2 | MenuItem): item is MenuItem;
-    // (undocumented)
     readonly items: i0.InputSignal<readonly (MenuItem_2 | MenuItem)[] | undefined>;
-    // (undocumented)
-    protected radioOrCheckboxTriggered(item: MenuItem_2): void;
-    // (undocumented)
-    protected runAction(item: MenuItemAction | MenuItemRadio | MenuItemCheckbox): void;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiMenuFactoryComponent, "si-menu-factory", never, { "items": { "alias": "items"; "required": false; "isSignal": true; }; "actionParam": { "alias": "actionParam"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)
@@ -153,12 +143,6 @@ export class SiMenuHeaderDirective {
 // @public (undocumented)
 export class SiMenuItemCheckboxComponent extends SiMenuItemBase {
     // (undocumented)
-    protected get checked(): boolean;
-    // (undocumented)
-    protected readonly hideCheckmark: boolean;
-    // (undocumented)
-    protected readonly icons: Record<"elementOk", string>;
-    // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiMenuItemCheckboxComponent, "si-menu-item-checkbox, button[si-menu-item-checkbox]", never, {}, {}, never, ["*"], true, [{ directive: typeof i1.CdkMenuItemCheckbox; inputs: { "cdkMenuItemChecked": "checked"; "cdkMenuItemDisabled": "disabled"; }; outputs: { "cdkMenuItemTriggered": "triggered"; }; }, { directive: typeof i1.CdkMenuTrigger; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SiMenuItemCheckboxComponent, never>;
@@ -167,10 +151,6 @@ export class SiMenuItemCheckboxComponent extends SiMenuItemBase {
 // @public (undocumented)
 export class SiMenuItemComponent extends SiMenuItemBase {
     // (undocumented)
-    protected get hasSubmenu(): boolean;
-    // (undocumented)
-    protected readonly icons: Record<"elementRight2", string>;
-    // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiMenuItemComponent, "si-menu-item, a[si-menu-item], button[si-menu-item]", never, {}, {}, never, ["*", ".end"], true, [{ directive: typeof i1.CdkMenuItem; inputs: { "cdkMenuItemDisabled": "disabled"; }; outputs: { "cdkMenuItemTriggered": "triggered"; }; }]>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SiMenuItemComponent, never>;
@@ -178,10 +158,6 @@ export class SiMenuItemComponent extends SiMenuItemBase {
 
 // @public (undocumented)
 export class SiMenuItemRadioComponent extends SiMenuItemBase {
-    // (undocumented)
-    protected get checked(): boolean;
-    // (undocumented)
-    protected readonly icons: Record<"elementRecordFilled", string>;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiMenuItemRadioComponent, "si-menu-item-radio", never, {}, {}, never, ["*"], true, [{ directive: typeof i1.CdkMenuItemRadio; inputs: { "cdkMenuItemChecked": "checked"; "cdkMenuItemDisabled": "disabled"; }; outputs: { "cdkMenuItemTriggered": "triggered"; }; }, { directive: typeof i1.CdkMenuTrigger; inputs: {}; outputs: {}; }]>;
     // (undocumented)

--- a/api-goldens/element-ng/modal/index.api.md
+++ b/api-goldens/element-ng/modal/index.api.md
@@ -62,10 +62,6 @@ export class ModalRef<T = never, CT = any> {
 
 // @public (undocumented)
 export class SiModalService {
-    // (undocumented)
-    protected buildInjector(): Injector;
-    // (undocumented)
-    protected detach(modalRef: ModalRef<unknown, any>): void;
     show<T, CT = any>(content: TemplateRef<any> | (new (...args: any[]) => T), config: ModalOptions<T>, closeValue?: CT): ModalRef<T, CT>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SiModalService, never>;

--- a/api-goldens/element-ng/navbar-vertical/index.api.md
+++ b/api-goldens/element-ng/navbar-vertical/index.api.md
@@ -82,19 +82,9 @@ export type NavbarVerticalSubItem = NavbarVerticalItemRouterLink | NavbarVertica
 // @public (undocumented)
 export class SiNavbarVerticalComponent implements OnChanges, OnInit {
     constructor();
-    // (undocumented)
-    protected readonly activatedRoute: ActivatedRoute | null;
     collapse(): void;
     readonly collapsed: _angular_core.ModelSignal<boolean>;
-    // (undocumented)
-    protected doSearch(event: string): void;
     expand(): void;
-    // (undocumented)
-    protected expandForSearch(): void;
-    // (undocumented)
-    protected readonly icons: Record<"elementSearch" | "elementDoubleLeft" | "elementDoubleRight", string>;
-    // (undocumented)
-    protected isLegacyStyle(item: MenuItem | NavbarVerticalItem): item is MenuItem;
     readonly items: _angular_core.ModelSignal<(MenuItem | NavbarVerticalItem)[]>;
     readonly navbarCollapseButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly navbarExpandButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
@@ -102,25 +92,13 @@ export class SiNavbarVerticalComponent implements OnChanges, OnInit {
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected readonly ready = true;
-    // (undocumented)
-    protected saveUIState(): void;
     readonly searchable: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly searchEvent: _angular_core.OutputEmitterRef<string>;
-    // (undocumented)
-    protected readonly searchInputDelay = 400;
     readonly searchPlaceholder: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly skipLinkMainContentLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly skipLinkNavigationLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly smallScreen: _angular_core.WritableSignal<boolean>;
     readonly stateId: _angular_core.InputSignal<string | undefined>;
     readonly textOnly: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected toggleCollapse(): void;
-    // (undocumented)
-    protected readonly uiStateExpandedItems: _angular_core.WritableSignal<Record<string, boolean>>;
     readonly visible: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiNavbarVerticalComponent, "si-navbar-vertical", never, { "collapsed": { "alias": "collapsed"; "required": false; "isSignal": true; }; "searchable": { "alias": "searchable"; "required": false; "isSignal": true; }; "searchPlaceholder": { "alias": "searchPlaceholder"; "required": false; "isSignal": true; }; "items": { "alias": "items"; "required": false; "isSignal": true; }; "textOnly": { "alias": "textOnly"; "required": false; "isSignal": true; }; "visible": { "alias": "visible"; "required": false; "isSignal": true; }; "navbarExpandButtonText": { "alias": "navbarExpandButtonText"; "required": false; "isSignal": true; }; "navbarCollapseButtonText": { "alias": "navbarCollapseButtonText"; "required": false; "isSignal": true; }; "stateId": { "alias": "stateId"; "required": false; "isSignal": true; }; "skipLinkNavigationLabel": { "alias": "skipLinkNavigationLabel"; "required": false; "isSignal": true; }; "skipLinkMainContentLabel": { "alias": "skipLinkMainContentLabel"; "required": false; "isSignal": true; }; }, { "collapsed": "collapsedChange"; "items": "itemsChange"; "searchEvent": "searchEvent"; }, never, ["*"], true, never>;

--- a/api-goldens/element-ng/navbar/index.api.md
+++ b/api-goldens/element-ng/navbar/index.api.md
@@ -50,16 +50,8 @@ export interface AppItemCategory {
 // @public @deprecated (undocumented)
 export class SiNavbarItemComponent implements OnInit, DoCheck, OnDestroy {
     // (undocumented)
-    protected active: boolean;
-    // (undocumented)
-    protected click(): void;
-    // (undocumented)
     readonly dropdownTrigger: _angular_core.Signal<SiHeaderDropdownTriggerDirective | undefined>;
-    // (undocumented)
-    protected readonly icons: Record<"elementDown2", string>;
     readonly item: _angular_core.InputSignal<MenuItem>;
-    // (undocumented)
-    protected navbar: SiNavbarPrimaryComponent;
     // (undocumented)
     ngDoCheck(): void;
     // (undocumented)
@@ -67,8 +59,6 @@ export class SiNavbarItemComponent implements OnInit, DoCheck, OnDestroy {
     // (undocumented)
     ngOnInit(): void;
     readonly quickAction: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected get visuallyHideTitle(): boolean;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiNavbarItemComponent, "si-navbar-item", never, { "item": { "alias": "item"; "required": true; "isSignal": true; }; "quickAction": { "alias": "quickAction"; "required": false; "isSignal": true; }; }, {}, never, ["si-avatar", "*"], true, never>;
     // (undocumented)
@@ -89,8 +79,6 @@ export class SiNavbarModule {
 export class SiNavbarPrimaryComponent implements OnChanges, HeaderWithDropdowns {
     readonly account: _angular_core.InputSignal<AccountItem | undefined>;
     readonly accountItems: _angular_core.InputSignal<MenuItem[] | undefined>;
-    // (undocumented)
-    protected active?: MenuItem;
     readonly allAppsLink: _angular_core.InputSignal<MenuItem | undefined>;
     readonly appCategoryItems: _angular_core.InputSignal<AppItemCategory[] | undefined>;
     // (undocumented)
@@ -109,10 +97,6 @@ export class SiNavbarPrimaryComponent implements OnChanges, HeaderWithDropdowns 
     readonly home: _angular_core.InputSignal<Link | undefined>;
     readonly logoUrl: _angular_core.InputSignal<string | undefined>;
     readonly navAriaLabel: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected newAppItems?: App[] | AppCategory[];
-    // (undocumented)
-    protected onFavoriteChange({ app, favorite }: FavoriteChangeEvent): void;
     readonly openAppSwitcherText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly primaryItems: _angular_core.InputSignal<MenuItem[]>;
     readonly showLessAppsTitle: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;

--- a/api-goldens/element-ng/notification-item/index.api.md
+++ b/api-goldens/element-ng/notification-item/index.api.md
@@ -94,12 +94,8 @@ export interface NotificationItemRouterLinkIcon extends NotificationItemBase {
 
 // @public
 export class SiNotificationItemComponent {
-    // (undocumented)
-    protected readonly activatedRoute: ActivatedRoute | null;
     readonly description: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly heading: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected readonly icons: Record<"elementOptionsVertical", string>;
     readonly itemLink: _angular_core.InputSignal<NotificationItemRouterLink | NotificationItemLink | undefined>;
     readonly primaryAction: _angular_core.InputSignal<NotificationItemPrimaryAction | undefined>;
     readonly quickActions: _angular_core.InputSignal<NotificationItemQuickAction[] | undefined>;

--- a/api-goldens/element-ng/number-input/index.api.md
+++ b/api-goldens/element-ng/number-input/index.api.md
@@ -20,49 +20,23 @@ import { ValidatorFn } from '@angular/forms';
 export class SiNumberInputComponent implements OnChanges, ControlValueAccessor, Validator, SiFormItemControl {
     readonly ariaLabel: _angular_core.InputSignal<TranslatableString | undefined>;
     // (undocumented)
-    protected autoUpdateStart(event: Event, isIncrement: boolean): void;
-    // (undocumented)
-    protected autoUpdateStop(): void;
-    // (undocumented)
-    protected canDec: boolean;
-    // (undocumented)
-    protected canInc: boolean;
-    // (undocumented)
-    protected readonly disabled: _angular_core.Signal<boolean>;
-    // (undocumented)
     readonly disabledInput: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly errormessageId: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected readonly icons: Record<"elementMinus" | "elementPlus", string>;
     // (undocumented)
     readonly id: _angular_core.Signal<string>;
     // (undocumented)
     readonly inputElement: _angular_core.Signal<ElementRef<HTMLInputElement>>;
     readonly inputId: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected readonly max: _angular_core.Signal<number | undefined>;
     readonly maxInput: _angular_core.InputSignalWithTransform<number | undefined, unknown>;
-    // (undocumented)
-    protected readonly min: _angular_core.Signal<number | undefined>;
     readonly minInput: _angular_core.InputSignalWithTransform<number | undefined, unknown>;
     // (undocumented)
-    protected modelChanged(): void;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
-    protected onChange: (val: any) => void;
-    // (undocumented)
-    protected onTouched: () => void;
-    // (undocumented)
-    protected onValidatorChanged: () => void;
     readonly placeholder: _angular_core.InputSignal<TranslatableString | undefined>;
     // (undocumented)
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly showButtons: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly step: _angular_core.InputSignal<number | "any">;
     readonly unit: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected validator: ValidatorFn | null;
     readonly value: _angular_core.InputSignal<number | undefined>;
     // (undocumented)
     readonly valueChange: _angular_core.OutputEmitterRef<number | undefined>;

--- a/api-goldens/element-ng/pagination/index.api.md
+++ b/api-goldens/element-ng/pagination/index.api.md
@@ -11,24 +11,9 @@ import * as _siemens_element_translate_ng_translate_types from '@siemens/element
 export class SiPaginationComponent {
     readonly backButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly currentPage: _angular_core.ModelSignal<number>;
-    // (undocumented)
-    protected direction(event: Event, delta: number): void;
     readonly forwardButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly icons: Record<"elementLeft3" | "elementRight3", string>;
     readonly navAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly nextDisabled: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly pageButtons: _angular_core.Signal<{
-        page: number;
-        sep: boolean;
-    }[]>;
     readonly pageSize: _angular_core.InputSignal<number | undefined>;
-    // (undocumented)
-    protected readonly prevDisabled: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected setPage(event: Event, page: number): void;
     readonly totalPages: _angular_core.InputSignal<number | undefined>;
     readonly totalRowCount: _angular_core.InputSignal<number | undefined>;
     // (undocumented)

--- a/api-goldens/element-ng/password-strength/index.api.md
+++ b/api-goldens/element-ng/password-strength/index.api.md
@@ -24,20 +24,8 @@ export interface PasswordPolicy {
 // @public (undocumented)
 export class SiPasswordStrengthComponent implements AfterViewInit {
     // (undocumented)
-    protected readonly bad: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly good: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly medium: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
     ngAfterViewInit(): void;
     readonly showVisibilityIcon: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected readonly strong: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected toggle(type: string): void;
-    // (undocumented)
-    protected readonly weak: _angular_core.WritableSignal<boolean>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiPasswordStrengthComponent, "si-password-strength", never, { "showVisibilityIcon": { "alias": "showVisibilityIcon"; "required": false; "isSignal": true; }; }, {}, ["passwordStrengthDirective", "passwordInput"], ["*"], true, never>;
     // (undocumented)
@@ -46,8 +34,6 @@ export class SiPasswordStrengthComponent implements AfterViewInit {
 
 // @public (undocumented)
 export class SiPasswordStrengthDirective implements Validator {
-    // (undocumented)
-    protected noValidation: boolean;
     readonly passwordStrengthChanged: _angular_core.OutputEmitterRef<number | void>;
     readonly siPasswordStrength: _angular_core.InputSignal<PasswordPolicy>;
     // (undocumented)

--- a/api-goldens/element-ng/password-toggle/index.api.md
+++ b/api-goldens/element-ng/password-toggle/index.api.md
@@ -10,15 +10,9 @@ import * as _siemens_element_translate_ng_translate_types from '@siemens/element
 // @public (undocumented)
 export class SiPasswordToggleComponent {
     readonly hideLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly icons: Record<"elementHide" | "elementShow", string>;
     get inputType(): string;
     readonly showLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly showPassword: _angular_core.WritableSignal<boolean>;
     readonly showVisibilityIcon: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected toggle(): void;
     readonly typeChange: _angular_core.OutputEmitterRef<string>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiPasswordToggleComponent, "si-password-toggle", never, { "showVisibilityIcon": { "alias": "showVisibilityIcon"; "required": false; "isSignal": true; }; "showLabel": { "alias": "showLabel"; "required": false; "isSignal": true; }; "hideLabel": { "alias": "hideLabel"; "required": false; "isSignal": true; }; }, { "typeChange": "typeChange"; }, never, ["*"], true, never>;

--- a/api-goldens/element-ng/phone-number/index.api.md
+++ b/api-goldens/element-ng/phone-number/index.api.md
@@ -37,60 +37,26 @@ export interface PhoneNumberModel {
 
 // @public (undocumented)
 export class SiPhoneNumberInputComponent implements ControlValueAccessor, Validator, OnChanges, SiFormItemControl {
-    // (undocumented)
-    protected blur(): void;
     readonly country: _angular_core.ModelSignal<string | undefined>;
-    // (undocumented)
-    protected readonly countryFocused: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected countryInput(num: CountryInfo): void;
-    // (undocumented)
-    protected readonly countryList: _angular_core.Signal<{
-        name: string;
-        countryCode: number;
-        isoCode: string;
-    }[]>;
     readonly defaultCountry: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly disabled: _angular_core.Signal<boolean>;
     // (undocumented)
     readonly disabledInput: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly errormessageId: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected readonly icons: Record<"elementDown2", string>;
     readonly id: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected input(): void;
     // (undocumented)
     readonly labelledby: _angular_core.InputSignal<string>;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
-    protected open: boolean;
-    // (undocumented)
-    protected openOverlay(): void;
-    // (undocumented)
-    protected overlayDetach(): void;
-    // (undocumented)
-    protected overlayWidth: number;
-    // (undocumented)
-    protected readonly phoneInput: _angular_core.Signal<ElementRef<HTMLInputElement>>;
     readonly phoneNumberAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected placeholder: string;
     readonly placeholderForSearch: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     // (undocumented)
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     readonly searchNoResultsFoundLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly selectCountryAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected selectedCountry?: CountryInfo;
     readonly supportedCountries: _angular_core.InputSignal<readonly string[] | null | undefined>;
     // (undocumented)
     readonly valueChange: _angular_core.OutputEmitterRef<PhoneDetails>;
-    // (undocumented)
-    protected valueProvider(country: CountryInfo): string;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiPhoneNumberInputComponent, "si-phone-number-input", never, { "id": { "alias": "id"; "required": false; "isSignal": true; }; "country": { "alias": "country"; "required": false; "isSignal": true; }; "defaultCountry": { "alias": "defaultCountry"; "required": false; "isSignal": true; }; "placeholderForSearch": { "alias": "placeholderForSearch"; "required": false; "isSignal": true; }; "searchNoResultsFoundLabel": { "alias": "searchNoResultsFoundLabel"; "required": false; "isSignal": true; }; "selectCountryAriaLabel": { "alias": "selectCountryAriaLabel"; "required": false; "isSignal": true; }; "phoneNumberAriaLabel": { "alias": "phoneNumberAriaLabel"; "required": false; "isSignal": true; }; "supportedCountries": { "alias": "supportedCountries"; "required": false; "isSignal": true; }; "labelledby": { "alias": "labelledby"; "required": false; "isSignal": true; }; "disabledInput": { "alias": "disabled"; "required": false; "isSignal": true; }; "readonly": { "alias": "readonly"; "required": false; "isSignal": true; }; "errormessageId": { "alias": "errormessageId"; "required": false; "isSignal": true; }; }, { "country": "countryChange"; "valueChange": "valueChange"; }, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/photo-upload/index.api.md
+++ b/api-goldens/element-ng/photo-upload/index.api.md
@@ -35,41 +35,16 @@ export class SiPhotoUploadComponent implements OnChanges, OnDestroy {
     readonly cropperAspectRatio: _angular_core.InputSignal<number>;
     readonly cropperContainWithinAspectRatio: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly cropperFrameAriaLabel: _angular_core.InputSignal<TranslatableString>;
-    protected cropperImageCropped(event: ImageCroppedEvent): void;
     readonly cropperImageFormat: _angular_core.InputSignal<"png" | "jpeg">;
     readonly cropperMaintainAspectRatio: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly cropperMaxHeight: _angular_core.InputSignal<number>;
     readonly cropperMaxWidth: _angular_core.InputSignal<number>;
     readonly cropperMinHeight: _angular_core.InputSignal<number>;
     readonly cropperMinWidth: _angular_core.InputSignal<number>;
-    protected cropperReady(): void;
-    // (undocumented)
-    protected readonly currentFileSizeKilobytes: _angular_core.WritableSignal<number>;
-    // (undocumented)
-    protected readonly currentFileSizeMegabytes: _angular_core.WritableSignal<number>;
     readonly disabledCropping: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly editButtonText: _angular_core.Signal<TranslatableString>;
-    // (undocumented)
-    protected readonly editPhotoTemplate: _angular_core.Signal<TemplateRef<any>>;
-    // (undocumented)
-    protected readonly fileInput: _angular_core.Signal<ElementRef<any>>;
-    // (undocumented)
-    protected fileUpload(event: Event): void;
-    // (undocumented)
-    protected readonly icons: Record<"elementCancel" | "elementCircleFilled" | "elementStateExclamationMark", string>;
-    // (undocumented)
-    protected readonly imageCropper: _angular_core.Signal<ImageCropperComponent | undefined>;
-    protected imageCropperApplied(): void;
-    // (undocumented)
-    protected imageCropperCanceled(): void;
-    protected readonly imageCropperPhoto: _angular_core.WritableSignal<string | undefined>;
     readonly maxFileSize: _angular_core.InputSignal<number>;
-    // (undocumented)
-    protected readonly maxSizeMb: _angular_core.Signal<number>;
     readonly modalDescription: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly modalHeader: _angular_core.InputSignal<TranslatableString>;
-    protected modalRef?: ModalRef;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
@@ -77,17 +52,10 @@ export class SiPhotoUploadComponent implements OnChanges, OnDestroy {
     readonly photoAltText: _angular_core.InputSignal<TranslatableString>;
     readonly placeholderAltText: _angular_core.InputSignal<TranslatableString>;
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected removePhoto(): void;
     readonly removePhotoText: _angular_core.InputSignal<TranslatableString>;
     readonly roundImage: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    protected readonly sanitizedPhotoUrl: _angular_core.WritableSignal<SafeResourceUrl | undefined>;
-    protected showCroppingDialog(): void;
     readonly sourcePhoto: _angular_core.ModelSignal<string | undefined>;
     readonly sourcePhotoUrl: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly titleId: string;
-    protected readonly uploadErrorMessage: _angular_core.WritableSignal<string | undefined>;
     readonly uploadErrorTooBig: _angular_core.InputSignal<TranslatableString>;
     readonly uploadErrorWrongType: _angular_core.InputSignal<TranslatableString>;
     readonly uploadPhotoText: _angular_core.InputSignal<TranslatableString>;

--- a/api-goldens/element-ng/pills-input/index.api.md
+++ b/api-goldens/element-ng/pills-input/index.api.md
@@ -13,52 +13,16 @@ import { Signal } from '@angular/core';
 
 // @public (undocumented)
 export class SiPillsInputComponent implements OnInit, ControlValueAccessor, SiFormItemControl {
-    // (undocumented)
-    protected readonly activeDescendant: _angular_core.Signal<string | null>;
-    // (undocumented)
-    protected readonly activePillIndex: _angular_core.WritableSignal<number | undefined>;
-    // (undocumented)
-    protected arrowLeft(): void;
-    // (undocumented)
-    protected arrowRight(): void;
-    // (undocumented)
-    protected blur(): void;
-    // (undocumented)
-    protected click(): void;
-    // (undocumented)
-    protected delete(): void;
-    // (undocumented)
-    protected readonly disabled: _angular_core.Signal<boolean>;
     readonly disabledInput: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly errormessageId: _angular_core.InputSignal<string>;
     readonly id: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected input(): void;
     readonly inputElementAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly inputId: _angular_core.Signal<string>;
-    // (undocumented)
-    protected inputValue: string;
-    // (undocumented)
-    protected keydownBackspace(event: Event): void;
-    // (undocumented)
-    protected keydownEnter(event: Event): void;
     // (undocumented)
     readonly labelledby: _angular_core.InputSignal<string>;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected onChange: (val: any) => void;
-    // (undocumented)
-    protected onTouched: () => void;
-    // (undocumented)
-    protected readonly pills: _angular_core.WritableSignal<string[]>;
     readonly placeholder: _angular_core.InputSignal<string | undefined>;
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected remove(index: number, focus?: boolean): void;
-    // (undocumented)
-    protected readonly tabindex: _angular_core.Signal<0 | -1 | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiPillsInputComponent, "si-pills-input", never, { "id": { "alias": "id"; "required": false; "isSignal": true; }; "inputElementAriaLabel": { "alias": "inputElementAriaLabel"; "required": false; "isSignal": true; }; "disabledInput": { "alias": "disabled"; "required": false; "isSignal": true; }; "readonly": { "alias": "readonly"; "required": false; "isSignal": true; }; "placeholder": { "alias": "placeholder"; "required": false; "isSignal": true; }; "labelledby": { "alias": "labelledby"; "required": false; "isSignal": true; }; "errormessageId": { "alias": "errormessageId"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/popover-legacy/index.api.md
+++ b/api-goldens/element-ng/popover-legacy/index.api.md
@@ -12,8 +12,6 @@ import { TemplateRef } from '@angular/core';
 // @public @deprecated (undocumented)
 export class SiPopoverLegacyDirective implements OnInit, OnDestroy {
     readonly containerClass: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected focusOut(): void;
     readonly hidden: _angular_core.OutputEmitterRef<void>;
     hide(): void;
     readonly icon: _angular_core.InputSignal<string | undefined>;
@@ -22,8 +20,6 @@ export class SiPopoverLegacyDirective implements OnInit, OnDestroy {
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected onTrigger(trigger: string): void;
     readonly outsideClick: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly placement: _angular_core.InputSignal<"auto" | "start" | "end" | "top" | "bottom">;
     // (undocumented)

--- a/api-goldens/element-ng/popover/index.api.md
+++ b/api-goldens/element-ng/popover/index.api.md
@@ -33,8 +33,6 @@ export class SiPopoverDirective implements OnDestroy {
     readonly icon: _angular_core.InputSignal<string | undefined>;
     // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
-    protected onClick(): void;
     readonly placement: _angular_core.InputSignal<"auto" | "start" | "end" | "top" | "bottom">;
     // (undocumented)
     readonly placementInternal: _angular_core.Signal<"auto" | "start" | "end" | "top" | "bottom">;

--- a/api-goldens/element-ng/progressbar/index.api.md
+++ b/api-goldens/element-ng/progressbar/index.api.md
@@ -16,8 +16,6 @@ export class SiProgressbarComponent {
     readonly heading: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly height: _angular_core.InputSignal<ProgressbarHeight>;
     readonly max: _angular_core.InputSignal<number>;
-    // (undocumented)
-    protected readonly percent: _angular_core.Signal<number>;
     readonly progress: _angular_core.InputSignal<string | undefined>;
     readonly value: _angular_core.InputSignal<number | undefined>;
     // (undocumented)

--- a/api-goldens/element-ng/result-details-list/index.api.md
+++ b/api-goldens/element-ng/result-details-list/index.api.md
@@ -23,10 +23,6 @@ export type ResultDetailStepState = 'passed' | 'failed' | 'running' | 'not-suppo
 
 // @public (undocumented)
 export class SiResultDetailsListComponent {
-    // (undocumented)
-    protected readonly icons: Record<"elementCircleFilled" | "elementNotChecked" | "elementOutOfService" | "elementStateExclamationMark" | "elementStateTick", string>;
-    // (undocumented)
-    protected readonly stepHasValue: i0.Signal<boolean>;
     readonly steps: i0.InputSignal<ResultDetailStep[]>;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiResultDetailsListComponent, "si-result-details-list", never, { "steps": { "alias": "steps"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;

--- a/api-goldens/element-ng/search-bar/index.api.md
+++ b/api-goldens/element-ng/search-bar/index.api.md
@@ -19,45 +19,21 @@ export class SiSearchBarComponent implements OnInit, OnDestroy, ControlValueAcce
     readonly colorVariant: _angular_core.InputSignal<BackgroundColorVariant>;
     readonly debounceTime: _angular_core.InputSignalWithTransform<number, unknown>;
     // (undocumented)
-    protected readonly disabled: _angular_core.Signal<boolean>;
-    // (undocumented)
     readonly disabledInput: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly icons: Record<"elementCancel" | "elementSearch", string>;
-    // (undocumented)
-    protected inFocus: boolean;
-    // (undocumented)
-    protected input(event: Event): void;
-    // (undocumented)
-    protected isInvalid: boolean;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected onBlur(): void;
-    // (undocumented)
-    protected onCancelFocus(event: Event): void;
-    // (undocumented)
-    protected onChange: (val: any) => void;
-    // (undocumented)
-    protected onTouch: () => void;
     readonly placeholder: _angular_core.InputSignal<string>;
     readonly prohibitedCharacters: _angular_core.InputSignal<string | undefined>;
     // (undocumented)
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected resetForm(): void;
     readonly searchChange: _angular_core.OutputEmitterRef<string>;
-    // (undocumented)
-    protected readonly searchValue: _angular_core.WritableSignal<string>;
     readonly showIcon: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly tabbable: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly value: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected writeSearchValue(value: string): void;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiSearchBarComponent, "si-search-bar", never, { "debounceTime": { "alias": "debounceTime"; "required": false; "isSignal": true; }; "prohibitedCharacters": { "alias": "prohibitedCharacters"; "required": false; "isSignal": true; }; "placeholder": { "alias": "placeholder"; "required": false; "isSignal": true; }; "showIcon": { "alias": "showIcon"; "required": false; "isSignal": true; }; "tabbable": { "alias": "tabbable"; "required": false; "isSignal": true; }; "value": { "alias": "value"; "required": false; "isSignal": true; }; "readonly": { "alias": "readonly"; "required": false; "isSignal": true; }; "colorVariant": { "alias": "colorVariant"; "required": false; "isSignal": true; }; "disabledInput": { "alias": "disabled"; "required": false; "isSignal": true; }; "clearButtonAriaLabel": { "alias": "clearButtonAriaLabel"; "required": false; "isSignal": true; }; }, { "searchChange": "searchChange"; }, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/select/index.api.md
+++ b/api-goldens/element-ng/select/index.api.md
@@ -67,8 +67,6 @@ export interface SelectOptionSource<TValue> {
 
 // @public (undocumented)
 export class SiSelectActionDirective {
-    // (undocumented)
-    protected close(): void;
     readonly selectActionAutoClose: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     static ɵdir: _angular_core.ɵɵDirectiveDeclaration<SiSelectActionDirective, "[siSelectAction]", ["si-select-action"], { "selectActionAutoClose": { "alias": "selectActionAutoClose"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
@@ -105,24 +103,14 @@ export class SiSelectComplexOptionsDirective<T> extends SiSelectOptionsStrategyB
 
 // @public (undocumented)
 export class SiSelectComponent<T> implements OnChanges, AfterContentInit, SiFormItemControl {
-    // (undocumented)
-    protected readonly actionsTemplate: _angular_core.Signal<TemplateRef<any> | undefined>;
     readonly ariaLabel: _angular_core.InputSignal<string | null>;
-    // (undocumented)
-    protected backdropClick(): void;
     close(): void;
     // @deprecated
     readonly dropdownClose: _angular_core.OutputEmitterRef<void>;
     readonly errormessageId: _angular_core.InputSignal<string>;
     readonly filterPlaceholder: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected readonly groupTemplate: _angular_core.Signal<TemplateRef<{
-        $implicit: SelectGroup<T>;
-    }> | undefined>;
     readonly hasFilter: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly id: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected readonly isOpen: _angular_core.WritableSignal<boolean>;
     readonly labelledbyInput: _angular_core.InputSignal<string | undefined>;
     // (undocumented)
     ngAfterContentInit(): void;
@@ -131,18 +119,8 @@ export class SiSelectComponent<T> implements OnChanges, AfterContentInit, SiForm
     readonly noResultsFoundLabel: _angular_core.InputSignal<TranslatableString>;
     open(): void;
     readonly openChange: _angular_core.OutputEmitterRef<boolean>;
-    // (undocumented)
-    protected readonly optionTemplate: _angular_core.Signal<TemplateRef<{
-        $implicit: SelectOption<T>;
-    }> | undefined>;
-    // (undocumented)
-    protected overlayWidth: number;
     readonly placeholder: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected rows: readonly SelectItem<T>[];
-    // (undocumented)
-    protected readonly selectionStrategy: SiSelectSelectionStrategy<any, any>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiSelectComponent<any>, "si-select", never, { "id": { "alias": "id"; "required": false; "isSignal": true; }; "ariaLabel": { "alias": "ariaLabel"; "required": false; "isSignal": true; }; "labelledbyInput": { "alias": "labelledby"; "required": false; "isSignal": true; }; "filterPlaceholder": { "alias": "filterPlaceholder"; "required": false; "isSignal": true; }; "noResultsFoundLabel": { "alias": "noResultsFoundLabel"; "required": false; "isSignal": true; }; "placeholder": { "alias": "placeholder"; "required": false; "isSignal": true; }; "readonly": { "alias": "readonly"; "required": false; "isSignal": true; }; "errormessageId": { "alias": "errormessageId"; "required": false; "isSignal": true; }; "hasFilter": { "alias": "hasFilter"; "required": false; "isSignal": true; }; }, { "dropdownClose": "dropdownClose"; "openChange": "openChange"; }, ["optionTemplate", "groupTemplate", "actionsTemplate"], never, true, never>;
     // (undocumented)
@@ -184,22 +162,10 @@ export class SiSelectLazyOptionsDirective<T> implements SiSelectOptionsStrategy<
 // @public (undocumented)
 export class SiSelectListHasFilterComponent<T> extends SiSelectListBase<T> implements OnInit {
     constructor();
-    // (undocumented)
-    protected readonly filterInput: Signal<ElementRef<HTMLInputElement>>;
     readonly filterPlaceholder: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected readonly icons: Record<"elementSearch", string>;
-    // (undocumented)
-    protected readonly id: Signal<string>;
-    // (undocumented)
-    protected readonly initIndex: Signal<number>;
-    // (undocumented)
-    protected input(): void;
     // (undocumented)
     ngOnInit(): void;
     readonly noResultsFoundLabel: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected select(newValue: T): void;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiSelectListHasFilterComponent<any>, "si-select-list-has-filter", never, { "filterPlaceholder": { "alias": "filterPlaceholder"; "required": true; "isSignal": true; }; "noResultsFoundLabel": { "alias": "noResultsFoundLabel"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)
@@ -219,10 +185,6 @@ export class SiSelectModule {
 // @public
 export class SiSelectMultiValueDirective<T> extends SiSelectSelectionStrategy<T, T[]> {
     readonly allowMultiple = true;
-    // (undocumented)
-    protected fromArrayValue(value: T[]): T[];
-    // (undocumented)
-    protected toArrayValue(value: T[] | undefined): T[];
     // (undocumented)
     static ɵdir: _angular_core.ɵɵDirectiveDeclaration<SiSelectMultiValueDirective<any>, "si-select[multi]", never, {}, {}, never, never, true, never>;
     // (undocumented)
@@ -254,10 +216,6 @@ export class SiSelectSimpleOptionsDirective<T = string> extends SiSelectOptionsS
 // @public
 export class SiSelectSingleValueDirective<T> extends SiSelectSelectionStrategy<T, T> {
     allowMultiple: boolean;
-    // (undocumented)
-    protected fromArrayValue([value]: readonly T[]): T;
-    // (undocumented)
-    protected toArrayValue(value: T | undefined): readonly T[];
     // (undocumented)
     static ɵdir: _angular_core.ɵɵDirectiveDeclaration<SiSelectSingleValueDirective<any>, "si-select:not([multi])", never, {}, {}, never, never, true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/shadow-root/index.api.md
+++ b/api-goldens/element-ng/shadow-root/index.api.md
@@ -10,8 +10,6 @@ import { OverlayContainer } from '@angular/cdk/overlay';
 // @public
 export class SiShadowRootDirective extends OverlayContainer {
     // (undocumented)
-    protected _createContainer(): void;
-    // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<SiShadowRootDirective, "[siShadowRoot]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SiShadowRootDirective, never>;

--- a/api-goldens/element-ng/side-panel/index.api.md
+++ b/api-goldens/element-ng/side-panel/index.api.md
@@ -61,28 +61,6 @@ export class SiSidePanelComponent implements OnInit, OnDestroy, OnChanges {
     readonly collapsible: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly contentResize: _angular_core.OutputEmitterRef<ElementDimensions>;
     readonly enableMobile: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly isCollapsed: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly isFullscreenOverlay: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly isHidden: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly isLg: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly isMd: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly isScrollMode: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly isSm: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly isXl: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly isXs: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly isXxl: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly isXxxl: _angular_core.WritableSignal<boolean>;
     readonly mode: _angular_core.InputSignal<SidePanelMode>;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
@@ -90,10 +68,6 @@ export class SiSidePanelComponent implements OnInit, OnDestroy, OnChanges {
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected readonly ready: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly showTempContent: _angular_core.WritableSignal<boolean>;
     readonly size: _angular_core.InputSignal<SidePanelSize>;
     readonly toggleItemLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     toggleSidePanel(): void;
@@ -106,31 +80,13 @@ export class SiSidePanelComponent implements OnInit, OnDestroy, OnChanges {
 // @public (undocumented)
 export class SiSidePanelContentComponent implements OnInit {
     constructor();
-    // (undocumented)
-    protected readonly activatedRoute: ActivatedRoute | null;
     readonly closeButtonLabel: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected readonly collapsible: _angular_core.Signal<boolean>;
     // @deprecated (undocumented)
     readonly collapsibleInput: _angular_core.InputSignalWithTransform<boolean | undefined, unknown>;
     readonly displayMode: _angular_core.InputSignal<SidePanelDisplayMode | undefined>;
-    // (undocumented)
-    protected readonly enableMobile: _angular_core.Signal<boolean>;
     readonly enterFullscreenLabel: _angular_core.InputSignal<TranslatableString>;
     readonly exitFullscreenLabel: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected readonly focusable: _angular_core.Signal<boolean>;
     readonly heading: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected readonly icons: Record<"elementCancel" | "elementDoubleLeft" | "elementDoubleRight", string>;
-    // (undocumented)
-    protected readonly isCollapsed: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly isExpanded: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly isFullscreen: _angular_core.WritableSignal<boolean>;
-    // (undocumented)
-    protected readonly mobileSize: _angular_core.WritableSignal<boolean>;
     readonly navigateConfig: _angular_core.InputSignal<SidePanelNavigateConfig | undefined>;
     // (undocumented)
     ngOnInit(): void;
@@ -139,14 +95,10 @@ export class SiSidePanelContentComponent implements OnInit {
     readonly searchEvent: _angular_core.OutputEmitterRef<string>;
     readonly searchPlaceholder: _angular_core.InputSignal<TranslatableString>;
     readonly secondaryActions: _angular_core.InputSignal<(MenuItem | MenuItem_2)[]>;
-    // (undocumented)
-    protected readonly service: SiSidePanelService;
     readonly showMobileDrawerBadge: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly statusActions: _angular_core.InputSignal<StatusItem[]>;
     toggleFullscreen(): void;
     readonly toggleItemLabel: _angular_core.InputSignal<TranslatableString>;
-    // (undocumented)
-    protected toggleSidePanel(event?: MouseEvent): void;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiSidePanelContentComponent, "si-side-panel-content", never, { "collapsibleInput": { "alias": "collapsible"; "required": false; "isSignal": true; }; "heading": { "alias": "heading"; "required": false; "isSignal": true; }; "primaryActions": { "alias": "primaryActions"; "required": false; "isSignal": true; }; "secondaryActions": { "alias": "secondaryActions"; "required": false; "isSignal": true; }; "statusActions": { "alias": "statusActions"; "required": false; "isSignal": true; }; "searchable": { "alias": "searchable"; "required": false; "isSignal": true; }; "searchPlaceholder": { "alias": "searchPlaceholder"; "required": false; "isSignal": true; }; "closeButtonLabel": { "alias": "closeButtonLabel"; "required": false; "isSignal": true; }; "toggleItemLabel": { "alias": "toggleItemLabel"; "required": false; "isSignal": true; }; "enterFullscreenLabel": { "alias": "enterFullscreenLabel"; "required": false; "isSignal": true; }; "exitFullscreenLabel": { "alias": "exitFullscreenLabel"; "required": false; "isSignal": true; }; "showMobileDrawerBadge": { "alias": "showMobileDrawerBadge"; "required": false; "isSignal": true; }; "displayMode": { "alias": "displayMode"; "required": false; "isSignal": true; }; "navigateConfig": { "alias": "navigateConfig"; "required": false; "isSignal": true; }; }, { "searchEvent": "searchEvent"; }, never, ["*"], true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/slider/index.api.md
+++ b/api-goldens/element-ng/slider/index.api.md
@@ -11,33 +11,13 @@ import { SiFormItemControl } from '@siemens/element-ng/form';
 
 // @public (undocumented)
 export class SiSliderComponent implements ControlValueAccessor, SiFormItemControl {
-    // (undocumented)
-    protected autoUpdateKeydown(event: KeyboardEvent): void;
-    // (undocumented)
-    protected autoUpdateStart(event: Event, isIncrement: boolean): void;
-    // (undocumented)
-    protected autoUpdateStop(): void;
     readonly decrementLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly disabled: _angular_core.Signal<boolean>;
     // (undocumented)
     readonly disabledInput: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly errormessageId: _angular_core.InputSignal<string>;
     // (undocumented)
-    protected handleMouseDown(event: MouseEvent): void;
-    // (undocumented)
-    protected handlePointerDown(event: Event): void;
-    // (undocumented)
-    protected handleTouchStart(event: TouchEvent): void;
-    // (undocumented)
-    protected readonly icons: Record<"elementMinus" | "elementPlus", string>;
-    // (undocumented)
     readonly id: _angular_core.InputSignal<string>;
     readonly incrementLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly indicatorPos: _angular_core.Signal<number>;
-    // (undocumented)
-    protected isDragging: boolean;
     // (undocumented)
     readonly labelledby: _angular_core.InputSignal<string>;
     readonly max: _angular_core.InputSignalWithTransform<number, unknown>;
@@ -45,8 +25,6 @@ export class SiSliderComponent implements ControlValueAccessor, SiFormItemContro
     readonly min: _angular_core.InputSignalWithTransform<number, unknown>;
     readonly minLabel: _angular_core.InputSignal<string>;
     readonly sliderLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly sliderValue: _angular_core.Signal<number>;
     readonly step: _angular_core.InputSignalWithTransform<number, unknown>;
     readonly thumbIcon: _angular_core.InputSignal<string | undefined>;
     readonly value: _angular_core.ModelSignal<number | undefined>;

--- a/api-goldens/element-ng/sort-bar/index.api.md
+++ b/api-goldens/element-ng/sort-bar/index.api.md
@@ -11,19 +11,11 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public (undocumented)
 export class SiSortBarComponent implements OnInit {
-    // (undocumented)
-    protected activeSortCriteria: SortCriteria['key'];
     readonly defaultSortCriteria: i0.InputSignal<string | number>;
     // (undocumented)
-    protected readonly icons: Record<"elementSortDown" | "elementSortUp", string>;
-    // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected setActive(key: SortCriteria['key']): void;
     readonly sortChange: i0.OutputEmitterRef<HttpParams>;
     readonly sortCriteria: i0.InputSignal<SortCriteria[]>;
-    // (undocumented)
-    protected sortIsDescending: boolean;
     readonly sortTitle: i0.InputSignal<TranslatableString>;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiSortBarComponent, "si-sort-bar", never, { "sortTitle": { "alias": "sortTitle"; "required": false; "isSignal": true; }; "sortCriteria": { "alias": "sortCriteria"; "required": true; "isSignal": true; }; "defaultSortCriteria": { "alias": "defaultSortCriteria"; "required": true; "isSignal": true; }; }, { "sortChange": "sortChange"; }, never, never, true, never>;

--- a/api-goldens/element-ng/split/index.api.md
+++ b/api-goldens/element-ng/split/index.api.md
@@ -41,14 +41,6 @@ export type Scale = 'none' | 'auto';
 // @public (undocumented)
 export class SiSplitComponent implements AfterContentInit, OnChanges {
     // (undocumented)
-    protected gridTemplateAreas: Signal<string>;
-    // (undocumented)
-    protected gridTemplateColumns: Signal<string>;
-    // (undocumented)
-    protected gridTemplateRows: Signal<string>;
-    // (undocumented)
-    protected gutters: Gutter[];
-    // (undocumented)
     gutterSize: number;
     // (undocumented)
     ngAfterContentInit(): void;
@@ -57,12 +49,6 @@ export class SiSplitComponent implements AfterContentInit, OnChanges {
     // (undocumented)
     get orientation(): SplitOrientation;
     set orientation(value: SplitOrientation);
-    // (undocumented)
-    protected readonly _orientation: _angular_core.WritableSignal<SplitOrientation>;
-    // (undocumented)
-    protected parts: QueryList<SiSplitPartComponent>;
-    // (undocumented)
-    protected resizeStart(gutter: Gutter, event: Event): void;
     // (undocumented)
     sizes: number[];
     // (undocumented)
@@ -100,10 +86,6 @@ export class SiSplitPartComponent implements OnChanges {
     set expanded(value: boolean);
     // (undocumented)
     get expanded(): boolean;
-    // (undocumented)
-    protected headerContext: {
-        $implicit: SiSplitPartComponent;
-    };
     // (undocumented)
     headerTemplate?: TemplateRef<any>;
     heading: TranslatableString;

--- a/api-goldens/element-ng/status-bar/index.api.md
+++ b/api-goldens/element-ng/status-bar/index.api.md
@@ -20,18 +20,10 @@ export class SiStatusBarComponent implements DoCheck, OnDestroy, OnChanges {
     constructor();
     readonly allOkText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly blink: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly blinkOnOff: _angular_core.WritableSignal<boolean | undefined>;
     readonly blinkPulse: _angular_core.InputSignal<Observable<boolean> | undefined>;
     readonly collapseButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly compact: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly contentHeight: _angular_core.WritableSignal<number | undefined>;
     readonly expandButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly expanded: _angular_core.WritableSignal<number>;
-    // (undocumented)
-    protected readonly icons: Record<"elementDown2" | "elementSoundMute" | "elementSoundOn", string>;
     readonly items: _angular_core.InputSignal<StatusBarItem[]>;
     readonly muteButton: _angular_core.InputSignal<boolean | undefined>;
     readonly muteButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
@@ -43,20 +35,6 @@ export class SiStatusBarComponent implements DoCheck, OnDestroy, OnChanges {
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
-    protected onItemClicked(item: StatusBarItem): void;
-    // (undocumented)
-    protected readonly placeholderHeight: _angular_core.WritableSignal<number>;
-    // (undocumented)
-    protected resizeHandler(): void;
-    // (undocumented)
-    protected readonly responsiveItems: _angular_core.WritableSignal<ExtendedStatusBarItem[]>;
-    // (undocumented)
-    protected responsiveMode: number;
-    // (undocumented)
-    protected statusId: string;
-    // (undocumented)
-    protected toggleExpand(): void;
-    // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiStatusBarComponent, "si-status-bar", never, { "items": { "alias": "items"; "required": true; "isSignal": true; }; "blink": { "alias": "blink"; "required": false; "isSignal": true; }; "muteButton": { "alias": "muteButton"; "required": false; "isSignal": true; }; "muteButtonText": { "alias": "muteButtonText"; "required": false; "isSignal": true; }; "allOkText": { "alias": "allOkText"; "required": false; "isSignal": true; }; "compact": { "alias": "compact"; "required": false; "isSignal": true; }; "blinkPulse": { "alias": "blinkPulse"; "required": false; "isSignal": true; }; "expandButtonText": { "alias": "expandButtonText"; "required": false; "isSignal": true; }; "collapseButtonText": { "alias": "collapseButtonText"; "required": false; "isSignal": true; }; }, { "muteToggle": "muteToggle"; }, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<SiStatusBarComponent, never>;
@@ -65,21 +43,15 @@ export class SiStatusBarComponent implements DoCheck, OnDestroy, OnChanges {
 // @public (undocumented)
 export class SiStatusBarItemComponent {
     // (undocumented)
-    protected readonly background: _angular_core.Signal<string>;
-    // (undocumented)
     readonly blink: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     readonly clickable: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     readonly color: _angular_core.InputSignal<string | undefined>;
     // (undocumented)
-    protected readonly contrastFix: _angular_core.Signal<boolean>;
-    // (undocumented)
     readonly heading: _angular_core.InputSignal<TranslatableString>;
     // (undocumented)
     readonly status: _angular_core.InputSignal<ExtendedStatusType | undefined>;
-    // (undocumented)
-    protected readonly statusIcon: _angular_core.Signal<_siemens_element_ng_common.StatusIcon | undefined>;
     // (undocumented)
     readonly value: _angular_core.InputSignal<number | TranslatableString>;
     // (undocumented)

--- a/api-goldens/element-ng/status-toggle/index.api.md
+++ b/api-goldens/element-ng/status-toggle/index.api.md
@@ -14,17 +14,7 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate-type
 
 // @public (undocumented)
 export class SiStatusToggleComponent implements ControlValueAccessor, OnInit, OnDestroy, OnChanges {
-    // (undocumented)
-    protected readonly animated: _angular_core.WritableSignal<boolean>;
     readonly disabled: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected readonly draggablePosition: _angular_core.WritableSignal<string>;
-    // (undocumented)
-    protected handleMouseDown(event: MouseEvent): void;
-    // (undocumented)
-    protected handleTouchStart(event: TouchEvent): void;
-    // (undocumented)
-    protected readonly isDisabled: _angular_core.Signal<boolean>;
     readonly itemClick: _angular_core.OutputEmitterRef<string | number>;
     readonly items: _angular_core.InputSignal<StatusToggleItem[]>;
     // (undocumented)
@@ -33,10 +23,6 @@ export class SiStatusToggleComponent implements ControlValueAccessor, OnInit, On
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected readonly selectedIndex: _angular_core.WritableSignal<number | undefined>;
-    // (undocumented)
-    protected selectItem(index: number | undefined, animated?: boolean, emit?: boolean): void;
     readonly value: _angular_core.ModelSignal<string | number | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiStatusToggleComponent, "si-status-toggle", never, { "items": { "alias": "items"; "required": true; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "value": { "alias": "value"; "required": false; "isSignal": true; }; }, { "value": "valueChange"; "itemClick": "itemClick"; }, never, never, true, never>;

--- a/api-goldens/element-ng/summary-chip/index.api.md
+++ b/api-goldens/element-ng/summary-chip/index.api.md
@@ -20,15 +20,6 @@ export class SiSummaryChipComponent {
     readonly stackedColor: _angular_core.InputSignal<string | undefined>;
     readonly stackedIcon: _angular_core.InputSignal<string | undefined>;
     readonly status: _angular_core.InputSignal<ExtendedStatusType | undefined>;
-    // (undocumented)
-    protected readonly statusIcon: _angular_core.Signal<_siemens_element_ng_common.StatusIcon | {
-        icon: string | undefined;
-        color: string | undefined;
-        stacked: string | undefined;
-        stackedColor: string | undefined;
-    }>;
-    // (undocumented)
-    protected toggleSelected(): void;
     readonly value: _angular_core.InputSignal<TranslatableString | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiSummaryChipComponent, "si-summary-chip", never, { "status": { "alias": "status"; "required": false; "isSignal": true; }; "icon": { "alias": "icon"; "required": false; "isSignal": true; }; "color": { "alias": "color"; "required": false; "isSignal": true; }; "stackedIcon": { "alias": "stackedIcon"; "required": false; "isSignal": true; }; "stackedColor": { "alias": "stackedColor"; "required": false; "isSignal": true; }; "label": { "alias": "label"; "required": true; "isSignal": true; }; "value": { "alias": "value"; "required": false; "isSignal": true; }; "selected": { "alias": "selected"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "hideLabel": { "alias": "hideLabel"; "required": false; "isSignal": true; }; }, { "selected": "selectedChange"; }, never, never, true, never>;

--- a/api-goldens/element-ng/summary-widget/index.api.md
+++ b/api-goldens/element-ng/summary-widget/index.api.md
@@ -14,23 +14,12 @@ export class SiSummaryWidgetComponent {
     readonly color: _angular_core.InputSignal<string | undefined>;
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly icon: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly interactive: _angular_core.Signal<boolean>;
     readonly label: _angular_core.InputSignal<TranslatableString>;
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly selected: _angular_core.ModelSignal<boolean>;
     readonly stackedColor: _angular_core.InputSignal<string | undefined>;
     readonly stackedIcon: _angular_core.InputSignal<string | undefined>;
     readonly status: _angular_core.InputSignal<ExtendedStatusType | undefined>;
-    // (undocumented)
-    protected readonly statusIcon: _angular_core.Signal<_siemens_element_ng_common.StatusIcon | {
-        icon: string | undefined;
-        color: string | undefined;
-        stacked: string | undefined;
-        stackedColor: string | undefined;
-    }>;
-    // (undocumented)
-    protected toggleSelected(): void;
     readonly value: _angular_core.InputSignal<TranslatableString>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiSummaryWidgetComponent, "si-summary-widget", never, { "status": { "alias": "status"; "required": false; "isSignal": true; }; "icon": { "alias": "icon"; "required": false; "isSignal": true; }; "color": { "alias": "color"; "required": false; "isSignal": true; }; "stackedIcon": { "alias": "stackedIcon"; "required": false; "isSignal": true; }; "stackedColor": { "alias": "stackedColor"; "required": false; "isSignal": true; }; "label": { "alias": "label"; "required": true; "isSignal": true; }; "value": { "alias": "value"; "required": true; "isSignal": true; }; "selected": { "alias": "selected"; "required": false; "isSignal": true; }; "readonly": { "alias": "readonly"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; }, { "selected": "selectedChange"; }, never, never, true, never>;

--- a/api-goldens/element-ng/system-banner/index.api.md
+++ b/api-goldens/element-ng/system-banner/index.api.md
@@ -10,8 +10,6 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public
 export class SiSystemBannerComponent {
-    // (undocumented)
-    protected readonly bannerClass: _angular_core.Signal<string>;
     readonly message: _angular_core.InputSignal<TranslatableString>;
     readonly status: _angular_core.InputSignal<ExtendedStatusType>;
     // (undocumented)

--- a/api-goldens/element-ng/tabs-legacy/index.api.md
+++ b/api-goldens/element-ng/tabs-legacy/index.api.md
@@ -30,8 +30,6 @@ export class SiTabLegacyComponent implements OnChanges {
     icon?: string;
     iconAltText?: TranslatableString;
     // (undocumented)
-    protected get isHidden(): boolean | null;
-    // (undocumented)
     static ngAcceptInputType_closable: unknown;
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
@@ -45,43 +43,18 @@ export class SiTabLegacyComponent implements OnChanges {
 
 // @public @deprecated (undocumented)
 export class SiTabsetLegacyComponent implements AfterViewInit, OnDestroy {
-    // (undocumented)
-    protected closeTab(event: MouseEvent, tab: SiTabLegacyComponent): void;
     readonly deselect: EventEmitter<SiTabDeselectionEvent>;
-    // (undocumented)
-    protected endArrowDisabled: boolean;
-    // (undocumented)
-    protected focusedTabIndex?: number;
-    // (undocumented)
-    protected focusNext(): void;
-    // (undocumented)
-    protected focusPrevious(): void;
-    // (undocumented)
-    protected readonly icons: Record<"elementCancel" | "elementLeft3" | "elementRight3", string>;
-    // (undocumented)
-    protected isTabFocusable(index: number): boolean;
-    // (undocumented)
-    protected mouseScroll(event: WheelEvent): void;
     // (undocumented)
     static ngAcceptInputType_selectDefaultTab: unknown;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
-    protected resize(): void;
-    protected scrollable: boolean;
-    protected scrollEnd(): void;
-    protected scrollStart(): void;
     selectDefaultTab: boolean;
     set selectedTabIndex(tabIndex: number);
     get selectedTabIndex(): number;
     readonly selectedTabIndexChange: EventEmitter<number>;
-    protected selectTab(selectedTab: SiTabLegacyComponent): void;
     tabButtonMaxWidth?: number;
-    protected tabPanels: QueryList<SiTabLegacyComponent>;
-    // (undocumented)
-    protected xPos: number;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiTabsetLegacyComponent, "si-tabset-legacy", never, { "selectDefaultTab": { "alias": "selectDefaultTab"; "required": false; }; "selectedTabIndex": { "alias": "selectedTabIndex"; "required": false; }; "tabButtonMaxWidth": { "alias": "tabButtonMaxWidth"; "required": false; }; }, { "selectedTabIndexChange": "selectedTabIndexChange"; "deselect": "deselect"; }, ["tabPanels"], ["*"], true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/tabs/index.api.md
+++ b/api-goldens/element-ng/tabs/index.api.md
@@ -25,8 +25,6 @@ export class SiTabComponent extends SiTabBaseDirective implements OnDestroy {
     // (undocumented)
     selectTab(retainFocus?: boolean): void;
     // (undocumented)
-    protected selectTabByUser(): void;
-    // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiTabComponent, "si-tab", never, { "active": { "alias": "active"; "required": false; "isSignal": true; }; "canActivate": { "alias": "canActivate"; "required": false; "isSignal": true; }; "canDeactivate": { "alias": "canDeactivate"; "required": false; "isSignal": true; }; }, { "active": "activeChange"; }, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<SiTabComponent, never>;
@@ -36,8 +34,6 @@ export class SiTabComponent extends SiTabBaseDirective implements OnDestroy {
 export class SiTabLinkComponent extends SiTabBaseDirective {
     // (undocumented)
     readonly active: _angular_core.Signal<boolean | undefined>;
-    // (undocumented)
-    protected routerLinkActive: RouterLinkActive;
     // (undocumented)
     selectTab(retainFocus?: boolean): void;
     // (undocumented)
@@ -49,14 +45,6 @@ export class SiTabLinkComponent extends SiTabBaseDirective {
 // @public
 export class SiTabsetComponent {
     constructor();
-    // (undocumented)
-    protected readonly icons: Record<"elementOptions", string>;
-    // (undocumented)
-    protected keydown(event: KeyboardEvent): void;
-    // (undocumented)
-    protected resizeContainer(width: number, scrollWidth: number): void;
-    // (undocumented)
-    protected tabIsLink(tab: unknown): tab is SiTabLinkComponent;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiTabsetComponent, "si-tabset", never, {}, {}, ["tabPanels"], ["*", "router-outlet"], true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/threshold/index.api.md
+++ b/api-goldens/element-ng/threshold/index.api.md
@@ -13,17 +13,9 @@ import * as _siemens_element_translate_ng_translate_types from '@siemens/element
 // @public (undocumented)
 export class SiThresholdComponent implements OnChanges {
     readonly addAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected addStep(index: number): void;
     readonly canAddRemoveSteps: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly colors: _angular_core.Signal<string[]>;
     readonly deleteAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected deleteStep(index: number): void;
     readonly horizontalLayout: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly icons: Record<"elementPlus" | "elementDelete", string>;
     readonly inputAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly maxSteps: _angular_core.InputSignal<number>;
     readonly maxValue: _angular_core.InputSignal<number>;
@@ -35,8 +27,6 @@ export class SiThresholdComponent implements OnChanges {
     readonly readonlyConditions: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly showDecIncButtons: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly statusAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected stepChange(): void;
     readonly stepSize: _angular_core.InputSignal<number>;
     readonly thresholdSteps: _angular_core.ModelSignal<ThresholdStep[]>;
     readonly unit: _angular_core.InputSignal<string>;

--- a/api-goldens/element-ng/tooltip/index.api.md
+++ b/api-goldens/element-ng/tooltip/index.api.md
@@ -16,20 +16,10 @@ import { Type } from '@angular/core';
 
 // @public (undocumented)
 export class SiTooltipDirective implements OnDestroy {
-    // (undocumented)
-    protected describedBy: string;
-    // (undocumented)
-    protected focusIn(): void;
-    // (undocumented)
-    protected hide(): void;
     readonly isDisabled: i0.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected mouseOut(): void;
     // (undocumented)
     ngOnDestroy(): void;
     readonly placement: i0.InputSignal<"auto" | "top" | "start" | "end" | "bottom">;
-    // (undocumented)
-    protected show(): void;
     readonly siTooltip: i0.InputSignal<TemplateRef<any> | TranslatableString>;
     readonly tooltipContext: i0.InputSignal<unknown>;
     readonly triggers: i0.InputSignal<"" | "focus" | undefined>;

--- a/api-goldens/element-ng/tree-view/index.api.md
+++ b/api-goldens/element-ng/tree-view/index.api.md
@@ -166,8 +166,6 @@ export class SiTreeViewComponent implements OnInit, OnChanges, OnDestroy, AfterV
     addChildItems(children: TreeItem[], parent?: TreeItem, position?: number): void;
     readonly ariaLabel: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly ariaLabelledBy: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly children: Signal<readonly SiTreeViewItemComponent[]>;
     readonly childrenIndentation: _angular_core.InputSignal<number>;
     collapseAll(items?: TreeItem[]): void;
     readonly collapseAllTooltip: _angular_core.InputSignal<TranslatableString>;
@@ -192,18 +190,12 @@ export class SiTreeViewComponent implements OnInit, OnChanges, OnDestroy, AfterV
     readonly flatTree: _angular_core.InputSignal<boolean>;
     readonly folderStateStart: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly groupedList: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected handleKeydown(event: KeyboardEvent): void;
-    protected get headerShowsRoot(): boolean;
-    protected get heightAfter(): string;
-    protected get heightBefore(): string;
     readonly horizontalScrolling: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly icons: _angular_core.InputSignal<TreeViewIconSet | undefined>;
     readonly inheritChecked: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly isVirtualized: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly items: _angular_core.InputSignal<TreeItem<any>[]>;
     readonly itemsVirtualizedChanged: _angular_core.OutputEmitterRef<ItemsVirtualizedArgs>;
-    protected get lastBreadCrumbItem(): TreeItem | null;
     readonly loadChildren: _angular_core.OutputEmitterRef<LoadChildrenEventArgs>;
     // (undocumented)
     ngAfterViewChecked(): void;
@@ -216,18 +208,6 @@ export class SiTreeViewComponent implements OnInit, OnChanges, OnDestroy, AfterV
     // (undocumented)
     ngOnInit(): void;
     readonly noActionsString: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected onFlatTreeNavigateHome(): void;
-    // (undocumented)
-    protected onFlatTreeNavigateUp(): void;
-    // (undocumented)
-    protected onKeyUpCtrl(): void;
-    // (undocumented)
-    protected onKeyUpMeta(): void;
-    // (undocumented)
-    protected onKeyUpShift(): void;
-    // (undocumented)
-    protected onMouseLeave(): void;
     readonly pageSize: _angular_core.InputSignalWithTransform<number, number>;
     readonly pagesVirtualized: _angular_core.InputSignalWithTransform<number, number>;
     refresh(): void;
@@ -238,15 +218,9 @@ export class SiTreeViewComponent implements OnInit, OnChanges, OnDestroy, AfterV
     readonly templates: Signal<readonly SiTreeViewItemTemplateDirective[]>;
     readonly treeItemCheckboxClicked: _angular_core.OutputEmitterRef<CheckboxClickEventArgs>;
     readonly treeItemClicked: _angular_core.OutputEmitterRef<TreeItem<any>>;
-    // (undocumented)
-    protected readonly treeItemContentTemplate: Signal<TemplateRef<any> | undefined>;
     readonly treeItemFolderClicked: _angular_core.OutputEmitterRef<FolderStateEventArgs>;
     readonly treeItemFolderStateChanged: _angular_core.OutputEmitterRef<FolderStateEventArgs>;
     readonly treeItemsSelected: _angular_core.OutputEmitterRef<TreeItem<any>[]>;
-    // (undocumented)
-    protected readonly treeViewInnerElement: Signal<ElementRef<HTMLDivElement>>;
-    // (undocumented)
-    protected updateVirtualizedItemList(): void;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiTreeViewComponent, "si-tree-view", never, { "contextMenuItems": { "alias": "contextMenuItems"; "required": false; "isSignal": true; }; "childrenIndentation": { "alias": "childrenIndentation"; "required": false; "isSignal": true; }; "horizontalScrolling": { "alias": "horizontalScrolling"; "required": false; "isSignal": true; }; "compactMode": { "alias": "compactMode"; "required": false; "isSignal": true; }; "expandCollapseAll": { "alias": "expandCollapseAll"; "required": false; "isSignal": true; }; "expandAllTooltip": { "alias": "expandAllTooltip"; "required": false; "isSignal": true; }; "collapseAllTooltip": { "alias": "collapseAllTooltip"; "required": false; "isSignal": true; }; "icons": { "alias": "icons"; "required": false; "isSignal": true; }; "pageSize": { "alias": "pageSize"; "required": false; "isSignal": true; }; "pagesVirtualized": { "alias": "pagesVirtualized"; "required": false; "isSignal": true; }; "folderStateStart": { "alias": "folderStateStart"; "required": false; "isSignal": true; }; "isVirtualized": { "alias": "isVirtualized"; "required": false; "isSignal": true; }; "items": { "alias": "items"; "required": false; "isSignal": true; }; "selectedItem": { "alias": "selectedItem"; "required": false; "isSignal": true; }; "singleSelectMode": { "alias": "singleSelectMode"; "required": false; "isSignal": true; }; "enableDataField1": { "alias": "enableDataField1"; "required": false; "isSignal": true; }; "enableDataField2": { "alias": "enableDataField2"; "required": false; "isSignal": true; }; "enableStateIndicator": { "alias": "enableStateIndicator"; "required": false; "isSignal": true; }; "enableIcon": { "alias": "enableIcon"; "required": false; "isSignal": true; }; "enableContextMenuButton": { "alias": "enableContextMenuButton"; "required": false; "isSignal": true; }; "enableSelection": { "alias": "enableSelection"; "required": false; "isSignal": true; }; "deleteChildrenOnCollapse": { "alias": "deleteChildrenOnCollapse"; "required": false; "isSignal": true; }; "flatTree": { "alias": "flatTree"; "required": false; "isSignal": true; }; "groupedList": { "alias": "groupedList"; "required": false; "isSignal": true; }; "enableCheckbox": { "alias": "enableCheckbox"; "required": false; "isSignal": true; }; "enableOptionbox": { "alias": "enableOptionbox"; "required": false; "isSignal": true; }; "expandOnClick": { "alias": "expandOnClick"; "required": false; "isSignal": true; }; "inheritChecked": { "alias": "inheritChecked"; "required": false; "isSignal": true; }; "noActionsString": { "alias": "noActionsString"; "required": false; "isSignal": true; }; "ariaLabel": { "alias": "ariaLabel"; "required": false; "isSignal": true; }; "ariaLabelledBy": { "alias": "ariaLabelledBy"; "required": false; "isSignal": true; }; }, { "itemsVirtualizedChanged": "itemsVirtualizedChanged"; "treeItemFolderClicked": "treeItemFolderClicked"; "treeItemFolderStateChanged": "treeItemFolderStateChanged"; "treeItemClicked": "treeItemClicked"; "treeItemCheckboxClicked": "treeItemCheckboxClicked"; "loadChildren": "loadChildren"; "treeItemsSelected": "treeItemsSelected"; }, ["templates", "treeItemContentTemplate", "nextItems"], ["[cdkDropList], [siTreeViewItem]"], true, never>;
     // (undocumented)
@@ -255,60 +229,8 @@ export class SiTreeViewComponent implements OnInit, OnChanges, OnDestroy, AfterV
 
 // @public (undocumented)
 export class SiTreeViewItemComponent implements OnInit, OnDestroy, AfterViewInit, FocusableOption, DoCheck {
-    // (undocumented)
-    protected get ariaChecked(): boolean | null;
-    // (undocumented)
-    protected get ariaExpanded(): boolean | null;
-    // (undocumented)
-    protected get ariaLevel(): number;
-    // (undocumented)
-    protected ariaPosinset?: number;
-    // (undocumented)
-    protected get ariaSelected(): boolean | null;
-    // (undocumented)
-    protected get ariaSetsize(): number;
-    // (undocumented)
-    protected get biggerPaddingStart(): string;
-    // (undocumented)
-    protected readonly contextMenuItems: _angular_core.WritableSignal<(MenuItem | MenuItem_2)[] | null>;
-    // (undocumented)
-    protected readonly deleteChildrenOnCollapse: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly enableContextMenuButton: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly enableDataField1: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly enableDataField2: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly enableSelection: _angular_core.InputSignalWithTransform<boolean, unknown>;
     focus(): void;
-    // (undocumented)
-    protected getInputType(): string;
-    // (undocumented)
-    protected getItemFolderStateClass(): string;
     getLabel(): string;
-    // (undocumented)
-    protected getStateIndicatorColor(): string;
-    // (undocumented)
-    protected icons: _angular_core.Signal<{
-        headerHome: string;
-        headerArrow: string;
-        itemMenu: string;
-        itemCollapsed: string;
-        itemCollapsedFlat: string;
-        itemCollapsedLeft: string;
-        itemExpanded: string;
-        itemExpandedFlat: string;
-        itemExpandedLeft: string;
-    }>;
-    // (undocumented)
-    protected readonly isContextMenuButtonVisible: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected get isExpanding(): boolean;
-    // (undocumented)
-    protected get isGroupedItem(): boolean;
-    // (undocumented)
-    protected readonly menuTrigger: _angular_core.Signal<CdkMenuTrigger | undefined>;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -317,47 +239,6 @@ export class SiTreeViewItemComponent implements OnInit, OnDestroy, AfterViewInit
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected onBoxClicked(): void;
-    // (undocumented)
-    protected onContextMenu(event: Event): boolean;
-    // (undocumented)
-    protected onItemClicked(event: Event): void;
-    // (undocumented)
-    protected onItemFolderClicked(newState?: string): void;
-    // (undocumented)
-    protected onKeydown(event: KeyboardEvent): void;
-    // (undocumented)
-    protected onMouseDownTreeItem(event: MouseEvent): void;
-    // (undocumented)
-    protected onToggleContextMenuClose(): void;
-    // (undocumented)
-    protected onToggleContextMenuOpen(): void;
-    // (undocumented)
-    protected get paddingStart(): string;
-    // (undocumented)
-    protected renderMatchingTemplate(treeItem: TreeItem): TemplateRef<any>;
-    // (undocumented)
-    protected get showCheckOrOptionBox(): boolean;
-    // (undocumented)
-    protected get showFolderStateEnd(): boolean;
-    // (undocumented)
-    protected get showFolderStateStart(): boolean;
-    // (undocumented)
-    protected readonly showIcon: _angular_core.Signal<boolean>;
-    // (undocumented)
-    protected readonly showStateIndicator: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly stickyEndItems: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected templates: _angular_core.Signal<readonly _siemens_element_ng_tree_view.SiTreeViewItemTemplateDirective[]>;
-    // (undocumented)
-    protected treeItemContext: {
-        record: _angular_core.IterableChangeRecord<TreeItem<any>>;
-        parent: _siemens_element_ng_tree_view.SiTreeViewComponent;
-    };
-    // (undocumented)
-    protected treeViewComponent: _siemens_element_ng_tree_view.SiTreeViewComponent;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiTreeViewItemComponent, "si-tree-view-item", never, {}, {}, never, [":not(si-tree-view-item):not([dragPreview])"], true, never>;
     // (undocumented)

--- a/api-goldens/element-ng/typeahead/index.api.md
+++ b/api-goldens/element-ng/typeahead/index.api.md
@@ -33,16 +33,6 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
-    protected onBlur(): void;
-    // (undocumented)
-    protected onInput(event: Event): void;
-    // (undocumented)
-    protected onKeydownEscape(): void;
-    // (undocumented)
-    protected onKeydownSpace(event: Event): void;
-    // (undocumented)
-    protected static readonly overlayPositions: ConnectionPositionPair[];
     readonly siTypeahead: _angular_core.InputSignal<Typeahead>;
     readonly typeaheadAutocompleteListLabel: _angular_core.InputSignal<TranslatableString>;
     readonly typeaheadAutoSelectIndex: _angular_core.InputSignalWithTransform<number, unknown>;

--- a/api-goldens/element-ng/wizard/index.api.md
+++ b/api-goldens/element-ng/wizard/index.api.md
@@ -11,42 +11,23 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public (undocumented)
 export class SiWizardComponent {
-    // (undocumented)
-    protected activateStep(event: Event, stepIndex: number): void;
-    protected readonly activeSteps: _angular_core.Signal<StepItem[]>;
     back(delta?: number): void;
     readonly backText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected canActivate(stepIndex: number): boolean;
     readonly cancelText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     readonly completionAction: _angular_core.OutputEmitterRef<void>;
     readonly completionPageVisibleTime: _angular_core.InputSignal<number>;
     readonly completionText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly containerSteps: _angular_core.Signal<ElementRef<HTMLDivElement> | undefined>;
     get currentStep(): SiWizardStepComponent | undefined;
     readonly enableCompletionPage: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected getAriaCurrent(stepIndex: number): string;
-    // (undocumented)
-    protected getAriaDisabled(stepIndex: number): string;
-    // (undocumented)
-    protected getState(step: SiWizardStepComponent, stepIndex: number): string;
-    // (undocumented)
-    protected getStateClass(stepIndex: number): string;
     readonly hasCancel: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly hideNavigation: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly hideSave: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
-    protected readonly icons: Record<"elementNotChecked" | "elementRadioChecked" | "elementCheckedFilled" | "elementWarningFilled" | "elementCancel" | "elementChecked" | "elementLeft4" | "elementRight4", string>;
     get index(): number;
     readonly inlineNavigation: _angular_core.InputSignalWithTransform<boolean, unknown>;
     next(delta?: number): void;
     readonly nextText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
     save(): void;
     readonly saveText: _angular_core.InputSignal<_siemens_element_translate_ng_translate_types.TranslatableString>;
-    // (undocumented)
-    protected readonly showCompletionPage: _angular_core.WritableSignal<boolean>;
     readonly showStepNumbers: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly showVerticalDivider: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly stepActiveIcon: _angular_core.InputSignal<string>;
@@ -54,15 +35,9 @@ export class SiWizardComponent {
     get stepCount(): number;
     readonly stepFailedIcon: _angular_core.InputSignal<string>;
     readonly stepIcon: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected readonly steps: _angular_core.Signal<readonly SiWizardStepComponent[]>;
-    // (undocumented)
-    protected updateVisibleSteps(): void;
     readonly verticalLayout: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly verticalMaxSize: _angular_core.InputSignal<string | undefined>;
     readonly verticalMinSize: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly visibleSteps: _angular_core.WritableSignal<number>;
     readonly wizardCancel: _angular_core.OutputEmitterRef<void>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiWizardComponent, "si-wizard", never, { "backText": { "alias": "backText"; "required": false; "isSignal": true; }; "nextText": { "alias": "nextText"; "required": false; "isSignal": true; }; "hideNavigation": { "alias": "hideNavigation"; "required": false; "isSignal": true; }; "saveText": { "alias": "saveText"; "required": false; "isSignal": true; }; "hideSave": { "alias": "hideSave"; "required": false; "isSignal": true; }; "completionText": { "alias": "completionText"; "required": false; "isSignal": true; }; "cancelText": { "alias": "cancelText"; "required": false; "isSignal": true; }; "hasCancel": { "alias": "hasCancel"; "required": false; "isSignal": true; }; "enableCompletionPage": { "alias": "enableCompletionPage"; "required": false; "isSignal": true; }; "completionPageVisibleTime": { "alias": "completionPageVisibleTime"; "required": false; "isSignal": true; }; "stepIcon": { "alias": "stepIcon"; "required": false; "isSignal": true; }; "stepActiveIcon": { "alias": "stepActiveIcon"; "required": false; "isSignal": true; }; "stepCompletedIcon": { "alias": "stepCompletedIcon"; "required": false; "isSignal": true; }; "stepFailedIcon": { "alias": "stepFailedIcon"; "required": false; "isSignal": true; }; "verticalLayout": { "alias": "verticalLayout"; "required": false; "isSignal": true; }; "inlineNavigation": { "alias": "inlineNavigation"; "required": false; "isSignal": true; }; "showStepNumbers": { "alias": "showStepNumbers"; "required": false; "isSignal": true; }; "showVerticalDivider": { "alias": "showVerticalDivider"; "required": false; "isSignal": true; }; "verticalMinSize": { "alias": "verticalMinSize"; "required": false; "isSignal": true; }; "verticalMaxSize": { "alias": "verticalMaxSize"; "required": false; "isSignal": true; }; }, { "completionAction": "completionAction"; "wizardCancel": "wizardCancel"; }, ["steps"], ["*"], true, never>;

--- a/api-goldens/live-preview/index.api.md
+++ b/api-goldens/live-preview/index.api.md
@@ -68,27 +68,13 @@ export class SiDummyComponent {
 // @public (undocumented)
 export class SiExampleOverviewComponent implements OnInit, OnDestroy {
     // (undocumented)
-    protected activeExampleRoute: Observable<string>;
-    // (undocumented)
-    protected baseUrl: string;
-    // (undocumented)
-    protected isCollapsed: boolean;
-    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)
     resetSearchBar(): void;
     // (undocumented)
-    protected searchControl: UntypedFormControl;
-    // (undocumented)
-    protected showContent: boolean;
-    // (undocumented)
-    protected ticketBaseUrl: string;
-    // (undocumented)
     toggleCollapse(): void;
-    // (undocumented)
-    protected tree: TreeItem[];
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<SiExampleOverviewComponent, "si-example-overview", never, {}, {}, never, never, true, never>;
     // (undocumented)
@@ -306,8 +292,6 @@ export interface SiLivePreviewConfig {
 // @public (undocumented)
 export class SiLivePreviewIframeComponent implements OnInit, OnChanges {
     // (undocumented)
-    protected availableDevices: Device[];
-    // (undocumented)
     baseUrl: string;
     // (undocumented)
     deviceChanged(): void;
@@ -322,13 +306,7 @@ export class SiLivePreviewIframeComponent implements OnInit, OnChanges {
     // (undocumented)
     isFullscreen: boolean;
     // (undocumented)
-    protected isMobile: boolean;
-    // (undocumented)
     isRTL?: boolean;
-    // (undocumented)
-    protected landscape: boolean;
-    // (undocumented)
-    protected landscapeEnabled: boolean | undefined;
     // (undocumented)
     loadJs?: boolean;
     // (undocumented)
@@ -346,31 +324,15 @@ export class SiLivePreviewIframeComponent implements OnInit, OnChanges {
     // (undocumented)
     readonly logRenderingError: i0.OutputEmitterRef<any>;
     // (undocumented)
-    protected mode: string;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)
     openQrMenu(): void;
     // (undocumented)
-    protected plainUrl: string;
-    // (undocumented)
-    protected plainUrlShort: string;
-    // (undocumented)
     readonly previewIframe: i0.Signal<ElementRef<any> | undefined>;
     // (undocumented)
     reactVueTemplate?: string;
-    // (undocumented)
-    protected selectedDevice?: Device;
-    // (undocumented)
-    protected showNotch: boolean;
-    // (undocumented)
-    protected showQrMenu: boolean;
-    // (undocumented)
-    protected supportsLandscape: boolean;
-    // (undocumented)
-    protected switcherEnabled: boolean | undefined;
     // (undocumented)
     template: string;
     // (undocumented)

--- a/api-goldens/native-charts-ng/gauge/index.api.md
+++ b/api-goldens/native-charts-ng/gauge/index.api.md
@@ -27,26 +27,9 @@ export interface GaugeSeries {
 
 // @public (undocumented)
 export class SiNChartGaugeComponent implements OnInit, OnChanges {
-    // (undocumented)
-    protected additionalHeight: number;
     readonly axisLabelFormatter: _angular_core.InputSignal<((val: number) => string) | undefined>;
     readonly axisNumberOfDecimals: _angular_core.InputSignal<number>;
-    // (undocumented)
-    protected backgroundPath: string;
-    // (undocumented)
-    protected center: Coordinate;
-    // (undocumented)
-    protected dim: {
-        width: number;
-        height: number;
-    };
     readonly endAngle: _angular_core.InputSignalWithTransform<number, unknown>;
-    // (undocumented)
-    protected init(): void;
-    // (undocumented)
-    protected internalSegments: InternalGaugeSegment[];
-    // (undocumented)
-    protected internalSeries: InternalSeries[];
     readonly legendPosition: _angular_core.InputSignal<"row" | "column">;
     readonly max: _angular_core.InputSignalWithTransform<number, unknown>;
     readonly maxNumberOfDecimals: _angular_core.InputSignal<number>;
@@ -57,23 +40,13 @@ export class SiNChartGaugeComponent implements OnInit, OnChanges {
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnInit(): void;
-    // (undocumented)
-    protected radius: number;
     readonly segments: _angular_core.InputSignal<GaugeSegment[]>;
     readonly series: _angular_core.InputSignal<GaugeSeries[]>;
     readonly showLegend: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly showRangeLabelsOutside: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly showTicks: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly startAngle: _angular_core.InputSignalWithTransform<number, unknown>;
-    // (undocumented)
-    protected ticks: Tick[];
-    // (undocumented)
-    protected totalSum: number;
-    // (undocumented)
-    protected totalSumString: string;
     readonly unit: _angular_core.InputSignal<string>;
-    // (undocumented)
-    protected valignMiddle: boolean;
     readonly valueFormatter: _angular_core.InputSignal<((val: number) => string) | undefined>;
     // (undocumented)
     static ɵcmp: _angular_core.ɵɵComponentDeclaration<SiNChartGaugeComponent, "si-nchart-gauge", never, { "startAngle": { "alias": "startAngle"; "required": false; "isSignal": true; }; "endAngle": { "alias": "endAngle"; "required": false; "isSignal": true; }; "min": { "alias": "min"; "required": false; "isSignal": true; }; "max": { "alias": "max"; "required": false; "isSignal": true; }; "mode": { "alias": "mode"; "required": false; "isSignal": true; }; "series": { "alias": "series"; "required": false; "isSignal": true; }; "segments": { "alias": "segments"; "required": false; "isSignal": true; }; "unit": { "alias": "unit"; "required": false; "isSignal": true; }; "minNumberOfDecimals": { "alias": "minNumberOfDecimals"; "required": false; "isSignal": true; }; "maxNumberOfDecimals": { "alias": "maxNumberOfDecimals"; "required": false; "isSignal": true; }; "axisNumberOfDecimals": { "alias": "axisNumberOfDecimals"; "required": false; "isSignal": true; }; "axisLabelFormatter": { "alias": "axisLabelFormatter"; "required": false; "isSignal": true; }; "valueFormatter": { "alias": "valueFormatter"; "required": false; "isSignal": true; }; "showTicks": { "alias": "showTicks"; "required": false; "isSignal": true; }; "showLegend": { "alias": "showLegend"; "required": false; "isSignal": true; }; "legendPosition": { "alias": "legendPosition"; "required": false; "isSignal": true; }; "showRangeLabelsOutside": { "alias": "showRangeLabelsOutside"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;

--- a/api-goldens/native-charts-ng/microchart-bar/index.api.md
+++ b/api-goldens/native-charts-ng/microchart-bar/index.api.md
@@ -17,11 +17,7 @@ export interface MicrochartBarSeries {
 // @public (undocumented)
 export class SiMicrochartBarComponent {
     // (undocumented)
-    protected barWidth: number;
-    // (undocumented)
     readonly height: _angular_core.InputSignal<number>;
-    // (undocumented)
-    protected readonly internalSeries: _angular_core.Signal<SeriesInternal[]>;
     readonly series: _angular_core.InputSignal<MicrochartBarSeries>;
     // (undocumented)
     readonly width: _angular_core.InputSignal<number>;

--- a/api-goldens/native-charts-ng/microchart-donut/index.api.md
+++ b/api-goldens/native-charts-ng/microchart-donut/index.api.md
@@ -15,17 +15,6 @@ export interface MicrochartDonutSeries {
 
 // @public (undocumented)
 export class SiMicrochartDonutComponent {
-    // (undocumented)
-    protected readonly arcThickness: _angular_core.Signal<number>;
-    // (undocumented)
-    protected readonly backgroundPath: _angular_core.Signal<string>;
-    // (undocumented)
-    protected readonly dim: _angular_core.Signal<{
-        width: number;
-        height: number;
-    }>;
-    // (undocumented)
-    protected readonly internalSeries: _angular_core.Signal<InternalSeries[]>;
     readonly radius: _angular_core.InputSignalWithTransform<number, unknown>;
     readonly series: _angular_core.InputSignal<MicrochartDonutSeries[]>;
     // (undocumented)

--- a/api-goldens/native-charts-ng/microchart-line/index.api.md
+++ b/api-goldens/native-charts-ng/microchart-line/index.api.md
@@ -16,24 +16,12 @@ export interface MicrochartLineSeries {
 // @public (undocumented)
 export class SiMicrochartLineComponent {
     // (undocumented)
-    protected readonly areaPath: _angular_core.Signal<string>;
-    // (undocumented)
-    protected readonly gradientId: string;
-    // (undocumented)
     readonly height: _angular_core.InputSignal<number>;
     readonly lineWidth: _angular_core.InputSignal<number>;
     readonly markerColor: _angular_core.InputSignal<string | undefined>;
-    // (undocumented)
-    protected readonly markerPoints: _angular_core.Signal<Coordinate[]>;
-    // (undocumented)
-    protected readonly markerRadius: _angular_core.Signal<number>;
-    // (undocumented)
-    protected readonly path: _angular_core.Signal<string>;
     readonly series: _angular_core.InputSignal<MicrochartLineSeries>;
     readonly showArea: _angular_core.InputSignal<boolean>;
     readonly showMarkers: _angular_core.InputSignal<boolean>;
-    // (undocumented)
-    protected readonly viewBox: _angular_core.Signal<string>;
     // (undocumented)
     readonly width: _angular_core.InputSignal<number>;
     // (undocumented)

--- a/tools/api-goldens/index.md
+++ b/tools/api-goldens/index.md
@@ -4,6 +4,9 @@ This directory contains the script needed to generate and verify API goldens for
 This script is using [API Extractor](https://api-extractor.com/) internally.
 Since the API Extractor is currently not supporting multiple entrypoints, it is called separately for each entrypoint.
 
+The script patches the API Extractor to flag all protected members as `internal`.
+This excludes them from the public API report.
+
 See the [Developer Guide](../../DEVELOPER.md) for usage instructions.
 
 


### PR DESCRIPTION
The only relevant change is in `tools/api-goldens/test_api_report.ts` where we monkey-patch the `Collector`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates API golden generation to exclude protected class members from public API reports.

### Key changes
- tools/api-goldens/test_api_report.ts: monkey-patches Collector.prototype.fetchApiItemMetadata so protected members (properties, methods, accessors, constructors) are marked Internal (effective and declared release tags), preventing them from appearing in public API goldens.
- api-goldens/**: many generated .api.md files updated to remove protected/undocumented members across numerous packages (charts, element-ng components, native-charts-ng, live-preview, tools, etc.).

### Impact
- The reported public API surface is reduced by hiding protected/internal members in the generated API goldens; actual public inputs/outputs and runtime behavior are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->