### PR TITLE
refactor(side-panel): use native CSS animations

### DIFF
--- a/projects/element-ng/side-panel/si-side-panel.component.html
+++ b/projects/element-ng/side-panel/si-side-panel.component.html
@@ -1,9 +1,5 @@
 @if (showBackdrop()) {
-  <div
-    class="modal-backdrop"
-    [@backdrop]="showBackdrop() ? 'show' : 'hide'"
-    (click)="toggleSidePanel()"
-  ></div>
+  <div class="modal-backdrop" animate.leave="backdrop-leave" (click)="toggleSidePanel()"></div>
 }
 <div #sidePanel class="side-panel focus-none" tabindex="-1">
   <div class="inner" [class.d-none]="showTempContent()">

--- a/projects/element-ng/side-panel/si-side-panel.component.scss
+++ b/projects/element-ng/side-panel/si-side-panel.component.scss
@@ -7,8 +7,8 @@ $rpanel-width-extended-xl: 640px;
 $rpanel-width-extended-xxl: 720px;
 $rpanel-width-extended-xxxl: 912px;
 $rpanel-transition-duration: all-variables.$element-default-transition-duration;
-$rpanel-overlay-bg: rgba(0, 0, 0, 0.4);
 $rpanel-collapsed-width: 48px;
+$transition: opacity 0.15s linear;
 
 :host {
   --rpanel-collapsed-padding: 0;
@@ -28,8 +28,18 @@ $rpanel-collapsed-width: 48px;
   }
 
   .modal-backdrop {
+    opacity: 1;
+    transition: $transition;
     z-index: all-variables.$zindex-sidepanel;
-    opacity: 0;
+
+    @starting-style {
+      opacity: 0;
+    }
+
+    &.backdrop-leave {
+      opacity: 0;
+      transition: $transition;
+    }
   }
 
   .side-panel,

--- a/projects/element-ng/side-panel/si-side-panel.component.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel.component.spec.ts
@@ -12,7 +12,6 @@ import {
   viewChild
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { Subject } from 'rxjs';
 
 import { ElementDimensions, ResizeObserverService } from '../resize-observer';
@@ -66,8 +65,7 @@ describe('SiSidePanelComponent', () => {
           provide: ResizeObserverService,
           useValue: resizeSpy
         },
-        provideZonelessChangeDetection(),
-        provideNoopAnimations()
+        provideZonelessChangeDetection()
       ]
     }).compileComponents();
   });

--- a/projects/element-ng/side-panel/si-side-panel.component.ts
+++ b/projects/element-ng/side-panel/si-side-panel.component.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { animate, state, style, transition, trigger } from '@angular/animations';
 import { CdkPortalOutlet, Portal, PortalModule } from '@angular/cdk/portal';
 import { isPlatformBrowser } from '@angular/common';
 import {
@@ -66,14 +65,7 @@ import { SidePanelMode, SidePanelSize } from './side-panel.model';
     '[class.rpanel-resize-xl]': 'isXl()',
     '[class.rpanel-resize-xxl]': 'isXxl()',
     '[class.rpanel-resize-xxxl]': 'isXxxl()'
-  },
-  animations: [
-    trigger('backdrop', [
-      state('show', style({ 'opacity': '1' })),
-      state('hide', style({ 'opacity': '0' })),
-      transition('* <=> *', [animate('0.15s linear')])
-    ])
-  ]
+  }
 })
 export class SiSidePanelComponent implements OnInit, OnDestroy, OnChanges {
   /**


### PR DESCRIPTION
> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Refactor side-panel to use native CSS animations

This PR replaces Angular animations with native CSS animations for the side-panel backdrop.

Changes:
- HTML: Removed Angular animation binding [@backdrop]; template now renders a static backdrop element using an animate.leave="backdrop-leave" alias while retaining showBackdrop() gating and (click)="toggleSidePanel()".
- SCSS: Reworked backdrop styles — default visible state, added backdrop-enter keyframes (0→1 opacity) and a backdrop-leave transition to fade opacity to 0 over 0.15s, replacing the previous Angular-driven opacity rules.
- TypeScript: Removed Angular animations imports and the animations metadata (backdrop trigger) from the component decorator.
- Tests: Removed provideNoopAnimations import/usage; tests keep provideZonelessChangeDetection().

Effect: Simplifies animation handling by moving from Angular's animation system to CSS-based enter/leave animations while preserving backdrop visibility logic and click behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->