### PR TITLE
build(release): update next release

### DIFF
--- a/.github/workflows/next-release.yaml
+++ b/.github/workflows/next-release.yaml
@@ -2,11 +2,6 @@ name: Next Release
 on:
   workflow_dispatch:
 
-# This must only be called from the next branch.
-# While one may think that calling from main should work, it does not.
-# The reason is only known to gh actions.
-# It seems like git objects are not fetched when calling from main, leading to semantic release not being able to resolve branch names.
-
 jobs:
   # This ensures that the next branch is update to date with main.
   update-next:
@@ -22,41 +17,21 @@ jobs:
           git merge origin/main --ff-only --quiet
           git push origin next
 
-  build-and-test:
+  trigger-release:
     needs:
       - update-next
-    uses: ./.github/workflows/build-and-test.yaml
-    secrets:
-      SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
-      SIEMENS_NPM_USER: ${{ secrets.SIEMENS_NPM_USER }}
-      MAPTILER_KEY: ${{ secrets.MAPTILER_KEY }}
-
-  publish:
     runs-on: ubuntu-24.04
-    needs:
-      - build-and-test
-    permissions:
-      id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - name: Dispatch release workflow on updated next
+        uses: actions/github-script@v7
         with:
-          ref: next # IMPORTANT! We ignore the actual branch. Enforcing the next branch for next releases.
-          fetch-depth: 0 # semantic-release needs this
-          token: ${{ secrets.ELEMENT_BOT_GITHUB_TOKEN }} # Otherwise, branch protection rules are not bypassed.
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/krypton
-          cache: 'npm'
-      - uses: actions/download-artifact@v7
-        with:
-          name: dist
-          path: dist
-      - run: npm ci --prefer-offline --no-audit
-      - run: npx semantic-release
-        env:
-          SKIP_COMMIT: 'true' # Next releases should not have a commit
-          GIT_AUTHOR_NAME: 'Siemens Element Bot'
-          GIT_AUTHOR_EMAIL: 'simpl.si@siemens.com'
-          GIT_COMMITTER_NAME: 'Siemens Element Bot'
-          GIT_COMMITTER_EMAIL: 'simpl.si@siemens.com'
-          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_GITHUB_TOKEN }}
+          # We must use the rest actions.
+          # Otherwise, the workflow will not run on the updated ref.
+          github-token: ${{ secrets.ELEMENT_BOT_GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yaml',
+              ref: 'next',
+            });

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,7 @@ jobs:
       - run: npm ci --prefer-offline --no-audit
       - run: npx semantic-release
         env:
+          SKIP_COMMIT: ${{ github.ref_name == 'next' && 'true' || '' }}
           GIT_AUTHOR_NAME: 'Siemens Element Bot'
           GIT_AUTHOR_EMAIL: 'simpl.si@siemens.com'
           GIT_COMMITTER_NAME: 'Siemens Element Bot'


### PR DESCRIPTION
We can no longer use a dedicated `next-release.yaml` workflow file to actually run the release.

Instead, we must run the `release.yaml` as this is the only file authorized at npm.

This change brings also a quality of live improvement, it now updates the next branch correctly automatically and then triggers a release.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
