### PR TITLE
test(filtered-search): avoid locator resolution to 2 elements

### DIFF
--- a/playwright/e2e/element-examples/si-filtered-search.spec.ts
+++ b/playwright/e2e/element-examples/si-filtered-search.spec.ts
@@ -65,7 +65,7 @@ test.describe('filtered search', () => {
     await page.keyboard.type('H');
     await expect(page.getByRole('option', { name: 'Karlsruhe' })).toHaveClass(/active/);
     await page.keyboard.type('annover');
-    await expect(page.getByRole('option')).not.toBeVisible(); // Ensures that the view was updated by Angular after typing.
+    await expect(page.getByRole('option').first()).not.toBeVisible(); // Ensures that the view was updated by Angular after typing.
     await page.keyboard.press('Enter');
     await expect(freeTextSearch).toBeFocused();
     await freeTextSearch.fill('Building:House');


### PR DESCRIPTION
We are asserting, that no options are visible in the modified line. Previously this did not work, as the locator would resolve two 2 elements and thus failing immediately without retrying.
With this change, we ensure it only matches one option.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
