### PR TITLE
chore(element-ng): narrow @siemens/ngx-datatable peer dependency to v25

### DIFF
--- a/projects/element-ng/package.json
+++ b/projects/element-ng/package.json
@@ -47,7 +47,7 @@
     "@ngx-formly/core": "^6.2.2",
     "@siemens/element-translate-ng": "48.9.0",
     "@siemens/element-theme": "48.9.0",
-    "@siemens/ngx-datatable": "22 - 25",
+    "@siemens/ngx-datatable": "25",
     "ag-grid-community": "^34.3.1",
     "flag-icons": "^7.3.2",
     "google-libphonenumber": "^3.2.40",


### PR DESCRIPTION
BREAKING CHANGE: Dropped support for @siemens/ngx-datatable versions 22-24. Only version 25 is now supported as a peer dependency.



- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
