### PR TITLE
feat(element-ng): replace `@angular/animations` with native CSS

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -80,10 +80,9 @@ Answer the following questions as desired. Note: We are not yet
 - `@siemens/element-translate-ng` provides a facade for different translation
   libraries (or none), including `ngx-translate` and `@angular/localize`
 - `@angular/cdk` for support from the Angular component development kit
-- `@angular/animations` for better animations (an option to skip animations is available)
 
 ```sh
-npm install @siemens/element-ng @siemens/element-theme @siemens/element-translate-ng @angular/cdk @angular/animations
+npm install @siemens/element-ng @siemens/element-theme @siemens/element-translate-ng @angular/cdk
 ```
 
 > **Note:** The versions of the Angular packages need to correspond to the
@@ -110,15 +109,12 @@ Include the styles in your application's `styles.scss`:
 @use '@siemens/element-ng/element-ng';
 ```
 
-Provide animations support and enable SVG icon usage in the `app.config.ts`:
-
 ```ts
 import {
   ApplicationConfig,
   provideBrowserGlobalErrorListeners,
   provideZoneChangeDetection
 } from '@angular/core';
-import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { provideIconConfig } from '@siemens/element-ng/icon';
 
@@ -126,7 +122,6 @@ import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideAnimations(),
     provideIconConfig({ disableSvgIcons: false }),
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
       "dependencies": {
         "@angular-architects/module-federation": "20.0.0",
         "@angular-architects/native-federation": "21.1.0",
-        "@angular/animations": "21.0.8",
         "@angular/cdk": "21.0.6",
         "@angular/common": "21.0.8",
         "@angular/core": "21.0.8",
@@ -422,6 +421,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.9.1.tgz",
       "integrity": "sha512-znN/Qm6M0U1t3iF10gu1hSxDkk18yz78yvk+AMB34UDzpXHiC1zbpIeV2CQNV5GCeafmCICmcn9y1qh7F54KTg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/sdk": "0.9.1",
         "@types/semver": "7.5.8",
@@ -433,6 +433,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.9.1.tgz",
       "integrity": "sha512-rS1AsgRvIMAWK8oMprEBF0YQ3WvsqnumjinvAZU1Dqut5DICmpQMTPEO1OrAKyjO+PQgEhmq13HggzN6ebGLrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.9.1",
         "@module-federation/sdk": "0.9.1",
@@ -448,6 +449,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.9.1.tgz",
       "integrity": "sha512-DezBrFaIKfDcEY7UhqyO1WbYocERYsR/CDN8AV6OvMnRlQ8u0rgM8qBUJwx0s+K59f+CFQFKEN4C8p7naCiHrw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.9.1",
         "@module-federation/managers": "0.9.1",
@@ -517,13 +519,15 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.9.1.tgz",
       "integrity": "sha512-q8spCvlwUzW42iX1irnlBTcwcZftRNHyGdlaoFO1z/fW4iphnBIfijzkigWQzOMhdPgzqN/up7XN+g5hjBGBtw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@angular-architects/module-federation/node_modules/@module-federation/inject-external-runtime-core-plugin": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.9.1.tgz",
       "integrity": "sha512-BPfzu1cqDU5BhM493enVF1VfxJWmruen0ktlHrWdJJlcddhZzyFBGaLAGoGc+83fS75aEllvJTEthw4kMViMQQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@module-federation/runtime-tools": "0.9.1"
       }
@@ -533,6 +537,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.9.1.tgz",
       "integrity": "sha512-8hpIrvGfiODxS1qelTd7eaLRVF7jrp17RWgeH1DWoprxELANxm5IVvqUryB+7j+BhoQzamog9DL5q4MuNfGgIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/sdk": "0.9.1",
         "find-pkg": "2.0.0",
@@ -544,6 +549,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.9.1.tgz",
       "integrity": "sha512-+GteKBXrAUkq49i2CSyWZXM4vYa+mEVXxR9Du71R55nXXxgbzAIoZj9gxjRunj9pcE8+YpAOyfHxLEdWngxWdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/dts-plugin": "0.9.1",
         "@module-federation/managers": "0.9.1",
@@ -557,6 +563,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.9.1.tgz",
       "integrity": "sha512-ZJqG75dWHhyTMa9I0YPJEV2XRt0MFxnDiuMOpI92esdmwWY633CBKyNh1XxcLd629YVeTv03+whr+Fz/f91JEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/bridge-react-webpack-plugin": "0.9.1",
         "@module-federation/dts-plugin": "0.9.1",
@@ -585,6 +592,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.9.1.tgz",
       "integrity": "sha512-jp7K06weabM5BF5sruHr/VLyalO+cilvRDy7vdEBqq88O9mjc0RserD8J+AP4WTl3ZzU7/GRqwRsiwjjN913dA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.9.1",
         "@module-federation/runtime-core": "0.9.1",
@@ -607,6 +615,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.9.1.tgz",
       "integrity": "sha512-r61ufhKt5pjl81v7TkmhzeIoSPOaNtLynW6+aCy3KZMa3RfRevFxmygJqv4Nug1L0NhqUeWtdLejh4VIglNy5Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.9.1",
         "@module-federation/sdk": "0.9.1"
@@ -616,13 +625,15 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.9.1.tgz",
       "integrity": "sha512-YQonPTImgnCqZjE/A+3N2g3J5ypR6kx1tbBzc9toUANKr/dw/S63qlh/zHKzWQzxjjNNVMdXRtTMp07g3kgEWg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@angular-architects/module-federation/node_modules/@module-federation/third-party-dts-extractor": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.9.1.tgz",
       "integrity": "sha512-KeIByP718hHyq+Mc53enZ419pZZ1fh9Ns6+/bYLkc3iCoJr/EDBeiLzkbMwh2AS4Qk57WW0yNC82xzf7r0Zrrw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-pkg": "2.0.0",
         "fs-extra": "9.1.0",
