### PR TITLE
feat(schematics): use ts program

### DIFF
--- a/projects/element-ng/schematics/migrations/data/class-member-replacement.ts
+++ b/projects/element-ng/schematics/migrations/data/class-member-replacement.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+
+export interface ClassMemberReplacementInstruction {
+  /** Regex to match module import path where the type is defined */
+  module: RegExp;
+  /** The type name(s) to match (e.g., 'SiResponsiveContainerDirective') */
+  typeNames: string[];
+  /** Property access transformations */
+  propertyReplacements: {
+    /** Original property name */
+    property: string;
+    /** Replacement string. Use placeholders: '$\{expression\}' for the object expression, '$\{property\}' for the property name */
+    replacement: string;
+  }[];
+}
+
+export const CLASS_MEMBER_REPLACEMENTS_MIGRATION: ClassMemberReplacementInstruction[] = [
+  {
+    module: /@(siemens|simpl)\/element-ng(\/resize-observer)?/,
+    typeNames: ['SiResponsiveContainerDirective'],
+    propertyReplacements: [
+      { property: 'isXs', replacement: '${expression}.xs()' },
+      { property: 'isSm', replacement: '${expression}.sm()' },
+      { property: 'isMd', replacement: '${expression}.md()' },
+      { property: 'isLg', replacement: '${expression}.lg()' },
+      { property: 'isXl', replacement: '${expression}.xl()' },
+      { property: 'isXxl', replacement: '${expression}.xxl()' }
+    ]
+  }
+];

--- a/projects/element-ng/schematics/migrations/data/index.ts
+++ b/projects/element-ng/schematics/migrations/data/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { ATTRIBUTE_SELECTORS_MIGRATION } from './attribute-selectors.js';
+import { CLASS_MEMBER_REPLACEMENTS_MIGRATION } from './class-member-replacement.js';
 import { COMPONENT_NAMES_MIGRATION } from './component-names.js';
 import { ELEMENT_SELECTORS_MIGRATION } from './element-selectors.js';
 import { OUTPUT_NAMES_MIGRATION } from './output-names.js';
@@ -11,22 +12,25 @@ import { SYMBOL_REMOVALS_MIGRATION } from './symbol-removals.js';
 
 export type ElementMigrationData = {
   attributeSelectorChanges: typeof ATTRIBUTE_SELECTORS_MIGRATION;
+  classMemberReplacementChanges: typeof CLASS_MEMBER_REPLACEMENTS_MIGRATION;
   componentNameChanges: typeof COMPONENT_NAMES_MIGRATION;
   elementSelectorChanges: typeof ELEMENT_SELECTORS_MIGRATION;
-  symbolRemovalChanges: typeof SYMBOL_REMOVALS_MIGRATION;
   outputNameChanges: typeof OUTPUT_NAMES_MIGRATION;
+  symbolRemovalChanges: typeof SYMBOL_REMOVALS_MIGRATION;
 };
 
 export const getElementMigrationData = (): ElementMigrationData => ({
   attributeSelectorChanges: ATTRIBUTE_SELECTORS_MIGRATION,
+  classMemberReplacementChanges: CLASS_MEMBER_REPLACEMENTS_MIGRATION,
   componentNameChanges: COMPONENT_NAMES_MIGRATION,
   elementSelectorChanges: ELEMENT_SELECTORS_MIGRATION,
-  symbolRemovalChanges: SYMBOL_REMOVALS_MIGRATION,
-  outputNameChanges: OUTPUT_NAMES_MIGRATION
+  outputNameChanges: OUTPUT_NAMES_MIGRATION,
+  symbolRemovalChanges: SYMBOL_REMOVALS_MIGRATION
 });
 
-export type { ComponentNamesInstruction } from './component-names.js';
 export type { AttributeSelectorInstruction } from './attribute-selectors.js';
+export type { ClassMemberReplacementInstruction } from './class-member-replacement.js';
+export type { ComponentNamesInstruction } from './component-names.js';
 export type { ElementSelectorInstruction } from './element-selectors.js';
 export type { OutputNamesInstruction } from './output-names.js';
 export type { SymbolRemovalInstruction } from './symbol-removals.js';

--- a/projects/element-ng/schematics/migrations/data/migration-test-data.ts
+++ b/projects/element-ng/schematics/migrations/data/migration-test-data.ts
@@ -9,7 +9,8 @@ import {
   ElementMigrationData,
   ElementSelectorInstruction,
   OutputNamesInstruction,
-  SymbolRemovalInstruction
+  SymbolRemovalInstruction,
+  ClassMemberReplacementInstruction
 } from './index.js';
 
 const COMPONENT_NAMES_MIGRATION: ComponentNamesInstruction[] = [
@@ -169,6 +170,21 @@ const OUTPUT_NAMES_MIGRATION: OutputNamesInstruction[] = [
   }
 ];
 
