### PR TITLE
refactor(collapsible-panel): use `siTooltip` instead of `title`

### DIFF
--- a/projects/element-ng/accordion/si-collapsible-panel.component.html
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.html
@@ -1,11 +1,12 @@
 <div
   role="button"
+  placement="start"
+  [siTooltip]="hcollapsed() && heading() ? (heading()! | translate) : ''"
   [class]="`collapsible-header focus-inside px-6 ${headerCssClasses()}`"
   [attr.tabindex]="disabled() ? '' : '0'"
   [id]="headerId"
   [class.open]="opened()"
   [class.disabled]="disabled()"
-  [title]="hcollapsed() ? (heading() | translate) : ''"
   [attr.aria-expanded]="opened() && !hcollapsed()"
   [attr.aria-disabled]="disabled()"
   [attr.aria-controls]="controlId"

--- a/projects/element-ng/accordion/si-collapsible-panel.component.ts
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.ts
@@ -18,6 +18,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BackgroundColorVariant } from '@siemens/element-ng/common';
 import { addIcons, elementDown2, SiIconComponent } from '@siemens/element-ng/icon';
+import { SiTooltipDirective } from '@siemens/element-ng/tooltip';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { filter } from 'rxjs';
 
@@ -28,7 +29,7 @@ let controlIdCounter = 1;
 
 @Component({
   selector: 'si-collapsible-panel',
-  imports: [SiIconComponent, SiTranslatePipe],
+  imports: [SiIconComponent, SiTranslatePipe, SiTooltipDirective],
   templateUrl: './si-collapsible-panel.component.html',
   styleUrl: './si-collapsible-panel.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
Adds support for tooltip to the collapsible panel.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
