### PR TITLE
refactor(charts): remove deprecated method

### DIFF
--- a/api-goldens/charts-ng/common/index.api.md
+++ b/api-goldens/charts-ng/common/index.api.md
@@ -262,8 +262,6 @@ export class SiChartBaseComponent implements AfterViewInit, OnChanges, OnInit, O
     readonly pointer: _angular_core.OutputEmitterRef<AxisPointerEvent>;
     refreshSeries(isLive?: boolean, dzToSet?: DataZoomRange): void;
     readonly renderer: _angular_core.InputSignal<"canvas" | "svg">;
-    // @deprecated
-    resetChart(): void;
     resize(): void;
     readonly selectedItem: _angular_core.InputSignal<SelectedLegendItem>;
     readonly selectionChanged: _angular_core.OutputEmitterRef<any>;

--- a/api-goldens/charts-ng/common/index.api.md
+++ b/api-goldens/charts-ng/common/index.api.md
@@ -258,8 +258,6 @@ export class SiChartBaseComponent implements AfterViewInit, OnChanges, OnInit, O
     readonly pointer: _angular_core.OutputEmitterRef<AxisPointerEvent>;
     refreshSeries(isLive?: boolean, dzToSet?: DataZoomRange): void;
     readonly renderer: _angular_core.InputSignal<"canvas" | "svg">;
-    // @deprecated
-    resetChart(): void;
     resize(): void;
     readonly selectedItem: _angular_core.InputSignal<SelectedLegendItem>;
     readonly selectionChanged: _angular_core.OutputEmitterRef<any>;

--- a/projects/charts-ng/common/si-chart-base.component.ts
+++ b/projects/charts-ng/common/si-chart-base.component.ts
@@ -386,8 +386,7 @@ export class SiChartBaseComponent implements AfterViewInit, OnChanges, OnInit, O
       this.actualOptions.color = changes.options.previousValue.color;
     }
     if (changes.theme || changes.renderer) {
-      // need to completely redo the chart for the theme change to take effect
-      return this.resetChart();
+      return this.themeSwitch();
     }
 
     let updates = 0;
@@ -609,32 +608,6 @@ export class SiChartBaseComponent implements AfterViewInit, OnChanges, OnInit, O
       this.extZoomSliderChart.setTheme(this.activeTheme);
       this.extZoomSliderChart.setOption(this.extZoomSliderOptions);
     }
-    this.cdRef.markForCheck();
-  }
-
-  /**
-   * Re-render the whole chart.
-   * @deprecated The method is deprecated and should not be used directly by the consumer.
-   */
-  resetChart(): void {
-    this.applyTheme();
-
-    if (!this.actualOptions) {
-      // this can happen if the SiThemeService fires the theme switch when the chart is not
-      // yet completely initialized
-      return;
-    }
-
-    this.disposeChart();
-    this.applyPalette();
-    const addOpts = this.additionalOptions();
-    if (addOpts?.palette) {
-      echarts.util.merge(this.actualOptions.palette, addOpts.palette, true);
-    }
-    this.themeChanged();
-    this.applyStyles();
-    this.applyTitles();
-    this.ngAfterViewInit(true); // eslint-disable-line @angular-eslint/no-lifecycle-call
     this.cdRef.markForCheck();
   }
 

--- a/projects/charts-ng/common/si-chart-base.component.ts
+++ b/projects/charts-ng/common/si-chart-base.component.ts
@@ -390,8 +390,7 @@ export class SiChartBaseComponent implements AfterViewInit, OnChanges, OnInit, O
       this.actualOptions.color = changes.options.previousValue.color;
     }
     if (changes.theme || changes.renderer) {
-      // need to completely redo the chart for the theme change to take effect
-      return this.resetChart();
+      return this.themeSwitch();
     }
 
     let updates = 0;
@@ -612,32 +611,6 @@ export class SiChartBaseComponent implements AfterViewInit, OnChanges, OnInit, O
       this.extZoomSliderChart.setTheme(this.activeTheme);
       this.extZoomSliderChart.setOption(this.extZoomSliderOptions);
     }
-    this.cdRef.markForCheck();
-  }
-
-  /**
-   * Re-render the whole chart.
-   * @deprecated The method is deprecated and should not be used directly by the consumer.
-   */
-  resetChart(): void {
-    this.applyTheme();
-
-    if (!this.actualOptions) {
-      // this can happen if the SiThemeService fires the theme switch when the chart is not
-      // yet completely initialized
-      return;
-    }
-
-    this.disposeChart();
-    this.applyPalette();
-    const addOpts = this.additionalOptions();
-    if (addOpts?.palette) {
-      echarts.util.merge(this.actualOptions.palette, addOpts.palette, true);
-    }
-    this.themeChanged();
-    this.applyStyles();
-    this.applyTitles();
-    this.ngAfterViewInit(true); // eslint-disable-line @angular-eslint/no-lifecycle-call
     this.cdRef.markForCheck();
   }
 


### PR DESCRIPTION
BREAKING CHANGE: Removed deprecated `SiChartBaseComponent.resetChart` method as it should not be directly used by the consumer.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1313/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1313/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1313/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1313/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1313/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1313/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1313/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1313/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1313/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1313/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

