### PR TITLE
refactor(ag-grid): simplify dateOfJoining generation logic

### DIFF
--- a/src/app/mocks/table-data.mock.ts
+++ b/src/app/mocks/table-data.mock.ts
@@ -49,10 +49,8 @@ export class TableDataService {
   }
 
   private getDateOfJoining(index: number): Date {
-    // Generate dates within the last 10 years
-    const currentDate = new Date();
     const daysAgo = (index * 37) % (365 * 10); // Spread dates across 10 years
-    const joiningDate = new Date(currentDate);
+    const joiningDate = new Date('2026-01-05');
     joiningDate.setDate(joiningDate.getDate() - daysAgo);
     return joiningDate;
   }


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Refactors getDateOfJoining() in src/app/mocks/table-data.mock.ts to anchor date generation to a fixed date (new Date('2026-01-05')) and subtract a computed daysAgo offset ((index * 37) % (365 * 10)). This replaces the previous sliding/current-date-based approach; distribution logic (daysAgo calculation) and public signatures remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->