### PR TITLE
fix(select): maintain filtered rows when updating all rows

### DIFF
--- a/api-goldens/element-ng/select/index.api.md
+++ b/api-goldens/element-ng/select/index.api.md
@@ -83,14 +83,12 @@ export class SiSelectActionsDirective {
 }
 
 // @public @deprecated
-export class SiSelectComplexOptionsDirective<T> extends SiSelectOptionsStrategyBase<T> implements OnChanges {
+export class SiSelectComplexOptionsDirective<T> extends SiSelectOptionsStrategyBase<T> {
     // (undocumented)
     readonly allRows: _angular_core.Signal<SelectOption<T>[] | SelectGroup<T>[]>;
     readonly complexOptions: _angular_core.InputSignal<T[] | Record<string, T[]> | null | undefined>;
     readonly disabledProvider: _angular_core.InputSignal<(dropdownOption: T) => boolean>;
     readonly groupProvider: _angular_core.InputSignal<(groupKey: string) => string | undefined>;
-    // (undocumented)
-    ngOnChanges(): void;
     readonly optionsEqual: _angular_core.InputSignal<(a: T, b: T) => boolean>;
     // @deprecated (undocumented)
     readonly trackBy: _angular_core.InputSignal<_angular_core.TrackByFunction<T>>;
@@ -200,11 +198,9 @@ export class SiSelectOptionTemplateDirective {
 }
 
 // @public
-export class SiSelectSimpleOptionsDirective<T = string> extends SiSelectOptionsStrategyBase<T> implements OnChanges {
+export class SiSelectSimpleOptionsDirective<T = string> extends SiSelectOptionsStrategyBase<T> {
     // (undocumented)
     readonly allRows: _angular_core.Signal<SelectItem<T>[]>;
-    // (undocumented)
-    ngOnChanges(): void;
     readonly options: _angular_core.InputSignal<(SelectOptionLegacy | SelectItem<T>)[] | null | undefined>;
     readonly optionsEqual: _angular_core.InputSignal<(a: T, b: T) => boolean>;
     // (undocumented)

--- a/projects/element-ng/select/options/si-select-complex-options.directive.ts
+++ b/projects/element-ng/select/options/si-select-complex-options.directive.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { computed, Directive, input, OnChanges } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 import { buildTrackByIdentity } from '@siemens/element-ng/common';
 
 import { SelectGroup, SelectOption } from '../si-select.types';
@@ -26,10 +26,7 @@ import { SiSelectOptionsStrategyBase } from './si-select-options-strategy.base';
   selector: 'si-select[complexOptions]',
   providers: [{ provide: SI_SELECT_OPTIONS_STRATEGY, useExisting: SiSelectComplexOptionsDirective }]
 })
-export class SiSelectComplexOptionsDirective<T>
-  extends SiSelectOptionsStrategyBase<T>
-  implements OnChanges
-{
+export class SiSelectComplexOptionsDirective<T> extends SiSelectOptionsStrategyBase<T> {
   /** Options to be shown in select dropdown. */
   readonly complexOptions = input<T[] | Record<string, T[]> | null>();
 
@@ -100,10 +97,6 @@ export class SiSelectComplexOptionsDirective<T>
       return [];
     }
   });
-
-  ngOnChanges(): void {
-    this.onFilter();
-  }
 
   private convertOptionsArray(options: T[]): SelectOption<T>[] {
     const provide = this.valueProvider();

--- a/projects/element-ng/select/options/si-select-options-strategy.base.ts
+++ b/projects/element-ng/select/options/si-select-options-strategy.base.ts
@@ -18,12 +18,6 @@ export abstract class SiSelectOptionsStrategyBase<T> implements SiSelectOptionsS
   abstract optionsEqual: InputSignal<(a: T, b: T) => boolean>;
 
   /**
-   * Rows that should be shown.
-   *
-   * @defaultValue []
-   */
-  readonly rows = signal<SelectItem<T>[]>([]);
-  /**
    * All group and option items in the dropdown.
    *
    * @defaultValue []
@@ -31,6 +25,41 @@ export abstract class SiSelectOptionsStrategyBase<T> implements SiSelectOptionsS
   abstract readonly allRows: Signal<(SelectItem<T> | SelectOption<T>)[]>;
 
   private readonly value = signal<T[]>([]);
+  private readonly filterValue = signal('');
+
+  /**
+   * Rows that should be shown.
+   *
+   * @defaultValue []
+   */
+  readonly rows = computed(() => {
+    const filterValue = this.filterValue();
+    if (filterValue) {
+      const filterValueLC = filterValue.toLowerCase();
+      const checkRow: (row: SelectOption<T>) => boolean = (row: SelectOption<T>) =>
+        (row.typeaheadLabel ?? row.label)!.toLowerCase().includes(filterValueLC!);
+
+      return this.allRows().reduce((rows, row) => {
+        if (row.type === 'option' && checkRow(row)) {
+          rows.push(row);
+        } else if (row.type === 'group') {
+          if (row.label!.toLowerCase().includes(filterValueLC!)) {
+            rows.push(row);
+          } else {
+            const options = row.options.filter(checkRow);
+
+            if (options.length) {
+              rows.push({ ...row, options });
+            }
+          }
+        }
+
+        return rows;
+      }, [] as SelectItem<T>[]);
+    } else {
+      return this.allRows();
+    }
+  });
 
   readonly selectedRows = computed(() => {
     const values = this.value();
@@ -45,32 +74,6 @@ export abstract class SiSelectOptionsStrategyBase<T> implements SiSelectOptionsS
   }
 
   onFilter(filterValue?: string): void {
-    if (filterValue) {
-      const filterValueLC = filterValue.toLowerCase();
-      const checkRow: (row: SelectOption<T>) => boolean = (row: SelectOption<T>) =>
-        (row.typeaheadLabel ?? row.label)!.toLowerCase().includes(filterValueLC!);
-
-      this.rows.set(
-        this.allRows().reduce((rows, row) => {
-          if (row.type === 'option' && checkRow(row)) {
-            rows.push(row);
-          } else if (row.type === 'group') {
-            if (row.label!.toLowerCase().includes(filterValueLC!)) {
-              rows.push(row);
-            } else {
-              const options = row.options.filter(checkRow);
-
-              if (options.length) {
-                rows.push({ ...row, options });
-              }
-            }
-          }
-
-          return rows;
-        }, [] as SelectItem<T>[])
-      );
-    } else {
-      this.rows.set(this.allRows());
-    }
+    this.filterValue.set(filterValue ?? '');
   }
 }

--- a/projects/element-ng/select/options/si-select-simple-options.directive.ts
+++ b/projects/element-ng/select/options/si-select-simple-options.directive.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { computed, Directive, input, OnChanges } from '@angular/core';
+import { computed, Directive, input } from '@angular/core';
 
 import { SelectItem, SelectOption, SelectOptionLegacy } from '../si-select.types';
 import { SI_SELECT_OPTIONS_STRATEGY } from './si-select-options-strategy';
@@ -22,10 +22,7 @@ import { SiSelectOptionsStrategyBase } from './si-select-options-strategy.base';
   selector: 'si-select[options]',
   providers: [{ provide: SI_SELECT_OPTIONS_STRATEGY, useExisting: SiSelectSimpleOptionsDirective }]
 })
