### PR TITLE
test(select): fix flaky e2e

### DIFF
--- a/playwright/e2e/element-examples/si-select.spec.ts
+++ b/playwright/e2e/element-examples/si-select.spec.ts
@@ -57,6 +57,7 @@ test.describe('si-select', () => {
 
     await si.runVisualAndA11yTests('filter-opened');
     await selectFormControlInput.pressSequentially('Bad');
+    await expect(page.getByRole('option')).toHaveText(['Bad', 'Very bad']);
     await page.keyboard.press('ArrowDown');
     await expect(page.getByRole('option', { name: 'Bad', exact: true })).toContainClass('active');
     await si.runVisualAndA11yTests('filter-searched');


### PR DESCRIPTION
In some cases, ArrowDown is pressed before
Angular updated the list.
So `Good` is selected instead of `Bad`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
