### PR TITLE
refactor(side-panel): use `siTooltip` instead of `title`

### DIFF
--- a/projects/element-ng/side-panel/si-side-panel-content.component.html
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.html
@@ -97,7 +97,10 @@
         @if (!dp.disabled) {
           <a
             class="rpanel-statusaction position-relative focus-inside"
-            [attr.aria-label]="!isCollapsed ? '' : (dp.title | translate)"
+            placement="start"
+            [attr.aria-label]="!isCollapsed() ? '' : (dp.title | translate)"
+            [siTooltip]="(dp.title | translate) || ''"
+            [isDisabled]="!isCollapsed()"
             [siLink]="dp"
           >
             <si-icon class="icon" [icon]="dp.icon!" />

--- a/projects/element-ng/side-panel/si-side-panel-content.component.ts
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.ts
@@ -29,6 +29,7 @@ import { SiLinkDirective } from '@siemens/element-ng/link';
 import { MenuItem } from '@siemens/element-ng/menu';
 import { BOOTSTRAP_BREAKPOINTS } from '@siemens/element-ng/resize-observer';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
+import { SiTooltipDirective } from '@siemens/element-ng/tooltip';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { timer } from 'rxjs';
 
@@ -50,7 +51,8 @@ export interface StatusItem extends MenuItemLegacy {
     SiLinkDirective,
     RouterLink,
     SiSearchBarComponent,
-    SiTranslatePipe
+    SiTranslatePipe,
+    SiTooltipDirective
   ],
   templateUrl: './si-side-panel-content.component.html',
   styleUrl: './si-side-panel-content.component.scss',

--- a/src/app/examples/si-side-panel/si-side-panel-collapsible.ts
+++ b/src/app/examples/si-side-panel/si-side-panel-collapsible.ts
@@ -89,20 +89,17 @@ export class SampleComponent implements OnDestroy {
   statusActions: StatusItem[] = [
     {
       title: 'Out of Service',
-      tooltip: 'Out of Service',
       icon: 'element-out-of-service status-warning',
       action: () => this.logEvent('Out of Service')
     },
     {
       title: 'System Operator',
-      tooltip: 'System Operator',
       icon: 'element-manual-filled status-warning',
       disabled: true,
       action: () => this.logEvent('System Operator')
     },
     {
       title: 'Event source\nactive, ack',
-      tooltip: 'Event source',
       icon: 'element-alarm-background-filled status-danger',
       overlayIcon: 'element-alarm-tick text-body',
       action: () => this.logEvent('Event source, active, ack')


### PR DESCRIPTION
Use `siTooltip` for status actions in the side panel.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
