### PR TITLE
fix(wizard): align save button correctly when hideNavigation is true (back port)

### DIFF
--- a/projects/element-ng/wizard/si-wizard.component.html
+++ b/projects/element-ng/wizard/si-wizard.component.html
@@ -175,6 +175,7 @@
           <button
             type="button"
             class="btn btn-primary save"
+            [class.end]="hideNavigation()"
             [disabled]="!currentStep?.isValid() || !currentStep?.isNextNavigable()"
             (click)="save()"
             >{{ saveText() | translate }}</button

--- a/projects/element-ng/wizard/si-wizard.component.spec.ts
+++ b/projects/element-ng/wizard/si-wizard.component.spec.ts
@@ -285,6 +285,19 @@ describe('SiWizardComponent', () => {
       expect(element.querySelector('.wizard-btn-container .back')).toBeFalsy();
       expect(element.querySelector('.wizard-btn-container .next')).toBeFalsy();
     });
+
+    it('should align save button to end on last step when navigation is hidden', async () => {
+      hostComponent.inlineNavigation = false;
+      await runOnPushChangeDetection(fixture);
+
+      // Navigate to the last step
+      component.next(hostComponent.steps.length - 1);
+      await runOnPushChangeDetection(fixture);
+
+      const saveButton = element.querySelector('.btn.save');
+      expect(saveButton).toBeTruthy();
+      expect(saveButton).toHaveClass('end');
+    });
   });
 
   describe('navigation buttons in footer', () => {


### PR DESCRIPTION
 Back port of #1507.

This fixes an edge case where hideNavigation is true and the previous/next buttons are hidden.

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
