### PR TITLE
refactor(buttons): replace btn-circle with btn-icon in notifications

### DIFF
--- a/api-goldens/element-ng/notification-item/index.api.md
+++ b/api-goldens/element-ng/notification-item/index.api.md
@@ -20,7 +20,7 @@ export interface NotificationItemActionButton {
     type: 'action-button';
 }
 
-// @public
+// @public @deprecated
 export interface NotificationItemActionCircleButton extends NotificationItemBase {
     // (undocumented)
     action: (source: this) => void;
@@ -28,6 +28,16 @@ export interface NotificationItemActionCircleButton extends NotificationItemBase
     customClass?: string;
     // (undocumented)
     type: 'action-circle-button';
+}
+
+// @public
+export interface NotificationItemActionIconButton extends NotificationItemBase {
+    // (undocumented)
+    action: (source: this) => void;
+    // (undocumented)
+    customClass?: string;
+    // (undocumented)
+    type: 'action-icon-button';
 }
 
 // @public
@@ -67,10 +77,10 @@ export interface NotificationItemMenu {
 }
 
 // @public
-export type NotificationItemPrimaryAction = NotificationItemActionCircleButton | NotificationItemLinkIcon | NotificationItemRouterLinkIcon | NotificationItemMenu | NotificationItemActionButton;
+export type NotificationItemPrimaryAction = NotificationItemActionCircleButton | NotificationItemActionIconButton | NotificationItemLinkIcon | NotificationItemRouterLinkIcon | NotificationItemMenu | NotificationItemActionButton;
 
 // @public