@@ -634,6 +645,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.9.1.tgz",
       "integrity": "sha512-CxySX01gT8cBowKl9xZh+voiHvThMZ471icasWnlDIZb14KasZoX1eCh9wpGvwoOdIk9rIRT7h70UvW9nmop6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.9.1",
         "@module-federation/sdk": "0.9.1"
@@ -644,6 +656,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -659,6 +672,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -672,6 +686,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -684,6 +699,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -693,6 +709,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -708,6 +725,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
       "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
@@ -724,6 +742,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -733,6 +752,7 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.4.tgz",
       "integrity": "sha512-7fNBIdrU2PEgLljXoPWoyY4r1e+ToWCmzS/wwMPbUNs7X+5MMET1ObhJBlUkF5uZG9B6QhM2zS1TsH6adegkiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^1.3.5",
         "cache-content-type": "^1.0.0",
@@ -767,6 +787,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -796,6 +817,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1351,7 +1373,6 @@
       "integrity": "sha512-My42P8i/FrZgEsTnsCS9IXKMk7ikJwa14i0aBcHg3lMBAPrdpHVzgDS6/1SOO1HsoVYF/SiPjwnlL152xlm8/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
         "@angular-devkit/architect": "0.2100.5",
@@ -1654,7 +1675,6 @@
       "integrity": "sha512-TCb3qYOC/uXKZCo56cJ6N9sHeWdFhyVqrbbYfFjTi09081T6jllgHDZL5Ms7gOMNY8KywWGGbhxwvzeA0RwTgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "21.2.0",
         "eslint-scope": "^9.0.0"
@@ -1696,22 +1716,6 @@
         "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "21.0.8",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.0.8.tgz",
-      "integrity": "sha512-1YXHZQO/LYiExbg7sZhiqqF5fMcH17iVgK1tI2Gk90Yy0HQAuqnteOv3pPGgUfLowNOWK0sGhCYbB2Lq21LA3w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "21.0.8"
       }
     },
     "node_modules/@angular/build": {
@@ -1852,7 +1856,6 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.0.6.tgz",
       "integrity": "sha512-5Gw8mXtKXvcvDMWEciPLRYB6Ja5vsikLAidZsdCEIF6Bc51GmoqT5Tk/Ke+ciCd5Hq9Aco/IcHxT1RC3470lZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -1869,7 +1872,6 @@
       "integrity": "sha512-UYFQqn9Ow1wFVSwdB/xfjmZo4Yb7CUNxilbeYDFIybesfxXSdjMJBbXLtV0+icIhjmqfSUm2gTls6WIrG8qv9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.2100.5",
         "@angular-devkit/core": "21.0.5",
@@ -1966,7 +1968,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.0.8.tgz",
       "integrity": "sha512-on1B4oc/pf7IlkbG08Et/cCDSX8dpZz9iwp3zMFN/0JvorspyL5YOovFJfjdpmjdlrIi+ToGImwyIkY9P8Mblw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1997,7 +1998,6 @@
       "integrity": "sha512-+i/wFvi5FTg47Ei+aiFf8j3iYfjQ79ieg8oJM86+Mw4bNwEKQqvWcpmKjoqcfmCescuw0sr2DXU6OEeX+yWeVg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.4",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -2091,7 +2091,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.0.8.tgz",
       "integrity": "sha512-8dNolIQn8WHrD3PsqGuPrujxDX5hjpMbioifIByjjX9yaJy9on7AewVGb8m/DHVwWQ1eGVAGmvW9wt+h+nlzLg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2133,7 +2132,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.0.8.tgz",
       "integrity": "sha512-H03A50elawXO53xkz0Aytar5kYT14GLeaj6dLKc1kcR5NqvX9Y/R7z3bY52tvypAdIR8CmPT7ad07TlT4O9lkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -2164,7 +2162,6 @@
       "integrity": "sha512-b4R3lLq32CbRXZrwMct4K7rQ5yzL7EXihg1IfyHNSEcxuuzdtXw/M1xexIkEVtLIfA+SROAThISbYgSgWq6rwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.4",
         "@types/babel__core": "7.20.5",
@@ -2250,7 +2247,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.0.8.tgz",
       "integrity": "sha512-5rPyrP6n6ClO0ZEUXndS2/Xb7nZrbjjYWOxgfCb+ZTCiU7eyN6zhSmicKk2dLQxE1M15wbTa87dN6/Ytuq2uvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2273,7 +2269,6 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.0.8.tgz",
       "integrity": "sha512-LPR65wyWBSyR46fGeQtD92+TM635o0lh+N5k9qPZdMacogwViTrtBHWPfKYBtBUXLWEWXXKJfSbXvhh3w3uLxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2328,7 +2323,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -3959,7 +3953,6 @@
       "integrity": "sha512-eohl3hKTiVyD1ilYdw9T0OiB4hnjef89e3dMYKz+mVKDzj+5IteTseASUsOB+EU9Tf6VNTCjDePcP6wkDGmLKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -4070,7 +4063,6 @@
       "integrity": "sha512-uuFKKpc7OtQM+6SRqT+a4kV818o1pS+uvv/gsRhyX7g4x495jg+Q7P0+O9VNGyLXBYP0syksS7gMRDJKcekr6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@commitlint/format": "^20.4.0",
         "@commitlint/lint": "^20.4.1",
@@ -4093,7 +4085,6 @@
       "integrity": "sha512-0YUvIeBtpi86XriqrR+TCULVFiyYTIOEPjK7tTRMxjcBm1qlzb+kz7IF2WxL6Fq5DaundG8VO37BNgMkMTBwqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@commitlint/types": "^20.4.0",
         "conventional-changelog-conventionalcommits": "^9.1.0"
@@ -4362,7 +4353,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4406,7 +4396,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5154,7 +5143,6 @@
       "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5542,7 +5530,6 @@
       "integrity": "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.0",
         "@inquirer/confirm": "^5.1.19",
@@ -6750,6 +6737,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.6.21.tgz",
       "integrity": "sha512-CLQiPP3kpcPbgPkiu/A1VURI2v4geFnEdizlB1tq0c6eDZqb5aLzvp87ZCGDVSuwY7DCq6jh1k+CM2WGge/2xA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.9.0",
         "@module-federation/sdk": "0.9.0"
@@ -6759,13 +6747,15 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.9.0.tgz",
       "integrity": "sha512-dNqIs5cQfE4p+WIdiZ64cTSRJ5KjGaV+epvZkGttrNjXW9XAAtE7zgpo7cMQ8GWA3wCGaKnFw7Dn48XcU5ZMNw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@module-federation/runtime-core/node_modules/@module-federation/sdk": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.9.0.tgz",
       "integrity": "sha512-84MklxE6Z79gCAr+6HCyqOpF95pqSah+fGnhLz+g4ePcWf98J73bWfrdOWFO/UfxMRneXKBZBNbpDVvPLgaFeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic-rslog": "0.0.7"
       }
