### PR TITLE
test(popover): fix flaky e2e

### DIFF
--- a/playwright/e2e/element-examples/si-popover-legacy.spec.ts
+++ b/playwright/e2e/element-examples/si-popover-legacy.spec.ts
@@ -11,11 +11,12 @@ test.describe('Popover', () => {
     test(direction, async ({ page, si }) => {
       await si.visitExample(example);
 
-      await page.locator('.btn').getByText(`Popover on ${direction}`).click();
+      const trigger = page.getByRole('button', { name: `Popover on ${direction}`, exact: true });
+      await trigger.hover({ position: { x: 10, y: 10 } });
+      await trigger.click({ position: { x: 10, y: 10 } });
       await expect(page.locator('.popover')).toBeVisible();
 
       await si.runVisualAndA11yTests(direction);
-      await page.locator('.popover').click();
     });
   });
 
@@ -23,11 +24,10 @@ test.describe('Popover', () => {
     test(direction, async ({ page, si }) => {
       await si.visitExample(example);
 
-      await page.locator('.btn').getByText(`Popover ${direction}`).first().click();
+      await page.getByRole('button', { name: `Popover ${direction}`, exact: true }).press('Space');
       await expect(page.locator('.popover')).toBeVisible();
 
       await si.runVisualAndA11yTests(direction);
-      await page.locator('.popover').click();
     });
   });
 });

--- a/playwright/e2e/element-examples/si-popover.spec.ts
+++ b/playwright/e2e/element-examples/si-popover.spec.ts
@@ -11,11 +11,12 @@ test.describe('Popover', () => {
     test(direction, async ({ page, si }) => {
       await si.visitExample(example);
 
-      await page.locator('.btn').getByText(`Popover on ${direction}`).click();
-      await expect(page.locator('.popover')).toBeVisible();
+      const trigger = page.getByRole('button', { name: `Popover on ${direction}`, exact: true });
+      await trigger.hover({ position: { x: 10, y: 10 } });
+      await trigger.click({ position: { x: 10, y: 10 } });
+      await expect(page.getByRole('dialog')).toBeVisible();
 
       await si.runVisualAndA11yTests(direction);
-      await page.locator('.popover').click();
     });
   });
 
@@ -23,19 +24,20 @@ test.describe('Popover', () => {
     test(template, async ({ page, si }) => {
       await si.visitExample(example);
 
-      await page.locator('.btn').getByText(`Popover ${template}`).first().click();
-      await expect(page.locator('.popover')).toBeVisible();
+      const trigger = page.getByRole('button', { name: `Popover ${template}`, exact: true });
+      await trigger.hover({ position: { x: 10, y: 10 } });
+      await trigger.click({ position: { x: 10, y: 10 } });
+      await expect(page.getByRole('dialog')).toBeVisible();
 
       await si.runVisualAndA11yTests(template);
-      await page.locator('.popover').click();
     });
   });
 
   test('focus on wrapper', async ({ page, si }) => {
     await si.visitExample(example);
 
-    await page.locator('.btn').getByText(`Popover on top`).press('Space');
-    await expect(page.locator('.popover')).toBeVisible();
+    await page.getByRole('button', { name: 'Popover on top', exact: true }).press('Space');
+    await expect(page.getByRole('dialog')).toBeVisible();
 
     await si.runVisualAndA11yTests('focus on wrapper');
   });
