### PR TITLE
chore: remove provideZonelessChangeDetection

### DIFF
--- a/projects/charts-ng/cartesian/si-chart-cartesian.component.spec.ts
+++ b/projects/charts-ng/cartesian/si-chart-cartesian.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  SimpleChange,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, SimpleChange, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ChartXAxis, ChartYAxis, EChartOption } from '@siemens/charts-ng/common';
 
@@ -42,13 +36,6 @@ class TestHostComponent {
   subTitle?: string;
 }
 describe('SiChartBarLineComponent', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
-
   const getOption = (component: SiChartCartesianComponent): any =>
     component.chart.getOption() as any;
 

--- a/projects/charts-ng/circle/si-chart-circle.component.spec.ts
+++ b/projects/charts-ng/circle/si-chart-circle.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, SimpleChange, viewChild } from '@angular/core';
+import { Component, SimpleChange, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiChartCircleComponent } from './si-chart-circle.component';
@@ -28,13 +28,6 @@ class TestHostComponent {
   subTitle?: string;
 }
 describe('SiChartCircleComponent', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
-
   const getOption = (component: SiChartCircleComponent): any => component.chart.getOption() as any;
 
   const createChartWithTestData = async (showLegend = false): Promise<any> => {

--- a/projects/charts-ng/common/si-chart-base.component.spec.ts
+++ b/projects/charts-ng/common/si-chart-base.component.spec.ts
@@ -2,12 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { echarts, EChartOption } from '@siemens/charts-ng/common';
 
@@ -25,13 +20,6 @@ class TestHostComponent {
 describe('SiChartBase', () => {
   let component: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/charts-ng/custom-legend/si-custom-legend.component.spec.ts
+++ b/projects/charts-ng/custom-legend/si-custom-legend.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiCustomLegendComponent } from './si-custom-legend.component';
@@ -29,13 +29,6 @@ describe('SiCustomLegendComponent', () => {
   let component: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
   let element: HTMLElement;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/charts-ng/gauge/si-chart-gauge.component.spec.ts
+++ b/projects/charts-ng/gauge/si-chart-gauge.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  SimpleChange,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, SimpleChange, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiChartGaugeComponent } from './si-chart-gauge.component';
@@ -35,13 +29,6 @@ class TestHostComponent {
 }
 
 describe('SiChartGaugeComponent', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
-
   const getOption = (component: SiChartGaugeComponent): any => component.chart.getOption() as any;
 
   const createChartWithTestData = (): any => {

--- a/projects/charts-ng/loading-spinner/si-chart-loading-spinner.component.spec.ts
+++ b/projects/charts-ng/loading-spinner/si-chart-loading-spinner.component.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiChartLoadingSpinnerComponent as TestComponent } from './si-chart-loading-spinner.component';
@@ -10,13 +9,6 @@ import { SiChartLoadingSpinnerComponent as TestComponent } from './si-chart-load
 describe('SiLoadingSpinnerComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let component: TestComponent;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/charts-ng/progress-bar/si-chart-progress-bar.component.spec.ts
+++ b/projects/charts-ng/progress-bar/si-chart-progress-bar.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  SimpleChange,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, SimpleChange, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiChartProgressBarComponent } from './si-chart-progress-bar.component';
@@ -35,13 +29,6 @@ class TestHostComponent {
   labelPosition?: string;
 }
 describe('SiChartProgressBarComponent', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
-
   const getOption = (component: TestHostComponent): any =>
     component.chartProgressBarComponent().chart.getOption() as any;
 

--- a/projects/charts-ng/progress/si-chart-progress.component.spec.ts
+++ b/projects/charts-ng/progress/si-chart-progress.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  SimpleChange,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, SimpleChange, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiChartProgressComponent } from './si-chart-progress.component';
@@ -33,13 +27,6 @@ class TestHostComponent {
   subTitle?: string;
 }
 describe('SiChartProgressComponent', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
-
   const getOption = (component: TestHostComponent): any =>
     component.chartProgressComponent().chart.getOption() as any;
 

--- a/projects/charts-ng/sankey/si-chart-sankey.component.spec.ts
+++ b/projects/charts-ng/sankey/si-chart-sankey.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, SimpleChange, viewChild } from '@angular/core';
+import { Component, SimpleChange, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { SankeySeriesOption } from '@siemens/charts-ng/common';
 
@@ -26,13 +26,6 @@ class TestHostComponent {
   subTitle?: string;
 }
 describe('SiChartSankeyComponent', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
-
   const getOption = (component: SiChartSankeyComponent): any => component.chart.getOption() as any;
 
   const createChartWithTestData = async (): Promise<any> => {

--- a/projects/charts-ng/sunburst/si-chart-sunburst.component.spec.ts
+++ b/projects/charts-ng/sunburst/si-chart-sunburst.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, SimpleChange, viewChild } from '@angular/core';
+import { Component, SimpleChange, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { SunburstSeriesOption } from '@siemens/charts-ng/common';
 
@@ -27,13 +27,6 @@ class TestHostComponent {
 }
 
 describe('SiChartSunburstComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
-
   const getOption = (component: SiChartSunburstComponent): any =>
     component.chart.getOption() as any;
 

--- a/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.spec.ts
+++ b/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SiTranslateModule } from '@siemens/element-translate-ng/translate';
@@ -15,8 +14,7 @@ describe('SiDashboardToolbarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiTranslateModule, SiDashboardToolbarComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiTranslateModule, SiDashboardToolbarComponent]
     }).compileComponents();
   });
 

--- a/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.spec.ts
+++ b/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.spec.ts
@@ -11,7 +11,6 @@ import {
   OnInit,
   output,
   OutputEmitterRef,
-  provideZonelessChangeDetection,
   SimpleChange,
   Type
 } from '@angular/core';
@@ -118,8 +117,7 @@ describe('SiFlexibleDashboardComponent', () => {
       await TestBed.configureTestingModule({
         providers: [
           { provide: SI_WIDGET_STORE, useClass: TestWidgetStorage },
-          { provide: SI_DASHBOARD_CONFIGURATION, useValue: {} },
-          provideZonelessChangeDetection()
+          { provide: SI_DASHBOARD_CONFIGURATION, useValue: {} }
         ],
         imports: [SiFlexibleDashboardComponent],
         schemas: [NO_ERRORS_SCHEMA]

--- a/projects/dashboards-ng/src/components/grid/si-grid.component.spec.ts
+++ b/projects/dashboards-ng/src/components/grid/si-grid.component.spec.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  Component,
-  OnInit,
-  output,
-  OutputEmitterRef,
-  provideZonelessChangeDetection,
-  SimpleChange
-} from '@angular/core';
+import { Component, OnInit, output, OutputEmitterRef, SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SiActionDialogService } from '@siemens/element-ng/action-modal';
@@ -58,7 +51,6 @@ describe('SiGridComponent', () => {
       providers: [
         { provide: SiWidgetStorage, useClass: SiDefaultWidgetStorage },
         { provide: SI_DASHBOARD_CONFIGURATION, useValue: {} },
-        provideZonelessChangeDetection(),
         SiActionDialogService
       ]
     })
@@ -251,8 +243,7 @@ describe('SiGridComponent with custom id resolver', () => {
           }
         },
         { provide: SI_DASHBOARD_CONFIGURATION, useValue: {} },
-        SiActionDialogService,
-        provideZonelessChangeDetection()
+        SiActionDialogService
       ]
     })
       .overrideComponent(SiGridComponent, {

--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SiActionDialogService } from '@siemens/element-ng/action-modal';
@@ -37,7 +37,7 @@ describe('SiGridstackWrapperComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [HostComponent],
-      providers: [SiActionDialogService, SiGridService, provideZonelessChangeDetection()]
+      providers: [SiActionDialogService, SiGridService]
     }).compileComponents();
     gridService = TestBed.inject(SiGridService);
     gridService.widgetCatalog.set([]);

--- a/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper.component.spec.ts
+++ b/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   DeleteConfirmationDialogResult,
@@ -30,8 +30,7 @@ describe('SiWidgetHostComponent', () => {
       imports: [SiWebComponentWrapperComponent],
       providers: [
         { provide: SiActionDialogService, useClass: SiActionDialogMockService },
-        SiGridService,
-        provideZonelessChangeDetection()
+        SiGridService
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ModalRef } from '@siemens/element-ng/modal';
@@ -25,7 +25,7 @@ describe('SiWidgetCatalogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestingModule, SiWidgetCatalogComponent],
-      providers: [{ provide: ModalRef, useValue: new ModalRef() }, provideZonelessChangeDetection()]
+      providers: [{ provide: ModalRef, useValue: new ModalRef() }]
     }).compileComponents();
   });
 

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CommonModule } from '@angular/common';
-import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
 import {
@@ -47,8 +47,7 @@ describe('SiWidgetHostComponent', () => {
           imports: [BrowserModule, CommonModule, TestingModule, SiWidgetHostComponent],
           providers: [
             { provide: SiActionDialogService, useClass: SiActionDialogMockService },
-            SiGridService,
-            provideZonelessChangeDetection()
+            SiGridService
           ],
           schemas: [NO_ERRORS_SCHEMA]
         }).compileComponents();

--- a/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ModalRef } from '@siemens/element-ng/modal';
@@ -25,7 +25,7 @@ describe('SiWidgetInstanceEditorDialogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestingModule, SiWidgetInstanceEditorDialogComponent],
-      providers: [{ provide: ModalRef, useValue: new ModalRef() }, provideZonelessChangeDetection()]
+      providers: [{ provide: ModalRef, useValue: new ModalRef() }]
     }).compileComponents();
   });
 

--- a/projects/dashboards-ng/src/model/si-widget-storage.spec.ts
+++ b/projects/dashboards-ng/src/model/si-widget-storage.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiDefaultWidgetStorage } from './si-widget-storage';
@@ -12,7 +11,7 @@ describe('SiDefaultWidgetStorage', () => {
 
   beforeEach(() => {
     widgetStorage = TestBed.configureTestingModule({
-      providers: [SiDefaultWidgetStorage, provideZonelessChangeDetection()]
+      providers: [SiDefaultWidgetStorage]
     }).inject(SiDefaultWidgetStorage);
   });
 

--- a/projects/dashboards-ng/src/services/si-grid.service.spec.ts
+++ b/projects/dashboards-ng/src/services/si-grid.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiGridService } from './si-grid.service';
@@ -12,7 +11,7 @@ describe('SiGridService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [SiGridService, provideZonelessChangeDetection()]
+      providers: [SiGridService]
     });
     service = TestBed.inject(SiGridService);
   });

--- a/projects/element-ng/about/si-about.component.spec.ts
+++ b/projects/element-ng/about/si-about.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { Link } from '@siemens/element-ng/link';
@@ -62,12 +62,7 @@ describe('SiAboutComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [
-        provideHttpClient(),
-        provideNoopAnimations(),
-        provideHttpClientTesting(),
-        provideZonelessChangeDetection()
-      ]
+      providers: [provideHttpClient(), provideNoopAnimations(), provideHttpClientTesting()]
     })
   );
 

--- a/projects/element-ng/accordion/si-accordion.component.spec.ts
+++ b/projects/element-ng/accordion/si-accordion.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -38,8 +32,7 @@ describe('SiAccordion', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [NoopAnimationsModule, TestHostComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/accordion/si-collapsible-panel.component.spec.ts
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -38,8 +38,7 @@ describe('SiCollapsiblePanel', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SiCollapsiblePanelComponent, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [NoopAnimationsModule, SiCollapsiblePanelComponent, TestHostComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/action-modal/si-action-dialog.service.spec.ts
+++ b/projects/element-ng/action-modal/si-action-dialog.service.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ApplicationRef, provideZonelessChangeDetection } from '@angular/core';
+import { ApplicationRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Subject } from 'rxjs';
@@ -22,8 +22,7 @@ describe('SiActionDialogService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
-      providers: [provideZonelessChangeDetection()]
+      imports: [NoopAnimationsModule]
     }).compileComponents();
     service = TestBed.inject(SiActionDialogService);
     appRef = TestBed.inject(ApplicationRef);

--- a/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
 
@@ -17,7 +16,7 @@ describe('SiAlertDialogComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SiAlertDialogComponent],
-      providers: [ModalRef, provideZonelessChangeDetection()]
+      providers: [ModalRef]
     }).compileComponents();
     modalRef = TestBed.inject(ModalRef);
   });

--- a/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
 