@@ -6775,7 +6765,6 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.24.1.tgz",
       "integrity": "sha512-+P6Yvyc+uaAvF7YceGxtiOg0wJDv6qfHv+AXsmzz54pC3N0PKu5azhBeKO28ILRmmsalnau8dkNPIv/JC04AmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.24.1",
         "@module-federation/webpack-bundler-runtime": "0.24.1"
@@ -7477,6 +7466,7 @@
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
@@ -7505,7 +7495,6 @@
       "resolved": "https://registry.npmjs.org/@ngx-formly/bootstrap/-/bootstrap-6.3.12.tgz",
       "integrity": "sha512-2HPqyC7DJjz5mwgNw+hkzXVmyaD4BfykWgUiF9peeNmhmYqF0z1JoGRotbdtzuwGeaGVkX86dPEt2pHJDeS3Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -7519,7 +7508,6 @@
       "resolved": "https://registry.npmjs.org/@ngx-formly/core/-/core-6.3.12.tgz",
       "integrity": "sha512-88MOfn9dM1B33t04jl8x0Glh0Ed0lUKMkhYajicRH7ZHTmwIdla1SQjiblp2C+EcCFvsY7XAU2/JUZQdl56aUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -7533,7 +7521,6 @@
       "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-16.0.4.tgz",
       "integrity": "sha512-s8llTL2SJvROhqttxvEs7Cg+6qSf4kvZPFYO+cTOY1d8DWTjlutRkWAleZcPPoeX927Dm7ALfL07G7oYDJ7z6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -7894,7 +7881,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -9229,6 +9215,7 @@
       "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.4.6.tgz",
       "integrity": "sha512-rRc6sbKWxhomxxJeqi4QS3S/2T6pKf4JwC/VHXs7KXw7lHXHa3yxPynmn3xHstL0H6VLaM5xQj87Wh7lQYRAPg==",
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "@rspack/binding-darwin-arm64": "1.4.6",
         "@rspack/binding-darwin-x64": "1.4.6",
@@ -9253,7 +9240,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-darwin-x64": {
       "version": "1.4.6",
@@ -9266,7 +9254,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
       "version": "1.4.6",
@@ -9279,7 +9268,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
       "version": "1.4.6",
@@ -9292,7 +9282,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
       "version": "1.4.6",
@@ -9305,7 +9296,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
       "version": "1.4.6",
@@ -9318,7 +9310,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-wasm32-wasi": {
       "version": "1.4.6",
@@ -9329,6 +9322,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.11"
       }
@@ -9344,7 +9338,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
       "version": "1.4.6",
@@ -9357,7 +9352,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
       "version": "1.4.6",
@@ -9370,7 +9366,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/core": {
       "version": "1.4.6",
@@ -9399,13 +9396,15 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.15.0.tgz",
       "integrity": "sha512-CFJSF+XKwTcy0PFZ2l/fSUpR4z247+Uwzp1sXVkdIfJ/ATsnqf0Q01f51qqSEA6MYdQi6FKos9FIcu3dCpQNdg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rspack/core/node_modules/@module-federation/runtime": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.15.0.tgz",
       "integrity": "sha512-dTPsCNum9Bhu3yPOcrPYq0YnM9eCMMMNB1wuiqf1+sFbQlNApF0vfZxooqz3ln0/MpgE0jerVvFsLVGfqvC9Ug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.15.0",
         "@module-federation/runtime-core": "0.15.0",
@@ -9417,6 +9416,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.15.0.tgz",
       "integrity": "sha512-RYzI61fRDrhyhaEOXH3AgIGlHiot0wPFXu7F43cr+ZnTi+VlSYWLdlZ4NBuT9uV6JSmH54/c+tEZm5SXgKR2sQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.15.0",
         "@module-federation/sdk": "0.15.0"
@@ -9427,6 +9427,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.15.0.tgz",
       "integrity": "sha512-kzFn3ObUeBp5vaEtN1WMxhTYBuYEErxugu1RzFUERD21X3BZ+b4cWwdFJuBDlsmVjctIg/QSOoZoPXRKAO0foA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.15.0",
         "@module-federation/webpack-bundler-runtime": "0.15.0"
