### PR TITLE
refactor: deprecate simpl type alias

### DIFF
--- a/projects/charts-ng/common/si-chart.interfaces.ts
+++ b/projects/charts-ng/common/si-chart.interfaces.ts
@@ -109,4 +109,7 @@ export interface SiSeriesOption {
   visible?: boolean;
 }
 
+/**
+ * @deprecated Use {@link SiSeriesOption} instead. The `Simpl` prefix is deprecated and will be removed in v51.
+ */
 export type { SiSeriesOption as SimplSeriesOption };

--- a/projects/charts-ng/public-api.module.ts
+++ b/projects/charts-ng/public-api.module.ts
@@ -45,4 +45,7 @@ import { SiChartSunburstComponent } from '@siemens/charts-ng/sunburst';
 })
 export class SiChartsNgModule {}
 
+/**
+ * @deprecated Use {@link SiChartsNgModule} instead. The `Simpl` prefix is deprecated and will be removed in v51.
+ */
 export { SiChartsNgModule as SimplChartsNgModule };

--- a/projects/live-preview/live-preview-routes.ts
+++ b/projects/live-preview/live-preview-routes.ts
@@ -57,4 +57,7 @@ export const livePreviewRoutes: Routes = [
 })
 export class SiLivePreviewRoutingModule {}
 
+/**
+ * @deprecated Use {@link SiLivePreviewRoutingModule} instead. The `Simpl` prefix is deprecated and will be removed in v51.
+ */
 export { SiLivePreviewRoutingModule as SimplLivePreviewRoutingModule };

--- a/projects/live-preview/public-api.module.ts
+++ b/projects/live-preview/public-api.module.ts
@@ -36,4 +36,7 @@ export class SiLivePreviewModule {
   }
 }
 
+/**
+ * @deprecated Use {@link SiLivePreviewModule} instead. The `Simpl` prefix is deprecated and will be removed in v51.
+ */
 export { SiLivePreviewModule as SimplLivePreviewModule };

--- a/projects/maps-ng/src/public-api.module.ts
+++ b/projects/maps-ng/src/public-api.module.ts
@@ -11,4 +11,7 @@ import { SiMapModule } from './components/si-map/index';
 })
 export class SiMapsNgModule {}
 
+/**
+ * @deprecated Use {@link SiMapsNgModule} instead. The `Simpl` prefix is deprecated and will be removed in v51.
+ */
 export { SiMapsNgModule as SimplMapsNgModule };

--- a/projects/native-charts-ng/public-api.module.ts
+++ b/projects/native-charts-ng/public-api.module.ts
@@ -11,4 +11,7 @@ import { SiNChartGaugeComponent } from '@siemens/native-charts-ng/gauge';
 })
 export class SiNativeChartsNgModule {}
 
+/**
+ * @deprecated Use {@link SiNativeChartsNgModule} instead. The `Simpl` prefix is deprecated and will be removed in v51.
+ */
 export { SiNativeChartsNgModule as SimplNativeChartsNgModule };


### PR DESCRIPTION
DEPRECATED: The type alias with `Simpl` prefix are deprecated, use types with `si` prefix instead as per below

`SimplChartsNgModule` -> Use `SiChartsNgModule` instead `SimplSeriesOption` -> Use `SiSeriesOption` instead `SimplLivePreviewRoutingModule` -> Use `SiLivePreviewRoutingModule` instead `SimplLivePreviewModule` -> Use `SiLivePreviewModule`  instead `SimplMapsNgModule` -> Use `SiMapsNgModule` instead `SimplNativeChartsNgModule` -> Use `SiNativeChartsNgModule` instead

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
