### PR TITLE
test(loading-button): wait for loading to start

### DIFF
--- a/playwright/e2e/element-examples/si-loading-button.spec.ts
+++ b/playwright/e2e/element-examples/si-loading-button.spec.ts
@@ -12,8 +12,7 @@ test.describe('si-loading-button', () => {
     await si.runVisualAndA11yTests('normal state');
 
     await page.locator('input[type=checkbox]').check();
-    const spinnerCount = await page.locator('si-loading-spinner').count();
-    expect(spinnerCount).toBeGreaterThan(0);
+    await expect(page.locator('si-loading-spinner')).not.toHaveCount(0);
     await si.runVisualAndA11yTests('second-step', { maxDiffPixels: 45 });
   });
 });


### PR DESCRIPTION
The previous implementation did not wait for loading to be started. Now the test waits until the loading started.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
