### PR TITLE
feat(file-uploader): provide translation params to uploader messages

### DIFF
--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--added-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--added-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd7ed8df05ce11da6e0e3ac61b00033b520e277ac57bd0838d19132b428ad49f
-size 31394
+oid sha256:4187c37eabea5f05ed8c93e980251bc430f64c5e051b3bffa7ce5ad38fde0d31
+size 31310

--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--added-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--added-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7138adb291c84cd4909a3b272e1d90b36c3d2ff8c1ff3c80ee3a2c266ef808d2
-size 30396
+oid sha256:0a8a10cc4d0c50084fd6dc442e2c5291f8b399442596d4e27ea5a9d91116daa3
+size 30333

--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--added.yaml
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--added.yaml
@@ -1,4 +1,4 @@
-- text: "/Drop files here or click to upload Maximum upload size: [\\d,.]+[bkmBKM]+\\. Accepted file types: image\\/\\*\\. siemens-healthineers-logo\\.svg [\\d,.]+[bkmBKM]+ 0 %/"
+- text: "/Drop files here or click to upload Max\\. [\\d,.]+[bkmBKM]+ upload size\\. Accepted file types: image\\/\\*\\. siemens-healthineers-logo\\.svg [\\d,.]+[bkmBKM]+ 0 %/"
 - progressbar "Uploading"
 - button "Remove"
 - text: /simpl-44x44\.png [\d,.]+[bkmBKM]+ 0 %/

--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--initial-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--initial-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:765e8c4b919d57c10de3bb6b4d4cf5fad4cddf847b216227b3c845086ffa2665
-size 17205
+oid sha256:294fba11d327569d79b0562e34c4e177336dcae7853cb962e257727e30c61edc
+size 17117

--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--initial-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--initial-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e91b63c8a957db298c2f35895504c42edd2f8aa2402f86509a7bdb6c737c5523
-size 16914
+oid sha256:94a73fd2aa92e2682fa0e43352fa936faf606e27f4f8294cd8b06cdfe0d36380
+size 16847

--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--initial.yaml
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--initial.yaml
@@ -1,4 +1,4 @@
-- text: "/Drop files here or click to upload Maximum upload size: [\\d,.]+[bkmBKM]+\\. Accepted file types: image\\/\\*\\./"
+- text: "/Drop files here or click to upload Max\\. [\\d,.]+[bkmBKM]+ upload size\\. Accepted file types: image\\/\\*\\./"
 - button "Clear" [disabled]
 - button "Upload" [disabled]
 - text: si-file-uploader settings

--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--uploaded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--uploaded-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24d4d6a4d196440261e91a7acf935043f653d9c61bed32422734a67a18e35d6f
-size 34605
+oid sha256:aacc962b7dc8236b9345e4e9d5220a21d44e45a9c332c6a6356e003da1cc34f1
+size 34522

--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--uploaded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--uploaded-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:018c8f5c9c6fd577bc06a8205b706029b71872d1c7af5dc976a099d85e0dfdf5
-size 33898
+oid sha256:ec8173144b9affa66b1da542f3929fc7c500ea0538d0b2adee0982cd85c42dcc
+size 33844

--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--uploaded.yaml
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--uploaded.yaml
@@ -1,4 +1,4 @@
-- text: "/Drop files here or click to upload Maximum upload size: [\\d,.]+[bkmBKM]+\\. Accepted file types: image\\/\\*\\. siemens-healthineers-logo\\.svg [\\d,.]+[bkmBKM]+ Danger Upload failed/"
+- text: "/Drop files here or click to upload Max\\. [\\d,.]+[bkmBKM]+ upload size\\. Accepted file types: image\\/\\*\\. siemens-healthineers-logo\\.svg [\\d,.]+[bkmBKM]+ Danger Upload failed/"
 - button "Upload"
 - button "Remove"
 - text: /simpl-44x44\.png [\d,.]+[bkmBKM]+ \d+ %/

--- a/projects/element-ng/file-uploader/si-file-dropzone.component.html
+++ b/projects/element-ng/file-uploader/si-file-dropzone.component.html
@@ -34,10 +34,10 @@
   @if (maxFileSize() || accept()) {
     <div class="allowed si-caption mt-6 text-center">
       @if (maxFileSize()) {
-        {{ maxFileSizeText() | translate }}: {{ maxFileSizeString() }}.
+        {{ maxFileSizeText() | translate: { maxFileSize: maxFileSizeString() } }}
       }
       @if (accept()) {
-        {{ acceptText() | translate }}: {{ accept() }}.
+        {{ acceptText() | translate: { accept: accept() } }}
       }
     </div>
   }

