### PR TITLE
fix(icon): ng-deep styles not getting applied with webpack builds

### DIFF
--- a/projects/element-ng/icon/si-icon.component.scss
+++ b/projects/element-ng/icon/si-icon.component.scss
@@ -1,0 +1,12 @@
+:host {
+  display: inline-flex;
+  font-weight: normal;
+  vertical-align: middle;
+  line-height: 1;
+
+  ::ng-deep svg {
+    display: block;
+    block-size: 1em;
+    fill: currentColor;
+  }
+}

--- a/projects/element-ng/icon/si-icon.component.ts
+++ b/projects/element-ng/icon/si-icon.component.ts
@@ -61,20 +61,7 @@ export const provideIconConfig = (config: IconConfig): Provider => ({
     [class]="svgIcon() ? '' : fontIcon()"
     [innerHTML]="svgIcon()"
   ></div>`,
-  styles: `
-    :host {
-      display: inline-flex;
-      font-weight: normal;
-      vertical-align: middle;
-      line-height: 1;
-
-      ::ng-deep svg {
-        display: block;
-        block-size: 1em;
-        fill: currentColor;
-      }
-    }
-  `,
+  styleUrl: './si-icon.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[attr.data-icon]': 'icon()'


### PR DESCRIPTION
inline styles somehow skips ng-deep when app is using webpack


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
