### PR TITLE
fix(filtered-search): omit daterange specific properties from datepickerConfig

### DIFF
--- a/api-goldens/element-ng/filtered-search/index.api.md
+++ b/api-goldens/element-ng/filtered-search/index.api.md
@@ -15,7 +15,7 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public
 export interface CriterionDefinition {
-    datepickerConfig?: DatepickerInputConfig;
+    datepickerConfig?: Omit<DatepickerInputConfig, 'enableDateRange' | 'enableTwoMonthDateRange'>;
     label?: TranslatableString;
     multiSelect?: boolean;
     name: string;

--- a/projects/element-ng/filtered-search/si-filtered-search.model.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.model.ts
@@ -58,7 +58,7 @@ export interface CriterionDefinition {
   /**
    * Optional configuration object for the datepicker.
    */
-  datepickerConfig?: DatepickerInputConfig;
+  datepickerConfig?: Omit<DatepickerInputConfig, 'enableDateRange' | 'enableTwoMonthDateRange'>;
   /**
    * Limit criterion options to the predefined ones.
    */


### PR DESCRIPTION
`enableDateRange` and `enableTwoMonthDateRange` have no effect when passed in `datepickerConfig` with filtered-search criterion.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1260/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1260/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1260/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1260/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1260/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1260/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1260/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1260/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1260/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1260/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