@@ -9436,13 +9437,15 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.15.0.tgz",
       "integrity": "sha512-PWiYbGcJrKUD6JZiEPihrXhV3bgXdll4bV7rU+opV7tHaun+Z0CdcawjZ82Xnpb8MCPGmqHwa1MPFeUs66zksw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rspack/core/node_modules/@module-federation/webpack-bundler-runtime": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.15.0.tgz",
       "integrity": "sha512-i+3wu2Ljh2TmuUpsnjwZVupOVqV50jP0ndA8PSP4gwMKlgdGeaZ4VH5KkHAXGr2eiYUxYLMrJXz1+eILJqeGDg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.15.0",
         "@module-federation/sdk": "0.15.0"
@@ -9453,6 +9456,7 @@
       "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.0.1.tgz",
       "integrity": "sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -9633,7 +9637,6 @@
       "integrity": "sha512-uNBIilq5bGnln3D7Nbm3/K+Ot++eGj4rygU0DCw//IZiTQU/iSyF3UAsN++iRetu/OMs+97T/RoGPjD22ryiZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.0.5",
         "@angular-devkit/schematics": "21.0.5",
@@ -10268,7 +10271,6 @@
       "resolved": "https://registry.npmjs.org/@siemens/ngx-datatable/-/ngx-datatable-25.0.0.tgz",
       "integrity": "sha512-iK1/ESVGApP/V6WHMtwP1YkK0f+7JRbcD8hE/vL8SOrtn+blchiCOrGwPDIzOb8HFRXX5+ptrYpBL4IRnXz0QQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -10735,6 +10737,7 @@
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
@@ -10786,7 +10789,8 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -10917,7 +10921,6 @@
       "integrity": "sha512-+0/4J266CBGPUq/ELg7QUHhN25WYjE0wYTPSQJn1xeu8DOlIOPxXxrNGiLmfAWl7HMMgWFWXpt9IDjMWrF5Iow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -10971,7 +10974,6 @@
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -11258,7 +11260,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -11650,7 +11651,6 @@
       "integrity": "sha512-USjyxm3gQEePdUwJBFjjGNG18xY9A2grDVGuk7/9AkjIF1L+ZrVnwR5VAU5JXtUnBL/Nwt3H31KlRDaksnM7/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -11694,7 +11694,6 @@
       "integrity": "sha512-AbSv11fklGXV6T28dp2Me04Uw90R2iJ30g2bgLz529Koehrmkbs1r7paFqr1vPCZi7hHwYxYtxfyQMRC8QaVSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.46.4",
@@ -11763,6 +11762,7 @@
       "integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
@@ -11781,6 +11781,7 @@
       "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/spy": "4.0.16",
         "estree-walker": "^3.0.3",
@@ -11808,6 +11809,7 @@
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -11818,6 +11820,7 @@
       "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^3.0.3"
       },
@@ -11831,6 +11834,7 @@
       "integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.16",
         "pathe": "^2.0.3"
@@ -11845,6 +11849,7 @@
       "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.0.16",
         "magic-string": "^0.30.21",
@@ -11860,6 +11865,7 @@
       "integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
@@ -11870,6 +11876,7 @@
       "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.0.16",
         "tinyrainbow": "^3.0.3"
@@ -12098,7 +12105,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12205,7 +12211,6 @@
       "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-34.3.1.tgz",
       "integrity": "sha512-PwlrPudsFOzGumphi2y9ihWeaUlIwKhOra/MXu2LjeV2U8DgLLcYS8CartE5Hszhn1poJHawwI9HWrxlKliwdw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ag-charts-types": "12.3.1"
       }
@@ -12239,7 +12244,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12328,7 +12332,6 @@
       "integrity": "sha512-pERqqHIMwD34UT0FoHSNTt4V332vHiAzgkY0rgdUaqSamS94IzbF02EfFxygr53UogQQOXhpLbSSDMOyovB3TA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/core": ">= 21.0.0 < 22.0.0",
         "@angular-devkit/schematics": ">= 21.0.0 < 22.0.0",
@@ -12506,6 +12509,7 @@
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12586,7 +12590,6 @@
       "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -13016,7 +13019,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -13127,6 +13129,7 @@
       "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
       "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "^2.1.18",
         "ylru": "^1.2.0"
@@ -13232,6 +13235,7 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13781,6 +13785,7 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -14313,7 +14318,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -14975,7 +14979,6 @@
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
       "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "6.0.0"
@@ -15486,7 +15489,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -15560,7 +15562,6 @@
       "integrity": "sha512-XxpUMpeVaSJF5rpF6NHmhj3xavHZrflKcRbDssAUWrHUU/+l3l7PPYnVJ6IOpR2KjQ1Blucaeb0cFL3LIBis0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.53.1",
         "natural-orderby": "^5.0.0"
@@ -15732,7 +15733,6 @@
       "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "eslint": ">=2.0.0"
       }
@@ -16167,6 +16167,7 @@
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -16762,8 +16763,7 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-7.5.0.tgz",
       "integrity": "sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/flat": {
       "version": "5.0.2",
@@ -17003,6 +17003,7 @@
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -17403,7 +17404,6 @@
       "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.44.tgz",
       "integrity": "sha512-9p2TghluF2LTChFMLWsDRD5N78SZDsILdUk4gyqYxBXluCyxoPiOq+Fqt7DKM+LUd33+OgRkdrc+cPR93AypCQ==",
       "license": "(MIT AND Apache-2.0)",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -17440,8 +17440,7 @@
           "url": "https://www.venmo.com/adumesny"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -18339,6 +18338,7 @@
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.4",
         "generator-function": "^2.0.0",
@@ -18589,6 +18589,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.7.tgz",
       "integrity": "sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.17.6"
       }
