### PR TITLE
refactor(buttons): use square buttons instead of circle in layout/nav components

### DIFF
--- a/projects/element-ng/electron-titlebar/si-electron-titlebar.component.html
+++ b/projects/element-ng/electron-titlebar/si-electron-titlebar.component.html
@@ -7,7 +7,7 @@
     >
     <button
       type="button"
-      class="btn btn-circle btn-sm btn-tertiary"
+      class="btn btn-icon btn-sm btn-tertiary"
       [class.unfocused]="!hasFocus()"
       [attr.aria-label]="ariaLabelBack() | translate"
       [disabled]="!canGoBack()"
@@ -17,7 +17,7 @@
     </button>
     <button
       type="button"
-      class="btn btn-circle btn-sm btn-tertiary"
+      class="btn btn-icon btn-sm btn-tertiary"
       [class.unfocused]="!hasFocus()"
       [attr.aria-label]="ariaLabelForward() | translate"
       [disabled]="!canGoForward()"
@@ -28,7 +28,7 @@
     @if (menuItems().length > 0) {
       <button
         type="button"
-        class="btn btn-circle electron-title-bar-btn btn-tertiary btn-sm"
+        class="btn btn-icon electron-title-bar-btn btn-tertiary btn-sm"
         [class.unfocused]="!hasFocus()"
         [attr.aria-label]="ariaLabelMenu() | translate"
         [cdkMenuTriggerFor]="menu"

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical.component.html
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical.component.html
@@ -17,7 +17,7 @@
       <div class="mobile-drawer focus-inside navbar-vertical-no-collapse">
         <button
           type="button"
-          class="btn btn-circle btn-ghost"
+          class="btn btn-icon btn-ghost"
           [attr.aria-label]="
             (collapsed() ? navbarExpandButtonText() : navbarCollapseButtonText()) | translate
           "

--- a/projects/element-ng/side-panel/si-side-panel-content.component.html
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.html
@@ -14,7 +14,7 @@
     @if (displayMode() === 'navigate' && navigateConfig) {
       @if (navigateConfig.type === 'router-link') {
         <a
-          class="btn btn-circle btn-ghost auto-hide"
+          class="btn btn-icon btn-ghost auto-hide"
           [class.ms-4]="collapsible()"
           [class.mx-4]="!collapsible() || service.isTemporaryOpen()"
           [routerLink]="navigateConfig.routerLink"
@@ -35,7 +35,7 @@
         >
       } @else if (navigateConfig.type === 'link') {
         <a
-          class="btn btn-circle btn-ghost auto-hide"
+          class="btn btn-icon btn-ghost auto-hide"
           [class.ms-4]="collapsible()"
           [class.mx-4]="!collapsible()"
           [href]="navigateConfig.href"
@@ -53,7 +53,7 @@
     @if (displayMode() === 'overlay') {
       <button
         type="button"
-        class="fullscreen-button btn btn-circle btn-ghost auto-hide"
+        class="fullscreen-button btn btn-icon btn-ghost auto-hide"
         [class.ms-4]="collapsible()"
         [class.mx-4]="!collapsible() || service.isTemporaryOpen()"
         [attr.aria-label]="
@@ -67,7 +67,7 @@
     }
     <button
       type="button"
-      class="close-button btn btn-circle btn-ghost me-4"
+      class="close-button btn btn-icon btn-ghost me-4"
       [attr.aria-label]="closeButtonLabel() | translate"
       [tabindex]="focusable() ? '0' : '-1'"
       (click)="toggleSidePanel($event)"
@@ -77,7 +77,7 @@
     <div class="collapse-toggle">
       <button
         type="button"
-        class="side-panel-collapse-toggle btn btn-circle btn-ghost mx-4"
+        class="side-panel-collapse-toggle btn btn-icon btn-ghost mx-4"
         [attr.aria-label]="toggleItemLabel() | translate"
         (click)="toggleSidePanel($event)"
       >

--- a/src/app/examples/si-list-details/si-list-details.html
+++ b/src/app/examples/si-list-details/si-list-details.html
@@ -20,7 +20,7 @@
       />
       <button
         type="button"
-        class="btn btn-circle btn-tertiary"
+        class="btn btn-icon btn-tertiary"
         aria-label="Options"
         [cdkMenuTriggerFor]="contextMenu"
       >
@@ -38,7 +38,7 @@
       />
       <button
         type="button"
-        class="btn btn-circle btn-ghost element-filter me-2"
+        class="btn btn-icon btn-ghost element-filter me-2"
         aria-label="Filters"
         (click)="logEvent('Filters')"
       ></button>


### PR DESCRIPTION
Use square buttons instead of circle in layout/nav components.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
