### PR TITLE
refactor(status-bar): replace NgClass by modern class syntax

### DIFF
--- a/projects/element-ng/status-bar/si-status-bar.component.html
+++ b/projects/element-ng/status-bar/si-status-bar.component.html
@@ -6,12 +6,12 @@
 <div
   #thebar
   aria-busy="true"
+  [class]="responsiveMode ? `responsive-${responsiveMode}` : ''"
   [class.responsive]="responsiveMode"
   [class.expanded]="expanded()"
   [class.compact]="responsiveMode || compact()"
   [class.pulse-off]="blinkOnOff() === false"
   [class.pulse-on]="blinkOnOff()"
-  [ngClass]="responsiveMode ? 'responsive-' + responsiveMode : ''"
 >
   <div
     class="status-bar-wrapper rounded-2"

--- a/projects/element-ng/status-bar/si-status-bar.component.ts
+++ b/projects/element-ng/status-bar/si-status-bar.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 /* eslint-disable @angular-eslint/no-conflicting-lifecycle */
-import { NgClass, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
   ChangeDetectionStrategy,
@@ -63,7 +63,6 @@ let idCounter = 1;
 @Component({
   selector: 'si-status-bar',
   imports: [
-    NgClass,
     NgTemplateOutlet,
     SiIconComponent,
     SiStatusBarItemComponent,


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Refactor: Replace NgClass with modern class syntax in status-bar component

Replaced Angular's [ngClass] usage with modern [class] binding in the status-bar template. The template now uses [class]="responsiveMode ? `responsive-${responsiveMode}` : ''" on the #thebar element while retaining the existing per-class bindings ([class.responsive], [class.expanded], [class.compact], [class.pulse-off], [class.pulse-on], etc.). Removed NgClass from the component's TypeScript imports and from the component's imports array.

Changes:
- si-status-bar.component.html: switched [ngClass] → [class] for responsive-mode class (no behavior change) (+1/-1)
- si-status-bar.component.ts: removed NgClass from imports (+1/-2)

No functional or public API changes; purely syntactic modernization of class bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->