### PR TITLE
refactor(toast-notification): use native CSS animations

### DIFF
--- a/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.html
+++ b/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.html
@@ -1,9 +1,9 @@
 @for (toast of toasts() | async; track toast) {
   <si-toast-notification
-    @toastTrigger
     class="position-relative"
+    animate.enter="toast-enter"
+    animate.leave="toast-leave"
     [toast]="toast"
-    [@.disabled]="animationsDisabled"
     (paused)="paused.emit(toast)"
     (resumed)="resumed.emit(toast)"
   />

--- a/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.scss
+++ b/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.scss
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+
+$toast-timing: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+
+/* Workaround for cdk-overlay not supporting the order of overlays */
+::ng-deep .cdk-global-overlay-wrapper:has(si-toast-notification-drawer) {
+  z-index: 2000;
+}
+
+si-toast-notification {
+  inset-inline-end: 0;
+}
+
+.toast-enter {
+  transition-property: opacity, transform;
+  transition-duration: 500ms;
+  transition-timing-function: $toast-timing;
+  opacity: 1;
+  transform: translateY(0);
+
+  @starting-style {
+    opacity: 0;
+    transform: translateY(100%);
+  }
+}
+
+.toast-leave {
+  transition-property: opacity, transform;
+  transition-duration: 300ms;
+  transition-timing-function: $toast-timing;
+  opacity: 0;
+  transform: translateX(100%);
+}
+
+/* Disable animations when animations are disabled (accessibility) */
+:host.animations-disabled si-toast-notification {
+  transition: none;
+
+  &.toast-enter,
+  &.toast-leave {
+    transition: none;
+  }
+}

--- a/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Observable, Subject } from 'rxjs';
 
 import { SiToast } from '../si-toast.model';
@@ -26,7 +25,7 @@ describe('SiToastNotificationDrawerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, TestHostComponent],
+      imports: [TestHostComponent],
       providers: [provideZonelessChangeDetection()]
     }).compileComponents();
   });

--- a/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { animate, style, transition, trigger } from '@angular/animations';
 import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { areAnimationsDisabled } from '@siemens/element-ng/common';
@@ -15,31 +14,12 @@ import { SiToast } from '../si-toast.model';
   selector: 'si-toast-notification-drawer',
   imports: [AsyncPipe, SiToastNotificationComponent],
   templateUrl: './si-toast-notification-drawer.component.html',
-  // workaround for cdk-overlay not supporting the order of overlays
-  styles: `
-    ::ng-deep .cdk-global-overlay-wrapper:has(si-toast-notification-drawer) {
-      z-index: 2000;
-    }
-  `,
+  styleUrl: './si-toast-notification-drawer.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    'aria-live': 'polite'
-  },
-  animations: [
-    trigger('toastTrigger', [
-      transition(':enter', [
-        style({ opacity: 0, transform: 'translateY(100%)' }),
-        animate(
-          '500ms cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-          style({ opacity: 1, transform: 'translateY(0%)' })
-        )
-      ]),
-      transition(':leave', [
-        style({ 'opacity': 1, 'inset-inline-end': '0%' }),
-        animate('300ms', style({ 'opacity': 0, 'inset-inline-end': '-100%' }))
-      ])
-    ])
-  ]
+    'aria-live': 'polite',
+    '[class.animations-disabled]': 'animationsDisabled'
+  }
 })
 export class SiToastNotificationDrawerComponent {
   readonly toasts = input<Observable<SiToast[]>>();


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Refactors the `si-toast-notification-drawer` component to use native CSS transitions/animations instead of Angular's animation system.

### Key Changes

- **Template**: Removed Angular animation trigger and disable bindings (removed @toastTrigger and [@.disabled]) and added animation bindings animate.enter="toast-enter" and animate.leave="toast-leave".
- **Component Logic**:
  - Removed Angular animation imports/configuration.
  - Replaced inline CDK overlay style with a referenced SCSS file.
  - Added protected `animationsDisabled = areAnimationsDisabled()` and bound `[class.animations-disabled]` to gate CSS animations.
- **Styling**:
  - New SCSS file with transition-based enter/leave rules (500ms enter: fade-in + slide-up; 300ms leave: fade-out + slide-out) using a cubic-bezier timing function.
  - CDK overlay z-index workaround (::ng-deep .cdk-global-overlay-wrapper:has(...){ z-index:2000 }).
  - Disables transitions when host has `animations-disabled` by setting `transition: none`.
- **Tests**:
  - Removed NoopAnimationsModule from tests.
  - Added a provider using `provideAppInitializer` to set `--element-animations-enabled` (disables animations) during tests.

### Notes

Moves animation control to CSS while preserving accessibility by honoring the global animations-disabled setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->