### PR TITLE
chore(dashboards-demo): incorrect signal binding

### DIFF
--- a/projects/dashboards-demo/src/app/components/widget-catalog/custom-widget-catalog.component.html
+++ b/projects/dashboards-demo/src/app/components/widget-catalog/custom-widget-catalog.component.html
@@ -28,7 +28,7 @@
   <button type="button" class="btn btn-secondary" (click)="onCancel()">{{
     'DASHBOARD.WIDGET_LIBRARY.CANCEL' | translate
   }}</button>
-  <button type="button" class="btn btn-primary" [disabled]="!selected" (click)="onAddWidget()">{{
+  <button type="button" class="btn btn-primary" [disabled]="!selected()" (click)="onAddWidget()">{{
     'DASHBOARD.WIDGET_LIBRARY.ADD' | translate
   }}</button>
 </div>


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixes an incorrect signal binding in the custom widget catalog component (projects/dashboards-demo/src/app/components/widget-catalog/custom-widget-catalog.component.html). Changes the Add button's disabled binding from `!selected` to `!selected()`, properly invoking the signal getter to evaluate the selected value instead of negating the signal object itself.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->