### PR TITLE
fix(tooltip): update content while tooltip is open

### DIFF
--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
@@ -105,9 +105,11 @@ export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
         describedBy: this.describedBy,
         injector: Injector.create({
           providers: [{ provide: SI_FORM_VALIDATION_TOOLTIP_DATA, useValue: this.errors }]
-        })
+        }),
+        tooltip: () => SiFormValidationTooltipComponent,
+        tooltipContext: () => undefined
       });
-      this.tooltipRef.show(SiFormValidationTooltipComponent);
+      this.tooltipRef.show();
     } else if (this.tooltipRef && (!errors.length || this.ngControl.pristine)) {
       this.destroyTooltip();
     }

--- a/projects/element-ng/tooltip/si-tooltip.component.html
+++ b/projects/element-ng/tooltip/si-tooltip.component.html
@@ -1,7 +1,7 @@
 <div
   class="tooltip show position-relative"
   role="tooltip"
-  [id]="id()"
+  [id]="config.id"
   [class]="tooltipPositionClass()"
 >
   <div
@@ -15,10 +15,10 @@
     } @else if (tooltipTemplate()) {
       <ng-template
         [ngTemplateOutlet]="tooltipTemplate()"
-        [ngTemplateOutletContext]="tooltipContext()"
+        [ngTemplateOutletContext]="config.tooltipContext()"
       />
     } @else if (tooltipComponent()) {
-      <ng-container [ngComponentOutlet]="tooltipComponent()" />
+      <ng-container [ngComponentOutlet]="tooltipComponent()!" />
     }
   </div>
 </div>

--- a/projects/element-ng/tooltip/si-tooltip.component.ts
+++ b/projects/element-ng/tooltip/si-tooltip.component.ts
@@ -4,18 +4,11 @@
  */
 import { ConnectedOverlayPositionChange } from '@angular/cdk/overlay';
 import { NgComponentOutlet, NgTemplateOutlet } from '@angular/common';
-import {
-  Component,
-  computed,
-  ElementRef,
-  inject,
-  input,
-  signal,
-  TemplateRef,
-  Type
-} from '@angular/core';
+import { Component, computed, ElementRef, inject, signal, TemplateRef } from '@angular/core';
 import { calculateOverlayArrowPosition, OverlayArrowPosition } from '@siemens/element-ng/common';
-import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
+
+import { SI_TOOLTIP_CONFIG } from './si-tooltip.model';
 
 @Component({
   selector: 'si-tooltip',
@@ -27,28 +20,24 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
   }
 })
 export class TooltipComponent {
-  /** @defaultValue '' */
-  readonly tooltip = input<TranslatableString | TemplateRef<any> | Type<any>>('');
   protected readonly tooltipPositionClass = signal('');
   protected readonly arrowPos = signal<OverlayArrowPosition | undefined>(undefined);
-  /** @internal */
-  readonly id = input('');
-  readonly tooltipContext = input();
 
-  private elementRef = inject(ElementRef);
+  protected readonly config = inject(SI_TOOLTIP_CONFIG);
+  private readonly elementRef = inject(ElementRef);
 
   protected readonly tooltipText = computed<string | null>(() => {
-    const tooltip = this.tooltip();
+    const tooltip = this.config.tooltip();
     return typeof tooltip === 'string' ? tooltip : null;
   });
 
   protected readonly tooltipTemplate = computed<TemplateRef<any> | null>(() => {
-    const tooltip = this.tooltip();
+    const tooltip = this.config.tooltip();
     return tooltip instanceof TemplateRef ? tooltip : null;
   });
 
   protected readonly tooltipComponent = computed(() => {
-    const tooltip = this.tooltip();
+    const tooltip = this.config.tooltip();
     return !(tooltip instanceof TemplateRef) && typeof tooltip !== 'string' ? tooltip : null;
   });
 

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -15,12 +15,13 @@ describe('SiTooltipDirective', () => {
 
     @Component({
       imports: [SiTooltipModule],
-      template: `<button type="button" siTooltip="test tooltip" [isDisabled]="isDisabled"
-        >Test</button
-      >`
+      template: `<button type="button" [siTooltip]="tooltipText" [isDisabled]="isDisabled">
+        Test
+      </button>`
     })
     class TestHostComponent {
       isDisabled = false;
+      tooltipText = 'test tooltip';
     }
 
     beforeEach(async () => {
@@ -76,6 +77,19 @@ describe('SiTooltipDirective', () => {
 
       button.dispatchEvent(new MouseEvent('mouseleave'));
       expect(document.querySelector('.tooltip')).toBeFalsy();
+    });
+
+    it('should update tooltip content while open', () => {
+      button.dispatchEvent(new Event('focus'));
+      jasmine.clock().tick(0);
+      fixture.detectChanges();
+      expect(document.querySelector('.tooltip')?.innerHTML).toContain('test tooltip');
+
+      component.tooltipText = 'updated tooltip';
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      expect(document.querySelector('.tooltip')?.innerHTML).toContain('updated tooltip');
     });
   });
 

--- a/projects/element-ng/tooltip/si-tooltip.directive.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.ts
@@ -90,9 +90,11 @@ export class SiTooltipDirective implements OnDestroy {
       this.tooltipRef ??= this.tooltipService.createTooltip({
         describedBy: this.describedBy,
         element: this.elementRef,
-        placement: this.placement()
+        placement: this.placement(),
+        tooltip: this.siTooltip,
+        tooltipContext: this.tooltipContext
       });
-      this.tooltipRef.show(this.siTooltip(), this.tooltipContext());
+      this.tooltipRef.show();
     }, delay);
   }
 

--- a/projects/element-ng/tooltip/si-tooltip.model.ts
+++ b/projects/element-ng/tooltip/si-tooltip.model.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Siemens 2016 - 2025
+ * SPDX-License-Identifier: MIT
+ */
+import { InjectionToken, TemplateRef, Type } from '@angular/core';
+import { TranslatableString } from '@siemens/element-translate-ng/translate';
+
+export type SiTooltipContent = TranslatableString | TemplateRef<any> | Type<any> | null | undefined;
+
+export interface SiTooltipConfig {
+  id: string;
+  tooltip: () => SiTooltipContent;
+  tooltipContext: () => unknown;
+}
+
+export const SI_TOOLTIP_CONFIG = new InjectionToken<SiTooltipConfig>('SiTooltipConfig');


### PR DESCRIPTION
Previously, the tooltip content was not updated,
if the input was changed while the tooltip was open.

This change how values are assigned to the inner tooltip component.
Before was set input values, now we use an injection token passing the signals into the component.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
