### PR TITLE
fix(dashboards-ng): drop ngx-translate peerDependency

### DIFF
--- a/projects/dashboards-ng/package.json
+++ b/projects/dashboards-ng/package.json
@@ -20,7 +20,6 @@
   "peerDependencies": {
     "@angular/common": "20 - 21",
     "@angular/core": "20 - 21",
-    "@ngx-translate/core": "15 - 16",
     "@siemens/element-ng": "48.9.0",
     "@siemens/element-theme": "48.9.0",
     "gridstack": "^12.3.3"


### PR DESCRIPTION

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Removes the `@ngx-translate/core` peer dependency from the dashboards-ng package.json (previously specified as range "15 - 16"), reducing external package requirements for the library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->