### PR TITLE
refactor(buttons): replace btn-circle with btn-icon in tree-view

### DIFF
--- a/projects/element-ng/tree-view/si-tree-view.component.html
+++ b/projects/element-ng/tree-view/si-tree-view.component.html
@@ -1,7 +1,7 @@
 @if (!flatTree() && expandCollapseAll()) {
   <div class="si-tree-view-expand-collapse-container p-4">
     <button
-      class="btn btn-circle btn-tertiary element-expand-all"
+      class="btn btn-icon btn-tertiary element-expand-all"
       type="button"
       [title]="expandAllTooltip() | translate"
       [attr.aria-label]="expandAllTooltip() | translate"
@@ -9,7 +9,7 @@
     >
     </button>
     <button
-      class="btn btn-circle btn-tertiary ms-4 element-collapse-all"
+      class="btn btn-icon btn-tertiary ms-4 element-collapse-all"
       type="button"
       [title]="collapseAllTooltip() | translate"
       [attr.aria-label]="collapseAllTooltip() | translate"


### PR DESCRIPTION
Use square buttons instead of circle in the tree-view.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