@@ -43,8 +45,8 @@ test.describe('Popover', () => {
   test('focus on first focusable', async ({ page, si }) => {
     await si.visitExample(example);
 
-    await page.locator('.btn').getByText(`Popover ${'with template'}`).first().press('Space');
-    await expect(page.locator('.popover')).toBeVisible();
+    await page.getByRole('button', { name: 'Popover with template', exact: true }).press('Space');
+    await expect(page.getByRole('dialog')).toBeVisible();
 
     await si.runVisualAndA11yTests('focus on first focusable');
   });

--- a/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--bottom-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--bottom-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9a82bbce4a8824225736afd21603b5c9357e49c08608bc9fa51d1bdf739a583
-size 18187
+oid sha256:fae9d99243962f54463bf5e36152e8b450a4b5eaa87d010e852a4393aa0babe5
+size 18020

--- a/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--end-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--end-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8da227a786c24bf5b42d7b53d2901184941429cf9ef989e35141066b3b370ff5
-size 15770
+oid sha256:121268ca516c6171ecdb0c906fa409e11f0fbe5216531aae2c92f6666dd3fbb0
+size 15823

--- a/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--end-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--end-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dbd14240a370d34973a35fdebdd9bf421fa248188d3aa8cd939ca8d878144a89
-size 17306
+oid sha256:2785449766dc9a46225dd63fa1132bd5a0ae6f41fbf8284a23a640bcb118afaa
+size 17119

--- a/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--start-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--start-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57693b63300fb943c25d2082b92fe854fdc587f7a4404cefe37e5144d5fd4b6a
-size 18005
+oid sha256:479f3c508a8a39a0b0a31b6dd2ccf1353a7f17475b05284523236cbf08efd57c
+size 17870

--- a/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--top-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--top-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bc9bf1e7cc33a8ba0eb3b8497eca783a21fb3b26019855179d0990a14155e13
-size 17750
+oid sha256:e5cb1883f3fcbe498a33731f96b37e101515ee38103681e50a4f4ae30d71b90f
+size 17607

--- a/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--with-template-and-context-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--with-template-and-context-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c980f7314938a1a26ed8cef06191bdf12394de962f04be7b81281e65975d8d8
-size 16259
+oid sha256:a57375b8684997b1cc61a9892e739fdcbac68081112e600e495a2fada2e1c9bb
+size 16653

--- a/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--with-template-and-context-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--with-template-and-context-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e661b524e812ee4b0b2eee6f9766b0265b6936083d094b6e66b6ec260d57d49e
-size 17314
+oid sha256:01a35a00d8b85502dd4d1a42360f93583bbe2ecd1a6c7a32e6783c55348e562c
+size 17544

--- a/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--with-template-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--with-template-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b4f2be07a82ea9dbf70e02643deb651a40f24c439d571106f24fbe3b05120e2
-size 12777
+oid sha256:3b3f782fbfc9d061dc53e43613c0cdcb0b7e908e89d8735dff12245eafdd61c4
+size 13203

--- a/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--with-template-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-popover-legacy.spec.ts-snapshots/si-popover-legacy--si-popover-legacy--with-template-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ed05eff1802ee925e1d302194a6c691c6e61482d2e708c2075ffc14ff0d77726
-size 13927
+oid sha256:1c69eedc931d4a3ed41639cda2a2368e969eb8fa9d695632ff9c78860bc055ce
+size 14209

--- a/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--bottom-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--bottom-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9a82bbce4a8824225736afd21603b5c9357e49c08608bc9fa51d1bdf739a583
-size 18187
+oid sha256:fae9d99243962f54463bf5e36152e8b450a4b5eaa87d010e852a4393aa0babe5
+size 18020

--- a/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--end-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--end-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dbd14240a370d34973a35fdebdd9bf421fa248188d3aa8cd939ca8d878144a89
-size 17306
+oid sha256:2785449766dc9a46225dd63fa1132bd5a0ae6f41fbf8284a23a640bcb118afaa
+size 17119

--- a/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--focus-on-wrapper-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--focus-on-wrapper-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c57445842da0f5a3658438beac22f79dd019adaad8eeef16525a57f3b21247a1
-size 15327
+oid sha256:30b1df24c3eace71adac3d496d7ae7511d5fd110d23f0212b96a8790dfaa0313
+size 15298

--- a/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--focus-on-wrapper-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--focus-on-wrapper-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6b33e8d05f2fe0a0bfcf9386669614e859bff6b7ab01fb21ac7c2756f52d166
-size 16416
+oid sha256:786489891999466dfd05333ec1a4a101066c181fed50ea6744c5c4cfbdd77d37
+size 16376

--- a/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--start-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--start-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57693b63300fb943c25d2082b92fe854fdc587f7a4404cefe37e5144d5fd4b6a
-size 18005
+oid sha256:479f3c508a8a39a0b0a31b6dd2ccf1353a7f17475b05284523236cbf08efd57c
+size 17870

--- a/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--top-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-popover.spec.ts-snapshots/si-popover--si-popover--top-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bc9bf1e7cc33a8ba0eb3b8497eca783a21fb3b26019855179d0990a14155e13
-size 17750
+oid sha256:e5cb1883f3fcbe498a33731f96b37e101515ee38103681e50a4f4ae30d71b90f
+size 17607


### PR DESCRIPTION
Previously, the popover buttons had inconsistently applied the hover effect when taking snapshots. With this change we ensure the cursor is positioned always inside so the hover is applied when taking the snapshots.

In addition, this also updates a few snapshots to the new brand colors which was missed on the last brand update.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
