### PR TITLE
test(select): reduce flakiness

### DIFF
--- a/playwright/e2e/element-examples/si-select.spec.ts
+++ b/playwright/e2e/element-examples/si-select.spec.ts
@@ -46,7 +46,8 @@ test.describe('si-select', () => {
     await si.visitExample(example);
 
     await page.getByRole('checkbox', { name: 'With filter' }).check();
-    const formControlSelect = page.getByRole('combobox', { name: 'FormControl' });
+    // When filters are enabled, the dropdown content is also a combobox. So we must make sure to select real outer combobox.
+    const formControlSelect = page.getByRole('combobox', { name: 'FormControl' }).first();
     await formControlSelect.click();
 
     const selectFormControlInput = page.getByRole('combobox', { name: 'FormControl' }).nth(1);


### PR DESCRIPTION
Previously the test was unstable,
as a selector resolved redundantly
if the select was open.
Now always the outer real `si-select-input` is targeted.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
