### PR TITLE
fix(dashboards-ng): use consistent spacing for draggable-overlay

### DIFF
--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.scss
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.scss
@@ -60,9 +60,7 @@
 }
 
 .draggable-overlay {
-  inset-block-end: map.get(variables.$spacers, 8);
-  inset-block-start: 40px;
-  inset-inline: map.get(variables.$spacers, 8);
+  inset: map.get(variables.$spacers, 4);
   position: absolute;
   z-index: 100;
 }


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
