### PR TITLE
refactor(buttons): replace btn-circle with btn-icon in chat messages

### DIFF
--- a/projects/element-ng/chat-messages/si-ai-message.component.html
+++ b/projects/element-ng/chat-messages/si-ai-message.component.html
@@ -13,7 +13,7 @@
       @for (action of actions(); track $index) {
         <button
           type="button"
-          class="btn btn-ghost btn-circle"
+          class="btn btn-ghost btn-icon"
           [disabled]="action.disabled"
           [attr.aria-label]="action.label | translate"
           (click)="action.action(actionParam(), action)"
@@ -25,7 +25,7 @@
       @if (secondaryActions()?.length ?? 0 > 0) {
         <button
           type="button"
-          class="btn btn-ghost btn-circle"
+          class="btn btn-ghost btn-icon"
           [cdkMenuTriggerFor]="secondaryActionsMenu"
           [attr.aria-label]="secondaryActionsLabel() | translate"
           [attr.title]="secondaryActionsLabel() | translate"

--- a/projects/element-ng/chat-messages/si-attachment-list.component.html
+++ b/projects/element-ng/chat-messages/si-attachment-list.component.html
@@ -44,7 +44,7 @@
       @if (removable()) {
         <button
           type="button"
-          class="btn btn-ghost btn-circle expand-button flex-shrink-0 ms-auto align-self-center focus-inside"
+          class="btn btn-ghost btn-icon expand-button flex-shrink-0 ms-auto align-self-center focus-inside"
           [attr.aria-label]="(removeLabel() | translate) + ' ' + attachment.name"
           (click)="remove.emit(attachment); $event.stopPropagation()"
         >

--- a/projects/element-ng/chat-messages/si-attachment-list.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-attachment-list.component.spec.ts
@@ -84,7 +84,7 @@ describe('SiAttachmentListComponent', () => {
     fixture.componentRef.setInput('attachments', attachments);
     fixture.detectChanges();
 
-    const removeButtons = debugElement.queryAll(By.css('.btn-circle'));
+    const removeButtons = debugElement.queryAll(By.css('.btn-icon'));
     expect(removeButtons.length).toBe(0);
   });
 
@@ -95,7 +95,7 @@ describe('SiAttachmentListComponent', () => {
     fixture.componentRef.setInput('removable', true);
     fixture.detectChanges();
 
-    const removeButtons = debugElement.queryAll(By.css('.btn-circle'));
+    const removeButtons = debugElement.queryAll(By.css('.btn-icon'));
     expect(removeButtons.length).toBe(2);
   });
 
@@ -111,7 +111,7 @@ describe('SiAttachmentListComponent', () => {
     fixture.componentRef.setInput('removable', true);
     fixture.detectChanges();
 
-    const removeButton = debugElement.query(By.css('.btn-circle'));
+    const removeButton = debugElement.query(By.css('.btn-icon'));
     removeButton.nativeElement.click();
 
     expect(emittedName).toBe('file.txt');

--- a/projects/element-ng/chat-messages/si-chat-input.component.html
+++ b/projects/element-ng/chat-messages/si-chat-input.component.html
@@ -50,7 +50,7 @@
 
         <button
           type="button"
-          class="btn btn-ghost btn-circle"
+          class="btn btn-ghost btn-icon"
           [attr.aria-label]="attachFileLabel() | translate"
           [disabled]="disabled()"
           (click)="fileInput.click()"
@@ -64,7 +64,7 @@
           @for (action of actions(); track $index) {
             <button
               type="button"
-              class="btn btn-ghost btn-circle"
+              class="btn btn-ghost btn-icon"
               [disabled]="action.disabled"
               [attr.aria-label]="action.label | translate"
               (click)="action.action(actionParam(), action)"
@@ -76,7 +76,7 @@
           @if (secondaryActions().length > 0) {
             <button
               type="button"
-              class="btn btn-ghost btn-circle"
+              class="btn btn-ghost btn-icon"
               [cdkMenuTriggerFor]="secondaryActionsMenu"
               [attr.aria-label]="secondaryActionsLabel() | translate"
               [attr.title]="secondaryActionsLabel() | translate"
@@ -97,7 +97,7 @@
 
     <button
       type="button"
-      class="btn btn-ghost btn-circle"
+      class="btn btn-ghost btn-icon"
       [disabled]="buttonDisabled()"
       [attr.aria-label]="buttonLabel() | translate"
       (click)="onButtonClick()"

--- a/projects/element-ng/chat-messages/si-user-message.component.html
+++ b/projects/element-ng/chat-messages/si-user-message.component.html
@@ -16,7 +16,7 @@
       @for (action of actions(); track $index) {
         <button
           type="button"
-          class="btn btn-ghost btn-circle"
+          class="btn btn-ghost btn-icon"
           [disabled]="action.disabled"
           [attr.aria-label]="action.label | translate"
           (click)="action.action(actionParam(), action)"
@@ -28,7 +28,7 @@
       @if (secondaryActions()?.length ?? 0 > 0) {
         <button
           type="button"
-          class="btn btn-ghost btn-circle"
+          class="btn btn-ghost btn-icon"
           [cdkMenuTriggerFor]="secondaryActionsMenu"
           [attr.aria-label]="secondaryActionsLabel() | translate"
           [attr.title]="secondaryActionsLabel() | translate"

--- a/src/app/examples/si-chat-messages/si-chat-input.html
+++ b/src/app/examples/si-chat-messages/si-chat-input.html
@@ -24,7 +24,7 @@
     <!-- Custom actions via ng-content slot -->
     <button
       type="button"
-      class="btn btn-ghost btn-circle"
+      class="btn btn-ghost btn-icon"
       title="Insert emoji"
       (click)="logEvent('Emoji picker clicked')"
     >


### PR DESCRIPTION
Use square buttons instead of circle in chat and messages.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