+const CLASS_MEMBER_REPLACEMENTS_MIGRATION: ClassMemberReplacementInstruction[] = [
+  {
+    module: /@(siemens|simpl)\/element-ng(\/resize-observer)?/,
+    typeNames: ['SiResponsiveContainerDirective'],
+    propertyReplacements: [
+      { property: 'isXs', replacement: '${expression}.xs()' },
+      { property: 'isSm', replacement: '${expression}.sm()' },
+      { property: 'isMd', replacement: '${expression}.md()' },
+      { property: 'isLg', replacement: '${expression}.lg()' },
+      { property: 'isXl', replacement: '${expression}.xl()' },
+      { property: 'isXxl', replacement: '${expression}.xxl()' }
+    ]
+  }
+];
+
 /**
  * Stable migration data for testing.
  * This data is frozen and used for testing to ensure test stability.
@@ -179,5 +195,6 @@ export const getElementMigrationTestData = (): ElementMigrationData => ({
   componentNameChanges: COMPONENT_NAMES_MIGRATION,
   elementSelectorChanges: ELEMENT_SELECTORS_MIGRATION,
   symbolRemovalChanges: SYMBOL_REMOVALS_MIGRATION,
-  outputNameChanges: OUTPUT_NAMES_MIGRATION
+  outputNameChanges: OUTPUT_NAMES_MIGRATION,
+  classMemberReplacementChanges: CLASS_MEMBER_REPLACEMENTS_MIGRATION
 });

--- a/projects/element-ng/schematics/migrations/element-migration/element-migration.spec.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/element-migration.spec.ts
@@ -146,4 +146,8 @@ describe('to legacy migration', () => {
   it('should remove the deprecated api from module based accordion', async () => {
     await checkTemplateMigration(['module-based.accordion-inline-template.ts']);
   });
+
+  it('should rename functions of classes', async () => {
+    await checkTemplateMigration(['function-rename.ts']);
+  });
 });

--- a/projects/element-ng/schematics/migrations/element-migration/files/expected.function-rename.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/expected.function-rename.ts
@@ -1,0 +1,26 @@
+import { inject } from '@angular/core';
+import { SiResponsiveContainerDirective } from '@siemens/element-ng/resize-observer';
+
+export class MyClass {
+  private resizeDirective = inject(SiResponsiveContainerDirective);
+
+  myMethod() {
+    console.log(this.resizeDirective.xs());
+    console.log(inject(SiResponsiveContainerDirective).xs());
+
+    console.log(this.resizeDirective.sm());
+    console.log(inject(SiResponsiveContainerDirective).sm());
+
+    console.log(this.resizeDirective.md());
+    console.log(inject(SiResponsiveContainerDirective).md());
+
+    console.log(this.resizeDirective.lg());
+    console.log(inject(SiResponsiveContainerDirective).lg());
+
+    console.log(this.resizeDirective.xl());
+    console.log(inject(SiResponsiveContainerDirective).xl());
+
+    console.log(this.resizeDirective.xxl());
+    console.log(inject(SiResponsiveContainerDirective).xxl());
+  }
+}

--- a/projects/element-ng/schematics/migrations/element-migration/files/function-rename.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/function-rename.ts
@@ -1,0 +1,26 @@
+import { inject } from '@angular/core';
+import { SiResponsiveContainerDirective } from '@siemens/element-ng/resize-observer';
+
+export class MyClass {
+  private resizeDirective = inject(SiResponsiveContainerDirective);
+
+  myMethod() {
+    console.log(this.resizeDirective.isXs);
+    console.log(inject(SiResponsiveContainerDirective).isXs);
+
+    console.log(this.resizeDirective.isSm);
+    console.log(inject(SiResponsiveContainerDirective).isSm);
+
+    console.log(this.resizeDirective.isMd);
+    console.log(inject(SiResponsiveContainerDirective).isMd);
+
+    console.log(this.resizeDirective.isLg);
+    console.log(inject(SiResponsiveContainerDirective).isLg);
+
+    console.log(this.resizeDirective.isXl);
+    console.log(inject(SiResponsiveContainerDirective).isXl);
+
+    console.log(this.resizeDirective.isXxl);
+    console.log(inject(SiResponsiveContainerDirective).isXxl);
+  }
+}

--- a/projects/element-ng/schematics/migrations/ngx-translate/index.ts
+++ b/projects/element-ng/schematics/migrations/ngx-translate/index.ts
@@ -15,20 +15,15 @@ export const missingTranslateMigrationRule = (options: { path: string }): Rule =
   return async (tree: Tree, context: SchematicContext) => {
     context.logger.info('🔄 Migrating missing translate provider...');
 
-    const tsSourceFiles = await discoverSourceFiles(tree, context, options.path);
-
-    for (const filePath of tsSourceFiles) {
+    for await (const { path: filePath, sourceFile } of discoverSourceFiles(
+      tree,
+      context,
+      options.path
+    )) {
       let content = tree.readText(filePath);
       if (!content) {
         continue;
       }
-
-      const sourceFile = ts.createSourceFile(
-        filePath,
-        content.toString(),
-        ts.ScriptTarget.Latest,
-        true
-      );
 
       const pendingTransformations: Transformation[] = [];
       [

--- a/projects/element-ng/schematics/utils/index.ts
+++ b/projects/element-ng/schematics/utils/index.ts
@@ -4,6 +4,7 @@
  */
 export * from './html-utils.js';
 export * from './project-utils.js';
