### PR TITLE
refactor(buttons): replace btn-circle with btn-icon in dashboard

### DIFF
--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-item.component.html
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-item.component.html
@@ -21,7 +21,7 @@
     @if (valueObject.action.action) {
       <button
         type="button"
-        class="btn btn-circle btn-tertiary ms-4 p-2"
+        class="btn btn-icon btn-tertiary ms-4 p-2"
         [attr.aria-label]="valueObject.action.title | translate"
         [siLink]="valueObject.action"
       >

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.html
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.html
@@ -28,7 +28,7 @@
             type="button"
             class="d-flex btn"
             [class]="action.customClass ?? 'btn-tertiary'"
-            [class.btn-circle]="action.iconOnly"
+            [class.btn-icon]="action.iconOnly"
             (click)="action.action(action)"
           >
             @if (action.icon) {
@@ -51,7 +51,7 @@
             [skipLocationChange]="action.extras?.skipLocationChange"
             [replaceUrl]="action.extras?.replaceUrl"
             [attr.aria-label]="action.label | translate"
-            [class.btn-circle]="action.iconOnly"
+            [class.btn-icon]="action.iconOnly"
           >
             @if (action.icon) {
               <si-icon class="icon" [icon]="action.icon" />
@@ -66,7 +66,7 @@
             [href]="action.href"
             [target]="action.target"
             [attr.aria-label]="action.label | translate"
-            [class.btn-circle]="action.iconOnly"
+            [class.btn-icon]="action.iconOnly"
           >
             @if (action.icon) {
               <si-icon class="icon" [icon]="action.icon" />
@@ -78,7 +78,7 @@
         } @else if (action.type === 'menu') {
           <button
             type="button"
-            class="btn btn-circle btn-tertiary element-options-vertical"
+            class="btn btn-icon btn-tertiary element-options-vertical"
             [attr.aria-label]="ariaLabelDropdown | translate"
             [cdkMenuTriggerFor]="actionMenu"
           ></button>

--- a/src/app/examples/si-dashboard/si-list-widget-css.html
+++ b/src/app/examples/si-dashboard/si-list-widget-css.html
@@ -17,7 +17,7 @@
             <span class="">10.7</span>
             <button
               type="button"
-              class="btn btn-circle btn-tertiary element-export ms-4"
+              class="btn btn-icon btn-tertiary element-export ms-4"
               aria-label="Action on building"
               (click)="logEvent('Action on building')"
             ></button>
@@ -28,7 +28,7 @@
             <span class="">10.7</span>
             <button
               type="button"
-              class="btn btn-circle btn-tertiary element-export ms-4"
+              class="btn btn-icon btn-tertiary element-export ms-4"
               aria-label="Action on building"
               (click)="logEvent('Action on building')"
             ></button>
@@ -39,7 +39,7 @@
             <span class="">10.7</span>
             <button
               type="button"
-              class="btn btn-circle btn-tertiary element-export ms-4"
+              class="btn btn-icon btn-tertiary element-export ms-4"
               aria-label="Action on building"
               (click)="logEvent('Action on building')"
             ></button>
@@ -50,7 +50,7 @@
             <span class="">10.7</span>
             <button
               type="button"
-              class="btn btn-circle btn-tertiary element-export ms-4"
+              class="btn btn-icon btn-tertiary element-export ms-4"
               aria-label="Action on building"
               (click)="logEvent('Action on building')"
             ></button>
@@ -61,7 +61,7 @@
             <span class="">10.7</span>
             <button
               type="button"
-              class="btn btn-circle btn-tertiary element-export ms-4"
+              class="btn btn-icon btn-tertiary element-export ms-4"
               aria-label="Action on building"
               (click)="logEvent('Action on building')"
             ></button>
@@ -72,7 +72,7 @@
             <span class="">10.7</span>
             <button
               type="button"
-              class="btn btn-circle btn-tertiary element-export ms-4"
+              class="btn btn-icon btn-tertiary element-export ms-4"
               aria-label="Action on building"
               (click)="logEvent('Action on building')"
             ></button>


### PR DESCRIPTION
Use square buttons instead of circle in the dashboard widgets.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
