### PR TITLE
refactor(avatar): replace NgClass by modern class syntax

### DIFF
--- a/projects/element-ng/avatar/si-avatar.component.html
+++ b/projects/element-ng/avatar/si-avatar.component.html
@@ -14,7 +14,7 @@
 @let iconConfig = statusIcon();
 @if (iconConfig) {
   <span class="indicator-size indicator icon-stack">
-    <si-icon class="drop-shadow" [ngClass]="iconConfig.color" [icon]="iconConfig.icon" />
-    <si-icon [ngClass]="iconConfig.stackedColor" [icon]="iconConfig.stacked" />
+    <si-icon [class]="`drop-shadow ${iconConfig.color}`" [icon]="iconConfig.icon" />
+    <si-icon [class]="iconConfig.stackedColor" [icon]="iconConfig.stacked" />
   </span>
 }

--- a/projects/element-ng/avatar/si-avatar.component.ts
+++ b/projects/element-ng/avatar/si-avatar.component.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { NgClass } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -22,7 +21,7 @@ export type AvatarSize = 'tiny' | 'xsmall' | 'small' | 'regular' | 'large' | 'xl
 
 @Component({
   selector: 'si-avatar',
-  imports: [NgClass, SiIconComponent],
+  imports: [SiIconComponent],
   templateUrl: './si-avatar.component.html',
   styleUrl: './si-avatar.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Refactor the avatar component to replace Angular's NgClass with the project's modern class binding syntax: two si-icon bindings in the template were changed from [ngClass] to [class] (one to `[class]="\`drop-shadow ${iconConfig.color}\`"` and the other to `[class]="iconConfig.stackedColor"`), and the NgClass import/usage was removed from the component decorator (imports now only include SiIconComponent). No public API or component logic changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->