### PR TITLE
refactor(status-counter): replace NgClass by modern class syntax

### DIFF
--- a/projects/element-ng/status-counter/si-status-counter.component.html
+++ b/projects/element-ng/status-counter/si-status-counter.component.html
@@ -1,14 +1,14 @@
 @let iconValue = icon();
 <span class="icon icon-stack">
   <si-icon
-    [ngClass]="isDisabledOrCountZero() ? undefined : color()"
+    [class]="isDisabledOrCountZero() ? undefined : color()"
     [class.inactive]="isDisabledOrCountZero()"
     [icon]="iconValue"
   />
   @let stackedValue = stackedIcon();
   @if (stackedValue) {
     <si-icon
-      [ngClass]="isDisabledOrCountZero() ? 'inactive-contrast' : color() + '-contrast'"
+      [class]="isDisabledOrCountZero() ? 'inactive-contrast' : `${color()}-contrast`"
       [icon]="stackedValue"
     />
   }

--- a/projects/element-ng/status-counter/si-status-counter.component.ts
+++ b/projects/element-ng/status-counter/si-status-counter.component.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { NgClass } from '@angular/common';
 import {
   booleanAttribute,
   ChangeDetectionStrategy,
@@ -15,7 +14,7 @@ import { SiIconComponent } from '@siemens/element-ng/icon';
 
 @Component({
   selector: 'si-status-counter, si-icon-status',
-  imports: [NgClass, SiIconComponent],
+  imports: [SiIconComponent],
   templateUrl: './si-status-counter.component.html',
   styleUrl: './si-status-counter.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Refactor Status Counter Component - Replace NgClass with Modern Class Syntax

This PR refactors the `si-status-counter` component to replace Angular's `NgClass` directive with the modern `[class]` binding syntax.

**Changes:**
- **Template**: Replaced `[ngClass]` bindings with `[class]` bindings on two `si-icon` elements, maintaining the same conditional logic for applying color and contrast classes
- **Component**: Removed the unused `NgClass` import from `@angular/common` and removed it from the component's imports array

**Impact**: Modernizes the component's class binding approach with no behavioral changes. The conditional class expressions function identically to the previous implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->