-export type NotificationItemQuickAction = NotificationItemActionCircleButton | NotificationItemLinkIcon | NotificationItemRouterLinkIcon;
+export type NotificationItemQuickAction = NotificationItemActionCircleButton | NotificationItemActionIconButton | NotificationItemLinkIcon | NotificationItemRouterLinkIcon;
 
 // @public
 export interface NotificationItemRouterLink {

--- a/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item--default-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item--default-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39d53f164bf0cec7bd60f0f74a2974ae12cdce2d5e16bc780b44abbad6f8ec0c
-size 91855
+oid sha256:d4cbe3b8c5476692f401bf65cd09f8e7c45e40a2b0444a6cf0076e1623eb48b4
+size 90570

--- a/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item--default-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item--default-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18c39439ec27bd818ab0bc66c57ec684565ac4d654d2d3469a89248f7128eb31
-size 86400
+oid sha256:7cae6228752a1cbde605a5cfcb14d02782a9b538a359cc7de0a6c2997430b45d
+size 85209

--- a/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item--unread-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item--unread-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5eceb9ade43b813d9970b7ed79fe3447197d25ee3e4b9cc666d01fabf806f2a8
-size 93510
+oid sha256:e9a0d9f168d3708e255d6037b08c6ecee07ae0ba7d9a0e1c1fb5f89e4205bce0
+size 92222

--- a/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item--unread-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item--unread-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96fdadeeadee3b408c05f98abd90a8f301979d36e08e697ebab9842d0d98d4ce
-size 87878
+oid sha256:19613fd35ed0c54aa3b258ad9f3d22b160198723272b10582e8cea72a6f4291a
+size 86708

--- a/projects/element-ng/notification-item/si-notification-item.component.html
+++ b/projects/element-ng/notification-item/si-notification-item.component.html
@@ -84,6 +84,9 @@
     @case ('action-circle-button') {
       <ng-container *ngTemplateOutlet="actionButton; context: { $implicit: action }" />
     }
+    @case ('action-icon-button') {
+      <ng-container *ngTemplateOutlet="actionButton; context: { $implicit: action }" />
+    }
     @case ('router-link') {
       <ng-container *ngTemplateOutlet="routerLink; context: { $implicit: action }" />
     }
@@ -109,7 +112,7 @@
 <ng-template #actionButton let-action>
   <button
     type="button"
-    class="btn btn-ghost btn-circle"
+    class="btn btn-ghost btn-icon"
     [attr.aria-label]="action.ariaLabel"
     (click)="action.action(action)"
   >
@@ -119,7 +122,7 @@
 
 <ng-template #routerLink let-action>
   <a
-    class="btn btn-ghost p-2 btn-circle"
+    class="btn btn-ghost p-2 btn-icon"
     [routerLink]="action.routerLink"
     [queryParams]="action.extras?.queryParams"
     [queryParamsHandling]="action.extras?.queryParamsHandling"
@@ -137,7 +140,7 @@
 
 <ng-template #link let-action>
   <a
-    class="btn btn-ghost p-2 btn-circle"
+    class="btn btn-ghost p-2 btn-icon"
     [href]="action.href"
     [target]="action.target"
     [attr.aria-label]="action.ariaLabel"
@@ -149,7 +152,7 @@
 <ng-template #menu let-action>
   <button
     type="button"
-    class="btn btn-ghost btn-circle"
+    class="btn btn-ghost btn-icon"
     [attr.aria-label]="heading() + ' dropdown'"
     [cdkMenuTriggerFor]="actionMenu"
   >

--- a/projects/element-ng/notification-item/si-notification-item.component.spec.ts
+++ b/projects/element-ng/notification-item/si-notification-item.component.spec.ts
@@ -106,7 +106,7 @@ describe('SiNotificationItemComponent', () => {
   it('should display the quick actions', () => {
     component.quickActions = [
       {
-        type: 'action-circle-button',
+        type: 'action-icon-button',
         action: () => {},
         ariaLabel: 'Action',
         icon: 'element-plant'

--- a/projects/element-ng/notification-item/si-notification-item.component.ts
+++ b/projects/element-ng/notification-item/si-notification-item.component.ts
@@ -49,9 +49,22 @@ export interface NotificationItemBase {
  * @param type - The type of the action, always 'action-circle-button'.
  * @param customClass - Optional custom CSS class for styling.
  * @param action - The action to perform when the button is clicked.
+ * @deprecated Use NotificationItemActionIconButton instead. This will be removed in a future release.
  */
 export interface NotificationItemActionCircleButton extends NotificationItemBase {
   type: 'action-circle-button';
+  customClass?: string;
+  action: (source: this) => void;
+}
+
+/**
+ * Interface for an action icon button in a notification item.
+ * @param type - The type of the action, always 'action-icon-button'.
+ * @param customClass - Optional custom CSS class for styling.
+ * @param action - The action to perform when the button is clicked.
+ */
+export interface NotificationItemActionIconButton extends NotificationItemBase {
+  type: 'action-icon-button';
   customClass?: string;
   action: (source: this) => void;
 }
@@ -107,6 +120,7 @@ export interface NotificationItemMenu {
  */
 export type NotificationItemQuickAction =
   | NotificationItemActionCircleButton
+  | NotificationItemActionIconButton
   | NotificationItemLinkIcon
   | NotificationItemRouterLinkIcon;
 
@@ -115,6 +129,7 @@ export type NotificationItemQuickAction =
  */
 export type NotificationItemPrimaryAction =
   | NotificationItemActionCircleButton
+  | NotificationItemActionIconButton
   | NotificationItemLinkIcon
   | NotificationItemRouterLinkIcon
   | NotificationItemMenu

--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.html
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.html
@@ -31,7 +31,7 @@
     <button
       type="button"
       tabindex="0"
-      class="btn btn-circle btn-ghost mt-n2 me-n2"
+      class="btn btn-icon btn-ghost mt-n2 me-n2"
       [attr.aria-label]="closeAriaLabel() | translate"
       (keydown.enter)="close()"
       (click)="close()"

--- a/src/app/examples/si-notification-item/si-notification-item-side-panel.ts
+++ b/src/app/examples/si-notification-item/si-notification-item-side-panel.ts
@@ -103,19 +103,19 @@ export class SampleComponent {
 
   quickActions: NotificationItemQuickAction[] = [
     {
-      type: 'action-circle-button',
+      type: 'action-icon-button',
       icon: 'element-checkbox-checked',
       ariaLabel: 'Read',
       action: () => this.logEvent('Read')
     },
     {
-      type: 'action-circle-button',
+      type: 'action-icon-button',
       icon: 'element-archive',
       ariaLabel: 'Archive',
       action: () => this.logEvent('Archive')
     },
     {
-      type: 'action-circle-button',
+      type: 'action-icon-button',
       icon: 'element-delete',
       ariaLabel: 'Delete',
       action: () => this.logEvent('Delete')

--- a/src/app/examples/si-notification-item/si-notification-item.html
+++ b/src/app/examples/si-notification-item/si-notification-item.html
@@ -15,7 +15,7 @@
         heading="Security Warning - High priority alert"
         [description]="description"
         [itemLink]="itemLink"
-        [primaryAction]="showPrimaryAction ? circleButton : undefined"
+        [primaryAction]="showPrimaryAction ? iconButton : undefined"
         [quickActions]="showQuickActions ? quickActions : undefined"
         [unread]="unread"
       >
@@ -68,14 +68,14 @@
         <button
           quick-actions
           type="button"
-          class="btn btn-circle btn-primary element-ok"
+          class="btn btn-icon btn-primary element-ok"
           aria-label="Approve request"
           (click)="logEvent('Approve request')"
         ></button>
         <button
           quick-actions
           type="button"
-          class="btn btn-circle btn-secondary-danger element-cancel"
+          class="btn btn-icon btn-secondary-danger element-cancel"
           aria-label="Reject request"
           (click)="logEvent('Reject request')"
         ></button>

--- a/src/app/examples/si-notification-item/si-notification-item.ts
+++ b/src/app/examples/si-notification-item/si-notification-item.ts
@@ -12,7 +12,7 @@ import {
   SiNotificationItemComponent,
   type NotificationItemQuickAction,
   type NotificationItemActionButton,
-  type NotificationItemActionCircleButton,
+  type NotificationItemActionIconButton,
   type NotificationItemMenu,
   type NotificationItemLink
 } from '@siemens/element-ng/notification-item';
@@ -50,19 +50,19 @@ export class SampleComponent {
 
   quickActions: NotificationItemQuickAction[] = [
     {
-      type: 'action-circle-button',
+      type: 'action-icon-button',
       icon: 'element-checkbox-checked',
       ariaLabel: 'Read',
       action: () => this.logEvent('Read')
     },
     {
-      type: 'action-circle-button',
+      type: 'action-icon-button',
       icon: 'element-archive',
       ariaLabel: 'Archive',
       action: () => this.logEvent('Archive')
     },
     {
-      type: 'action-circle-button',
+      type: 'action-icon-button',
       icon: 'element-delete',
       ariaLabel: 'Delete',
       action: () => this.logEvent('Delete')
@@ -106,8 +106,8 @@ export class SampleComponent {
     ]
   };
 
-  circleButton: NotificationItemActionCircleButton = {
-    type: 'action-circle-button',
+  iconButton: NotificationItemActionIconButton = {
+    type: 'action-icon-button',
     icon: 'element-share',
     ariaLabel: 'Share',
     action: () => this.logEvent('Share')


### PR DESCRIPTION
Use square buttons instead of circle in notifications.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
