### PR TITLE
build(CODEOWNERS): always make `@siemens/siemens-element-owners` an owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,47 +8,47 @@
 # review when someone opens a pull request.
 * @siemens/siemens-element-owners
 
-projects/charts-ng/* @akashsonune @dr-itz
-api-goldens/charts-ng/* @akashsonune @dr-itz
-projects/native-charts-ng/* @akashsonune @dr-itz
-api-goldens/native-charts-ng/* @akashsonune @dr-itz
-src/app/examples/si-charts/* @akashsonune @dr-itz
+projects/charts-ng/* @siemens/siemens-element-owners @akashsonune @dr-itz
+api-goldens/charts-ng/* @siemens/siemens-element-owners @akashsonune @dr-itz
+projects/native-charts-ng/* @siemens/siemens-element-owners @akashsonune @dr-itz
+api-goldens/native-charts-ng/* @siemens/siemens-element-owners @akashsonune @dr-itz
+src/app/examples/si-charts/* @siemens/siemens-element-owners @akashsonune @dr-itz
 
-projects/maps-ng/* @dr-itz @spliffone
-api-goldens/maps-ng/* @dr-itz @spliffone
-src/app/examples/si-map/* @dr-itz @spliffone
+projects/maps-ng/* @siemens/siemens-element-owners @dr-itz @spliffone
+api-goldens/maps-ng/* @siemens/siemens-element-owners @dr-itz @spliffone
+src/app/examples/si-map/* @siemens/siemens-element-owners @dr-itz @spliffone
 
-projects/dashboards-ng/* @chintankavathia
-api-goldens/dashboards-ng/* @chintankavathia
-projects/dashboards-demo/* @chintankavathia
+projects/dashboards-ng/* @siemens/siemens-element-owners @chintankavathia
+api-goldens/dashboards-ng/* @siemens/siemens-element-owners @chintankavathia
+projects/dashboards-demo/* @siemens/siemens-element-owners @chintankavathia
 
-projects/live-preview/* @dr-itz @chintankavathia
-api-goldens/live-preview/* @dr-itz @chintankavathia
+projects/live-preview/* @siemens/siemens-element-owners @dr-itz @chintankavathia
+api-goldens/live-preview/* @siemens/siemens-element-owners @dr-itz @chintankavathia
 
-projects/element-theme/* @dr-itz
+projects/element-theme/* @siemens/siemens-element-owners @dr-itz
 
-projects/element-docs-builder/* @Killusions @spliffone
+projects/element-docs-builder/* @siemens/siemens-element-owners @Killusions @spliffone
 
-projects/element-ng/filtered-search/* @chintankavathia @spliffone
-api-goldens/element-ng/filtered-search/* @chintankavathia @spliffone
-projects/element-ng/data-range-filter/* @dr-itz @spliffone
-api-goldens/element-ng/data-range-filter/* @dr-itz @spliffone
-projects/element-ng/datepicker/* @dr-itz @spliffone
-api-goldens/element-ng/datepicker/* @dr-itz @spliffone
-projects/element-ng/schematics/* @mistrykaran91
-projects/element-ng/landing-page/* @dauriamarco
-api-goldens/element-ng/landing-page/* @dauriamarco
-projects/element-ng/ip-input/* @spliffone
-api-goldens/element-ng/ip-input/* @spliffone
-projects/element-ng/formly/* @chintankavathia
-api-goldens/element-ng/formly/* @chintankavathia
-projects/element-ng/threshold/* @dr-itz
-api-goldens/element-ng/threshold/* @dr-itz
-projects/element-ng/tour/* @dr-itz
-api-goldens/element-ng/tour/* @dr-itz
+projects/element-ng/filtered-search/* @siemens/siemens-element-owners @chintankavathia @spliffone
+api-goldens/element-ng/filtered-search/* @siemens/siemens-element-owners @chintankavathia @spliffone
+projects/element-ng/data-range-filter/* @siemens/siemens-element-owners @dr-itz @spliffone
+api-goldens/element-ng/data-range-filter/* @siemens/siemens-element-owners @dr-itz @spliffone
+projects/element-ng/datepicker/* @siemens/siemens-element-owners @dr-itz @spliffone
+api-goldens/element-ng/datepicker/* @siemens/siemens-element-owners @dr-itz @spliffone
+projects/element-ng/schematics/* @siemens/siemens-element-owners @mistrykaran91
+projects/element-ng/landing-page/* @siemens/siemens-element-owners @dauriamarco
+api-goldens/element-ng/landing-page/* @siemens/siemens-element-owners @dauriamarco
+projects/element-ng/ip-input/* @siemens/siemens-element-owners @spliffone
+api-goldens/element-ng/ip-input/* @siemens/siemens-element-owners @spliffone
+projects/element-ng/formly/* @siemens/siemens-element-owners @chintankavathia
+api-goldens/element-ng/formly/* @siemens/siemens-element-owners @chintankavathia
+projects/element-ng/threshold/* @siemens/siemens-element-owners @dr-itz
+api-goldens/element-ng/threshold/* @siemens/siemens-element-owners @dr-itz
+projects/element-ng/tour/* @siemens/siemens-element-owners @dr-itz
+api-goldens/element-ng/tour/* @siemens/siemens-element-owners @dr-itz
 
-playwright/* @siemens/siemens-element-members
-docs/* @siemens/siemens-element-members
-src/* @siemens/siemens-element-members
+playwright/* @siemens/siemens-element-owners @siemens/siemens-element-members
+docs/* @siemens/siemens-element-owners @siemens/siemens-element-members
+src/* @siemens/siemens-element-owners @siemens/siemens-element-members
 
-tools/semantic-release/* @ljanner
+tools/semantic-release/* @siemens/siemens-element-owners @ljanner


### PR DESCRIPTION
Always adding `@siemens/siemens-element-owners` should do the trick.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates the CODEOWNERS file to always include the @siemens/siemens-element-owners team for many paths (charts-ng, native-charts-ng, maps-ng, dashboards, dashboards-demo, live-preview, element-theme, element-docs-builder, element-ng subpaths, top-level src, docs, playwright/docs, etc.). Existing individual maintainers are kept alongside the team to standardize and broaden ownership while preserving prior responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->