### PR TITLE
fix(datepicker): update date even on changing only time

### DIFF
--- a/projects/element-ng/datepicker/si-datepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-datepicker.component.spec.ts
@@ -9,7 +9,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiDatepickerComponent, SiDatepickerModule } from '.';
 import { runOnPushChangeDetection } from '../test-helpers';
-import { CalendarTestHelper, generateKeyEvent } from './components/test-helper.spec';
+import { CalendarTestHelper, enterValue, generateKeyEvent } from './components/test-helper.spec';
 import { today } from './date-time-helper';
 import { DatepickerConfig, DateRange } from './si-datepicker.model';
 import { SiCalendarCellHarness } from './testing/si-calendar-cell.harness';
@@ -103,6 +103,57 @@ describe('SiDatepickerComponent', () => {
 
     await toggleTimeSwitch.toggle();
     expect(component.config().disabledTime).toBeFalse();
+  });
+
+  it('should restore original time when consider time is disabled and then re-enabled', async () => {
+    const initialDate = new Date('2023-12-15T10:00:00');
+    component.date.set(initialDate);
+    await updateConfig({
+      ...component.config(),
+      disabledTime: false,
+      showTime: true,
+      showMinutes: true
+    });
+
+    enterValue(helper.getTimeInputHours(), '14');
+    enterValue(helper.getTimeInputMinutes(), '30');
+    helper.getTimeInputMinutes().dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const toggleTimeSwitch = await picker.considerTimeSwitch();
+    expect(await toggleTimeSwitch.isChecked()).toBeTrue();
+
+    // Disable consider time
+    await toggleTimeSwitch.toggle();
+    expect(component.config().disabledTime).toBeTrue();
+
+    // Re-enable consider time
+    await toggleTimeSwitch.toggle();
+    expect(component.config().disabledTime).toBeFalse();
+
+    // Verify that the original time is restored
+    expect(component.changedDate).toBeDefined();
+    expect(component.changedDate!.getHours()).toBe(14);
+    expect(component.changedDate!.getMinutes()).toBe(30);
+  });
+
+  it('should update date when only time is changed in timepicker', async () => {
+    const initialDate = new Date('2023-12-15T10:00:00');
+    component.date.set(initialDate);
+    await updateConfig({ ...component.config(), showTime: true, showMinutes: true });
+
+    enterValue(helper.getTimeInputHours(), '14');
+    enterValue(helper.getTimeInputMinutes(), '30');
+    helper.getTimeInputMinutes().dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.changedDate).toBeDefined();
+    expect(component.changedDate!.getHours()).toBe(14);
+    expect(component.changedDate!.getMinutes()).toBe(30);
+    expect(component.changedDate!.getDate()).toBe(15);
+    expect(component.changedDate!.getMonth()).toBe(11); // December
   });
 
   it('should ignore invalid dates', () => {

--- a/projects/element-ng/datepicker/si-datepicker.component.ts
+++ b/projects/element-ng/datepicker/si-datepicker.component.ts
@@ -284,10 +284,15 @@ export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
     nonNullable: true
   });
   /**
+   * Stores the current time value before a new time change is applied.
+   * Used to detect actual changes and avoid redundant updates.
+   */
+  private previousTime?: Date;
+  /**
    * Used to hold the last time when setting the time to disabled.
    * Value will be reset on enabling the time again.
    */
-  private previousTime?: Date;
+  private lastTimeBeforeDisable?: Date;
 
   /** Reference to the current day selection component. Shown when view === 'week' */
   private readonly daySelection = viewChild(SiDaySelectionComponent);
@@ -511,7 +516,13 @@ export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   protected timeSelected(newTime?: Date): void {
-    if (newTime == null || newTime === this.time.value) {
+    if (
+      newTime == null ||
+      (newTime.getHours() === this.previousTime?.getHours() &&
+        newTime.getMinutes() === this.previousTime.getMinutes() &&
+        newTime.getSeconds() === this.previousTime.getSeconds() &&
+        newTime.getMilliseconds() === this.previousTime.getMilliseconds())
+    ) {
       return;
     }
 
@@ -560,9 +571,10 @@ export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
         const newTime = new Date(
           Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0)
         );
+        this.lastTimeBeforeDisable = this.previousTime;
         this.timeSelected(newTime);
       } else if (this.previousTime) {
-        this.timeSelected(this.previousTime);
+        this.timeSelected(this.lastTimeBeforeDisable);
       } else {
         this.timeSelected(new Date());
       }


### PR DESCRIPTION
currently date never updates when only time value is changed in datepicker.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
