### PR TITLE
chore(breadcrumb-router): use better variable name

### DIFF
--- a/projects/element-ng/breadcrumb-router/si-breadcrumb-router.component.ts
+++ b/projects/element-ng/breadcrumb-router/si-breadcrumb-router.component.ts
@@ -112,11 +112,11 @@ export class SiBreadcrumbRouterComponent implements OnInit, OnDestroy {
   private getUrl(route: ActivatedRouteSnapshot): string {
     let url = '';
     for (const routeSegment of route.pathFromRoot) {
-      const myUrl: string = routeSegment.url.map(o => o.toString()).join('/');
+      const segmentUrl = routeSegment.url.map(o => o.toString()).join('/');
       if (!url.endsWith('/')) {
         url = url + '/';
       }
-      url = url + myUrl;
+      url = url + segmentUrl;
     }
     return url;
   }


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