-export class SiSelectSimpleOptionsDirective<T = string>
-  extends SiSelectOptionsStrategyBase<T>
-  implements OnChanges
-{
+export class SiSelectSimpleOptionsDirective<T = string> extends SiSelectOptionsStrategyBase<T> {
   /** Options to be shown in select dropdown */
   readonly options = input<(SelectOptionLegacy | SelectItem<T>)[] | null>();
 
@@ -61,8 +58,4 @@ export class SiSelectSimpleOptionsDirective<T = string>
       return [];
     }
   });
-
-  ngOnChanges(): void {
-    this.onFilter();
-  }
 }

--- a/projects/element-ng/select/si-select.component.spec.ts
+++ b/projects/element-ng/select/si-select.component.spec.ts
@@ -357,6 +357,20 @@ describe('SiSelectComponent', () => {
         const item = await selectHarness.getList().then(list => list!.getItemByText('c'));
         expect(await item.isActive()).toBeTrue();
       });
+
+      it('should apply current filter when options are applied', async () => {
+        await selectHarness.open();
+        await selectHarness.getList().then(list => list!.sendKeys('c'));
+        hostComponent.options = [...hostComponent.options!, { id: 'aaa', title: 'aaa' }];
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+        const items = await selectHarness.getList().then(list => list!.getAllItemTexts());
+        expect(items).not.toContain('a');
+        expect(items).not.toContain('b');
+        expect(items).not.toContain('ab');
+        expect(items).not.toContain('aaa');
+        expect(items).toContain('c');
+      });
     });
   });
 


### PR DESCRIPTION
This commit turns the rows 
(which represents the rows that are visible)
for eagerly loaded options into a computed signal.
In addition, it stores the current filter value,
so we no longer need to call the filter function
when new options are provided.
Thus, the filter value is maintained and the rows
are anyway updated based on the new options.

Co-authored-by: Bajohr, Rayk <rayk.bajohr@siemens.com>

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes the select component to preserve the active filter and maintain filtered (visible) rows when all options are updated.

### Key changes

- Removed the `OnChanges` lifecycle hook from `SiSelectComplexOptionsDirective` and `SiSelectSimpleOptionsDirective`.
- Refactored filtering in `SiSelectOptionsStrategyBase`:
  - Added an abstract `allRows` to represent all options.
  - Converted `rows` from a writable signal to a computed signal derived from `allRows` and an internal `filterValue`.
  - `onFilter` now updates the internal `filterValue` instead of mutating `rows`.
- Added a test verifying the current filter is applied when options are updated.

### Impact

Visible rows now preserve the active filter when new options are provided, avoiding unnecessary re-filtering or reset and ensuring consistent filter state across updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->