### PR TITLE
chore(gemini): disable PR summary

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,13 @@
+have_fun: false
+memory_config:
+  disabled: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: true
+    include_drafts: true
+ignore_patterns: []


### PR DESCRIPTION
Configures Gemini, to disable PR summaries.
All other configs remain in default settings.
See https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github#add-configuration-files

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
