### PR TITLE
refactor(toast-notification): replace NgClass by modern class syntax

### DIFF
--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.html
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.html
@@ -9,7 +9,7 @@
       [style.--toast-timer-duration.s]="toastTimeoutInSeconds()"
     ></div>
   }
-  <div class="bar" [ngClass]="statusColor()"></div>
+  <div [class]="`bar ${statusColor()}`"></div>
   <si-status-icon class="icon" [status]="status()" />
 
   <div class="toast-content px-4">

--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { NgClass } from '@angular/common';
 import { Component, computed, HostListener, inject, input, output, signal } from '@angular/core';
 import {
   addIcons,
@@ -18,7 +17,7 @@ import { SI_TOAST_AUTO_HIDE_DELAY, SiToast } from '../si-toast.model';
 
 @Component({
   selector: 'si-toast-notification',
-  imports: [NgClass, SiLinkModule, SiIconComponent, SiStatusIconComponent, SiTranslatePipe],
+  imports: [SiLinkModule, SiIconComponent, SiStatusIconComponent, SiTranslatePipe],
   templateUrl: './si-toast-notification.component.html',
   styleUrl: './si-toast-notification.component.scss'
 })


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Refactors the toast-notification component to replace the NgClass directive with modern class binding syntax.

### Changes

- **Template**: Replaced `[ngClass]="statusColor()"` with `[class]="\`bar ${statusColor()}\`"` to combine the base "bar" class with dynamic status color using template literals
- **Component**: Removed the unused NgClass import from both the top-level imports and the component decorator's imports array

The refactoring maintains the same functionality while adopting more modern Angular binding patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->