@@ -18735,8 +18736,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.13.0.tgz",
       "integrity": "sha512-vsYjfh7lyqvZX5QgqKc4YH8phs7g96Z8bsdIFNEU3VqXhlHaq+vov/Fgn/sr6MiUczdZkyXRC3TX369Ll4Nzbw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jasmine/node_modules/glob": {
       "version": "10.5.0",
@@ -18961,7 +18961,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -19536,6 +19535,7 @@
       "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
       "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "co": "^4.6.0",
         "koa-compose": "^4.1.0"
@@ -19640,7 +19640,6 @@
       "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -19806,7 +19805,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -20253,7 +20251,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -20916,7 +20913,6 @@
       "integrity": "sha512-IZGxuF226GF0d8FOZIfPvHsyBl53PrDEg/IB2+CVamsm3r4+gUw3mBp27eygpowBpdVLG0Sm2IbUiH4aSspzyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@rollup/plugin-json": "^6.1.0",
@@ -21465,7 +21461,6 @@
       "resolved": "https://registry.npmjs.org/ngx-image-cropper/-/ngx-image-cropper-9.1.6.tgz",
       "integrity": "sha512-b250YJ+jZovfqIj8vdEOrpEFay34be5f1Hpvg6Db68VMlvdyyuzboJdR0gCupbXtVcG6qQ86L7YG+SYxXJwApw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -24246,7 +24241,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24531,14 +24525,14 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ol": {
       "version": "10.7.0",
       "resolved": "https://registry.npmjs.org/ol/-/ol-10.7.0.tgz",
       "integrity": "sha512-122U5gamPqNgLpLOkogFJhgpywvd/5en2kETIDW+Ubfi9lPnZ0G9HWRdG+CX0oP8od2d6u6ky3eewIYYlrVczw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@types/rbush": "4.0.0",
         "earcut": "^3.0.0",
@@ -24556,7 +24550,6 @@
       "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-4.0.37.tgz",
       "integrity": "sha512-RxzdgMWnNBDP9VZCza3oS3rl1+OCl+1SJLMjt7ATyDDLZl/zzrsQELfJ25WAL6HIWgjkQ2vYDh3nnHFupxOH4w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "peerDependencies": {
         "ol": ">= 5.3.0"
       }
@@ -24566,7 +24559,6 @@
       "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-13.2.0.tgz",
       "integrity": "sha512-7jKoejdVMBxdUk97DlaHy/7ZddGslBq8obnW1yGEMD705Eo+khqZiaVbaABpszzDLAf17fKeXn+fm+WWT9OYCQ==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^23.1.0",
         "mapbox-to-css-font": "^3.2.0"
@@ -24626,7 +24618,8 @@
     "node_modules/only": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
-      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ=="
+      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
+      "peer": true
     },
     "node_modules/open": {
       "version": "10.2.0",
@@ -25169,7 +25162,8 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pbf": {
       "version": "4.0.1",
@@ -25355,7 +25349,6 @@
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -25412,7 +25405,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -25578,7 +25570,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0"
       },
@@ -25592,7 +25583,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -25624,7 +25614,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -26484,7 +26473,6 @@
       "integrity": "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -26608,7 +26596,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -26663,7 +26650,6 @@
       "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -26732,7 +26718,8 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -26804,7 +26791,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -27578,7 +27564,8 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -28086,7 +28073,8 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -28102,7 +28090,8 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -28401,7 +28390,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -28456,7 +28444,6 @@
       "integrity": "sha512-H88kCC+6Vtzj76NsC8rv6x/LW8slBzIbyeSjsKVlS+4qaEJoDrcJR4L+8JdrR2ORdTscrBzYWiiT2jq6leYR1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.1",
         "is-plain-object": "^5.0.0",
@@ -29084,7 +29071,8 @@
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyexec": {
       "version": "1.0.2",
@@ -29125,6 +29113,7 @@
       "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -29283,8 +29272,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -29301,7 +29289,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -29886,7 +29873,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -29901,7 +29887,6 @@
       "integrity": "sha512-CKsJ+g53QpsNPqbzUsfKVgd3Lny4yKZ1pP4qN3jdMOg/sisIDLGyDMezycquXLE5JsEU0wp3dGNdzig0/fmSVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.54.0",
         "@typescript-eslint/parser": "8.54.0",
@@ -30446,7 +30431,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -31084,7 +31068,8 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/void-elements": {
       "version": "2.0.1",
@@ -31146,7 +31131,6 @@
       "integrity": "sha512-5DeICTX8BVgNp6afSPYXAFjskIgWGlygQH58bcozPOXgo2r/6xx39Y1+cULZ3gTxUYQP88jmwLj2anu4Xaq84g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -31253,7 +31237,6 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -31842,6 +31825,7 @@
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -32078,7 +32062,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -32271,6 +32254,7 @@
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
       "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -32317,7 +32301,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -32390,9 +32373,7 @@
       "name": "@siemens/element-ng",
       "version": "48.9.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@angular/animations": "21",
         "@angular/cdk": "21",
         "@angular/common": "21",
         "@angular/core": "21",
