### PR TITLE
refactor(circle-status): replace NgClass by modern class syntax

### DIFF
--- a/projects/element-ng/circle-status/si-circle-status.component.html
+++ b/projects/element-ng/circle-status/si-circle-status.component.html
@@ -7,11 +7,10 @@
 >
   <div
     #bg
-    class="bg"
+    [class]="`bg ${backgroundClass()}`"
     [class.pulse]="blinkOn()"
     [class.deprecated-color]="!status()"
     [class.contrast-fix]="contrastFix()"
-    [ngClass]="backgroundClass()"
     [style.background-color]="color()"
   ></div>
   @if (!status()) {
@@ -20,12 +19,8 @@
   @let iconConfig = statusIcon();
   @if (iconConfig) {
     <span class="status-icon icon-stack indicator">
-      <si-icon class="status-icon" [ngClass]="iconConfig.color" [icon]="iconConfig.icon" />
-      <si-icon
-        class="status-icon"
-        [ngClass]="iconConfig.stackedColor"
-        [icon]="iconConfig.stacked"
-      />
+      <si-icon [class]="`status-icon ${iconConfig.color}`" [icon]="iconConfig.icon" />
+      <si-icon [class]="`status-icon ${iconConfig.stackedColor}`" [icon]="iconConfig.stacked" />
     </span>
   }
   @let eventIconValue = eventIcon();

--- a/projects/element-ng/circle-status/si-circle-status.component.ts
+++ b/projects/element-ng/circle-status/si-circle-status.component.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { NgClass } from '@angular/common';
 import {
   booleanAttribute,
   ChangeDetectionStrategy,
@@ -29,7 +28,7 @@ import { Observable, Subscription } from 'rxjs';
 
 @Component({
   selector: 'si-circle-status',
-  imports: [NgClass, SiIconComponent, SiTranslatePipe],
+  imports: [SiIconComponent, SiTranslatePipe],
   templateUrl: './si-circle-status.component.html',
   styleUrl: './si-circle-status.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Refactor: Replace NgClass with modern class syntax in circle-status component

Modernizes the circle-status component by replacing Angular's NgClass directive with direct [class] binding using template literals.

Changes:
- Template: Replaced `[ngClass]` usages with `[class]` template-literal bindings (e.g., `[class]="\`bg ${backgroundClass()}\`"`, `[class]="\`status-icon ${iconConfig.color}\`"`).
- Component: Removed NgClass from the component's imports array (imports now [SiIconComponent, SiTranslatePipe]).

Behavior is unchanged; this is a syntactic refactor to use modern Angular class binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->