### PR TITLE
refactor(tree-view): replace HostListener by host event binding

### DIFF
--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
@@ -13,7 +13,6 @@ import {
   DoCheck,
   ElementRef,
   HostBinding,
-  HostListener,
   inject,
   OnDestroy,
   OnInit,
@@ -66,7 +65,9 @@ import {
     '[class.si-tree-ellipsis]': 'treeViewComponent.horizontalScrolling()',
     '[class.si-tree-view-top-level-item]':
       '!treeViewComponent.compactMode() && (treeViewComponent.flatTree() || (treeItem.level ?? 0) < 1)',
-    '[attr.aria-haspopup]': 'isContextMenuButtonVisible()'
+    '[attr.aria-haspopup]': 'isContextMenuButtonVisible()',
+    '(contextmenu)': 'onContextMenu($event)',
+    '(keydown)': 'onKeydown($event)'
   }
 })
 export class SiTreeViewItemComponent
@@ -417,12 +418,11 @@ export class SiTreeViewItemComponent
     return templateDirective ? templateDirective.template : this.templates()![0].template;
   }
 
-  @HostListener('contextmenu', ['$event']) protected onContextMenu(event: Event): boolean {
+  protected onContextMenu(event: Event): boolean {
     this.handleContextMenuEvent(event);
     return false;
   }
 
-  @HostListener('keydown', ['$event'])
   protected onKeydown(event: KeyboardEvent): void {
     const rtlCorrectedKey = correctKeyRTL(event.key);
     if (rtlCorrectedKey === 'Enter') {

--- a/projects/element-ng/tree-view/si-tree-view.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.ts
@@ -19,7 +19,6 @@ import {
   contentChild,
   contentChildren,
   ElementRef,
-  HostListener,
   inject,
   INJECTOR,
   input,
@@ -118,7 +117,14 @@ const rootDefaults: TreeItem = {
     SiTreeViewItemHeightService,
     SiTreeViewService,
     SiTreeViewVirtualizationService
-  ]
+  ],
+  host: {
+    '(document:keyup.shift)': 'onKeyUpShift()',
+    '(document:keyup.control)': 'onKeyUpCtrl()',
+    '(document:keyup.meta)': 'onKeyUpMeta()',
+    '(document:mouseleave)': 'onMouseLeave()',
+    '(keydown)': 'handleKeydown($event)'
+  }
 })
 export class SiTreeViewComponent
   implements OnInit, OnChanges, OnDestroy, AfterViewInit, AfterViewChecked
@@ -901,7 +907,6 @@ export class SiTreeViewComponent
     }
   }
 
-  @HostListener('document:keyup.shift')
   protected onKeyUpShift(): void {
     if (this._multiSelectionActive) {
       this._multiSelectionActive = false;
@@ -909,7 +914,6 @@ export class SiTreeViewComponent
     }
   }
 
-  @HostListener('document:keyup.control')
   protected onKeyUpCtrl(): void {
     if (this._multiSelectionActive) {
       this._multiSelectionActive = false;
@@ -917,7 +921,6 @@ export class SiTreeViewComponent
     }
   }
 
-  @HostListener('document:keyup.meta')
   protected onKeyUpMeta(): void {
     if (this._multiSelectionActive) {
       this._multiSelectionActive = false;
@@ -925,7 +928,6 @@ export class SiTreeViewComponent
     }
   }
 
-  @HostListener('document:mouseleave')
   protected onMouseLeave(): void {
     if (this._multiSelectionActive) {
       this._multiSelectionActive = false;
@@ -933,7 +935,6 @@ export class SiTreeViewComponent
     }
   }
 
-  @HostListener('keydown', ['$event'])
   protected handleKeydown(event: KeyboardEvent): void {
     this.keyManager.onKeydown(event);
   }


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Refactor tree-view component event handling

Replace `@HostListener` decorators with host event bindings in the component decorator metadata for both tree-view components.

Changes:
- **si-tree-view-item.component.ts**: Moves `contextmenu` and `keydown` listeners from method decorators to host binding configuration.
- **si-tree-view.component.ts**: Consolidates multiple per-method `@HostListener` decorators into a single host binding map for `document:keyup.shift`, `document:keyup.control`, `document:keyup.meta`, `document:mouseleave`, and `keydown`.

Impact: Internal refactor only—no functional behavior or public API changes. Event handlers remain and are invoked via host bindings instead of decorators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->