### PR TITLE
fix(filtered-search): avoid expression change errors in zoneless apps

### DIFF
--- a/projects/element-ng/autocomplete/si-autocomplete-listbox.directive.ts
+++ b/projects/element-ng/autocomplete/si-autocomplete-listbox.directive.ts
@@ -77,10 +77,10 @@ export class SiAutocompleteListboxDirective<T> implements OnInit {
     // For some reason, this is needed sometimes. Otherwise, one may get ExpressionChangedAfterItHasBeenCheckedError.
     queueMicrotask(() => {
       this.changeDetectorRef.markForCheck();
-      this.autocomplete().listbox = this;
+      this.autocomplete().listbox.set(this);
     });
     this.destroyRef.onDestroy(() => {
-      this.autocomplete().listbox = undefined;
+      this.autocomplete().listbox.set(undefined);
     });
   }
 

--- a/projects/element-ng/autocomplete/si-autocomplete.directive.ts
+++ b/projects/element-ng/autocomplete/si-autocomplete.directive.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Directive, HostBinding, HostListener } from '@angular/core';
+import { Directive, HostListener, signal } from '@angular/core';
 
 import { SiAutocompleteListboxDirective } from './si-autocomplete-listbox.directive';
 import { SiAutocompleteOptionDirective } from './si-autocomplete-option.directive';
@@ -11,35 +11,27 @@ import { SiAutocompleteOptionDirective } from './si-autocomplete-option.directiv
   selector: 'input[siAutocomplete]',
   host: {
     role: 'combobox',
-    'aria-autocomplete': 'list'
+    'aria-autocomplete': 'list',
+    '[attr.aria-activedescendant]': 'activeDescendant',
+    '[attr.aria-controls]': 'listbox()?.id()',
+    '[attr.aria-expanded]': '!!listbox()'
   },
   exportAs: 'siAutocomplete'
 })
 export class SiAutocompleteDirective<T> {
   /** @internal */
-  listbox?: SiAutocompleteListboxDirective<T>;
+  readonly listbox = signal<SiAutocompleteListboxDirective<T> | undefined>(undefined);
 
-  @HostBinding('attr.aria-activedescendant')
   protected get activeDescendant(): string {
-    return this.listbox?.active?.id() ?? '';
-  }
-
-  @HostBinding('attr.aria-controls')
-  protected get ariaControls(): string | undefined {
-    return this.listbox?.id();
-  }
-
-  @HostBinding('attr.aria-expanded')
-  protected get expanded(): boolean {
-    return !!this.listbox;
+    return this.listbox()?.active?.id() ?? '';
   }
 
   @HostListener('keydown', ['$event'])
   protected keydown(event: KeyboardEvent): void {
-    this.listbox?.onKeydown(event);
+    this.listbox()?.onKeydown(event);
   }
 
   get active(): SiAutocompleteOptionDirective<T> | undefined | null {
-    return this.listbox?.active;
+    return this.listbox()?.active;
   }
 }


### PR DESCRIPTION
this doesn't reproduce on our live previewer somehow.
but when running apps in zoneless mode we get the expression change errors.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
