### PR TITLE
refactor(dashboards): use common util for federation component loading

### DIFF
--- a/projects/dashboards-ng/module-federation/index.ts
+++ b/projects/dashboards-ng/module-federation/index.ts
@@ -3,9 +3,15 @@
  * SPDX-License-Identifier: MIT
  */
 import { loadRemoteModule } from '@angular-architects/module-federation';
-import { ComponentRef, EnvironmentInjector, Injector, ViewContainerRef, Type } from '@angular/core';
-import { FederatedModule, SetupComponentFn, widgetFactoryRegistry } from '@siemens/dashboards-ng';
-import { Observable, Subject } from 'rxjs';
+import { ComponentRef, EnvironmentInjector, Injector, ViewContainerRef } from '@angular/core';
+import {
+  FederatedModule,
+  FederatedModuleExports,
+  handleFederatedModuleLoad,
+  SetupComponentFn,
+  widgetFactoryRegistry
+} from '@siemens/dashboards-ng';
+import { Observable } from 'rxjs';
 
 const setupRemoteComponent = <T>(
   factory: FederatedModule,
@@ -13,31 +19,15 @@ const setupRemoteComponent = <T>(
   host: ViewContainerRef,
   injector: Injector,
   environmentInjector: EnvironmentInjector
-): Observable<ComponentRef<T>> => {
-  const result = new Subject<ComponentRef<T>>();
-
-  loadRemoteModule<Type<T>[]>(factory).then(
-    module => {
-      const componentType = module[factory[componentName]];
-      const widgetInstanceRef = host.createComponent<T>(componentType, {
-        injector,
-        environmentInjector
-      });
-      result.next(widgetInstanceRef);
-      result.complete();
-    },
-    rejection => {
-      const msg = rejection
-        ? `Loading widget module ${factory.exposedModule} failed with ${JSON.stringify(
-            rejection.toString()
-          )}`
-        : `Loading widget module ${factory.exposedModule} failed`;
-      result.error(msg);
-      result.complete();
-    }
-  );
-  return result;
-};
+): Observable<ComponentRef<T>> =>
+  handleFederatedModuleLoad({
+    loadPromise: loadRemoteModule<FederatedModuleExports<T>>(factory),
+    factory,
+    componentName,
+    host,
+    injector,
+    environmentInjector
+  });
 
 export const registerModuleFederatedWidgetLoader = (): void => {
   widgetFactoryRegistry.register('module-federation', setupRemoteComponent as SetupComponentFn);

--- a/projects/dashboards-ng/native-federation/index.ts
+++ b/projects/dashboards-ng/native-federation/index.ts
@@ -3,9 +3,15 @@
  * SPDX-License-Identifier: MIT
  */
 import { loadRemoteModule } from '@angular-architects/native-federation';
-import { ComponentRef, EnvironmentInjector, Injector, ViewContainerRef, Type } from '@angular/core';
-import { FederatedModule, SetupComponentFn, widgetFactoryRegistry } from '@siemens/dashboards-ng';
-import { Observable, Subject } from 'rxjs';
+import { ComponentRef, EnvironmentInjector, Injector, ViewContainerRef } from '@angular/core';
+import {
+  FederatedModule,
+  FederatedModuleExports,
+  handleFederatedModuleLoad,
+  SetupComponentFn,
+  widgetFactoryRegistry
+} from '@siemens/dashboards-ng';
+import { Observable } from 'rxjs';
 
 const setupRemoteComponent = <T>(
   factory: FederatedModule,
@@ -13,33 +19,15 @@ const setupRemoteComponent = <T>(
   host: ViewContainerRef,
   injector: Injector,
   environmentInjector: EnvironmentInjector
-): Observable<ComponentRef<T>> => {
-  const result = new Subject<ComponentRef<T>>();
-
-  loadRemoteModule<Type<T>[]>(factory).then(
-    module => {
-      if (module) {
-        const componentType = module[factory[componentName]];
-        const widgetInstanceRef = host.createComponent<T>(componentType, {
-          injector,
-          environmentInjector
-        });
-        result.next(widgetInstanceRef);
-      }
-      result.complete();
-    },
-    rejection => {
-      const msg = rejection
-        ? `Loading widget module ${factory.exposedModule} failed with ${JSON.stringify(
-            rejection.toString()
-          )}`
-        : `Loading widget module ${factory.exposedModule} failed`;
-      result.error(msg);
-      result.complete();
-    }
-  );
-  return result;
-};
+): Observable<ComponentRef<T>> =>
+  handleFederatedModuleLoad({
+    loadPromise: loadRemoteModule<FederatedModuleExports<T>>(factory),
+    factory,
+    componentName,
+    host,
+    injector,
+    environmentInjector
+  });
 
 export const registerNativeFederatedWidgetLoader = (): void => {
   widgetFactoryRegistry.register('native-federation', setupRemoteComponent as SetupComponentFn);

--- a/projects/dashboards-ng/src/public-api.ts
+++ b/projects/dashboards-ng/src/public-api.ts
@@ -14,6 +14,7 @@ export * from './model/widgets.model';
 export * from './model/si-dashboard-toolbar.model';
 export * from './model/si-widget-id-provider';
 export * from './widget-loader';
+export * from './services/federation-loader.util';
 
 export * from '@siemens/dashboards-ng/translate';
 export * from './public-api.module';

--- a/projects/dashboards-ng/src/services/federation-loader.util.ts
+++ b/projects/dashboards-ng/src/services/federation-loader.util.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { ComponentRef, EnvironmentInjector, Injector, ViewContainerRef, Type } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+
+/**
+ * Common factory configuration fields required for federated module loading.
+ * @internal
+ */
+export interface FederationFactoryBase {
+  exposedModule?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Module loaded from federation, containing exported components keyed by name.
+ * @internal
+ */
+export type FederatedModuleExports<T> = Record<string, Type<T>>;
+
+/**
+ * Options for handling federated module loading.
+ */
+interface FederatedModuleLoadOptions<T> {
+  loadPromise: Promise<FederatedModuleExports<T> | null | undefined>;
+  factory: FederationFactoryBase;
+  componentName: string;
+  host: ViewContainerRef;
+  injector: Injector;
+  environmentInjector: EnvironmentInjector;
+}
+
+/**
+ * Formats an error message for failed module loading.
+ */
+const formatLoadingError = (factory: FederationFactoryBase, rejection: unknown): string =>
+  rejection
+    ? `Loading widget module ${factory.exposedModule} failed with ${String(rejection)}`
+    : `Loading widget module ${factory.exposedModule} failed`;
+
+/**
+ * Handles the result of a federated module loading promise.
+ * This is the main utility function that encapsulates the common loading pattern
+ * used across module-federation, native-federation, and mf-bridge loaders.
+ *
+ * @param options - Configuration options for loading and creating the component
+ * @returns Observable that emits the ComponentRef once the component is created
+ * @internal
+ */
+export const handleFederatedModuleLoad = <T>({
+  loadPromise,
+  factory,
+  componentName,
+  host,
+  injector,
+  environmentInjector
+}: FederatedModuleLoadOptions<T>): Observable<ComponentRef<T>> => {
+  const result = new Subject<ComponentRef<T>>();
+
+  loadPromise.then(
+    module => {
+      if (module) {
+        const componentType = module[factory[componentName] as string];
+        const widgetInstanceRef = host.createComponent<T>(componentType, {
+          injector,
+          environmentInjector
+        });
+        result.next(widgetInstanceRef);
+      }
+      result.complete();
+    },
+    rejection => result.error(formatLoadingError(factory, rejection))
+  );
+
+  return result;
+};


### PR DESCRIPTION
Moves component creation and error handling logic from module-federation, native-federation, mf-bridge into common util.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
