### PR TITLE
fix(side-panel): set default display to inline-flex

### DIFF
--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74b3a6f8fa18d538c557b7eb1224f0bc91fd2e649686b4e6d1eabb72bea88ec5
-size 71051
+oid sha256:acf7d87bfe91fd2a2547bca5864e5c3c16a679d71545d5276bde3420e7ae02ac
+size 71035

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4cfe547b0afa90dec4151ca6a455b10a0394c3f1ff498be1091c4c78d595ce8
-size 74074
+oid sha256:f974455fedb9cd3e9facfed21ca986868ac9d95226afdf38c6e3ed99d2cd71de
+size 74070

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode-no-backdrop-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode-no-backdrop-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b163ec0ddae1b5e6813cf790a8fdc609b5a67b340d63f8de2b0b6f19987649ca
-size 71415
+oid sha256:2f8289942c92a91844e6b1f10470e26f186f23cdc4d8f4f2b1f3d1868801723f
+size 71417

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode-no-backdrop-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode-no-backdrop-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81548fc2b4ae09d2568b518e6405727d37b61486a968f9b73ad92fc2f3b8b87c
-size 72578
+oid sha256:6f69fd41f4c40323838b6170e8cb6d8cf43af1c83320e31bcda9dd92594b876b
+size 72571

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--scroll-mode-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--scroll-mode-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff4da46afe4a37d9d0550910758b8bde782b53a3f33b08ba3278babce2f6ba52
-size 87992
+oid sha256:471f496ccebfde37f38be1aac189d360b72f9077e7af9032f05b8661216f82a2
+size 87997

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--scroll-mode-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--scroll-mode-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8be17067ccd0795d99b001e03b7cc1ba71772fe0077dca4b031f83a996bfc5b3
-size 89203
+oid sha256:edc5896bdaef6996cdec8fecf3bce54c49fffc0d688c623006df32bf9358654f
+size 89196

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible--open-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible--open-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9681d366ebc531c72a83452fbf856fac0559627cd8f607664df2a81d522dbef9
-size 56336
+oid sha256:676c0a8e4d6758a580e47d1a075c4caee8c9ff7c5e2a53cf45227dfb5dbe6a1a
+size 56321

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible--open-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible--open-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1aadef886a373bbe7bf82056d604f9a11483615e2f3329e0af11e18826ab021
-size 57214
+oid sha256:c5b2084265f8b33a1ad1f7b8fbcfb457bf0d1530bd3f2109f9ad8ae032e84a43
+size 57199

--- a/projects/element-ng/side-panel/si-side-panel-content.component.scss
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.scss
@@ -57,7 +57,7 @@
 }
 
 .fullscreen-button {
-  display: var(--fullscreen-button-display);
+  display: var(--fullscreen-button-display, inline-flex);
 }
 
 .collapse-toggle {


### PR DESCRIPTION
Sets the default display to `inline-flex` for the fullscreen button in the side panel.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
