### PR TITLE
fix(typeahead): treat `space` as normal search text in multi select

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
@@ -1102,7 +1102,7 @@ describe('SiFilteredSearchComponent', () => {
       await criteriaValue?.focus();
       await criteriaValue?.sendKeys('Z');
       await tick();
-      await criteriaValue?.sendKeys(' ');
+      await criteriaValue?.sendKeys(TestKey.ENTER);
 
       expect(component.filteredSearch().searchCriteria()).toEqual({
         criteria: [jasmine.objectContaining({ name: 'location', value: ['Munich'] })],
@@ -1132,7 +1132,7 @@ describe('SiFilteredSearchComponent', () => {
       await criteriaValue?.clearText();
       await criteriaValue?.sendKeys('K');
       await tick();
-      await criteriaValue?.sendKeys(' ');
+      await criteriaValue?.sendKeys(TestKey.ENTER);
       expect(component.searchCriteria()).toEqual({
         criteria: [
           jasmine.objectContaining({ name: 'location', value: ['Munich', 'Zug', 'Karlsruhe'] })

--- a/projects/element-ng/typeahead/si-typeahead.directive.ts
+++ b/projects/element-ng/typeahead/si-typeahead.directive.ts
@@ -277,7 +277,6 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
   private overlay = inject(Overlay);
   private elementRef = inject<ElementRef<HTMLInputElement>>(ElementRef);
   private injector = inject(Injector);
-  private autoComplete = inject<SiAutocompleteDirective<TypeaheadMatch>>(SiAutocompleteDirective);
 
   private $typeahead = new ReplaySubject<TypeaheadArray>(1);
   private componentRef?: ComponentRef<SiTypeaheadComponent>;
@@ -432,20 +431,6 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
     if (this.typeaheadCloseOnEsc()) {
       this.clearTimer();
       this.canBeOpen.set(false);
-    }
-  }
-
-  @HostListener('keydown.space', ['$event'])
-  protected onKeydownSpace(event: Event): void {
-    if (this.typeaheadMultiSelect()) {
-      // Avoid space character to be inserted into the input field
-      event.preventDefault();
-      const value = this.autoComplete.active?.value();
-      if (value) {
-        this.selectMatch(value);
-        // this forces change detection in the typeahead component.
-        this.selectionCounter.update(v => v + 1);
-      }
     }
   }
 


### PR DESCRIPTION
NOTE: The typeahead multi selection which is also used in the `filtered-search` no longer selects values when pressing `space`.
Instead `space` is treated as a normal search value.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR modifies the typeahead component to treat the space key as normal search text rather than a selection trigger in multi-select mode.

### Changes

- **si-typeahead.directive.ts**: Removed the space key (`keydown.space`) HostListener that was preventing default behavior and selecting the active match. Space input is now handled as regular search text.

- **si-filtered-search.component.spec.ts**: Updated tests to use the Enter key instead of space for confirming selections, aligning with the new behavior.

### Effect

Users can now include spaces in their search queries without accidentally selecting items. Selection now requires explicitly using the Enter key or other designated confirmation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->