### PR TITLE
refactor: deprecate simpl type alias

### DIFF
--- a/projects/charts-ng/cartesian/si-chart-cartesian.interfaces.ts
+++ b/projects/charts-ng/cartesian/si-chart-cartesian.interfaces.ts
@@ -65,6 +65,11 @@ export type MarkAreaData = NonNullable<MarkAreaComponentOption['data']>;
 export type MarkPointData = NonNullable<MarkPointComponentOption['data']>;
 export type MarkLineData = NonNullable<MarkLineComponentOption['data']>;
 
+/**
+ * @deprecated Use {@link SiLineSeriesOption}, {@link SiBarSeriesOption}, {@link SiHeatmapSeriesOption}
+ * {@link SiScatterSeriesOption}, {@link SiCandlestickSeriesOption} instead. The `Simpl` prefix is deprecated
+ * and will be removed in v51.
+ */
 export type {
   SiLineSeriesOption as SimplLineSeriesOption,
   SiBarSeriesOption as SimplBarSeriesOption,


### PR DESCRIPTION
DEPRECATED: The type alias with `Simpl` prefix are deprecated, use types with `si` prefix instead as per below

`SimplLineSeriesOption` -> Use `SiLineSeriesOption` instead `SimplBarSeriesOption` -> Use `SiBarSeriesOption` instead `SimplHeatmapSeriesOption` -> Use `SiHeatmapSeriesOption` instead `SimplScatterSeriesOption` -> Use `SiScatterSeriesOption`  instead `SimplCandlestickSeriesOption` -> Use `SiCandlestickSeriesOption` instead

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
