### PR TITLE
feat(schematics): property to signal migration

### DIFF
--- a/projects/element-ng/schematics/migrations/data/component-names.ts
+++ b/projects/element-ng/schematics/migrations/data/component-names.ts
@@ -6,6 +6,7 @@ export interface ComponentNamesInstruction {
   module: RegExp;
   toModule?: string;
   symbolRenamings: { replace: string; replaceWith: string }[];
+  propertyAccessOnly?: boolean;
 }
 
 export const COMPONENT_NAMES_MIGRATION: ComponentNamesInstruction[] = [
@@ -85,5 +86,19 @@ export const COMPONENT_NAMES_MIGRATION: ComponentNamesInstruction[] = [
       { replace: 'SiPopoverNextModule', replaceWith: 'SiPopoverModule' }
     ],
     toModule: '@siemens/element-ng/popover'
+  },
+
+  // Resize observer property to signal replacements
+  {
+    module: /@(siemens|simpl)\/element-ng(\/resize-observer)?/,
+    propertyAccessOnly: true,
+    symbolRenamings: [
+      { replace: 'isXs', replaceWith: 'xs()' },
+      { replace: 'isSm', replaceWith: 'sm()' },
+      { replace: 'isMd', replaceWith: 'md()' },
+      { replace: 'isLg', replaceWith: 'lg()' },
+      { replace: 'isXl', replaceWith: 'xl()' },
+      { replace: 'isXxl', replaceWith: 'xxl()' }
+    ]
   }
 ];

--- a/projects/element-ng/schematics/migrations/element-migration/element-migration.spec.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/element-migration.spec.ts
@@ -130,4 +130,8 @@ describe('to legacy migration', () => {
   it('should remove the deprecated api from module based accordion', async () => {
     await checkTemplateMigration(['module-based.accordion-inline-template.ts']);
   });
+
+  it('should replace deprecated properties with signals for SiResponsiveContainerDirective', async () => {
+    await checkTemplateMigration(['resize-observer-property-access.ts']);
+  });
 });

--- a/projects/element-ng/schematics/migrations/element-migration/files/expected.resize-observer-property-access.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/expected.resize-observer-property-access.ts
@@ -1,0 +1,31 @@
+import { Component, viewChild } from '@angular/core';
+import { SiResponsiveContainerDirective } from '@siemens/element-ng/resize-observer';
+
+@Component({
+  selector: 'si-test',
+  template: `<div siResponsiveContainer></div>`
+})
+export class TestComponent {
+  private readonly container = viewChild.required(SiResponsiveContainerDirective);
+
+  checkSize(): void {
+    if (this.container()?.xs()) {
+      console.log('Extra small');
+    }
+    if (this.container()?.sm()) {
+      console.log('Small');
+    }
+    if (this.container()?.md()) {
+      console.log('Medium');
+    }
+    if (this.container()?.lg()) {
+      console.log('Large');
+    }
+    if (this.container()?.xl()) {
+      console.log('Extra large');
+    }
+    if (this.container()?.xxl()) {
+      console.log('Extra extra large');
+    }
+  }
+}

--- a/projects/element-ng/schematics/migrations/element-migration/files/resize-observer-property-access.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/resize-observer-property-access.ts
@@ -1,0 +1,31 @@
+import { Component, viewChild } from '@angular/core';
+import { SiResponsiveContainerDirective } from '@siemens/element-ng/resize-observer';
+
+@Component({
+  selector: 'si-test',
+  template: `<div siResponsiveContainer></div>`
+})
+export class TestComponent {
+  private readonly container = viewChild.required(SiResponsiveContainerDirective);
+
+  checkSize(): void {
+    if (this.container()?.isXs) {
+      console.log('Extra small');
+    }
+    if (this.container()?.isSm) {
+      console.log('Small');
+    }
+    if (this.container()?.isMd) {
+      console.log('Medium');
+    }
+    if (this.container()?.isLg) {
+      console.log('Large');
+    }
+    if (this.container()?.isXl) {
+      console.log('Extra large');
+    }
+    if (this.container()?.isXxl) {
+      console.log('Extra extra large');
+    }
+  }
+}


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Property to Signal Migration Schematic

This PR introduces a migration schematic that automatically converts deprecated property access patterns on the `SiResponsiveContainerDirective` to function call equivalents.

### Key Changes

1. **Extended Migration Configuration**: Added `propertyAccessOnly` flag to `ComponentNamesInstruction` interface to enable property-to-signal transformations.

2. **New Resize-Observer Migration**: Configured a new migration that maps the deprecated responsive properties (`isXs`, `isSm`, `isMd`, `isLg`, `isXl`, `isXxl`) to their corresponding signal functions (`xs()`, `sm()`, `md()`, `lg()`, `xl()`, `xxl()`) for the `@siemens/element-ng/resize-observer` module.

3. **Enhanced Property Access Handling**: Updated `ts-utils.ts` to intelligently handle property access expression replacement, replacing property names within property access chains and standalone identifiers separately.

4. **Test Coverage**: Added test case with input and expected output files demonstrating the migration transforming property access calls to signal function calls on the `SiResponsiveContainerDirective`.

### Impact
Developers using the Element-NG library will be able to automatically migrate their components to use the new signal-based API for responsive breakpoint checks, replacing manual property access with function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->