### PR TITLE
refactor(file-uploader): replace NgClass by modern class syntax

### DIFF
--- a/projects/element-ng/file-uploader/si-file-uploader.component.html
+++ b/projects/element-ng/file-uploader/si-file-uploader.component.html
@@ -1,6 +1,6 @@
 <si-file-dropzone
   #dropZone
-  [ngClass]="autoUpload() ? 'mb-8' : 'mb-4'"
+  [class]="autoUpload() ? 'mb-8' : 'mb-4'"
   [uploadTextFileSelect]="uploadTextFileSelect()"
   [uploadDropText]="uploadDropText()"
   [multiple]="maxFiles() > 1"
@@ -20,11 +20,7 @@
 
 <div class="file-list">
   @for (file of files; track file) {
-    <div
-      class="file d-flex"
-      [ngClass]="autoUpload() ? 'mb-8' : 'mb-4'"
-      [class.fade-out]="file.fadeOut"
-    >
+    <div [class]="`file d-flex ${autoUpload() ? 'mb-8' : 'mb-4'}`" [class.fade-out]="file.fadeOut">
       <si-icon class="icon align-self-center ms-6 me-4" [icon]="icons.elementDocument" />
       <div class="flex-fill overflow-hidden">
         <div class="file-info">

--- a/projects/element-ng/file-uploader/si-file-uploader.component.ts
+++ b/projects/element-ng/file-uploader/si-file-uploader.component.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { NgClass } from '@angular/common';
 import {
   HttpClient,
   HttpErrorResponse,
@@ -89,7 +88,6 @@ interface ExtUploadFile extends UploadFile {
 @Component({
   selector: 'si-file-uploader',
   imports: [
-    NgClass,
     SiStatusIconComponent,
     SiFileDropzoneComponent,
     SiIconComponent,


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Refactor: Replace NgClass with modern class binding syntax

Modernizes the file-uploader component by replacing Angular's NgClass directive with the contemporary `[class]` binding syntax.

**Changes:**
- **Template**: Replaces `[ngClass]` with a dynamic `[class]` binding that constructs the same class string, preserving all conditional styling (including flex layout and margin utilities)
- **Component**: Removes the unused NgClass import from @angular/common

**Impact**: No functional changes; purely a syntax modernization with reduced code lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->