--- a/projects/element-ng/file-uploader/si-file-dropzone.component.ts
+++ b/projects/element-ng/file-uploader/si-file-dropzone.component.ts
@@ -51,22 +51,22 @@ export class SiFileDropzoneComponent {
    *
    * @defaultValue
    * ```
-   * t(() => $localize`:@@SI_FILE_UPLOADER.MAX_SIZE:Maximum upload size`)
+   * t(() => $localize`:@@SI_FILE_UPLOADER.MAX_SIZE:Max. {{maxFileSize}} upload size.`)
    * ```
    */
   readonly maxFileSizeText = input(
-    t(() => $localize`:@@SI_FILE_UPLOADER.MAX_SIZE:Maximum upload size`)
+    t(() => $localize`:@@SI_FILE_UPLOADER.MAX_SIZE:Max. {{maxFileSize}} upload size.`)
   );
   /**
    * Text or translation key for accepted types.
    *
    * @defaultValue
    * ```
-   * t(() => $localize`:@@SI_FILE_UPLOADER.ACCEPTED_FILE_TYPES:Accepted file types`)
+   * t(() => $localize`:@@SI_FILE_UPLOADER.ACCEPTED_FILE_TYPES:Accepted file types: {{accept}}.`)
    * ```
    */
   readonly acceptText = input(
-    t(() => $localize`:@@SI_FILE_UPLOADER.ACCEPTED_FILE_TYPES:Accepted file types`)
+    t(() => $localize`:@@SI_FILE_UPLOADER.ACCEPTED_FILE_TYPES:Accepted file types: {{accept}}.`)
   );
   /**
    * Text or translation key of message title if incorrect file type is dragged / dropped.

--- a/projects/element-ng/file-uploader/si-file-uploader.component.html
+++ b/projects/element-ng/file-uploader/si-file-uploader.component.html
@@ -15,7 +15,12 @@
 />
 
 @if (maxFilesReached) {
-  <si-inline-notification class="mb-4" severity="info" [message]="maxFilesReachedText()" />
+  <si-inline-notification
+    class="mb-4"
+    severity="info"
+    [message]="maxFilesReachedText()"
+    [translationParams]="{ maxFiles: maxFiles() }"
+  />
 }
 
 <div class="file-list">

--- a/projects/element-ng/file-uploader/si-file-uploader.component.ts
+++ b/projects/element-ng/file-uploader/si-file-uploader.component.ts
@@ -117,33 +117,33 @@ export class SiFileUploaderComponent implements OnChanges {
    *
    * @defaultValue
    * ```
-   * t(() => $localize`:@@SI_FILE_UPLOADER.MAX_SIZE:Maximum upload size`)
+   * t(() => $localize`:@@SI_FILE_UPLOADER.MAX_SIZE:Max. {{maxFileSize}} upload size.`)
    * ```
    */
   readonly maxFileSizeText = input(
-    t(() => $localize`:@@SI_FILE_UPLOADER.MAX_SIZE:Maximum upload size`)
+    t(() => $localize`:@@SI_FILE_UPLOADER.MAX_SIZE:Max. {{maxFileSize}} upload size.`)
   );
   /**
    * Error message shown when the maximum number of files are reached.
    *
    * @defaultValue
    * ```
-   * t(() => $localize`:@@SI_FILE_UPLOADER.MAX_FILE_REACHED:Maximum number of files reached`)
+   * t(() => $localize`:@@SI_FILE_UPLOADER.MAX_FILE_REACHED:Max. {{maxFiles}} files`)
    * ```
    */
   readonly maxFilesReachedText = input(
-    t(() => $localize`:@@SI_FILE_UPLOADER.MAX_FILE_REACHED:Maximum number of files reached`)
+    t(() => $localize`:@@SI_FILE_UPLOADER.MAX_FILE_REACHED:Max. {{maxFiles}} files`)
   );
   /**
    * Text for the accepted file types.
    *
    * @defaultValue
    * ```
-   * t(() => $localize`:@@SI_FILE_UPLOADER.ACCEPTED_FILE_TYPES:Accepted file types`)
+   * t(() => $localize`:@@SI_FILE_UPLOADER.ACCEPTED_FILE_TYPES:Accepted file types: {{accept}}.`)
    * ```
    */
   readonly acceptText = input(
-    t(() => $localize`:@@SI_FILE_UPLOADER.ACCEPTED_FILE_TYPES:Accepted file types`)
+    t(() => $localize`:@@SI_FILE_UPLOADER.ACCEPTED_FILE_TYPES:Accepted file types: {{accept}}.`)
   );
   /**
    * Text used inside the upload button.


### PR DESCRIPTION
fixes #1447

BREAKING CHANGE: File uploader translation strings now require interpolation placeholders.

The `SiFileUploaderComponent` and `SiFileDropzoneComponent` inputs:

- `maxFileSizeText` requires the placeholder `{{maxFileSize}}` to display the maximum file size.
- `acceptText` requires the placeholder `{{accept}}` to display the accepted file types.
- `maxFilesReachedText` requires the placeholder `{{maxFiles}}` to display the maximum number of files allowed.

Migration guide for english default translation keys:

Before:
```json
{
  "SI_FILE_UPLOADER.MAX_SIZE": "Maximum upload size",
  "SI_FILE_UPLOADER.ACCEPTED_FILE_TYPES": "Accepted file types",
  "SI_FILE_UPLOADER.MAX_FILE_REACHED": "Maximum number of files reached"
}
```

After:
```json
{
  "SI_FILE_UPLOADER.MAX_SIZE": "Max. {{maxFileSize}} upload size.",
  "SI_FILE_UPLOADER.ACCEPTED_FILE_TYPES": "Accepted file types: {{accept}}.",
  "SI_FILE_UPLOADER.MAX_FILE_REACHED": "Max. {{maxFiles}} files"
}
```

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