@@ -17,7 +16,7 @@ describe('SiConfirmationDialogComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SiConfirmationDialogComponent],
-      providers: [ModalRef, provideZonelessChangeDetection()]
+      providers: [ModalRef]
     }).compileComponents();
     modalRef = TestBed.inject(ModalRef);
   });

--- a/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
 
@@ -17,7 +16,7 @@ describe('SiDeleteConfirmationDialogComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SiDeleteConfirmationDialogComponent],
-      providers: [ModalRef, provideZonelessChangeDetection()]
+      providers: [ModalRef]
     });
     modalRef = TestBed.inject(ModalRef);
   });

--- a/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.spec.ts
+++ b/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
 
@@ -17,7 +16,7 @@ describe('SiEditDiscardDialogComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SiEditDiscardDialogComponent],
-      providers: [ModalRef, provideZonelessChangeDetection()]
+      providers: [ModalRef]
     }).compileComponents();
     modalRef = TestBed.inject(ModalRef);
   });

--- a/projects/element-ng/application-header/launchpad/si-launchpad.spec.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiApplicationHeaderComponent } from '../si-application-header.component';
@@ -33,10 +33,7 @@ describe('SiLaunchpad', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [
-        { provide: SiApplicationHeaderComponent, useValue: {} },
-        provideZonelessChangeDetection()
-      ]
+      providers: [{ provide: SiApplicationHeaderComponent, useValue: {} }]
     }).compileComponents();
   });
 

--- a/projects/element-ng/application-header/si-application-header.component.spec.ts
+++ b/projects/element-ng/application-header/si-application-header.component.spec.ts
@@ -5,12 +5,7 @@
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Injectable,
-  provideZonelessChangeDetection
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injectable } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   SiHeaderDropdownComponent,
@@ -99,12 +94,6 @@ describe('SiApplicationHeaderComponent', () => {
     class TestHostComponent {}
 
     let fixture: ComponentFixture<TestHostComponent>;
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [provideZonelessChangeDetection()]
-      });
-    });
 
     beforeEach(async () => {
       fixture = TestBed.createComponent(TestHostComponent);
@@ -216,12 +205,6 @@ describe('SiApplicationHeaderComponent', () => {
     let component: TestHostComponent;
     let actionItem1Harness: SiHeaderItemHarness;
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [provideZonelessChangeDetection()]
-      });
-    });
-
     beforeEach(async () => {
       fixture = TestBed.createComponent(TestHostComponent);
       component = fixture.componentInstance;
@@ -304,10 +287,7 @@ describe('SiApplicationHeaderComponent', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        providers: [
-          { provide: BreakpointObserver, useExisting: BreakpointObserverMock },
-          provideZonelessChangeDetection()
-        ]
+        providers: [{ provide: BreakpointObserver, useExisting: BreakpointObserverMock }]
       });
     });
 
