### PR TITLE
fix(tree-view): use hasAnyChildren from parent to determine inline padding

### DIFF
--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
@@ -97,7 +97,6 @@ export class SiTreeViewItemComponent
   });
 
   protected readonly stickyEndItems = this.treeViewComponent.horizontalScrolling;
-  private displayFolderState = this.treeViewComponent.hasAnyChildren;
 
   protected icons = this.treeViewComponent.computedIcons;
 
@@ -211,7 +210,7 @@ export class SiTreeViewItemComponent
 
   protected get showFolderStateStart(): boolean {
     return (
-      this.displayFolderState &&
+      this.treeViewComponent.hasAnyChildren &&
       this.treeViewComponent.folderStateStart() &&
       !this.treeViewComponent.flatTree() &&
       (!!this.isGroupedItem || !this.siTreeViewService.groupedList)
@@ -219,7 +218,7 @@ export class SiTreeViewItemComponent
   }
 
   protected get showFolderStateEnd(): boolean {
-    return this.displayFolderState && !this.showFolderStateStart;
+    return this.treeViewComponent.hasAnyChildren && !this.showFolderStateStart;
   }
 
   protected get isExpanding(): boolean {


### PR DESCRIPTION
caching `hasAnyChildren` in variable during initialization doesn't always sync with parent and causes unexpected padding calculation when tree items are filtered and added again.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Removed the cached displayFolderState and replaced it with direct checks of this.treeViewComponent.hasAnyChildren. The getters showFolderStateStart and showFolderStateEnd now read the parent's hasAnyChildren dynamically so inline padding reflects the current parent state (fixes incorrect padding when items are filtered and re-added).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->