@@ -32435,8 +32416,7 @@
     "projects/element-theme": {
       "name": "@siemens/element-theme",
       "version": "48.9.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "projects/element-translate-cli": {
       "name": "@siemens/element-translate-cli",
@@ -32453,7 +32433,6 @@
       "name": "@siemens/element-translate-ng",
       "version": "48.9.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@angular/common": "21",
         "@angular/core": "21",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@angular-architects/module-federation": "20.0.0",
     "@angular-architects/native-federation": "21.1.0",
-    "@angular/animations": "21.0.8",
+    "@angular-architects/native-federation": "21.1.0",
     "@angular/cdk": "21.0.6",
     "@angular/common": "21.0.8",
     "@angular/core": "21.0.8",

--- a/playwright/snapshots/si-shadow-root.spec.ts-snapshots/si-shadow-root--si-shadow-root-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-shadow-root.spec.ts-snapshots/si-shadow-root--si-shadow-root-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e26087b3041f443cfa3676d820b6ad14d8fd7491581f9c51435809cef87a8dfd
-size 17902
+oid sha256:416a05f9af48f438b23c9e814fbe408867858457fda08f9cbf20cef731c82508
+size 17839

--- a/playwright/snapshots/si-shadow-root.spec.ts-snapshots/si-shadow-root--si-shadow-root-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-shadow-root.spec.ts-snapshots/si-shadow-root--si-shadow-root-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:809d7b303ed8c4d1bb86dd11f94019caf2e9aa0eecbbd47c20f2c2351c88fb14
-size 17736
+oid sha256:930ec310b163b970900db073414734de5d3e7398e52951477a9fa07027ec842d
+size 17853

--- a/projects/dashboards-demo/federation.config.js
+++ b/projects/dashboards-demo/federation.config.js
@@ -17,6 +17,7 @@ module.exports = withNativeFederation({
     'rxjs/webSocket',
     '@siemens/ngx-datatable',
     // Use RegExp to skip ALL entry points!
+    /^@angular\/platform-browser\/animations/,
     /^@module-federation/,
     /^@ngx-formly/,
     /^ol/,

--- a/projects/dashboards-demo/mfe/federation.config.js
+++ b/projects/dashboards-demo/mfe/federation.config.js
@@ -12,6 +12,7 @@ module.exports = withNativeFederation({
     'rxjs/testing',
     'rxjs/webSocket',
     // Use RegExp to skip ALL entry points!
+    /^@angular\/platform-browser\/animations/,
     /^@module-federation/,
     // Skip packages with assets that can't be bundled for browser
     'flag-icons'

--- a/projects/dashboards-demo/src/app/app.config.ts
+++ b/projects/dashboards-demo/src/app/app.config.ts
@@ -4,7 +4,6 @@
  */
 import { HttpBackend, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { ApplicationConfig } from '@angular/core';
-import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, withHashLocation } from '@angular/router';
 import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
 import {
@@ -48,8 +47,6 @@ export const appConfig: ApplicationConfig = {
         deps: [HttpBackend]
       }
     }),
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    provideAnimations(),
     provideHttpClient(withInterceptorsFromDi()),
     provideNgxTranslateForElement()
   ]

--- a/projects/dashboards-ng/README.md
+++ b/projects/dashboards-ng/README.md
@@ -36,7 +36,6 @@ providers: [
     },
     missingTranslationHandler: provideMissingTranslationHandlerForElement()
   }),
-  provideAnimations(),
   provideNgxTranslateForElement(),
   provideHttpClient(withInterceptorsFromDi())
 ];

--- a/projects/element-ng/about/si-about.component.spec.ts
+++ b/projects/element-ng/about/si-about.component.spec.ts
@@ -6,7 +6,6 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { Link } from '@siemens/element-ng/link';
 
 import { LicenseInfo } from './si-about-data.model';
@@ -62,7 +61,7 @@ describe('SiAboutComponent', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [provideHttpClient(), provideNoopAnimations(), provideHttpClientTesting()]
+      providers: [provideHttpClient(), provideHttpClientTesting()]
     })
   );
 

--- a/projects/element-ng/accordion/si-accordion.component.spec.ts
+++ b/projects/element-ng/accordion/si-accordion.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SiAccordionComponent } from './si-accordion.component';
 import { SiCollapsiblePanelComponent } from './si-collapsible-panel.component';
@@ -32,7 +31,7 @@ describe('SiAccordion', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, TestHostComponent]
+      imports: [TestHostComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/accordion/si-collapsible-panel.component.spec.ts
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.spec.ts
@@ -5,7 +5,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SiCollapsiblePanelComponent } from './index';
 
@@ -38,7 +37,7 @@ describe('SiCollapsiblePanel', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SiCollapsiblePanelComponent, TestHostComponent]
+      imports: [SiCollapsiblePanelComponent, TestHostComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/action-modal/si-action-dialog.service.spec.ts
+++ b/projects/element-ng/action-modal/si-action-dialog.service.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ApplicationRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Subject } from 'rxjs';
 
 import { SiActionDialogService } from './si-action-dialog.service';
@@ -21,9 +20,6 @@ describe('SiActionDialogService', () => {
   };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule]
-    }).compileComponents();
     service = TestBed.inject(SiActionDialogService);
     appRef = TestBed.inject(ApplicationRef);
   });

--- a/projects/element-ng/card/si-card.component.spec.ts
+++ b/projects/element-ng/card/si-card.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import { ContentActionBarMainItem, ViewType } from '@siemens/element-ng/content-action-bar';
 import { MenuItem } from '@siemens/element-ng/menu';
@@ -53,7 +52,7 @@ describe('SiCardComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [RouterModule, NoopAnimationsModule, WrapperComponent]
+      imports: [RouterModule, WrapperComponent]
     })
   );
 

--- a/projects/element-ng/chat-messages/si-chat-input.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-chat-input.component.spec.ts
@@ -5,7 +5,6 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { FileUploadError, UploadFile } from '@siemens/element-ng/file-uploader';
 
 import { MessageAction } from './message-action.model';
