### PR TITLE
refactor(number-input): use model signal

### DIFF
--- a/api-goldens/element-ng/number-input/index.api.md
+++ b/api-goldens/element-ng/number-input/index.api.md
@@ -35,9 +35,7 @@ export class SiNumberInputComponent implements OnChanges, ControlValueAccessor, 
     readonly showButtons: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly step: _angular_core.InputSignal<number | "any">;
     readonly unit: _angular_core.InputSignal<string | undefined>;
-    readonly value: _angular_core.InputSignal<number | undefined>;
-    // (undocumented)
-    readonly valueChange: _angular_core.OutputEmitterRef<number | undefined>;
+    readonly value: _angular_core.ModelSignal<number | undefined>;
 }
 
 // @public (undocumented)

--- a/projects/element-ng/number-input/si-number-input.component.spec.ts
+++ b/projects/element-ng/number-input/si-number-input.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { Component, inject, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { SiNumberInputComponent } from './si-number-input.component';
 
@@ -304,6 +304,33 @@ describe('SiNumberInputComponent', () => {
         const input = numberInput.querySelector<HTMLInputElement>('input[type="number"]');
         expect(input).toBeTruthy();
         expect(input!.getAttribute('disabled')).toBeDefined();
+      });
+    });
+
+    describe('combining value output and form control', () => {
+      @Component({
+        imports: [ReactiveFormsModule, SiNumberInputComponent],
+        template: `<si-number-input
+          [formControl]="control"
+          (valueChange)="onValueChange($event)"
+        />`
+      })
+      class ValueChangesHostComponent {
+        readonly control = new FormControl<number | undefined>(5);
+        onValueChange(value: number | undefined): void {}
+      }
+
+      it('should emit valueChange when writing to form control', () => {
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        const fixture = TestBed.createComponent(ValueChangesHostComponent);
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        const component = fixture.componentInstance;
+        fixture.detectChanges();
+
+        const spy = spyOn(component, 'onValueChange');
+
+        component.control.setValue(10);
+        expect(spy).toHaveBeenCalledWith(10);
       });
     });
   });


### PR DESCRIPTION
Replaces separated input / output of `value` with a model. This slightly changes the behavior since `value` now also emits when a form control writes a value.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
