### PR TITLE
fix(dashboards-ng): correctly overlap gridstack resize icon on custom resize icon

### DIFF
--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.scss
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.scss
@@ -37,16 +37,20 @@
     }
   }
 
+  /* stylelint-disable declaration-no-important */
   .ui-resizable-handle {
     // Overwrite to always show the handle in edit mode
-    display: block !important; // stylelint-disable-line declaration-no-important
+    display: block !important;
   }
 
   .ui-resizable-se {
     // Overwrite to hide the gridstack.js icon
-    background-image: none !important; // stylelint-disable-line declaration-no-important
-    transform: none !important; // stylelint-disable-line declaration-no-important
+    background-image: none !important;
+    transform: none !important;
+    inset-block-end: map.get(variables.$spacers, 3) !important;
+    inset-inline-end: map.get(variables.$spacers, 3) !important;
   }
+  /* stylelint-enable declaration-no-important */
 }
 
 .resize-handle {


### PR DESCRIPTION


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
