### PR TITLE
build(translation): update keys from maps package

### DIFF
--- a/element-translate.conf.json
+++ b/element-translate.conf.json
@@ -14,6 +14,13 @@
       "keysFile": "projects/dashboards-ng/translate/si-translatable-keys.interface.ts",
       "keysInterfaceName": "SiTranslatableKeys",
       "messagesFile": "dist/@siemens/dashboards-ng/template-i18n.json"
+    },
+    {
+      "name": "siemens-maps-ng",
+      "locationPrefix": "projects/maps-ng",
+      "keysFile": "projects/maps-ng/translate/si-translatable-keys.interface.ts",
+      "keysInterfaceName": "SiTranslatableKeys",
+      "messagesFile": "dist/@siemens/maps-ng/template-i18n.json"
     }
   ]
 }


### PR DESCRIPTION
To make `build:all:update-translatable-keys` extract the keys from the maps-ng package.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
