### PR TITLE
refactor(summary-chip): replace NgClass by modern class syntax

### DIFF
--- a/projects/element-ng/summary-chip/si-summary-chip.component.html
+++ b/projects/element-ng/summary-chip/si-summary-chip.component.html
@@ -12,9 +12,9 @@
   @let actualIcon = statusIcon();
   @if (actualIcon.icon) {
     <span class="icon icon-stack my-n2 ms-n2">
-      <si-icon [ngClass]="actualIcon.color" [icon]="actualIcon.icon" />
+      <si-icon [class]="actualIcon.color" [icon]="actualIcon.icon" />
       @if (actualIcon.stacked) {
-        <si-icon [ngClass]="actualIcon.stackedColor" [icon]="actualIcon.stacked" />
+        <si-icon [class]="actualIcon.stackedColor" [icon]="actualIcon.stacked" />
       }
     </span>
   }

--- a/projects/element-ng/summary-chip/si-summary-chip.component.ts
+++ b/projects/element-ng/summary-chip/si-summary-chip.component.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { NgClass } from '@angular/common';
 import {
   booleanAttribute,
   ChangeDetectionStrategy,
@@ -18,7 +17,7 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
 
 @Component({
   selector: 'si-summary-chip',
-  imports: [NgClass, SiIconComponent, SiTranslatePipe],
+  imports: [SiIconComponent, SiTranslatePipe],
   templateUrl: './si-summary-chip.component.html',
   styleUrl: './si-summary-chip.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Refactors the summary-chip component to replace Angular's `[ngClass]` directive with the modern `[class]` binding syntax. 

### Changes
- **Template**: Replaced `[ngClass]="actualIcon.color"` and `[ngClass]="actualIcon.stackedColor"` with `[class]` bindings on two si-icon elements
- **Component**: Removed the unused `NgClass` import from the standalone component's imports

### Impact
No functional changes. The component behavior remains identical; only the CSS class binding syntax has been modernized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->