### PR TITLE
refactor(date-range-filter): use signal `model` for value input

### DIFF
--- a/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
@@ -20,10 +20,9 @@ const ONE_DAY = ONE_MINUTE * 60 * 24;
   imports: [SiRelativeDateComponent],
   template: `<si-relative-date
     [enableTimeSelection]="enableTimeSelection"
-    [value]="value()"
     [unitLabel]="unitLabel"
     [valueLabel]="valueLabel"
-    (valueChange)="value.set($event)"
+    [(value)]="value"
   /> `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })


### PR DESCRIPTION
Use a `model` signal for the `value` input.
Remove the redundant `internalValue` signal.

This is a linter finding in a newer version.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Refactors SiRelativeDateComponent to use a signal-based model for value handling and updates tests.

Changes:
- Replaces the public `value` input with `readonly value = model(0)` (signal).
- Removes `valueChange` output and the `internalValue` signal.
- Simplifies ngOnChanges to trigger calculateOffset on value changes.
- calculateOffset, updateValue, and changeUnit now read/write `value()` directly (no output emissions).
- Tests updated to use two-way binding [(value)]="value" with a host signal.

Motivation: addresses linter findings for signal-based patterns; contributor confirms compliance with contribution guidelines.

Known issue: reviewers reported a visual-regression where displayed range doesn't match the selected "after" value when switching modes; PR #1262 was referenced but did not resolve it — reviewer expects the issue to be fixed once that follow-up is merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->