### PR TITLE
build(typescript): update build target

### DIFF
--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["node"],
-    "target": "es2022",
-    "lib": ["dom", "es2022"]
+    "types": ["node"]
   },
   "include": ["**/*.ts"]
 }

--- a/projects/element-ng/tsconfig.schematics.json
+++ b/projects/element-ng/tsconfig.schematics.json
@@ -7,7 +7,6 @@
     "rootDir": "schematics",
     "outDir": "../../dist/@siemens/element-ng/schematics",
     "sourceMap": false,
-    "target": "es2022",
     "types": ["node"]
   },
   "include": ["schematics/**/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2022",
+    "target": "es2024",
     "strict": true,
     "allowUmdGlobalAccess": true,
     "isolatedModules": true,


### PR DESCRIPTION
`es2022` lacking a few features which are baseline for more than two years. Updating the target allows us using them.
Removes redundant information from sub tsconfig which extends to root tsconfig.
The `lib` option is non longer needed as it is inferred by `target`.

BREAKING CHANGE: Element now requires ECMA script 2024 or newer. This is implemented by all evergreen browsers for more than two years.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
