### PR TITLE
build(npm): use correct override for @simpl/brand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32380,7 +32380,7 @@
         "@angular-architects/native-federation": "^21.1.0",
         "@angular/common": "21",
         "@angular/core": "21",
-        "@module-federation/enhanced": "^0.24.0 || ^2.0.0",
+        "@module-federation/enhanced": "^2.0.0",
         "@siemens/element-ng": "48.9.0",
         "@siemens/element-theme": "48.9.0",
         "gridstack": "^12.3.3"

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
       "typescript": "$typescript"
     },
     "@simpl/brand": {
-      "@siemens/element-theme": ">1.0.0"
+      "@siemens/element-theme": "file:projects/element-theme"
     }
   }
 }


### PR DESCRIPTION
We previously just accepted a broad range,
which did not cover `-rc.x` release.
So npm failed when doing a release.
The new override is pointing the local package instead, which solves the problem.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