@@ -21,8 +20,7 @@ describe('SiChatInputComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestComponent],
-      providers: [provideNoopAnimations()]
+      imports: [TestComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/content-action-bar/si-content-action-bar.component.spec.ts
+++ b/projects/element-ng/content-action-bar/si-content-action-bar.component.spec.ts
@@ -6,7 +6,6 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { booleanAttribute, Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { MenuItem } from '@siemens/element-ng/menu';
 
@@ -44,7 +43,7 @@ describe('SiContentActionBarComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, TestComponent],
+      imports: [TestComponent],
       providers: [provideRouter([])]
     }).compileComponents();
   });

--- a/projects/element-ng/dashboard/si-dashboard-card.component.spec.ts
+++ b/projects/element-ng/dashboard/si-dashboard-card.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 
 import { SiDashboardCardComponent } from './index';
@@ -36,7 +35,7 @@ describe('SiDashboardCardComponent', () => {
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [RouterModule, NoopAnimationsModule, TestHostComponent]
+      imports: [RouterModule, TestHostComponent]
     })
   );
 

--- a/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
@@ -13,7 +13,6 @@ import {
   viewChild
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule, provideNoopAnimations } from '@angular/platform-browser/animations';
 import { CriterionDefinition } from '@siemens/element-ng/filtered-search';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
 import {
@@ -104,7 +103,7 @@ describe('SiFilteredSearchComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, TestHostComponent]
+      imports: [TestHostComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);
@@ -2303,7 +2302,6 @@ describe('SiFilteredSearchComponent - With translation', () => {
     TestBed.configureTestingModule({
       imports: [TestHostComponent],
       providers: [
-        provideNoopAnimations(),
         provideMockTranslateServiceBuilder(
           () =>
             ({

--- a/projects/element-ng/formly/fields/button/si-formly-button.component.spec.ts
+++ b/projects/element-ng/formly/fields/button/si-formly-button.component.spec.ts
@@ -6,7 +6,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 import { SiTranslateService } from '@siemens/element-ng/translate';
 import {
@@ -51,7 +50,6 @@ describe('formly button type', () => {
     });
     await TestBed.configureTestingModule({
       imports: [
-        NoopAnimationsModule,
         ReactiveFormsModule,
         FormlyModule.forRoot({
           types: [

--- a/projects/element-ng/formly/fields/date-range/si-formly-date-range.component.spec.ts
+++ b/projects/element-ng/formly/fields/date-range/si-formly-date-range.component.spec.ts
@@ -6,7 +6,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 
 import { SiFormlyWrapperComponent } from '../../wrapper/si-formly-wrapper.component';
@@ -48,7 +47,6 @@ describe('formly date range type', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        NoopAnimationsModule,
         ReactiveFormsModule,
         FormlyModule.forRoot({
           types: [

--- a/projects/element-ng/formly/fields/datetime/si-formly-datetime.component.spec.ts
+++ b/projects/element-ng/formly/fields/datetime/si-formly-datetime.component.spec.ts
@@ -6,7 +6,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 import { SiDatepickerModule } from '@siemens/element-ng/datepicker';
 
@@ -53,7 +52,6 @@ describe('formly datetime-type', () => {
 
     TestBed.configureTestingModule({
       imports: [
-        NoopAnimationsModule,
         ReactiveFormsModule,
         SiDatepickerModule,
         FormlyModule.forRoot({

--- a/projects/element-ng/formly/fields/email/si-formly-email.component.spec.ts
+++ b/projects/element-ng/formly/fields/email/si-formly-email.component.spec.ts
@@ -6,7 +6,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 
 import { SiFormlyEmailComponent } from './si-formly-email.component';
@@ -30,7 +29,6 @@ describe('formly email type', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        NoopAnimationsModule,
         ReactiveFormsModule,
         FormlyModule.forRoot({
           types: [

--- a/projects/element-ng/formly/fields/number/si-formly-number.component.spec.ts
+++ b/projects/element-ng/formly/fields/number/si-formly-number.component.spec.ts
@@ -6,7 +6,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 
 import { SiFormlyWrapperComponent } from '../../wrapper/si-formly-wrapper.component';
@@ -43,7 +42,6 @@ describe('formly number type', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        NoopAnimationsModule,
         ReactiveFormsModule,
         FormlyModule.forRoot({
           types: [

--- a/projects/element-ng/formly/fields/text/si-formly-text-display.component.spec.ts
+++ b/projects/element-ng/formly/fields/text/si-formly-text-display.component.spec.ts
@@ -6,7 +6,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 import {
   provideMockTranslateServiceBuilder,
@@ -46,7 +45,6 @@ describe('formly text-display-type', () => {
     });
     TestBed.configureTestingModule({
       imports: [
-        NoopAnimationsModule,
         SiFormlyTextDisplayComponent,
         FormlyModule.forRoot({
           types: [

--- a/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.spec.ts
+++ b/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.spec.ts
@@ -6,7 +6,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 
 import { SiFormlyTextareaComponent } from './si-formly-textarea.component';
@@ -30,7 +29,6 @@ describe('formly autogrowing textarea type', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        NoopAnimationsModule,
         ReactiveFormsModule,
         SiFormlyTextareaComponent,
         FormlyModule.forRoot({

--- a/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.spec.ts
@@ -6,7 +6,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { SiFormlyModule } from '@siemens/element-ng/formly';
 
@@ -96,7 +95,7 @@ describe('formly accordion type', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SiFormlyModule, FormlyTestComponent]
+      imports: [SiFormlyModule, FormlyTestComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/formly/structural/si-formly-object-grid/si-formly-object-grid.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-object-grid/si-formly-object-grid.component.spec.ts
@@ -6,7 +6,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 import { SiFormModule } from '@siemens/element-ng/form';
 
@@ -31,7 +30,6 @@ describe('formly grid  type', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        NoopAnimationsModule,
         ReactiveFormsModule,
         SiFormModule,
         SiFormlyObjectGridComponent,

--- a/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.spec.ts
@@ -6,7 +6,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 
 import { SiFormlyObjectTabsetComponent } from './si-formly-object-tabset.component';
@@ -30,7 +29,6 @@ describe('formly tabset type', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        NoopAnimationsModule,
         ReactiveFormsModule,
 
         FormlyModule.forRoot({

--- a/projects/element-ng/landing-page/login-basic/si-login-basic.component.spec.ts
+++ b/projects/element-ng/landing-page/login-basic/si-login-basic.component.spec.ts
@@ -4,19 +4,12 @@
  */
 import { ComponentRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SiLoginBasicComponent as TestComponent } from './si-login-basic.component';
 
 describe('SiLoginBasicComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let component: ComponentRef<TestComponent>;
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [TestComponent, BrowserAnimationsModule]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);

--- a/projects/element-ng/loading-spinner/si-loading-spinner.directive.spec.ts
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.directive.spec.ts
@@ -4,7 +4,6 @@
  */
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SiLoadingSpinnerModule } from './si-loading-spinner.module';
 
@@ -35,7 +34,7 @@ describe('SiLoadingSpinnerDirective', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiLoadingSpinnerModule, NoopAnimationsModule, TestHostComponent]
+      imports: [SiLoadingSpinnerModule, TestHostComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical.spec.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical.spec.ts
@@ -7,7 +7,6 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component, Injectable } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter, Router } from '@angular/router';
 import {
   MenuItem,
@@ -86,7 +85,7 @@ describe('SiNavbarVertical', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SiNavbarVerticalComponent, NoopAnimationsModule, TestHostComponent],
+      imports: [SiNavbarVerticalComponent, TestHostComponent],
       providers: [
         provideSiUiState({ store: SynchronousMockStore }),
         provideRouter([

--- a/projects/element-ng/package.json
+++ b/projects/element-ng/package.json
@@ -38,7 +38,6 @@
     "migrations": "./schematics/migration.json"
   },
   "peerDependencies": {
-    "@angular/animations": "21",
     "@angular/cdk": "21",
     "@angular/common": "21",
     "@angular/core": "21",

--- a/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
+++ b/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
@@ -7,7 +7,6 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { Observable, of } from 'rxjs';
 
 import { SiSelectMultiValueDirective } from '../selection/si-select-multi-value.directive';
@@ -48,10 +47,6 @@ describe('SelectLazyOptionsDirective', () => {
   let component: TestHostComponent;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestHostComponent],
-      providers: [provideNoopAnimations()]
-    });
     fixture = TestBed.createComponent(TestHostComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
     component = fixture.componentInstance;

--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.spec.ts
@@ -4,7 +4,6 @@
  */
 import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { STATUS_ICON } from '@siemens/element-ng/common';
 import { Subject } from 'rxjs';
 
@@ -33,7 +32,7 @@ describe('SiToastNotificationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SiToastNotificationComponent, TestHostComponent]
+      imports: [SiToastNotificationComponent, TestHostComponent]
     }).compileComponents();
   });
 

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.html
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.html
@@ -183,7 +183,7 @@
     (click)="onItemFolderClicked()"
   >
     @if (isExpanding) {
-      <si-loading-spinner [@.disabled]="true" />
+      <si-loading-spinner />
     } @else {
       <i aria-hidden="true" [class]="`${toggleIcon} ${folderStateClass}`"></i>
     }

--- a/projects/element-ng/tree-view/si-tree-view.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.spec.ts
@@ -12,7 +12,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SiLoadingSpinnerModule } from '@siemens/element-ng/loading-spinner';
 import { MenuItem } from '@siemens/element-ng/menu';
 import { MenuItemsProvider, SiTreeViewModule } from '@siemens/element-ng/tree-view';
@@ -126,7 +125,7 @@ describe('SiTreeViewComponent', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
-      imports: [SiLoadingSpinnerModule, NoopAnimationsModule, SiTreeViewModule, WrapperComponent]
+      imports: [SiLoadingSpinnerModule, SiTreeViewModule, WrapperComponent]
     });
   });
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -16,7 +16,6 @@ import {
   provideAppInitializer,
   ɵLocaleDataIndex
 } from '@angular/core';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
 import { provideSiAgGridConfig } from '@siemens/element-ng/ag-grid';
 import { provideSiUiState } from '@siemens/element-ng/common';
@@ -148,8 +147,6 @@ export const APP_CONFIG: ApplicationConfig = {
     { provide: SiLivePreviewThemeApi, useClass: LivePreviewThemeApiService },
     { provide: SiLivePreviewLocaleApi, useClass: LivePreviewLocaleApiService },
     { provide: HTTP_INTERCEPTORS, useExisting: FileUploadInterceptor, multi: true },
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    provideAnimationsAsync(navigator.webdriver ? 'noop' : 'animations'),
     provideHttpClient(withInterceptorsFromDi()),
     provideTranslateService(
       // Npm dependencies


### PR DESCRIPTION
All usages of `@angular/animations` (deprecated) were removed.
With this commit we remove the entire package.

BREAKING CHANGE: Animations can no longer be disabled using
`@angular/animations` specific features like:
- `NoopAnimationsModule`
- `BrowserAnimationsModule.withConfig({disableAnimations: false})`
- `provideNoopAnimations`
- `provideAnimationsAsync('noop')`

Use CSS to disable animations. See: https://element.siemens.io/architecture/motion-animation/

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
