### PR TITLE
refactor(filtered-search): delete criterion by index

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search.component.html
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.html
@@ -20,7 +20,7 @@
       [onlySelectValue]="onlySelectValue()"
       [searchDebounceTime]="searchDebounceTime()"
       (submitCriterion)="focusNext($index, $event)"
-      (deleteCriterion)="deleteCriterion(criterion.value, $index, $event)"
+      (deleteCriterion)="deleteCriterion($index, $event)"
       (valueChange)="valueChange($event, criterion)"
     />
   }

--- a/projects/element-ng/filtered-search/si-filtered-search.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.ts
@@ -517,11 +517,7 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     this.submit();
   }
 
-  protected deleteCriterion(
-    criterion: CriterionValue,
-    index: number,
-    event: { triggerSearch: boolean } | void
-  ): void {
+  protected deleteCriterion(index: number, event: { triggerSearch: boolean } | void): void {
     if (this.disabled()) {
       return;
     }
@@ -534,7 +530,7 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     });
     this.cdRef.detectChanges();
 
-    this.values = this.values.filter(v => v.value !== criterion);
+    this.values = this.values.filter((_, i) => i !== index);
     this.emitChangeEvent();
     this.allowedCriteriaCache = undefined;
     if (this.values.length !== index) {


### PR DESCRIPTION
The previous approach of deleting by references
was flaky.
When deleting by pressing backspace in an empty value sometimes (I don't know when), the value is updated first and then the event is emitted using the old
reference.
As a consequence the criterion is not removed.
By using the index, we avoid this behavior.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
