### PR TITLE
feat(content-action-bar): add tooltip support

### DIFF
--- a/playwright/e2e/dashboards-demo/dashboard.spec.ts
+++ b/playwright/e2e/dashboards-demo/dashboard.spec.ts
@@ -148,7 +148,7 @@ test.describe('dashboard', () => {
     const editBtn = page.getByLabel('Edit');
     editBtn.click();
     const pieChart = page.getByText('Pie Chart', { exact: true }).locator('..');
-    pieChart.getByTitle('Remove').click();
+    pieChart.getByLabel('Remove').click();
     await page.waitForTimeout(100);
     await expect(page.locator('si-delete-confirmation-dialog')).toBeVisible();
     await si.runVisualAndA11yTests('delete-confirmation-dialog');

--- a/playwright/snapshots/si-dashboard.spec.ts-snapshots/si-dashboard--si-dashboard-layout--mobile-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-dashboard.spec.ts-snapshots/si-dashboard--si-dashboard-layout--mobile-expanded-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d201c8112259fc30e5d755e544be00aeda3a51ec748512b9f3db9cffbfd0656e
-size 22489
+oid sha256:59b7497c49a62a160e48bc6dca053a7162e5e2f8cfcb42d3572a0a20f9c3c80b
+size 23617

--- a/playwright/snapshots/si-dashboard.spec.ts-snapshots/si-dashboard--si-dashboard-layout--mobile-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-dashboard.spec.ts-snapshots/si-dashboard--si-dashboard-layout--mobile-expanded-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:adb607a489d847f14e76aefadf0c274dd94ffb9fa52d910635b5f2bd30ee9522
-size 22004
+oid sha256:298844f019bbe13ada8a124ce83b2c5e4aeff14efd036a0944a9550f455da0e9
+size 23211

--- a/projects/element-ng/content-action-bar/si-content-action-bar.component.html
+++ b/projects/element-ng/content-action-bar/si-content-action-bar.component.html
@@ -25,9 +25,8 @@
                 type="button"
                 si-menu-item
                 [attr.data-id]="primaryAction.id"
-                [attr.title]="
-                  primaryAction.iconOnly ? (primaryAction.label | translate) : undefined
-                "
+                [attr.aria-label]="primaryAction.label | translate"
+                [siTooltip]="primaryAction.iconOnly ? (primaryAction.label | translate) : ''"
                 [badge]="primaryAction.badge"
                 [badgeColor]="primaryAction.badgeColor ?? 'secondary'"
                 [disabled]="primaryAction.disabled || disabled()"
@@ -45,9 +44,8 @@
                 type="button"
                 si-menu-item-checkbox
                 [attr.data-id]="primaryAction.id"
-                [attr.title]="
-                  primaryAction.iconOnly ? (primaryAction.label | translate) : undefined
-                "
+                [attr.aria-label]="primaryAction.label | translate"
+                [siTooltip]="primaryAction.iconOnly ? (primaryAction.label | translate) : ''"
                 [checked]="primaryAction.checked"
                 [badge]="primaryAction.badge"
                 [badgeColor]="primaryAction.badgeColor ?? 'secondary'"
@@ -67,9 +65,8 @@
                 type="button"
                 si-menu-item
                 [attr.data-id]="primaryAction.id"
-                [attr.title]="
-                  primaryAction.iconOnly ? (primaryAction.label | translate) : undefined
-                "
+                [attr.aria-label]="primaryAction.label | translate"
+                [siTooltip]="primaryAction.iconOnly ? (primaryAction.label | translate) : ''"
                 [badge]="primaryAction.badge"
                 [badgeColor]="primaryAction.badgeColor ?? 'secondary'"
                 [disabled]="primaryAction.disabled || disabled()"
@@ -90,9 +87,8 @@
               <a
                 si-menu-item
                 [attr.data-id]="primaryAction.id"
-                [attr.title]="
-                  primaryAction.iconOnly ? (primaryAction.label | translate) : undefined
-                "
+                [attr.aria-label]="primaryAction.label | translate"
+                [siTooltip]="primaryAction.iconOnly ? (primaryAction.label | translate) : ''"
                 [badge]="primaryAction.badge"
                 [badgeColor]="primaryAction.badgeColor ?? 'secondary'"
                 [disabled]="primaryAction.disabled || disabled()"
@@ -117,9 +113,8 @@
               <a
                 si-menu-item
                 [attr.data-id]="primaryAction.id"
-                [attr.title]="
-                  primaryAction.iconOnly ? (primaryAction.label | translate) : undefined
-                "
+                [attr.aria-label]="primaryAction.label | translate"
+                [siTooltip]="primaryAction.iconOnly ? (primaryAction.label | translate) : ''"
                 [badge]="primaryAction.badge"
                 [badgeColor]="primaryAction.badgeColor ?? 'secondary'"
                 [disabled]="primaryAction.disabled || disabled()"

--- a/projects/element-ng/content-action-bar/si-content-action-bar.component.ts
+++ b/projects/element-ng/content-action-bar/si-content-action-bar.component.ts
@@ -28,6 +28,7 @@ import {
   SiMenuActionService,
   SiMenuModule
 } from '@siemens/element-ng/menu';
+import { SiTooltipDirective } from '@siemens/element-ng/tooltip';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
 import { SiContentActionBarToggleComponent } from './si-content-action-bar-toggle.component';
@@ -42,6 +43,7 @@ import { ContentActionBarMainItem, ViewType } from './si-content-action-bar.mode
     SiTranslatePipe,
     SiLinkModule,
     SiContentActionBarToggleComponent,
+    SiTooltipDirective,
     RouterLink
   ],
   templateUrl: './si-content-action-bar.component.html',

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget.component.spec.ts
@@ -122,12 +122,10 @@ describe('SiListWidgetComponent', () => {
     ];
     fixture.detectChanges();
 
-    let action: HTMLButtonElement | undefined = undefined;
-    element.querySelectorAll('button').forEach(btn => {
-      if (btn.getAttribute('title') === 'Sort descending') {
-        action = btn;
-      }
-    });
+    const action = element.querySelector(
+      'si-content-action-bar button[aria-label="Sort descending"]'
+    ) as HTMLButtonElement;
+
     expect(action).toBeDefined();
     action!.click();
     fixture.detectChanges();
@@ -136,11 +134,6 @@ describe('SiListWidgetComponent', () => {
     expect(items.length).toBe(4);
     expect(items.item(0).textContent).toContain('item_3');
 
-    element.querySelectorAll('button').forEach(btn => {
-      if (btn.getAttribute('title') === 'Sort ascending') {
-        action = btn;
-      }
-    });
     expect(action).toBeDefined();
     action!.click();
     fixture.detectChanges();


### PR DESCRIPTION
Adds tooltip support to the content action bar.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
