### PR TITLE
test(filtered-search): ensure typeahead is open before proceeding

### DIFF
--- a/playwright/e2e/element-examples/si-filtered-search.spec.ts
+++ b/playwright/e2e/element-examples/si-filtered-search.spec.ts
@@ -47,6 +47,11 @@ test.describe('filtered search', () => {
     ).toBeFocused();
     await page.keyboard.press('Control+KeyA');
     await page.keyboard.press('Backspace');
+    // There are currently two combox with the label "search". The input of the pill and the free text search.
+    // TODO: pill and free text should have different labels.
+    await expect(
+      page.locator('.pill-group').getByRole('combobox', { name: 'search' })
+    ).toHaveAttribute('aria-expanded', 'true');
     await si.runVisualAndA11yTests('typeahead-open');
     await page.keyboard.press('Backspace');
     await si.runVisualAndA11yTests('empty');


### PR DESCRIPTION
Previously this was failing in some cases, where the test was too fast.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