@@ -353,12 +333,6 @@ describe('SiApplicationHeaderComponent', () => {
       `
     })
     class TestHostComponent {}
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [provideZonelessChangeDetection()]
-      });
-    });
 
     beforeEach(async () => {
       const fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list.directive.spec.ts
+++ b/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, signal, viewChildren } from '@angular/core';
+import { Component, signal, viewChildren } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {
@@ -106,8 +106,7 @@ describe('SiAutoCollapsableListDirective', () => {
   beforeEach(async () => {
     mockResizeObserver();
     await TestBed.configureTestingModule({
-      imports: [SiAutoCollapsableListModule, TestComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiAutoCollapsableListModule, TestComponent]
     }).compileComponents();
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentInstance;

--- a/projects/element-ng/autocomplete/si-autocomplete.directive.spec.ts
+++ b/projects/element-ng/autocomplete/si-autocomplete.directive.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { DOWN_ARROW, ENTER, UP_ARROW } from '@angular/cdk/keycodes';
-import { Component, ErrorHandler, provideZonelessChangeDetection } from '@angular/core';
+import { Component, ErrorHandler } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -46,9 +46,6 @@ describe('SiAutocompleteDirective', () => {
   let fixture: ComponentFixture<TestHostComponent>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     fixture = TestBed.createComponent(TestHostComponent);
     testComponent = fixture.componentInstance;
   });

--- a/projects/element-ng/avatar/si-avatar.component.spec.ts
+++ b/projects/element-ng/avatar/si-avatar.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EntityStatusType } from '@siemens/element-ng/common';
 
@@ -38,8 +38,7 @@ describe('SiAvatarComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiAvatarComponent, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiAvatarComponent, TestHostComponent]
     }).compileComponents()
   );
 

--- a/projects/element-ng/breadcrumb-router/si-breadcrumb-default-resolver.service.spec.ts
+++ b/projects/element-ng/breadcrumb-router/si-breadcrumb-default-resolver.service.spec.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { provideZonelessChangeDetection } from '@angular/core';
 import { inject, TestBed } from '@angular/core/testing';
 import { UrlSegment } from '@angular/router';
 import { BreadcrumbItem } from '@siemens/element-ng/breadcrumb';
@@ -21,11 +20,7 @@ interface FakeActivatedRouteSnapshot {
 describe('BreadcrumbDefaultResolverService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        SiBreadcrumbDefaultResolverService,
-        provideHttpClientTesting(),
-        provideZonelessChangeDetection()
-      ]
+      providers: [SiBreadcrumbDefaultResolverService, provideHttpClientTesting()]
     });
   });
 

--- a/projects/element-ng/breadcrumb-router/si-breadcrumb-router.component.spec.ts
+++ b/projects/element-ng/breadcrumb-router/si-breadcrumb-router.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, ElementRef, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, ElementRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router, RouterModule, RouterOutlet, Routes } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
@@ -84,8 +84,7 @@ describe('SiBreadcrumbRouterComponent', () => {
         {
           provide: SI_BREADCRUMB_RESOLVER_SERVICE,
           useClass: SiBreadcrumbDefaultResolverService
-        },
-        provideZonelessChangeDetection()
+        }
       ]
     }).compileComponents();
   });

--- a/projects/element-ng/breadcrumb/si-breadcrumb.component.spec.ts
+++ b/projects/element-ng/breadcrumb/si-breadcrumb.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Router, RouterModule, Routes } from '@angular/router';
@@ -77,8 +77,7 @@ describe('SiBreadcrumbComponent', () => {
         SiTranslateNgxTModule,
         TranslateModule.forRoot(),
         WrapperComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
   });
 

--- a/projects/element-ng/card/si-action-card.spec.ts
+++ b/projects/element-ng/card/si-action-card.spec.ts
@@ -5,12 +5,7 @@
 
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  input,
-  provideZonelessChangeDetection
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 
@@ -44,9 +39,6 @@ describe('SiActionCardComponent', () => {
   let actionCardHarness: SiActionCardHarness;
 
   beforeEach(async () => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     fixture = TestBed.createComponent(WrapperComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
     actionCardHarness = await loader.getHarness(SiActionCardHarness);

--- a/projects/element-ng/card/si-card.component.spec.ts
+++ b/projects/element-ng/card/si-card.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
@@ -53,8 +53,7 @@ describe('SiCardComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [RouterModule, NoopAnimationsModule, WrapperComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [RouterModule, NoopAnimationsModule, WrapperComponent]
     })
   );
 

--- a/projects/element-ng/chat-messages/si-ai-message.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-ai-message.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By, DomSanitizer } from '@angular/platform-browser';
 import { getMarkdownRenderer } from '@siemens/element-ng/markdown-renderer';
@@ -14,12 +14,7 @@ describe('SiAiMessageComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let debugElement: DebugElement;
   let markdownRenderer: (text: string) => string | Node;
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-
+  beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);
     debugElement = fixture.debugElement;
     const sanitizer = TestBed.inject(DomSanitizer);

--- a/projects/element-ng/chat-messages/si-attachment-list.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-attachment-list.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement, provideZonelessChangeDetection, TemplateRef } from '@angular/core';
+import { DebugElement, TemplateRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SiModalService } from '@siemens/element-ng/modal';
@@ -21,10 +21,7 @@ describe('SiAttachmentListComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [TestComponent],
-      providers: [
-        { provide: SiModalService, useValue: modalServiceSpy },
-        provideZonelessChangeDetection()
-      ]
+      providers: [{ provide: SiModalService, useValue: modalServiceSpy }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/chat-messages/si-chat-container.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-chat-container.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement, Component, provideZonelessChangeDetection } from '@angular/core';
+import { DebugElement, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -27,12 +27,7 @@ describe('SiChatContainerComponent', () => {
   let debugElement: DebugElement;
   let component: SiChatContainerComponent;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [SiChatContainerComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-
+  beforeEach(() => {
     fixture = TestBed.createComponent(SiChatContainerComponent);
     debugElement = fixture.debugElement;
     component = fixture.componentInstance;

--- a/projects/element-ng/chat-messages/si-chat-input.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-chat-input.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
@@ -22,7 +22,7 @@ describe('SiChatInputComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestComponent],
-      providers: [provideNoopAnimations(), provideZonelessChangeDetection()]
+      providers: [provideNoopAnimations()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/chat-messages/si-chat-message.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-chat-message.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -13,11 +13,6 @@ describe('SiChatMessageComponent', () => {
   let debugElement: DebugElement;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-
     fixture = TestBed.createComponent(TestComponent);
     debugElement = fixture.debugElement;
   });

--- a/projects/element-ng/chat-messages/si-user-message.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-user-message.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By, DomSanitizer } from '@angular/platform-browser';
 import { getMarkdownRenderer } from '@siemens/element-ng/markdown-renderer';
@@ -16,12 +16,7 @@ describe('SiUserMessageComponent', () => {
   let debugElement: DebugElement;
   let markdownRenderer: (text: string) => string | Node;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-
+  beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);
     debugElement = fixture.debugElement;
     const sanitizer = TestBed.inject(DomSanitizer);

--- a/projects/element-ng/circle-status/si-circle-status.component.spec.ts
+++ b/projects/element-ng/circle-status/si-circle-status.component.spec.ts
@@ -2,12 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  ComponentRef,
-  provideZonelessChangeDetection,
-  SimpleChange
-} from '@angular/core';
+import { ChangeDetectionStrategy, ComponentRef, SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiCircleStatusComponent, SiCircleStatusComponent as TestComponent } from './index';
@@ -23,8 +18,7 @@ describe('SiCircleStatusComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [TestComponent]
     })
       // because of https://github.com/angular/angular/issues/12313
       .overrideComponent(SiCircleStatusComponent, {

--- a/projects/element-ng/color-picker/si-color-picker.component.spec.ts
+++ b/projects/element-ng/color-picker/si-color-picker.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ComponentRef,
-  provideZonelessChangeDetection,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ComponentRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -25,13 +19,6 @@ class FormHostComponent {
 }
 
 describe('SiColorPickerComponent', () => {
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent, FormHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents()
-  );
-
   describe('with direct usage', () => {
     let componentRef: ComponentRef<TestComponent>;
     let fixture: ComponentFixture<TestComponent>;

--- a/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.spec.ts
+++ b/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.spec.ts
@@ -2,11 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  ComponentRef,
-  provideZonelessChangeDetection
-} from '@angular/core';
+import { ChangeDetectionStrategy, ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalRef } from '@siemens/element-ng/modal';
 
@@ -76,7 +72,7 @@ describe('ColumnDialogComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [ModalRef, provideZonelessChangeDetection()]
+      providers: [ModalRef]
     })
       .overrideComponent(SiColumnSelectionDialogComponent, {
         set: { changeDetection: ChangeDetectionStrategy.Default }

--- a/projects/element-ng/column-selection-dialog/si-column-selection-dialog.service.spec.ts
+++ b/projects/element-ng/column-selection-dialog/si-column-selection-dialog.service.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ApplicationRef, provideZonelessChangeDetection } from '@angular/core';
+import { ApplicationRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiColumnSelectionDialogService } from './si-column-selection-dialog.service';
@@ -19,9 +19,6 @@ describe('SiColumnSelectionDialogService', () => {
   };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     service = TestBed.inject(SiColumnSelectionDialogService);
     appRef = TestBed.inject(ApplicationRef);
   });

--- a/projects/element-ng/common/services/blink.service.spec.ts
+++ b/projects/element-ng/common/services/blink.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { BlinkService } from './blink.service';
@@ -12,7 +11,7 @@ describe('BlinkService', () => {
 
   beforeEach(() => {
     jasmine.clock().install();
-    TestBed.configureTestingModule({ providers: [BlinkService, provideZonelessChangeDetection()] });
+    TestBed.configureTestingModule({ providers: [BlinkService] });
     service = TestBed.inject(BlinkService);
   });
 

--- a/projects/element-ng/common/services/si-uistate.service.spec.ts
+++ b/projects/element-ng/common/services/si-uistate.service.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Injectable, provideZonelessChangeDetection } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import {
@@ -30,10 +30,7 @@ describe('SiUIStateService', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        providers: [
-          provideSiUiState({ store: SynchronousMockStore }),
-          provideZonelessChangeDetection()
-        ]
+        providers: [provideSiUiState({ store: SynchronousMockStore })]
       }).compileComponents();
       service = TestBed.inject(SI_UI_STATE_SERVICE);
     });
@@ -61,10 +58,7 @@ describe('SiUIStateService', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        providers: [
-          provideSiUiState({ store: AsynchronousMockStore }),
-          provideZonelessChangeDetection()
-        ]
+        providers: [provideSiUiState({ store: AsynchronousMockStore })]
       }).compileComponents();
       service = TestBed.inject(SI_UI_STATE_SERVICE);
     });

--- a/projects/element-ng/common/services/text-measure.service.spec.ts
+++ b/projects/element-ng/common/services/text-measure.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { TextMeasureService as TestService } from './text-measure.service';
@@ -12,7 +11,7 @@ describe('TextMeasureService', () => {
   let div: HTMLElement | undefined;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({ providers: [TestService, provideZonelessChangeDetection()] });
+    TestBed.configureTestingModule({ providers: [TestService] });
     service = TestBed.inject(TestService);
   });
 

--- a/projects/element-ng/connection-strength/si-connection-strength.component.spec.ts
+++ b/projects/element-ng/connection-strength/si-connection-strength.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiConnectionStrengthComponent as TestComponent } from './index';
@@ -11,13 +11,6 @@ describe('SiConnectionStrengthComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let component: ComponentRef<TestComponent>;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/content-action-bar/si-content-action-bar.component.spec.ts
+++ b/projects/element-ng/content-action-bar/si-content-action-bar.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { booleanAttribute, Component, Input, provideZonelessChangeDetection } from '@angular/core';
+import { booleanAttribute, Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
@@ -45,7 +45,7 @@ describe('SiContentActionBarComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, TestComponent],
-      providers: [provideRouter([]), provideZonelessChangeDetection()]
+      providers: [provideRouter([])]
     }).compileComponents();
   });
 

--- a/projects/element-ng/copyright-notice/si-copyright-notice.component.spec.ts
+++ b/projects/element-ng/copyright-notice/si-copyright-notice.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CopyrightDetails, SI_COPYRIGHT_DETAILS } from '@siemens/element-ng/copyright-notice';
 
@@ -30,8 +30,7 @@ describe('SiCopyrightNoticeComponent', () => {
             startYear: 2012,
             lastUpdateYear: 2019
           }
-        },
-        provideZonelessChangeDetection()
+        }
       ]
     }).compileComponents();
 
@@ -82,11 +81,7 @@ describe('SiCopyrightNoticeComponentWithInput', () => {
   let fixture: ComponentFixture<WrapperWithInputComponent>;
   let element: HTMLElement;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-
+  beforeEach(() => {
     fixture = TestBed.createComponent(WrapperWithInputComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/projects/element-ng/dashboard/si-dashboard-card.component.spec.ts
+++ b/projects/element-ng/dashboard/si-dashboard-card.component.spec.ts
@@ -2,12 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
@@ -41,8 +36,7 @@ describe('SiDashboardCardComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [RouterModule, NoopAnimationsModule, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [RouterModule, NoopAnimationsModule, TestHostComponent]
     })
   );
 

--- a/projects/element-ng/dashboard/si-dashboard.component.spec.ts
+++ b/projects/element-ng/dashboard/si-dashboard.component.spec.ts
@@ -8,7 +8,6 @@ import {
   ChangeDetectorRef,
   Component,
   inject,
-  provideZonelessChangeDetection,
   signal,
   viewChild,
   viewChildren
@@ -82,8 +81,7 @@ describe('SiDashboardComponent', () => {
         {
           provide: ResizeObserverService,
           useValue: resizeSpy
-        },
-        provideZonelessChangeDetection()
+        }
       ]
     }).compileComponents();
   });

--- a/projects/element-ng/dashboard/si-dashboard.service.spec.ts
+++ b/projects/element-ng/dashboard/si-dashboard.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiDashboardCardComponent } from './si-dashboard-card.component';
@@ -13,7 +12,7 @@ describe('SiDashboardService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [{ provide: TestService }, provideZonelessChangeDetection()]
+      providers: [{ provide: TestService }]
     }).compileComponents();
     service = TestBed.inject(TestService);
   });

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
 import { TestScheduler } from 'rxjs/testing';
@@ -38,11 +38,6 @@ describe('SiListWidgetBodyComponent', () => {
   beforeEach(() => {
     testScheduler = new TestScheduler((actual, expected) => {
       expect(actual).toEqual(expected);
-    });
-
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
     });
   });
 

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-item.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiListWidgetItem, SiListWidgetItemComponent } from './si-list-widget-item.component';
@@ -20,13 +20,6 @@ describe('SiListWidgetItemComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let component: TestHostComponent;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
 import { TestScheduler } from 'rxjs/testing';
@@ -39,11 +39,6 @@ describe('SiListWidgetComponent', () => {
   beforeEach(() => {
     testScheduler = new TestScheduler((actual, expected) => {
       expect(actual).toEqual(expected);
-    });
-
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
     });
   });
 

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-body.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-body.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiTimelineWidgetBodyComponent } from './si-timeline-widget-body.component';
@@ -29,13 +29,6 @@ describe('SiTimelineWidgetBodyComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let component: TestHostComponent;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {
@@ -24,13 +24,6 @@ describe('SiTimelineWidgetItemComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let component: TestHostComponent;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiTimelineWidgetItem } from './si-timeline-widget-item.component';
@@ -29,13 +29,6 @@ describe('SiTimelineWidgetComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let component: TestHostComponent;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/dashboard/widgets/si-value-widget.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-value-widget.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ContentActionBarMainItem } from '@siemens/element-ng/content-action-bar';
 import { MenuItem } from '@siemens/element-ng/menu';
@@ -36,13 +36,6 @@ describe('SiValueWidgetComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let component: TestHostComponent;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/datatable/si-datatable-interaction.directive.spec.ts
+++ b/projects/element-ng/datatable/si-datatable-interaction.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 
@@ -122,8 +122,7 @@ describe('SiDatatableInteractionDirective', () => {
         SiDatatableModule,
         NgxDatatableModule.forRoot(SI_DATATABLE_CONFIG),
         WrapperComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     })
   );
 

--- a/projects/element-ng/date-range-filter/si-date-range-calculation.service.spec.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-calculation.service.spec.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 import { formatDate } from '@angular/common';
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiDateRangeCalculationService } from './si-date-range-calculation.service';
@@ -20,7 +19,7 @@ describe('SiDateRangeCalculationService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [SiDateRangeCalculationService, provideZonelessChangeDetection()]
+      providers: [SiDateRangeCalculationService]
     });
     service = TestBed.inject(SiDateRangeCalculationService);
   });

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.spec.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.spec.ts
@@ -4,12 +4,7 @@
  */
 import { MediaMatcher } from '@angular/cdk/layout';
 import { formatDate } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { TestScheduler } from 'rxjs/testing';
@@ -90,7 +85,6 @@ describe('SiDateRangeFilterComponent', () => {
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
       providers: [
-        provideZonelessChangeDetection(),
         {
           provide: MediaMatcher,
           useValue: {

--- a/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
@@ -2,12 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { t } from '@siemens/element-translate-ng/translate';
 
@@ -50,8 +45,7 @@ describe('SiRelativeDateComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiRelativeDateComponent, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiRelativeDateComponent, TestHostComponent]
     })
   );
 

--- a/projects/element-ng/datepicker/components/si-day-selection.component.spec.ts
+++ b/projects/element-ng/datepicker/components/si-day-selection.component.spec.ts
@@ -3,12 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { DatePipe } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {
@@ -136,12 +131,6 @@ describe('SiDaySelectionComponent', () => {
       ?.dispatchEvent(new Event('mouseover', { bubbles: true }));
     fixture.detectChanges();
   };
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
 
   describe('When Single Select View', () => {
     let wrapperComponent: SingleSelectComponent;

--- a/projects/element-ng/datepicker/components/si-month-selection.component.spec.ts
+++ b/projects/element-ng/datepicker/components/si-month-selection.component.spec.ts
@@ -3,12 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { A11yModule } from '@angular/cdk/a11y';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { getLocaleMonthNames } from '../date-time-helper';
@@ -65,9 +60,6 @@ describe('SiMonthSelectionComponent', () => {
   let helper: CalendarTestHelper;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     fixture = TestBed.createComponent(WrapperComponent);
     wrapperComponent = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/projects/element-ng/datepicker/components/si-year-selection.component.spec.ts
+++ b/projects/element-ng/datepicker/components/si-year-selection.component.spec.ts
@@ -3,12 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { A11yModule } from '@angular/cdk/a11y';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiDatepickerModule } from '../si-datepicker.module';
@@ -53,9 +48,6 @@ describe('SiYearSelectionComponent', () => {
   let helper: CalendarTestHelper;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     fixture = TestBed.createComponent(WrapperComponent);
     wrapperComponent = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/projects/element-ng/datepicker/date-time-helper.spec.ts
+++ b/projects/element-ng/datepicker/date-time-helper.spec.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 import { DatePipe } from '@angular/common';
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import {
@@ -28,7 +27,7 @@ describe('date time helper', () => {
   let dtPipe: DatePipe;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [DatePipe, provideZonelessChangeDetection()]
+      providers: [DatePipe]
     });
     dtPipe = TestBed.inject(DatePipe);
   });

--- a/projects/element-ng/datepicker/si-calendar-button.component.spec.ts
+++ b/projects/element-ng/datepicker/si-calendar-button.component.spec.ts
@@ -2,12 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DatepickerInputConfig, SiDatepickerDirective } from '@siemens/element-ng/datepicker';
@@ -52,10 +47,6 @@ describe('SiCalendarButtonComponent', () => {
 
   beforeEach(async () => {
     jasmine.clock().mockDate(new Date('2023-12-31'));
-    TestBed.configureTestingModule({
-      imports: [WrapperComponent],
-      providers: [provideZonelessChangeDetection()]
-    });
     fixture = TestBed.createComponent(WrapperComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/projects/element-ng/datepicker/si-date-input.directive.spec.ts
+++ b/projects/element-ng/datepicker/si-date-input.directive.spec.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl } from '@angular/forms';
 
@@ -60,13 +53,6 @@ describe('SiDateInputDirective', () => {
   };
 
   const dateInput = (): HTMLInputElement => element.querySelector<HTMLInputElement>('input')!;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [WrapperComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(async () => {
     fixture = TestBed.createComponent(WrapperComponent);

--- a/projects/element-ng/datepicker/si-date-range.component.spec.ts
+++ b/projects/element-ng/datepicker/si-date-range.component.spec.ts
@@ -4,13 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
@@ -58,9 +52,6 @@ describe('SiDateRangeComponent', () => {
     element.querySelector<HTMLElement>('[aria-label="Open calendar"]')!;
 
   beforeEach(async () => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     fixture = TestBed.createComponent(WrapperComponent);
     component = fixture.componentInstance.siDateRangeComponent();
     element = fixture.nativeElement;
@@ -280,9 +271,6 @@ describe('SiDateRangeComponent within form', () => {
     element.querySelector<HTMLElement>('[aria-label="Open calendar"]')!;
 
   beforeEach(async () => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     fixture = TestBed.createComponent(FormWrapperComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/projects/element-ng/datepicker/si-datepicker-overlay.directive.spec.ts
+++ b/projects/element-ng/datepicker/si-datepicker-overlay.directive.spec.ts
@@ -8,7 +8,6 @@ import {
   ComponentRef,
   HostListener,
   inject,
-  provideZonelessChangeDetection,
   signal
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -82,13 +81,6 @@ describe('SiDatepickerOverlayDirective', () => {
     fixture.detectChanges();
     await fixture.whenStable();
   };
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [WrapperComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WrapperComponent);

--- a/projects/element-ng/datepicker/si-datepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-datepicker.component.spec.ts
@@ -4,13 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiDatepickerComponent, SiDatepickerModule } from '.';
@@ -58,10 +52,6 @@ describe('SiDatepickerComponent', () => {
   };
 
   beforeEach(async () => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     jasmine.clock().mockDate(new Date('2023-12-31'));
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;

--- a/projects/element-ng/datepicker/si-datepicker.directive.spec.ts
+++ b/projects/element-ng/datepicker/si-datepicker.directive.spec.ts
@@ -4,14 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl } from '@angular/forms';
 
@@ -90,9 +83,6 @@ describe('SiDatepickerDirective', () => {
   const getTestDate = (): Date => new Date('2022-03-12T05:30:20');
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    });
     fixture = TestBed.createComponent(WrapperComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/projects/element-ng/datepicker/si-timepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -66,10 +66,6 @@ describe('SiTimepickerComponent', () => {
     let fixture: ComponentFixture<TestComponent>;
 
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [TestComponent],
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
       fixture = TestBed.createComponent(TestComponent);
       element = fixture.nativeElement;
       fixture.detectChanges();
@@ -88,9 +84,6 @@ describe('SiTimepickerComponent', () => {
     let component: WrapperComponent;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
       fixture = TestBed.createComponent(WrapperComponent);
       component = fixture.componentInstance;
       element = fixture.nativeElement;

--- a/projects/element-ng/electron-titlebar/si-electron-titlebar.component.spec.ts
+++ b/projects/element-ng/electron-titlebar/si-electron-titlebar.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MenuItem } from '@siemens/element-ng/menu';
 
@@ -42,13 +42,6 @@ describe('SiElectrontitlebarComponent', () => {
     element.querySelector<HTMLButtonElement>('[aria-label="Forward"]')!;
   const backButton = (): HTMLButtonElement =>
     element.querySelector<HTMLButtonElement>('[aria-label="Back"]')!;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/empty-state/si-empty-state.component.spec.ts
+++ b/projects/element-ng/empty-state/si-empty-state.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiEmptyStateComponent as TestComponent } from '.';
@@ -11,13 +11,6 @@ describe('SiEmptyStateComponent', () => {
   let componentRef: ComponentRef<TestComponent>;
   let fixture: ComponentFixture<TestComponent>;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/file-uploader/si-file-dropzone.component.spec.ts
+++ b/projects/element-ng/file-uploader/si-file-dropzone.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -54,8 +48,7 @@ describe('SiFileDropzoneComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot(), TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [TranslateModule.forRoot(), TestHostComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/file-uploader/si-file-uploader.component.spec.ts
+++ b/projects/element-ng/file-uploader/si-file-uploader.component.spec.ts
@@ -4,13 +4,7 @@
  */
 import { HttpErrorResponse, HttpHeaders, provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  SimpleChange,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, SimpleChange, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { runOnPushChangeDetection } from '../test-helpers/change-detection.helper';
@@ -88,7 +82,7 @@ describe('SiFileUploaderComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideZonelessChangeDetection()]
+      providers: [provideHttpClient(), provideHttpClientTesting()]
     });
     httpMock = TestBed.inject(HttpTestingController);
   });

--- a/projects/element-ng/filter-bar/si-filter-bar.component.spec.ts
+++ b/projects/element-ng/filter-bar/si-filter-bar.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { Filter, SiFilterBarComponent } from './index';
@@ -49,13 +43,6 @@ describe('SiFilterBarComponent', () => {
 
   const removeButtons = (): HTMLElement[] =>
     Array.from(element.querySelectorAll<HTMLElement>('[aria-label="Remove"]'));
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents()
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/filter-bar/si-filter-pill.component.spec.ts
+++ b/projects/element-ng/filter-bar/si-filter-pill.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { Filter } from './filter';
@@ -27,8 +27,7 @@ describe('SiFilterPillComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiFilterPillComponent, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiFilterPillComponent, TestHostComponent]
     })
   );
 

--- a/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
@@ -9,7 +9,6 @@ import {
   ChangeDetectorRef,
   Component,
   inject,
-  provideZonelessChangeDetection,
   signal,
   viewChild
 } from '@angular/core';
@@ -105,8 +104,7 @@ describe('SiFilteredSearchComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [NoopAnimationsModule, TestHostComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);
@@ -2305,7 +2303,6 @@ describe('SiFilteredSearchComponent - With translation', () => {
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
       providers: [
-        provideZonelessChangeDetection(),
         provideNoopAnimations(),
         provideMockTranslateServiceBuilder(
           () =>

--- a/projects/element-ng/footer/si-footer.component.spec.ts
+++ b/projects/element-ng/footer/si-footer.component.spec.ts
@@ -2,12 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { Link } from '@siemens/element-ng/link';
@@ -42,7 +37,7 @@ describe('SiFooterComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [provideRouter([]), provideZonelessChangeDetection()]
+      providers: [provideRouter([])]
     })
   );
 

--- a/projects/element-ng/form/si-form-container/si-form-container.component.spec.ts
+++ b/projects/element-ng/form/si-form-container/si-form-container.component.spec.ts
@@ -7,7 +7,6 @@ import {
   ChangeDetectorRef,
   Component,
   inject,
-  provideZonelessChangeDetection,
   viewChild
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -80,8 +79,7 @@ describe('SiFormContainerComponent', () => {
             validationErrorMapper: { minlength: 'custom-length-message' }
           }),
           TestHostComponent
-        ],
-        providers: [provideZonelessChangeDetection()]
+        ]
       }).compileComponents();
     });
 
@@ -166,13 +164,6 @@ describe('SiFormContainerComponent', () => {
 
   describe('with nested form containers', () => {
     let fixture: ComponentFixture<TestHostWithNestingComponent>;
-
-    beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [TestHostWithNestingComponent],
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
-    });
 
     beforeEach(() => {
       fixture = TestBed.createComponent(TestHostWithNestingComponent);

--- a/projects/element-ng/form/si-form-item/si-form-item.component.spec.ts
+++ b/projects/element-ng/form/si-form-item/si-form-item.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiFormItemComponent } from './si-form-item.component';
@@ -34,13 +28,6 @@ describe('SiFormItemComponent', () => {
   const getLabel = (): HTMLElement | null => {
     return fixture.nativeElement.querySelector('label');
   };
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -23,9 +23,6 @@ describe('SiFormValidationTooltipDirective', () => {
   let harness: SiFormValidationTooltipHarness;
 
   beforeEach(async () => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     fixture = TestBed.createComponent(TestHostComponent);
     harness = await TestbedHarnessEnvironment.loader(fixture).getHarness(
       SiFormValidationTooltipHarness

--- a/projects/element-ng/form/si-form.spec.ts
+++ b/projects/element-ng/form/si-form.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   FormControl,
@@ -88,8 +88,7 @@ describe('SiForm', () => {
         imports: [
           TestHostComponent,
           SiFormModule.withConfiguration({ validationErrorMapper: { required: 'required' } })
-        ],
-        providers: [provideZonelessChangeDetection()]
+        ]
       }).compileComponents();
     });
 
@@ -168,13 +167,6 @@ describe('SiForm', () => {
     let fixture: ComponentFixture<TestHostComponent>;
     let loader: HarnessLoader;
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [TestHostComponent],
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
-    });
-
     beforeEach(async () => {
       fixture = TestBed.createComponent(TestHostComponent);
       fixture.detectChanges();
@@ -223,13 +215,6 @@ describe('SiForm', () => {
     let fixture: ComponentFixture<TestHostComponent>;
     let loader: HarnessLoader;
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [TestHostComponent],
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
-    });
-
     beforeEach(async () => {
       fixture = TestBed.createComponent(TestHostComponent);
       fixture.detectChanges();
@@ -275,8 +260,7 @@ describe('SiForm', () => {
         providers: [
           provideFormValidationErrorMapper({
             email: emailMapperSpy
-          }),
-          provideZonelessChangeDetection()
+          })
         ]
       }).compileComponents();
       fixture = TestBed.createComponent(TestHostComponent);
@@ -310,9 +294,6 @@ describe('SiForm', () => {
     let loader: HarnessLoader;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
       fixture = TestBed.createComponent(TestHostComponent);
       loader = TestbedHarnessEnvironment.loader(fixture);
     });

--- a/projects/element-ng/formly/fields/button/si-formly-button.component.spec.ts
+++ b/projects/element-ng/formly/fields/button/si-formly-button.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -63,8 +63,7 @@ describe('formly button type', () => {
         }),
         SiFormlyButtonComponent,
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/fields/date-range/si-formly-date-range.component.spec.ts
+++ b/projects/element-ng/formly/fields/date-range/si-formly-date-range.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -62,8 +62,7 @@ describe('formly date range type', () => {
         }),
         SiFormlyDateRangeComponent,
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/fields/datetime/si-formly-datetime.component.spec.ts
+++ b/projects/element-ng/formly/fields/datetime/si-formly-datetime.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -66,8 +66,7 @@ describe('formly datetime-type', () => {
         }),
         SiFormlyDateTimeComponent,
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/fields/email/si-formly-email.component.spec.ts
+++ b/projects/element-ng/formly/fields/email/si-formly-email.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -42,8 +42,7 @@ describe('formly email type', () => {
         }),
         SiFormlyEmailComponent,
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/fields/ip-input/si-formly-ip-input.component.spec.ts
+++ b/projects/element-ng/formly/fields/ip-input/si-formly-ip-input.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -44,8 +44,7 @@ describe('formly ip', () => {
         }),
         SiFormlyIpInputComponent,
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
     fixture = TestBed.createComponent(FormlyTestComponent);
   });

--- a/projects/element-ng/formly/fields/number/si-formly-number.component.spec.ts
+++ b/projects/element-ng/formly/fields/number/si-formly-number.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -57,8 +57,7 @@ describe('formly number type', () => {
         }),
         SiFormlyNumberComponent,
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/fields/select/si-formly-select.component.spec.ts
+++ b/projects/element-ng/formly/fields/select/si-formly-select.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -55,8 +55,7 @@ describe('formly si-select', () => {
           ]
         }),
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
     fixture = TestBed.createComponent(FormlyTestComponent);
   });

--- a/projects/element-ng/formly/fields/text/si-formly-text-display.component.spec.ts
+++ b/projects/element-ng/formly/fields/text/si-formly-text-display.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -57,8 +57,7 @@ describe('formly text-display-type', () => {
           ]
         }),
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.spec.ts
+++ b/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -42,8 +42,7 @@ describe('formly autogrowing textarea type', () => {
           ]
         }),
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/fields/time/si-formly-time.component.spec.ts
+++ b/projects/element-ng/formly/fields/time/si-formly-time.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  inject,
-  provideZonelessChangeDetection
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -51,8 +45,7 @@ describe('formly time-type', () => {
           ]
         }),
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/si-formly-translate.extension.spec.ts
+++ b/projects/element-ng/formly/si-formly-translate.extension.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { SiTranslateService } from '@siemens/element-ng/translate';
@@ -19,10 +18,7 @@ describe('Formly translations', () => {
     mockTranslationService = jasmine.createSpyObj<SiTranslateService>(['translateAsync']);
     mockTranslationService.translateAsync.and.returnValue(of('translated'));
     TestBed.configureTestingModule({
-      providers: [
-        provideMockTranslateServiceBuilder(() => mockTranslationService),
-        provideZonelessChangeDetection()
-      ]
+      providers: [provideMockTranslateServiceBuilder(() => mockTranslationService)]
     });
     extension = TestBed.runInInjectionContext(() => new SiFormlyTranslateExtension());
   });

--- a/projects/element-ng/formly/si-formly.component.spec.ts
+++ b/projects/element-ng/formly/si-formly.component.spec.ts
@@ -2,12 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormGroup, FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { FormlyBootstrapModule } from '@ngx-formly/bootstrap';
@@ -61,8 +56,7 @@ describe('ElementFormComponent', () => {
               translateAsync: (key: string, params: Record<string, any>) =>
                 of(`translated=>${key}-${JSON.stringify(params)}`)
             }) as SiTranslateService
-        ),
-        provideZonelessChangeDetection()
+        )
       ]
     }).compileComponents();
   });

--- a/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -96,8 +96,7 @@ describe('formly accordion type', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SiFormlyModule, FormlyTestComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [NoopAnimationsModule, SiFormlyModule, FormlyTestComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/structural/si-formly-array/si-formly-array.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-array/si-formly-array.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -48,7 +48,6 @@ describe('ElementFormComponent', () => {
         WrapperComponent
       ],
       providers: [
-        provideZonelessChangeDetection(),
         {
           provide: SiTranslateService,
           useValue: {

--- a/projects/element-ng/formly/structural/si-formly-object-grid/si-formly-object-grid.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-object-grid/si-formly-object-grid.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -44,8 +44,7 @@ describe('formly grid  type', () => {
           ]
         }),
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/structural/si-formly-object-plain/si-formly-object-plain.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-object-plain/si-formly-object-plain.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -47,7 +47,6 @@ describe('ElementFormComponent', () => {
         WrapperComponent
       ],
       providers: [
-        provideZonelessChangeDetection(),
         provideMockTranslateServiceBuilder(
           () =>
             ({

--- a/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -42,8 +42,7 @@ describe('formly tabset type', () => {
           ]
         }),
         FormlyTestComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents();
   });
 

--- a/projects/element-ng/header-dropdown/si-header-dropdown.directive.spec.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown.directive.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 
@@ -52,13 +52,6 @@ describe('SiHeaderDropdown', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let loader: HarnessLoader;
   let trigger1Harness: SiHeaderDropdownTriggerHarness;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    });
-  });
 
   beforeEach(async () => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/icon/si-icon-legacy.component.spec.ts
+++ b/projects/element-ng/icon/si-icon-legacy.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiIconLegacyComponent as TestComponent } from './si-icon-legacy.component';
@@ -10,13 +10,6 @@ import { SiIconLegacyComponent as TestComponent } from './si-icon-legacy.compone
 describe('SiIconComponent', () => {
   let component: ComponentRef<TestComponent>;
   let fixture: ComponentFixture<TestComponent>;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/icon/si-icon.component.spec.ts
+++ b/projects/element-ng/icon/si-icon.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SiThemeService } from '@siemens/element-ng/theme';
@@ -36,10 +36,7 @@ describe('SiSvgIconComponent', () => {
     describe('with enabled svg icons', () => {
       beforeEach(async () => {
         TestBed.configureTestingModule({
-          providers: [
-            provideIconConfig({ disableSvgIcons: false }),
-            provideZonelessChangeDetection()
-          ]
+          providers: [provideIconConfig({ disableSvgIcons: false })]
         });
         fixture = TestBed.createComponent(TestHostComponent);
         component = fixture.componentInstance;
@@ -108,10 +105,7 @@ describe('SiSvgIconComponent', () => {
     });
 
     describe('with disabled svg icons', () => {
-      beforeEach(async () => {
-        TestBed.configureTestingModule({
-          providers: [provideZonelessChangeDetection()]
-        }).compileComponents();
+      beforeEach(() => {
         fixture = TestBed.createComponent(TestHostComponent);
         component = fixture.componentInstance;
         fixture.detectChanges();
@@ -168,9 +162,6 @@ describe('SiSvgIconComponent', () => {
     let component: TestHostComponent;
     let iconService: IconService;
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
       fixture = TestBed.createComponent(TestHostComponent);
       component = fixture.componentInstance;
       iconService = TestBed.inject(IconService);

--- a/projects/element-ng/info-page/si-info-page.component.spec.ts
+++ b/projects/element-ng/info-page/si-info-page.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router, RouterModule } from '@angular/router';
 
@@ -13,14 +13,10 @@ describe('SiInfoPageComponent', () => {
   let component: ComponentRef<TestComponent>;
   let element: HTMLElement;
 
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent, RouterModule],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
-
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestComponent, RouterModule]
+    });
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentRef;
     element = fixture.nativeElement;

--- a/projects/element-ng/inline-notification/si-inline-notification.component.spec.ts
+++ b/projects/element-ng/inline-notification/si-inline-notification.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { StatusType } from '@siemens/element-ng/common';
 import { Link } from '@siemens/element-ng/link';
@@ -42,7 +42,6 @@ describe('SiInlineNotificationComponent', () => {
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
       providers: [
-        provideZonelessChangeDetection(),
         provideMockTranslateServiceBuilder(
           () =>
             ({

--- a/projects/element-ng/ip-input/si-ip4-input.directive.spec.ts
+++ b/projects/element-ng/ip-input/si-ip4-input.directive.spec.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  DebugElement,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, DebugElement, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -49,10 +42,6 @@ describe('SiIp4InputDirective', () => {
   };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [WrapperComponent],
-      providers: [provideZonelessChangeDetection()]
-    });
     fixture = TestBed.createComponent(WrapperComponent);
     component = fixture.componentInstance;
     debugElement = fixture.debugElement;

--- a/projects/element-ng/ip-input/si-ip6-input.directive.spec.ts
+++ b/projects/element-ng/ip-input/si-ip6-input.directive.spec.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  DebugElement,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, DebugElement, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -55,10 +48,6 @@ describe('SiIp6InputDirective', () => {
   };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [WrapperComponent],
-      providers: [provideZonelessChangeDetection()]
-    });
     fixture = TestBed.createComponent(WrapperComponent);
     component = fixture.componentInstance;
     debugElement = fixture.debugElement;

--- a/projects/element-ng/landing-page/change-password/si-change-password.component.spec.ts
+++ b/projects/element-ng/landing-page/change-password/si-change-password.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { enterValue } from '@siemens/element-ng/datepicker/components/test-helper.spec';
 
@@ -19,13 +19,6 @@ const passwordStrengthValue = {
 describe('SiChangePasswordComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let component: ComponentRef<TestComponent>;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(async () => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/landing-page/explicit-legal-acknowledge/si-explicit-legal-acknowledge.component.spec.ts
+++ b/projects/element-ng/landing-page/explicit-legal-acknowledge/si-explicit-legal-acknowledge.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiExplicitLegalAcknowledgeComponent as TestComponent } from './si-explicit-legal-acknowledge.component';
@@ -10,13 +10,6 @@ import { SiExplicitLegalAcknowledgeComponent as TestComponent } from './si-expli
 describe('SiExplicitLegalAcknowledgeComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let component: ComponentRef<TestComponent>;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(async () => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/landing-page/login-basic/si-login-basic.component.spec.ts
+++ b/projects/element-ng/landing-page/login-basic/si-login-basic.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -14,8 +14,7 @@ describe('SiLoginBasicComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestComponent, BrowserAnimationsModule],
-      providers: [provideZonelessChangeDetection()]
+      imports: [TestComponent, BrowserAnimationsModule]
     })
   );
 

--- a/projects/element-ng/landing-page/login-single-sign-on/si-login-single-sign-on.component.spec.ts
+++ b/projects/element-ng/landing-page/login-single-sign-on/si-login-single-sign-on.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiLoginSingleSignOnComponent as TestComponent } from './si-login-single-sign-on.component';
@@ -10,13 +10,6 @@ import { SiLoginSingleSignOnComponent as TestComponent } from './si-login-single
 describe('SiLoginSingleSignOnComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let component: ComponentRef<TestComponent>;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/landing-page/si-landing-page.component.spec.ts
+++ b/projects/element-ng/landing-page/si-landing-page.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiLandingPageComponent as TestComponent } from '.';
@@ -10,13 +10,6 @@ import { SiLandingPageComponent as TestComponent } from '.';
 describe('SiLandingPageComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let component: ComponentRef<TestComponent>;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/language-switcher/si-language-switcher.component.spec.ts
+++ b/projects/element-ng/language-switcher/si-language-switcher.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SiTranslateNgxTModule } from '@siemens/element-translate-ng/ngx-translate';
@@ -33,8 +33,7 @@ describe('SiLanguageSwitcherComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiTranslateNgxTModule, TranslateModule.forRoot(), TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiTranslateNgxTModule, TranslateModule.forRoot(), TestHostComponent]
     })
   );
 

--- a/projects/element-ng/link/si-link.directive.spec.ts
+++ b/projects/element-ng/link/si-link.directive.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  inject,
-  provideZonelessChangeDetection
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
@@ -63,8 +57,7 @@ describe('SiLinkDirective', () => {
             ({
               translateAsync: (keys, params) => of(`translated=>${keys}-${JSON.stringify(params)}`)
             }) as SiTranslateService
-        ),
-        provideZonelessChangeDetection()
+        )
       ]
     }).compileComponents();
   });
@@ -232,8 +225,7 @@ describe('SiLinkDirective', () => {
             {
               provide: SI_LINK_DEFAULT_NAVIGATION_EXTRA,
               useValue: { preserveFragment: false, queryParamsHandling: '' }
-            },
-            provideZonelessChangeDetection()
+            }
           ]
         });
 

--- a/projects/element-ng/list-details/si-list-details.component.spec.ts
+++ b/projects/element-ng/list-details/si-list-details.component.spec.ts
@@ -8,7 +8,6 @@ import {
   Component,
   DebugElement,
   inject,
-  provideZonelessChangeDetection,
   ViewChild
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -168,8 +167,7 @@ describe('ListDetailsComponent', () => {
           {
             provide: ResizeObserverService,
             useValue: resizeSpy
-          },
-          provideZonelessChangeDetection()
+          }
         ]
       }).compileComponents();
 
@@ -458,8 +456,7 @@ describe('ListDetailsComponent', () => {
                 }
               ]
             }
-          ]),
-          provideZonelessChangeDetection()
+          ])
         ]
       });
     });

--- a/projects/element-ng/loading-spinner/si-loading-spinner.component.spec.ts
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiLoadingSpinnerComponent as TestComponent } from './index';
@@ -10,13 +10,6 @@ import { SiLoadingSpinnerComponent as TestComponent } from './index';
 describe('SiLoadingSpinnerComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let component: ComponentRef<TestComponent>;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/loading-spinner/si-loading-spinner.directive.spec.ts
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -35,8 +35,7 @@ describe('SiLoadingSpinnerDirective', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiLoadingSpinnerModule, NoopAnimationsModule, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiLoadingSpinnerModule, NoopAnimationsModule, TestHostComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/localization/si-locale-id.spec.ts
+++ b/projects/element-ng/localization/si-locale-id.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { LOCALE_ID, provideZonelessChangeDetection } from '@angular/core';
+import { LOCALE_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiLocaleId } from './si-locale-id';
@@ -20,8 +20,7 @@ describe('SiLocaleId', () => {
     TestBed.configureTestingModule({
       providers: [
         { provide: LOCALE_ID, useClass: SiLocaleId, deps: [SiLocaleService] },
-        { provide: SiLocaleService, useClass: SiLocaleServiceMock },
-        provideZonelessChangeDetection()
+        { provide: SiLocaleService, useClass: SiLocaleServiceMock }
       ]
     });
     localeId = TestBed.inject(LOCALE_ID).toString();

--- a/projects/element-ng/localization/si-locale.service.spec.ts
+++ b/projects/element-ng/localization/si-locale.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SiTranslateNgxTModule } from '@siemens/element-translate-ng/ngx-translate';
@@ -38,8 +37,7 @@ describe('SiLocaleService', () => {
   describe('with empty configuration', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-        providers: [provideZonelessChangeDetection()]
+        imports: [SiTranslateNgxTModule, TranslateModule.forRoot()]
       });
       service = TestBed.inject(SiLocaleService);
     });
@@ -81,7 +79,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
     });
     service = TestBed.inject(SiLocaleService);
     expect(service.config.defaultLocale).toBe('fr');
@@ -92,7 +90,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
     });
     service = TestBed.inject(SiLocaleService);
     expect(service.config.defaultLocale).toBe('en');
@@ -105,7 +103,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
     });
     service = TestBed.inject(SiLocaleService);
     expect(service.config.availableLocales![0]).toBe('en');
@@ -118,7 +116,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
     });
     service = TestBed.inject(SiLocaleService);
     const translate = TestBed.inject(TranslateService);
@@ -135,7 +133,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
     });
     service = TestBed.inject(SiLocaleService);
     const translate = TestBed.inject(TranslateService);
@@ -151,7 +149,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
     });
     service = TestBed.inject(SiLocaleService);
     expect(service.locale$.value).toBe('en');
@@ -166,7 +164,7 @@ describe('SiLocaleService', () => {
 
     TestBed.configureTestingModule({
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
-      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }, provideZonelessChangeDetection()]
+      providers: [{ provide: SI_LOCALE_CONFIG, useValue: config }]
     });
     service = TestBed.inject(SiLocaleService);
     expect(service.hasLocale('de')).toBeTrue();
@@ -192,8 +190,7 @@ describe('SiLocaleService', () => {
         imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
         providers: [
           { provide: SI_LOCALE_CONFIG, useValue: config },
-          { provide: SiLocaleStore, useClass: NoLocaleStore },
-          provideZonelessChangeDetection()
+          { provide: SiLocaleStore, useClass: NoLocaleStore }
         ]
       });
 
@@ -257,8 +254,7 @@ describe('SiLocaleService', () => {
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
       providers: [
         { provide: SI_LOCALE_CONFIG, useValue: config },
-        { provide: SiLocaleStore, useClass: DeLocaleStore },
-        provideZonelessChangeDetection()
+        { provide: SiLocaleStore, useClass: DeLocaleStore }
       ]
     });
     service = TestBed.inject(SiLocaleService);
@@ -275,8 +271,7 @@ describe('SiLocaleService', () => {
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
       providers: [
         { provide: SI_LOCALE_CONFIG, useValue: config },
-        { provide: SiLocaleStore, useClass: DeLocaleStore },
-        provideZonelessChangeDetection()
+        { provide: SiLocaleStore, useClass: DeLocaleStore }
       ]
     });
     service = TestBed.inject(SiLocaleService);
@@ -301,8 +296,7 @@ describe('SiLocaleService', () => {
       imports: [SiTranslateNgxTModule, TranslateModule.forRoot()],
       providers: [
         { provide: SI_LOCALE_CONFIG, useValue: config },
-        { provide: SiLocaleStore, useClass: DeLocaleStore },
-        provideZonelessChangeDetection()
+        { provide: SiLocaleStore, useClass: DeLocaleStore }
       ]
     });
     service = TestBed.inject(SiLocaleService);

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
@@ -8,7 +8,6 @@ import {
   Component,
   DebugElement,
   inject,
-  provideZonelessChangeDetection,
   viewChild
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -103,8 +102,7 @@ describe('MainDetailContainerComponent', () => {
         {
           provide: ResizeObserverService,
           useValue: resizeSpy
-        },
-        provideZonelessChangeDetection()
+        }
       ]
     }).compileComponents();
 

--- a/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
+++ b/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiMarkdownRendererComponent as TestComponent } from './si-markdown-renderer.component';
@@ -11,12 +10,7 @@ describe('SiMarkdownRendererComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let hostElement: HTMLElement;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-
+  beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);
     hostElement = fixture.nativeElement;
   });

--- a/projects/element-ng/menu/si-menu.spec.ts
+++ b/projects/element-ng/menu/si-menu.spec.ts
@@ -5,7 +5,7 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu';
 import { ComponentHarness, HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MenuItem } from '@siemens/element-ng/common';
 import { SiLinkActionService } from '@siemens/element-ng/link';
@@ -85,10 +85,7 @@ const withObjectType = <ItemType extends MenuItem, ComponentType extends { items
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        providers: [
-          { provide: SiLinkActionService, useValue: jasmine.createSpyObj(['emit']) },
-          provideZonelessChangeDetection()
-        ]
+        providers: [{ provide: SiLinkActionService, useValue: jasmine.createSpyObj(['emit']) }]
       });
       fixture = TestBed.createComponent(componentType);
       loader = TestbedHarnessEnvironment.loader(fixture);

--- a/projects/element-ng/modal/si-modal-service.spec.ts
+++ b/projects/element-ng/modal/si-modal-service.spec.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ApplicationRef,
-  Component,
-  input,
-  provideZonelessChangeDetection,
-  TemplateRef,
-  viewChild
-} from '@angular/core';
+import { ApplicationRef, Component, input, TemplateRef, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiModalService } from './si-modal.service';
@@ -39,8 +32,7 @@ describe('SiModalService', () => {
   beforeEach(() => {
     jasmine.clock().install();
     TestBed.configureTestingModule({
-      imports: [DialogComponent, DialogTemplateComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [DialogComponent, DialogTemplateComponent]
     }).compileComponents();
 
     service = TestBed.inject(SiModalService);

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.spec.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiNavbarVerticalItemComponent } from './si-navbar-vertical-item.component';
@@ -33,10 +33,7 @@ describe('SiNavbarVerticalItemComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [
-        { provide: SI_NAVBAR_VERTICAL, useValue: mockNavbar },
-        provideZonelessChangeDetection()
-      ]
+      providers: [{ provide: SI_NAVBAR_VERTICAL, useValue: mockNavbar }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical.spec.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical.spec.ts
@@ -5,7 +5,7 @@
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, Injectable, provideZonelessChangeDetection } from '@angular/core';
+import { Component, Injectable } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter, Router } from '@angular/router';
@@ -88,7 +88,6 @@ describe('SiNavbarVertical', () => {
     await TestBed.configureTestingModule({
       imports: [SiNavbarVerticalComponent, NoopAnimationsModule, TestHostComponent],
       providers: [
-        provideZonelessChangeDetection(),
         provideSiUiState({ store: SynchronousMockStore }),
         provideRouter([
           {

--- a/projects/element-ng/navbar/si-navbar-item/si-navbar-item.component.spec.ts
+++ b/projects/element-ng/navbar/si-navbar-item/si-navbar-item.component.spec.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MenuItem } from '@siemens/element-ng/common';
 import { SiNavbarPrimaryComponent } from '@siemens/element-ng/navbar';
@@ -45,8 +38,7 @@ describe('SiNavbarItemComponent', () => {
             header: signal({ closeMobileMenus: NEVER }),
             navItemCount: signal(0)
           }
-        },
-        provideZonelessChangeDetection()
+        }
       ]
     })
   );

--- a/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.spec.ts
+++ b/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.spec.ts
@@ -4,13 +4,7 @@
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideLocationMocks } from '@angular/common/testing';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  provideZonelessChangeDetection,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { SiApplicationHeaderHarness } from '@siemens/element-ng/application-header/testing/si-application-header.harness';
@@ -47,7 +41,7 @@ describe('SiNavbarPrimaryComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [provideRouter([]), provideLocationMocks(), provideZonelessChangeDetection()]
+      providers: [provideRouter([]), provideLocationMocks()]
     })
   );
 

--- a/projects/element-ng/notification-item/si-notification-item.component.spec.ts
+++ b/projects/element-ng/notification-item/si-notification-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -55,9 +55,6 @@ describe('SiNotificationItemComponent', () => {
   let element: HTMLElement;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/projects/element-ng/number-input/si-number-input.component.spec.ts
+++ b/projects/element-ng/number-input/si-number-input.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, inject, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, inject, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
@@ -88,8 +88,7 @@ describe('SiNumberInputComponent', () => {
         FormHostComponent,
         HostComponent,
         AttributeComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     })
   );
 

--- a/projects/element-ng/pagination/si-pagination.component.spec.ts
+++ b/projects/element-ng/pagination/si-pagination.component.spec.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { CommonModule } from '@angular/common';
-import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiPaginationComponent as TestComponent } from '.';
@@ -20,13 +18,6 @@ describe('SiPaginationComponent', () => {
   const getSeparators = (): NodeListOf<HTMLElement> => element.querySelectorAll('.separator');
   const getCurrentItem = (): HTMLElement =>
     element.querySelector('.page-item.active') as HTMLElement;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [CommonModule, TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/password-strength/si-password-strength.component.spec.ts
+++ b/projects/element-ng/password-strength/si-password-strength.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  provideZonelessChangeDetection,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
@@ -70,8 +64,7 @@ describe('SiPasswordStrengthDirective', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiPasswordStrengthModule, FormsModule, WrapperComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiPasswordStrengthModule, FormsModule, WrapperComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/password-toggle/si-password-toggle.component.spec.ts
+++ b/projects/element-ng/password-toggle/si-password-toggle.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, input, provideZonelessChangeDetection } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
@@ -26,8 +26,7 @@ describe('SiPasswordToggleComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule, SiPasswordToggleModule, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [FormsModule, SiPasswordToggleModule, TestHostComponent]
     });
   });
 

--- a/projects/element-ng/phone-number/si-phone-number-input.component.spec.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -69,8 +69,7 @@ describe('SiPhoneNumberInputComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiPhoneNumberInputComponent, ReactiveFormsModule, WrapperComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiPhoneNumberInputComponent, ReactiveFormsModule, WrapperComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/photo-upload/si-photo-upload.component.spec.ts
+++ b/projects/element-ng/photo-upload/si-photo-upload.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -58,11 +58,6 @@ describe(`SiPhotoUploadComponent`, () => {
     Array.from(parent.querySelectorAll(`button`)).filter(e => e.innerHTML.trim().includes(text))[0];
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [SiPhotoUploadComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-
     fixture = TestBed.createComponent(SiPhotoUploadComponent);
     component = fixture.componentInstance;
     componentRef = fixture.componentRef;

--- a/projects/element-ng/pills-input/si-pills-input.component.spec.ts
+++ b/projects/element-ng/pills-input/si-pills-input.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
@@ -37,8 +37,7 @@ describe('SiPillsInputComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiPillsInputModule, FormsModule, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiPillsInputModule, FormsModule, TestHostComponent]
     });
   });
 

--- a/projects/element-ng/popover-legacy/si-popover.directive.spec.ts
+++ b/projects/element-ng/popover-legacy/si-popover.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiPopoverLegacyDirective } from './si-popover-legacy.directive';
@@ -22,13 +22,6 @@ export class TestHostComponent {
 describe('SiPopoverDirective', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let wrapperComponent: TestHostComponent;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/popover/si-popover.directive.spec.ts
+++ b/projects/element-ng/popover/si-popover.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiPopoverDirective } from './si-popover.directive';
@@ -41,8 +41,7 @@ describe('SiPopoverNextDirective', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HostComponent, CustomTemplateHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [HostComponent, CustomTemplateHostComponent]
     }).compileComponents();
   });
 
@@ -178,9 +177,6 @@ describe('with custom template', () => {
   let fixture: ComponentFixture<CustomTemplateHostComponent>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     fixture = TestBed.createComponent(CustomTemplateHostComponent);
   });
 

--- a/projects/element-ng/progressbar/si-progressbar.component.spec.ts
+++ b/projects/element-ng/progressbar/si-progressbar.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiProgressbarComponent as TestComponent } from './si-progressbar.component';
@@ -11,13 +11,6 @@ describe('SiProgressbarComponent', () => {
   let componentRef: ComponentRef<TestComponent>;
   let fixture: ComponentFixture<TestComponent>;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/resize-observer/resize-observer.service.spec.ts
+++ b/projects/element-ng/resize-observer/resize-observer.service.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  Component,
-  ElementRef,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { Component, ElementRef, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subscription } from 'rxjs';
 
@@ -57,10 +51,6 @@ describe('ResizeObserverService', () => {
 
   beforeEach(() => {
     mockResizeObserver();
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    });
     service = TestBed.inject(ResizeObserverService);
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;

--- a/projects/element-ng/resize-observer/si-resize-observer.directive.spec.ts
+++ b/projects/element-ng/resize-observer/si-resize-observer.directive.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  Component,
-  ElementRef,
-  provideZonelessChangeDetection,
-  signal,
-  viewChild
-} from '@angular/core';
+import { Component, ElementRef, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ElementDimensions } from './index';
@@ -57,10 +51,6 @@ describe('SiResizeObserverDirective', () => {
 
   beforeEach(() => {
     mockResizeObserver();
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    });
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
     spy = spyOn(component, 'resizeHandler');
@@ -114,13 +104,6 @@ describe('SiResizeObserverDirective with emitInitial=false', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let component: TestHostComponent;
   let spy: jasmine.Spy<(dim: ElementDimensions) => void>;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/resize-observer/si-responsive-container.directive.spec.ts
+++ b/projects/element-ng/resize-observer/si-responsive-container.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiResponsiveContainerDirective } from './index';
@@ -36,10 +36,6 @@ describe('SiResponsiveContainerDirective', () => {
 
   beforeEach(() => {
     mockResizeObserver();
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    });
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/projects/element-ng/result-details-list/si-result-details-list.component.spec.ts
+++ b/projects/element-ng/result-details-list/si-result-details-list.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ResultDetailStep, SiResultDetailsListComponent } from '.';
@@ -20,13 +20,6 @@ describe('SiResultDetailsListComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let component: TestHostComponent;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/search-bar/si-search-bar.component.spec.ts
+++ b/projects/element-ng/search-bar/si-search-bar.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -49,9 +49,6 @@ describe('SiSearchBarComponent', () => {
     }
 
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
       fixture = TestBed.createComponent(TestComponent);
       testComponent = fixture.componentInstance;
       component = fixture.componentInstance.searchBar();
@@ -165,10 +162,6 @@ describe('SiSearchBarComponent', () => {
     }
 
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [TestComponent],
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
       fixture = TestBed.createComponent(TestComponent);
       testComponent = fixture.componentInstance;
       component = fixture.componentInstance.searchBar();

--- a/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
+++ b/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
@@ -50,7 +50,7 @@ describe('SelectLazyOptionsDirective', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [provideNoopAnimations(), provideZonelessChangeDetection()]
+      providers: [provideNoopAnimations()]
     });
     fixture = TestBed.createComponent(TestHostComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/projects/element-ng/select/selection/si-select-multi-value.directive.spec.ts
+++ b/projects/element-ng/select/selection/si-select-multi-value.directive.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -50,8 +50,7 @@ describe('SiSelectMultiValueDirective', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiSelectModule, ReactiveFormsModule, TranslateModule.forRoot(), TestComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiSelectModule, ReactiveFormsModule, TranslateModule.forRoot(), TestComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/select/si-select.component.spec.ts
+++ b/projects/element-ng/select/si-select.component.spec.ts
@@ -5,7 +5,7 @@
 import { HarnessLoader, TestKey } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { CommonModule } from '@angular/common';
-import { Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SiSelectHarness } from '@siemens/element-ng/select/testing';
@@ -161,8 +161,7 @@ describe('SiSelectComponent', () => {
 
     beforeEach(async () => {
       TestBed.configureTestingModule({
-        imports: [SiSelectModule, TestHostComponent],
-        providers: [provideZonelessChangeDetection()]
+        imports: [SiSelectModule, TestHostComponent]
       });
 
       const typedFixture = TestBed.createComponent(TestHostComponent);
@@ -374,8 +373,7 @@ describe('SiSelectComponent', () => {
 
     beforeEach(async () => {
       TestBed.configureTestingModule({
-        imports: [SiSelectModule, TestHostNumberComponent],
-        providers: [provideZonelessChangeDetection()]
+        imports: [SiSelectModule, TestHostNumberComponent]
       });
 
       const typedFixture = TestBed.createComponent(TestHostNumberComponent);
@@ -429,14 +427,7 @@ describe('SiSelectComponent', () => {
 
     beforeEach(async () => {
       TestBed.configureTestingModule({
-        imports: [
-          CommonModule,
-          FormsModule,
-          ReactiveFormsModule,
-          SiSelectModule,
-          FormHostComponent
-        ],
-        providers: [provideZonelessChangeDetection()]
+        imports: [CommonModule, FormsModule, ReactiveFormsModule, SiSelectModule, FormHostComponent]
       });
 
       const typedFixture = TestBed.createComponent(FormHostComponent);
@@ -476,8 +467,7 @@ describe('SiSelectComponent', () => {
 
     beforeEach(async () => {
       TestBed.configureTestingModule({
-        imports: [SiSelectModule, TestHostMultiComponent],
-        providers: [provideZonelessChangeDetection()]
+        imports: [SiSelectModule, TestHostMultiComponent]
       });
 
       const typedFixture = TestBed.createComponent(TestHostMultiComponent);
@@ -601,9 +591,6 @@ describe('SiSelectComponent', () => {
     let component: TestHostCustomActionComponent;
 
     beforeEach(async () => {
-      TestBed.configureTestingModule({
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
       const typedFixture = TestBed.createComponent(TestHostCustomActionComponent);
       fixture = typedFixture;
       loader = TestbedHarnessEnvironment.loader(fixture);

--- a/projects/element-ng/shadow-root/si-shadow-root.directive.spec.ts
+++ b/projects/element-ng/shadow-root/si-shadow-root.directive.spec.ts
@@ -3,13 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
-import {
-  Component,
-  input,
-  provideZonelessChangeDetection,
-  signal,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, input, signal, ViewEncapsulation } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiShadowRootDirective } from './si-shadow-root.directive';
@@ -57,9 +51,6 @@ describe('ShadowRootDirective', () => {
   let fixture: ComponentFixture<TestHostComponent>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
     fixture = TestBed.createComponent(TestHostComponent);
   });
 

--- a/projects/element-ng/side-panel/si-side-panel-content.component.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiSidePanelModule } from './si-side-panel.module';
@@ -23,8 +23,7 @@ describe('SiSidePanelContentComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiSidePanelModule, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiSidePanelModule, TestHostComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/side-panel/si-side-panel-service.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel-service.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkPortal, PortalModule } from '@angular/cdk/portal';
-import { Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiSidePanelService } from './si-side-panel.service';
@@ -25,7 +25,7 @@ describe('SiSidePanelService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [PortalModule, MockComponent],
-      providers: [SiSidePanelService, provideZonelessChangeDetection()]
+      providers: [SiSidePanelService]
     }).compileComponents();
   });
 

--- a/projects/element-ng/side-panel/si-side-panel.component.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel.component.spec.ts
@@ -3,14 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkPortal, PortalModule } from '@angular/cdk/portal';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal,
-  SimpleChange,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, SimpleChange, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 
@@ -64,8 +57,7 @@ describe('SiSidePanelComponent', () => {
         {
           provide: ResizeObserverService,
           useValue: resizeSpy
-        },
-        provideZonelessChangeDetection()
+        }
       ]
     }).compileComponents();
   });

--- a/projects/element-ng/skip-links/si-skip-links.spec.ts
+++ b/projects/element-ng/skip-links/si-skip-links.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiSkipLinkTargetDirective } from './si-skip-link-target.directive';
@@ -20,10 +20,6 @@ describe('SkipLinksComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    });
     fixture = TestBed.createComponent(TestHostComponent);
     fixture.detectChanges();
   });

--- a/projects/element-ng/slider/si-slider.component.spec.ts
+++ b/projects/element-ng/slider/si-slider.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, inject, provideZonelessChangeDetection, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
@@ -72,8 +72,7 @@ describe('SiSliderComponent', () => {
         SiSliderComponent,
         FormHostComponent,
         HostComponent
-      ],
-      providers: [provideZonelessChangeDetection()]
+      ]
     }).compileComponents()
   );
 

--- a/projects/element-ng/sort-bar/si-sort-bar.component.spec.ts
+++ b/projects/element-ng/sort-bar/si-sort-bar.component.spec.ts
@@ -3,12 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { HttpParams } from '@angular/common/http';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiSortBarComponent } from './si-sort-bar.component';
@@ -49,13 +44,6 @@ describe('SiSortBarComponent', () => {
 
   const getIconByIndex = (itemIndex: number): HTMLElement | null =>
     getItemByIndex(itemIndex)?.querySelector('.icon div') ?? null;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/split/si-split.component.spec.ts
+++ b/projects/element-ng/split/si-split.component.spec.ts
@@ -7,7 +7,6 @@ import {
   Component,
   ElementRef,
   Injectable,
-  provideZonelessChangeDetection,
   TemplateRef,
   viewChild
 } from '@angular/core';
@@ -348,9 +347,7 @@ describe('SiSplitComponent', () => {
   };
 
   const setup = (useStateService = false): void => {
-    const providers = useStateService
-      ? [provideSiUiState({ store: SynchronousMockStore }), provideZonelessChangeDetection()]
-      : [provideZonelessChangeDetection()];
+    const providers = useStateService ? [provideSiUiState({ store: SynchronousMockStore })] : [];
     beforeEach(async () => {
       await TestBed.configureTestingModule({
         imports: [SiSplitModule, WrapperComponent],

--- a/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.spec.ts
+++ b/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SiIconModule } from '@siemens/element-ng/icon';
 
@@ -36,8 +36,7 @@ describe('SiStatusBarItemComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiIconModule, SiStatusBarItemComponent, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiIconModule, SiStatusBarItemComponent, TestHostComponent]
     }).compileComponents()
   );
 

--- a/projects/element-ng/status-bar/si-status-bar.component.spec.ts
+++ b/projects/element-ng/status-bar/si-status-bar.component.spec.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  inject,
-  provideZonelessChangeDetection,
-  signal
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, inject, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {
@@ -44,13 +37,6 @@ describe('SiStatusBarComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let component: TestHostComponent;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     mockResizeObserver();

--- a/projects/element-ng/status-counter/si-status-counter.component.spec.ts
+++ b/projects/element-ng/status-counter/si-status-counter.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SiIconModule } from '@siemens/element-ng/icon';
 
@@ -20,8 +20,7 @@ describe('SiStatusCounterComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiIconModule, TestComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiIconModule, TestComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/status-toggle/si-status-toggle.component.spec.ts
+++ b/projects/element-ng/status-toggle/si-status-toggle.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -115,8 +115,7 @@ describe('SiStatusToggleComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HostComponent, FormHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [HostComponent, FormHostComponent]
     });
   });
 

--- a/projects/element-ng/summary-chip/si-summary-chip.component.spec.ts
+++ b/projects/element-ng/summary-chip/si-summary-chip.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiSummaryChipComponent } from './index';
@@ -11,13 +11,6 @@ describe('SiSummaryChipComponent', () => {
   let componentRef: ComponentRef<SiSummaryChipComponent>;
   let fixture: ComponentFixture<SiSummaryChipComponent>;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [SiSummaryChipComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents()
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SiSummaryChipComponent);

--- a/projects/element-ng/summary-widget/si-summary-widget.component.spec.ts
+++ b/projects/element-ng/summary-widget/si-summary-widget.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiSummaryWidgetComponent } from './index';
@@ -11,13 +11,6 @@ describe('SiSummaryWidgetComponent', () => {
   let componentRef: ComponentRef<SiSummaryWidgetComponent>;
   let fixture: ComponentFixture<SiSummaryWidgetComponent>;
   let element: HTMLElement;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [SiSummaryWidgetComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents()
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SiSummaryWidgetComponent);

--- a/projects/element-ng/system-banner/system-banner.component.spec.ts
+++ b/projects/element-ng/system-banner/system-banner.component.spec.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { NgClass } from '@angular/common';
-import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiSystemBannerComponent } from './system-banner.component';
@@ -11,13 +9,6 @@ import { SiSystemBannerComponent } from './system-banner.component';
 describe('SiSystemBannerComponent', () => {
   let component: SiSystemBannerComponent;
   let fixture: ComponentFixture<SiSystemBannerComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [SiSystemBannerComponent, NgClass],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SiSystemBannerComponent);

--- a/projects/element-ng/tabs-legacy/si-tabset/si-tabset-legacy.component.spec.ts
+++ b/projects/element-ng/tabs-legacy/si-tabset/si-tabset-legacy.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, DebugElement, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, DebugElement, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -87,8 +87,7 @@ describe('SiTabset', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SiTabsLegacyModule, TestComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiTabsLegacyModule, TestComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/tabs/si-tabset.component.spec.ts
+++ b/projects/element-ng/tabs/si-tabset.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader, TestKey } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, provideZonelessChangeDetection, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, RouterLink, RouterOutlet } from '@angular/router';
 
@@ -142,7 +142,7 @@ describe('SiTabset', () => {
     mockResizeObserver();
     await TestBed.configureTestingModule({
       imports: [TestComponent],
-      providers: [provideRouter([]), provideZonelessChangeDetection()]
+      providers: [provideRouter([])]
     }).compileComponents();
     fixture = TestBed.createComponent(TestComponent);
     testComponent = fixture.componentInstance;
@@ -411,8 +411,7 @@ describe('SiTabset Routing', () => {
             path: 'tab-route',
             component: SiTabRouteComponent
           }
-        ]),
-        provideZonelessChangeDetection()
+        ])
       ]
     }).compileComponents();
   });

--- a/projects/element-ng/theme/si-theme.service.spec.ts
+++ b/projects/element-ng/theme/si-theme.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
@@ -26,11 +25,7 @@ describe('SiThemeService', () => {
         }) as any
     );
     TestBed.configureTestingModule({
-      providers: [
-        TestService,
-        { provide: SiThemeStore, useValue: store },
-        provideZonelessChangeDetection()
-      ]
+      providers: [TestService, { provide: SiThemeStore, useValue: store }]
     });
     service = TestBed.inject(TestService);
     service.resolvedColorScheme$.subscribe(themeSwitchSpy);

--- a/projects/element-ng/threshold/si-threshold.component.spec.ts
+++ b/projects/element-ng/threshold/si-threshold.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader, parallel } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SelectOption } from '@siemens/element-ng/select';
@@ -93,13 +93,6 @@ describe('SiThresholdComponent', () => {
     });
     return calculatedColors;
   };
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Observable, Subject } from 'rxjs';
 
@@ -22,13 +22,6 @@ describe('SiToastNotificationDrawerComponent', () => {
   let component: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
   let element: HTMLElement;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);

--- a/projects/element-ng/toast-notification/si-toast-notification.service.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiToastNotificationService } from './si-toast-notification.service';
@@ -12,7 +11,7 @@ describe('SiToastNotificationService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [SiToastNotificationService, provideZonelessChangeDetection()]
+      providers: [SiToastNotificationService]
     });
   });
 

--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.spec.ts
@@ -2,12 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { STATUS_ICON } from '@siemens/element-ng/common';
@@ -38,8 +33,7 @@ describe('SiToastNotificationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SiToastNotificationComponent, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [NoopAnimationsModule, SiToastNotificationComponent, TestHostComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiTooltipModule } from './si-tooltip.module';
@@ -30,8 +30,7 @@ describe('SiTooltipDirective', () => {
 
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        imports: [SiTooltipModule, TestHostComponent],
-        providers: [provideZonelessChangeDetection()]
+        imports: [SiTooltipModule, TestHostComponent]
       }).compileComponents();
     });
 
@@ -103,13 +102,6 @@ describe('SiTooltipDirective', () => {
     class TestHostComponent {
       tooltipContext = {};
     }
-
-    beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [TestHostComponent],
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
-    });
 
     beforeEach(() => {
       jasmine.clock().install();

--- a/projects/element-ng/tour/si-tour.service.spec.ts
+++ b/projects/element-ng/tour/si-tour.service.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, inject, provideZonelessChangeDetection } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiTourService } from './si-tour.service';
@@ -18,12 +18,6 @@ describe('SiTourService', () => {
   let component: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
-  });
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;

--- a/projects/element-ng/tree-view/si-tree-view-converter.service.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-converter.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { inject, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { SiTreeViewConverterService } from './si-tree-view-converter.service';
@@ -12,7 +11,7 @@ export const main = (): void => {
   describe('SiTreeViewConverterService', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        providers: [SiTreeViewService, SiTreeViewConverterService, provideZonelessChangeDetection()]
+        providers: [SiTreeViewService, SiTreeViewConverterService]
       }).compileComponents();
     }));
 

--- a/projects/element-ng/tree-view/si-tree-view-item-height.service.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item-height.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { inject, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { SiTreeViewItemHeightService } from './si-tree-view-item-height.service';
@@ -12,11 +11,7 @@ export const main = (): void => {
   describe('SiTreeViewItemHeightService', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        providers: [
-          SiTreeViewService,
-          SiTreeViewItemHeightService,
-          provideZonelessChangeDetection()
-        ]
+        providers: [SiTreeViewService, SiTreeViewItemHeightService]
       }).compileComponents();
     }));
 

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
@@ -3,13 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkDragDrop, CdkDropList, DragDropModule } from '@angular/cdk/drag-drop';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  DebugElement,
-  provideZonelessChangeDetection,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, DebugElement, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
@@ -127,8 +121,7 @@ describe('SiTreeViewComponentWithDragDrop', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
-      imports: [SiTreeViewModule, DragDropModule, WrapperComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiTreeViewModule, DragDropModule, WrapperComponent]
     });
   });
 

--- a/projects/element-ng/tree-view/si-tree-view-virtualization.service.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-virtualization.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { inject, TestBed } from '@angular/core/testing';
 
 import { SiTreeViewItemHeightService } from './si-tree-view-item-height.service';
@@ -93,12 +92,7 @@ export const main = (): void => {
   describe('ListVirtualizationService', () => {
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        providers: [
-          SiTreeViewService,
-          SiTreeViewItemHeightService,
-          SiTreeViewVirtualizationService,
-          provideZonelessChangeDetection()
-        ]
+        providers: [SiTreeViewService, SiTreeViewItemHeightService, SiTreeViewVirtualizationService]
       }).compileComponents();
     });
 

--- a/projects/element-ng/tree-view/si-tree-view.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.spec.ts
@@ -8,7 +8,6 @@ import {
   Component,
   DebugElement,
   inject,
-  provideZonelessChangeDetection,
   viewChild
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -127,8 +126,7 @@ describe('SiTreeViewComponent', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
-      imports: [SiLoadingSpinnerModule, NoopAnimationsModule, SiTreeViewModule, WrapperComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiLoadingSpinnerModule, NoopAnimationsModule, SiTreeViewModule, WrapperComponent]
     });
   });
 

--- a/projects/element-ng/tree-view/si-tree-view.service.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { inject, TestBed } from '@angular/core/testing';
 
 import { SiTreeViewService } from './si-tree-view.service';
@@ -11,7 +10,7 @@ export const main = (): void => {
   describe('SiTreeViewService', () => {
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        providers: [SiTreeViewService, provideZonelessChangeDetection()]
+        providers: [SiTreeViewService]
       }).compileComponents();
     });
 

--- a/projects/element-ng/typeahead/si-typeahead.directive.spec.ts
+++ b/projects/element-ng/typeahead/si-typeahead.directive.spec.ts
@@ -5,13 +5,7 @@
 import { DOWN_ARROW, ENTER } from '@angular/cdk/keycodes';
 import { HarnessLoader, TestKey } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  TemplateRef,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, TemplateRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { BehaviorSubject, of } from 'rxjs';
@@ -102,11 +96,7 @@ describe('SiTypeaheadDirective', () => {
 
   const testList = ['sweet', 'home', 'alabama', 'where', 'the', 'skies', 'are', 'so', 'blue'];
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [SiTypeaheadDirective, FormsModule, WrapperComponent],
-      providers: [provideZonelessChangeDetection()]
-    }).compileComponents();
+  beforeEach(() => {
     fixture = TestBed.createComponent(WrapperComponent);
     wrapperComponent = fixture.componentInstance;
     wrapperElement = fixture.nativeElement;

--- a/projects/element-ng/wizard/si-wizard.component.spec.ts
+++ b/projects/element-ng/wizard/si-wizard.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, input, provideZonelessChangeDetection, viewChild } from '@angular/core';
+import { Component, input, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SiResizeObserverModule } from '@siemens/element-ng/resize-observer';
@@ -63,8 +63,7 @@ describe('SiWizardComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [SiResizeObserverModule, TestHostComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiResizeObserverModule, TestHostComponent]
     })
   );
 

--- a/projects/element-translate-ng/ngx-translate/si-translate-ngxt.spec.ts
+++ b/projects/element-translate-ng/ngx-translate/si-translate-ngxt.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, DOCUMENT, Injectable, provideZonelessChangeDetection } from '@angular/core';
+import { Component, DOCUMENT, Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RouterModule, RouterOutlet } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
@@ -67,7 +67,7 @@ describe('SiTranslateNgxT', () => {
           ]),
           HostComponent
         ],
-        providers: [RootTestService, provideZonelessChangeDetection()]
+        providers: [RootTestService]
       });
     });
 
@@ -102,8 +102,7 @@ describe('SiTranslateNgxT', () => {
               } as TranslateLoader
             }
           })
-        ],
-        providers: [provideZonelessChangeDetection()]
+        ]
       });
     });
     beforeEach(() => {

--- a/projects/element-translate-ng/translate/si-no-translate.spec.ts
+++ b/projects/element-translate-ng/translate/si-no-translate.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { injectSiTranslateService } from './si-translate.inject';
@@ -12,9 +11,6 @@ describe('SiNoTranslate', () => {
   let service: SiTranslateService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    });
     service = TestBed.runInInjectionContext(() => injectSiTranslateService());
   });
 

--- a/projects/element-translate-ng/translate/si-translatable.spec.ts
+++ b/projects/element-translate-ng/translate/si-translatable.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiNoTranslateService } from './si-no-translate.service';
@@ -13,20 +12,13 @@ import { SiTranslateService } from './si-translate.service';
 describe('SiTranslatable', () => {
   let service: SiTranslatableService;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()]
-    });
-  });
-
   describe('with SiTranslateService', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         providers: [
           { provide: SiTranslateService, useClass: SiNoTranslateService },
           { provide: SI_TRANSLATABLE_VALUES, useValue: { KEY1: 'value1' }, multi: true },
-          { provide: SI_TRANSLATABLE_VALUES, useValue: { KEY2: 'value2' }, multi: true },
-          provideZonelessChangeDetection()
+          { provide: SI_TRANSLATABLE_VALUES, useValue: { KEY2: 'value2' }, multi: true }
         ]
       });
       service = TestBed.inject(SiTranslatableService);

--- a/projects/element-translate-ng/translate/si-translate.pipe.spec.ts
+++ b/projects/element-translate-ng/translate/si-translate.pipe.spec.ts
@@ -7,8 +7,7 @@ import {
   ChangeDetectorRef,
   Component,
   inject,
-  Injectable,
-  provideZonelessChangeDetection
+  Injectable
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { injectSiTranslateService, t } from '@siemens/element-translate-ng/translate';
@@ -89,8 +88,7 @@ describe('SiTranslatePipe', () => {
       TestBed.configureTestingModule({
         imports: [TestComponent],
         providers: [
-          provideMockTranslateServiceBuilder(injector => injector.get(SiAsyncTranslateService)),
-          provideZonelessChangeDetection()
+          provideMockTranslateServiceBuilder(injector => injector.get(SiAsyncTranslateService))
         ]
       }).compileComponents();
     });
@@ -143,8 +141,7 @@ describe('SiTranslatePipe', () => {
                 translate: (key: string, params: Record<string, any>) =>
                   `translated=>${key}-${JSON.stringify(params)}`
               }) as SiTranslateService
-          ),
-          provideZonelessChangeDetection()
+          )
         ]
       }).compileComponents();
     });
@@ -177,13 +174,6 @@ describe('SiTranslatePipe', () => {
     let fixture: ComponentFixture<TestComponent>;
     let component: TestComponent;
     let nativeElement: HTMLElement;
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [TestComponent],
-        providers: [provideZonelessChangeDetection()]
-      }).compileComponents();
-    });
 
     beforeEach(() => {
       fixture = TestBed.createComponent(TestComponent);

--- a/projects/maps-ng/src/components/si-map/components/si-map-popover/si-map-popover.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/components/si-map-popover/si-map-popover.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MapPointMetaData } from '../../models';
@@ -20,8 +20,7 @@ describe('SiMapPopoverComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiMapPopoverComponent, MockCustomPopoverComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiMapPopoverComponent, MockCustomPopoverComponent]
     }).compileComponents();
   });
 

--- a/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -17,8 +16,7 @@ describe('SiMapTooltipComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiMapTooltipComponent],
-      providers: [provideZonelessChangeDetection()]
+      imports: [SiMapTooltipComponent]
     }).compileComponents();
   });
 

--- a/projects/maps-ng/src/components/si-map/services/map.service.spec.ts
+++ b/projects/maps-ng/src/components/si-map/services/map.service.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { MapService } from './map.service';
@@ -12,7 +11,7 @@ describe('Service: Map', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      providers: [MapService, provideZonelessChangeDetection()]
+      providers: [MapService]
     }).compileComponents();
     mapService = TestBed.inject(MapService);
   });

--- a/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { TranslateModule } from '@ngx-translate/core';
@@ -50,7 +50,7 @@ describe('SiMapComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [SiMapModule, TranslateModule.forRoot()],
-      providers: [MapService, provideZonelessChangeDetection()]
+      providers: [MapService]
     })
   );
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -14,7 +14,6 @@ import {
   Injectable,
   LOCALE_ID,
   provideAppInitializer,
-  provideZonelessChangeDetection,
   ɵLocaleDataIndex
 } from '@angular/core';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
@@ -160,7 +159,6 @@ export const APP_CONFIG: ApplicationConfig = {
     provideSiDatatableConfig(),
     provideIconConfig({ disableSvgIcons: false }),
     provideSiUiState(),
-    provideSiAgGridConfig(),
-    provideZonelessChangeDetection()
+    provideSiAgGridConfig()
   ]
 };


### PR DESCRIPTION
Since zone.js has been removed from the project,
provideZonelessChangeDetection is no longer needed.

This removes all usages of provideZonelessChangeDetection from the codebase including:
- src/app/app.config.ts
- All spec files in projects/element-ng
- All spec files in projects/charts-ng
- All spec files in projects/dashboards-ng
- All spec files in projects/element-translate-ng
- All spec files in projects/maps-ng


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
