### PR TITLE
fix(wizard): align save button correctly when hideNavigation is true

### DIFF
--- a/projects/element-ng/wizard/si-wizard.component.html
+++ b/projects/element-ng/wizard/si-wizard.component.html
@@ -172,6 +172,7 @@
           <button
             type="button"
             class="btn btn-primary save"
+            [class.end]="hideNavigation()"
             [disabled]="!currentStep?.isValid() || !currentStep?.isNextNavigable()"
             (click)="save()"
             >{{ saveText() | translate }}</button

--- a/projects/element-ng/wizard/si-wizard.component.spec.ts
+++ b/projects/element-ng/wizard/si-wizard.component.spec.ts
@@ -284,6 +284,19 @@ describe('SiWizardComponent', () => {
       expect(element.querySelector('.wizard-btn-container .back')).toBeFalsy();
       expect(element.querySelector('.wizard-btn-container .next')).toBeFalsy();
     });
+
+    it('should align save button to end on last step when navigation is hidden', async () => {
+      hostComponent.inlineNavigation = false;
+      await runOnPushChangeDetection(fixture);
+
+      // Navigate to the last step
+      component.next(hostComponent.steps.length - 1);
+      await runOnPushChangeDetection(fixture);
+
+      const saveButton = element.querySelector('.btn.save');
+      expect(saveButton).toBeTruthy();
+      expect(saveButton).toHaveClass('end');
+    });
   });
 
   describe('navigation buttons in footer', () => {


### PR DESCRIPTION
This fixes an edge case where hideNavigation is true and the previous/next buttons are hidden.

This can be tested with the wizard playground: 
1. Open the wizard playground example
2. Disable **Inline navigation**
3. Disable **Show previous/next buttons**
4. Use the **External navigation** to go to the last step of the wizard

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
