### PR TITLE
feat(schematics): add migration for Simpl* to Si* module renamings

### DIFF
--- a/projects/element-ng/schematics/migrations/data/symbol-renaming.ts
+++ b/projects/element-ng/schematics/migrations/data/symbol-renaming.ts
@@ -25,5 +25,34 @@ export const SYMBOL_RENAMING_MIGRATION: SymbolRenamingInstruction[] = [
       { replace: 'SiUnauthorizedPageComponent', replaceWith: 'SiInfoPageComponent' }
     ],
     toModule: '@siemens/element-ng/info-page'
+  },
+  {
+    module: /@siemens\/charts-ng/,
+    symbolRenamings: [
+      { replace: 'SimplChartsNgModule', replaceWith: 'SiChartsNgModule' },
+      { replace: 'SimplSeriesOption', replaceWith: 'SiSeriesOption' },
+      { replace: 'SimplLineSeriesOption', replaceWith: 'SiLineSeriesOption' },
+      { replace: 'SimplBarSeriesOption', replaceWith: 'SiBarSeriesOption' },
+      { replace: 'SimplHeatmapSeriesOption', replaceWith: 'SiHeatmapSeriesOption' },
+      { replace: 'SimplScatterSeriesOption', replaceWith: 'SiScatterSeriesOption' },
+      { replace: 'SimplCandlestickSeriesOption', replaceWith: 'SiCandlestickSeriesOption' }
+    ]
+  },
+  {
+    module: /@siemens\/live-preview/,
+    symbolRenamings: [
+      { replace: 'SimplLivePreviewRoutingModule', replaceWith: 'SiLivePreviewRoutingModule' },
+      { replace: 'SimplLivePreviewModule', replaceWith: 'SiLivePreviewModule' }
+    ]
+  },
+  {
+    module: /@siemens\/maps-ng/,
+    symbolRenamings: [{ replace: 'SimplMapsNgModule', replaceWith: 'SiMapsNgModule' }]
+  },
+  {
+    module: /@siemens\/native-charts-ng/,
+    symbolRenamings: [
+      { replace: 'SimplNativeChartsNgModule', replaceWith: 'SiNativeChartsNgModule' }
+    ]
   }
 ];


### PR DESCRIPTION
Add symbol renaming migrations for charts-ng, live-preview, maps-ng, and native-charts-ng packages to migrate from legacy "Simpl" prefix to new "Si" prefix naming convention.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