+export * from './ts-compiler-host.js';
 export * from './schematics-file-system.js';
 export * from './template-utils.js';
 export * from './testing.js';

--- a/projects/element-ng/schematics/utils/testing.ts
+++ b/projects/element-ng/schematics/utils/testing.ts
@@ -24,12 +24,14 @@ export const createTestApp = async (
     tree
   );
 
-  return runner.runExternalSchematic(
+  tree = await runner.runExternalSchematic(
     '@schematics/angular',
     'application',
     { name: 'second-app', ...appOptions },
     tree
   );
+
+  return tree;
 };
 
 const createWorkspace = (runner: SchematicTestRunner): Promise<UnitTestTree> => {

--- a/projects/element-ng/schematics/utils/ts-compiler-host.ts
+++ b/projects/element-ng/schematics/utils/ts-compiler-host.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+
+import { normalize } from '@angular-devkit/core';
+import { Tree } from '@angular-devkit/schematics';
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, relative, resolve } from 'path/posix';
+import * as ts from 'typescript';
+
+export const createTreeAwareCompilerHost = (
+  tree: Tree,
+  options: ts.CompilerOptions
+): ts.CompilerHost => {
+  const host = ts.createCompilerHost(options, true);
+  const basePath = normalize(process.cwd());
+
+  const toAbsolutePath = (targetPath: string): string => {
+    return isAbsolute(targetPath) ? targetPath : resolve(basePath, targetPath);
+  };
+
+  const toTreePath = (targetPath: string): string | null => {
+    const absolutePath = toAbsolutePath(targetPath);
+    const relativePath = relative(basePath, absolutePath);
+    if (relativePath.startsWith('..')) {
+      return null;
+    }
+    if (!relativePath || relativePath === '.') {
+      return '/';
+    }
+    return normalize(relativePath);
+  };
+
+  host.fileExists = (path: string): boolean => {
+    const treePath = toTreePath(path);
+    if (treePath && tree.exists(treePath)) {
+      return true;
+    }
+    return existsSync(toAbsolutePath(path));
+  };
+
+  host.readFile = path => {
+    const treePath = toTreePath(path);
+    if (treePath && tree.exists(treePath)) {
+      return tree.readText(treePath);
+    }
+    const absolutePath = toAbsolutePath(path);
+    if (existsSync(absolutePath)) {
+      return readFileSync(absolutePath, 'utf-8');
+    }
+    return undefined;
+  };
+
+  host.directoryExists = path => {
+    const treePath = toTreePath(path);
+    if (treePath) {
+      const dir = tree.getDir(treePath);
+      if (dir.subfiles.length || dir.subdirs.length) {
+        return true;
+      }
+    }
+    return ts.sys.directoryExists(toAbsolutePath(path));
+  };
+
+  host.readDirectory = (path, extensions, exclude, include, depth) => {
+    const absolutePath = toAbsolutePath(path);
+    const entries = new Set<string>(
+      ts.sys.readDirectory(absolutePath, extensions, exclude, include, depth)
+    );
+
+    const treePath = toTreePath(path);
+    if (treePath !== null) {
+      const treeDir = tree.getDir(treePath);
+      treeDir.subfiles.forEach(subfile => {
+        entries.add(resolve(absolutePath, subfile));
+      });
+      treeDir.subdirs.forEach(subdir => {
+        entries.add(resolve(absolutePath, subdir));
+      });
+    }
+
+    return Array.from(entries);
+  };
+
+  return host;
+};


### PR DESCRIPTION
Enables use of ts.Program and ts.TypeChecker which allows us writing more specific schematics.
This is significantly slower than before. But theoretically less error prone.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
