### PR TITLE
refactor(tooltip): move all logic into the service

### DIFF
--- a/api-goldens/element-ng/tooltip/index.api.md
+++ b/api-goldens/element-ng/tooltip/index.api.md
@@ -8,7 +8,6 @@ import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
 import { Injector } from '@angular/core';
 import { OnDestroy } from '@angular/core';
-import { OverlayRef } from '@angular/cdk/overlay';
 import { positions } from '@siemens/element-ng/common';
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import { TemplateRef } from '@angular/core';
@@ -17,6 +16,7 @@ import { Type } from '@angular/core';
 
 // @public (undocumented)
 export class SiTooltipDirective implements OnDestroy {
+    constructor();
     readonly isDisabled: i0.InputSignalWithTransform<boolean, unknown>;
     readonly placement: i0.InputSignal<"auto" | "start" | "end" | "top" | "bottom">;
     readonly siTooltip: i0.InputSignal<TemplateRef<any> | TranslatableString>;

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
@@ -19,14 +19,24 @@ describe('SiFormValidationTooltipDirective', () => {
     control = new FormControl('');
   }
 
+  const hoverDelay = 500;
   let fixture: ComponentFixture<TestHostComponent>;
   let harness: SiFormValidationTooltipHarness;
+  let inputElement: HTMLInputElement;
 
   beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setTimerTickMode('nextTimerAsync');
     fixture = TestBed.createComponent(TestHostComponent);
+    inputElement = fixture.nativeElement.querySelector('input')!;
+    vi.spyOn(inputElement, 'matches').mockReturnValue(true);
     harness = await TestbedHarnessEnvironment.loader(fixture).getHarness(
       SiFormValidationTooltipHarness
     );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should show tooltip when control is hovered and becomes touched', async () => {
@@ -38,9 +48,11 @@ describe('SiFormValidationTooltipDirective', () => {
 
   it('should show tooltip when hovered or focused', async () => {
     fixture.componentInstance.control.markAsTouched();
+    await fixture.whenStable();
     await harness.focus();
     expect(await harness.getTooltip()).toBe('Required');
     await harness.hover();
+    await vi.advanceTimersByTimeAsync(hoverDelay);
     await harness.mouseAway();
     expect(await harness.getTooltip()).toBe('Required');
     await harness.blur();
@@ -49,7 +61,9 @@ describe('SiFormValidationTooltipDirective', () => {
 
   it('should hide tooltip when control becomes valid', async () => {
     fixture.componentInstance.control.markAsTouched();
+    await fixture.whenStable();
     await harness.hover();
+    await vi.advanceTimersByTimeAsync(hoverDelay);
     expect(await harness.getTooltip()).toBe('Required');
     await harness.sendKeys('Lorem ipsum');
     expect(await harness.getTooltip()).toBeFalsy();
@@ -57,9 +71,12 @@ describe('SiFormValidationTooltipDirective', () => {
 
   it('should hide tooltip when control becomes untouched', async () => {
     fixture.componentInstance.control.markAsTouched();
+    await fixture.whenStable();
     await harness.hover();
+    await vi.advanceTimersByTimeAsync(hoverDelay);
     expect(await harness.getTooltip()).toBe('Required');
     fixture.componentInstance.control.markAsUntouched();
+    await fixture.whenStable();
     expect(await harness.getTooltip()).toBeFalsy();
   });
 });

--- a/projects/element-ng/form/testing/si-form-validation-tooltip.harness.ts
+++ b/projects/element-ng/form/testing/si-form-validation-tooltip.harness.ts
@@ -8,19 +8,19 @@ export class SiFormValidationTooltipHarness extends ComponentHarness {
   static readonly hostSelector = 'input';
 
   async hover(): Promise<void> {
-    this.host().then(host => host.hover());
+    await this.host().then(host => host.hover());
   }
 
   async mouseAway(): Promise<void> {
-    this.host().then(host => host.mouseAway());
+    await this.host().then(host => host.mouseAway());
   }
 
   async focus(): Promise<void> {
-    this.host().then(host => host.focus());
+    await this.host().then(host => host.focus());
   }
 
   async blur(): Promise<void> {
-    this.host().then(host => host.blur());
+    await this.host().then(host => host.blur());
   }
 
   async sendKeys(...keys: (string | TestKey)[]): Promise<void> {

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -10,6 +10,15 @@ import { userEvent } from 'vitest/browser';
 import { SiTooltipModule } from './si-tooltip.module';
 
 describe('SiTooltipDirective', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setTimerTickMode('nextTimerAsync');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe('with text', () => {
     let fixture: ComponentFixture<TestHostComponent>;
     let component: TestHostComponent;
@@ -27,55 +36,66 @@ describe('SiTooltipDirective', () => {
     }
 
     beforeEach(() => {
-      vi.useFakeTimers();
       fixture = TestBed.createComponent(TestHostComponent);
       component = fixture.componentInstance;
       button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
-      vi.spyOn(button, 'matches').mockReturnValue(true);
+      vi.spyOn(button, 'matches').mockImplementation(selector => selector === ':focus-visible');
       fixture.detectChanges();
     });
 
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
     it('should open on focus', async () => {
-      button.dispatchEvent(new Event('focus'));
-      // Focus should be immediate (no delay) but still need to tick for setTimeout(0)
-      vi.advanceTimersByTime(0);
+      button.dispatchEvent(new FocusEvent('focus'));
+      await vi.advanceTimersByTimeAsync(0);
       await fixture.whenStable();
 
       expect(document.querySelector('.tooltip')).toBeInTheDocument();
       expect(document.querySelector('.tooltip')).toHaveTextContent('test tooltip');
 
-      button.dispatchEvent(new Event('focusout'));
-      vi.advanceTimersByTime(500);
+      button.dispatchEvent(new FocusEvent('focusout'));
+      await vi.advanceTimersByTimeAsync(500);
+      await fixture.whenStable();
 
       expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
     });
 
-    it('should not show tooltip when disabled', () => {
+    it('should not show tooltip when disabled', async () => {
       component.isDisabled.set(true);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
-      button.dispatchEvent(new Event('focus'));
+      button.dispatchEvent(new FocusEvent('focus'));
+      await fixture.whenStable();
+      expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
+    });
+
+    it('should cancel pending tooltip when disabled while waiting', async () => {
+      button.dispatchEvent(new MouseEvent('mouseenter'));
+      await vi.advanceTimersByTimeAsync(0);
+      await fixture.whenStable();
+      expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
+
+      component.isDisabled.set(true);
+      await fixture.whenStable();
+
+      await vi.advanceTimersByTimeAsync(500);
+      await fixture.whenStable();
       expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
     });
 
     it('should show tooltip on mouse over', async () => {
       button.dispatchEvent(new MouseEvent('mouseenter'));
-      // hover should have 500ms delay
       expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
 
-      vi.advanceTimersByTime(500);
+      await vi.advanceTimersByTimeAsync(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).toBeInTheDocument();
 
       button.dispatchEvent(new MouseEvent('mouseleave'));
+      await fixture.whenStable();
       expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
     });
 
     it('should cancel the pending hover tooltip on focusout', async () => {
+      vi.setTimerTickMode('manual');
       await userEvent.hover(button);
       vi.advanceTimersByTime(250);
       await fixture.whenStable();
@@ -113,13 +133,13 @@ describe('SiTooltipDirective', () => {
     });
 
     it('should update tooltip content while open', async () => {
-      button.dispatchEvent(new Event('focus'));
-      vi.advanceTimersByTime(0);
+      button.dispatchEvent(new FocusEvent('focus'));
+      await vi.advanceTimersByTimeAsync(0);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).toHaveTextContent('test tooltip');
 
       component.tooltipText.set('updated tooltip');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(document.querySelector('.tooltip')).toHaveTextContent('updated tooltip');
     });
@@ -141,37 +161,32 @@ describe('SiTooltipDirective', () => {
     }
 
     beforeEach(() => {
-      vi.useFakeTimers();
       fixture = TestBed.createComponent(TestHostComponent);
       button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
-      vi.spyOn(button, 'matches').mockReturnValue(true);
+      vi.spyOn(button, 'matches').mockImplementation(selector => selector === ':focus-visible');
       fixture.detectChanges();
     });
 
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
     it('should render the template', async () => {
-      button.dispatchEvent(new Event('focus'));
-      vi.advanceTimersByTime(500);
+      button.dispatchEvent(new FocusEvent('focus'));
+      await vi.advanceTimersByTimeAsync(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).toHaveTextContent('Template content');
-      button.dispatchEvent(new Event('focusout'));
-      vi.advanceTimersByTime(500);
+      button.dispatchEvent(new FocusEvent('focusout'));
+      await vi.advanceTimersByTimeAsync(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
     });
 
     it('should render the template with context', async () => {
       fixture.componentInstance.tooltipContext.set({ tooltip: 'test' });
-      fixture.detectChanges();
-      button.dispatchEvent(new Event('focus'));
-      vi.advanceTimersByTime(500);
+      await fixture.whenStable();
+      button.dispatchEvent(new FocusEvent('focus'));
+      await vi.advanceTimersByTimeAsync(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).toHaveTextContent('Template content test');
-      button.dispatchEvent(new Event('focusout'));
-      vi.advanceTimersByTime(500);
+      button.dispatchEvent(new FocusEvent('focusout'));
+      await vi.advanceTimersByTimeAsync(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
     });
@@ -193,30 +208,25 @@ describe('SiTooltipDirective', () => {
     }
 
     beforeEach(() => {
-      vi.useFakeTimers();
       fixture = TestBed.createComponent(TestHostComponent);
       button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
-      vi.spyOn(button, 'matches').mockReturnValue(true);
+      vi.spyOn(button, 'matches').mockImplementation(selector => selector === ':focus-visible');
       fixture.detectChanges();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
     });
 
     it('should close tooltip on scroll when custom close scroll strategy is provided', async () => {
       const overlay = TestBed.inject(Overlay);
       fixture.componentInstance.scrollStrategy.set(overlay.scrollStrategies.close());
-      fixture.detectChanges();
+      await fixture.whenStable();
 
-      button.dispatchEvent(new Event('focus'));
-      vi.advanceTimersByTime(0);
+      button.dispatchEvent(new FocusEvent('focus'));
+      await vi.advanceTimersByTimeAsync(0);
       await fixture.whenStable();
 
       expect(document.querySelector('.tooltip')).toBeInTheDocument();
 
       document.dispatchEvent(new Event('scroll', { bubbles: true }));
-      vi.advanceTimersByTime(0);
+      await vi.advanceTimersByTimeAsync(0);
       await fixture.whenStable();
 
       expect(document.querySelector('.tooltip')).not.toBeInTheDocument();

--- a/projects/element-ng/tooltip/si-tooltip.directive.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.ts
@@ -3,15 +3,14 @@
  * SPDX-License-Identifier: MIT
  */
 import { ScrollStrategy } from '@angular/cdk/overlay';
-import { isPlatformBrowser } from '@angular/common';
 import {
   booleanAttribute,
   Directive,
+  effect,
   ElementRef,
   inject,
   input,
   OnDestroy,
-  PLATFORM_ID,
   TemplateRef
 } from '@angular/core';
 import { positions } from '@siemens/element-ng/common';
@@ -23,12 +22,7 @@ import { SiTooltipService, TooltipRef } from './si-tooltip.service';
   selector: '[siTooltip]',
   providers: [SiTooltipService],
   host: {
-    '[attr.aria-describedby]': 'isDisabled() ? null : describedBy',
-    '(focus)': 'focusIn($event)',
-    '(mouseenter)': 'show()',
-    '(touchstart)': 'hide()',
-    '(focusout)': 'hide()',
-    '(mouseleave)': 'hide()'
+    '[attr.aria-describedby]': 'isDisabled() ? null : describedBy'
   }
 })
 export class SiTooltipDirective implements OnDestroy {
@@ -69,58 +63,31 @@ export class SiTooltipDirective implements OnDestroy {
   protected describedBy = `__tooltip_${SiTooltipDirective.idCounter++}`;
 
   private tooltipRef?: TooltipRef;
-  private showTimeout?: ReturnType<typeof setTimeout>;
   private tooltipService = inject(SiTooltipService);
   private elementRef = inject(ElementRef);
-  private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
+  constructor() {
+    effect(() => {
+      const tooltip = this.siTooltip();
+      const disabled = this.isDisabled();
+
+      if (tooltip && !disabled) {
+        this.tooltipRef ??= this.tooltipService.createTooltip({
+          describedBy: this.describedBy,
+          element: this.elementRef,
+          placement: this.placement(),
+          tooltip: this.siTooltip,
+          tooltipContext: this.tooltipContext,
+          scrollStrategy: this.tooltipScrollStrategy
+        });
+      } else if (this.tooltipRef) {
+        this.tooltipRef.destroy();
+        this.tooltipRef = undefined;
+      }
+    });
+  }
 
   ngOnDestroy(): void {
-    this.clearShowTimeout();
     this.tooltipRef?.destroy();
-  }
-
-  private clearShowTimeout(): void {
-    if (this.showTimeout) {
-      clearTimeout(this.showTimeout);
-      this.showTimeout = undefined;
-    }
-  }
-
-  private showTooltip(immediate = false): void {
-    const siTooltip = this.siTooltip();
-    if (this.isDisabled() || !siTooltip) {
-      return;
-    }
-
-    this.clearShowTimeout();
-
-    const delay = immediate ? 0 : 500;
-
-    this.showTimeout = setTimeout(() => {
-      this.tooltipRef ??= this.tooltipService.createTooltip({
-        describedBy: this.describedBy,
-        element: this.elementRef,
-        placement: this.placement(),
-        tooltip: this.siTooltip,
-        tooltipContext: this.tooltipContext,
-        scrollStrategy: this.tooltipScrollStrategy()
-      });
-      this.tooltipRef.show();
-    }, delay);
-  }
-
-  protected focusIn(event: FocusEvent): void {
-    if (this.isBrowser && (event.target as Element).matches(':focus-visible')) {
-      this.showTooltip(true);
-    }
-  }
-
-  protected show(): void {
-    this.showTooltip(false);
-  }
-
-  protected hide(): void {
-    this.clearShowTimeout();
-    this.tooltipRef?.hide();
   }
 }

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -4,51 +4,176 @@
  */
 import { Overlay, OverlayRef, ScrollStrategy } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { ComponentRef, ElementRef, inject, Injectable, Injector } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { ComponentRef, ElementRef, inject, Injectable, Injector, PLATFORM_ID } from '@angular/core';
 import { getOverlay, getPositionStrategy, positions } from '@siemens/element-ng/common';
-import { Subscription } from 'rxjs';
+import { fromEvent, Subject, Subscription, timer } from 'rxjs';
+import { delayWhen, filter, takeUntil } from 'rxjs/operators';
 
 import { TooltipComponent } from './si-tooltip.component';
 import { SI_TOOLTIP_CONFIG, SiTooltipContent } from './si-tooltip.model';
 
+/** @internal */
+interface TooltipRef {
+  destroy(): void;
+}
+
 /**
- * TooltipRef is attached to a specific element.
+ * A no-op TooltipRef used on platform server where DOM APIs are unavailable.
+ *
+ * @internal
+ */
+class NoopTooltipRef {
+  destroy(): void {}
+}
+
+/**
+ * BrowserTooltipRef is attached to a specific element.
  * Use it to show or hide a tooltip for that element.
  *
  * @internal
  */
-class TooltipRef {
+class BrowserTooltipRef {
+  private readonly destroy$ = new Subject<void>();
+  private isFocused = false;
+  private isHovered = false;
+  private overlayRef?: OverlayRef;
+  private positionSubscription?: Subscription;
+
   constructor(
-    private overlayRef: OverlayRef,
-    private element: ElementRef,
-    private injector?: Injector
-  ) {}
+    private config: {
+      describedBy: string;
+      element: ElementRef;
+      injector?: Injector;
+      overlay: Overlay;
+      placement: keyof typeof positions;
+      scrollStrategy?: () => ScrollStrategy | undefined;
+      tooltip: () => SiTooltipContent;
+      tooltipContext: () => unknown;
+    }
+  ) {
+    const nativeElement = this.config.element.nativeElement;
 
-  private subscription?: Subscription;
+    fromEvent(nativeElement, 'focus')
+      .pipe(
+        filter(event => event instanceof FocusEvent),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(event => this.onFocus(event));
 
-  show(): void {
-    if (this.overlayRef.hasAttached()) {
+    fromEvent(nativeElement, 'mouseenter')
+      .pipe(
+        delayWhen(() =>
+          // UX Guideline: tooltips on hover should be delayed by 500ms
+          timer(500).pipe(
+            takeUntil(fromEvent(nativeElement, 'mouseleave')),
+            takeUntil(fromEvent(nativeElement, 'focusout')) // user started using keyboard
+          )
+        ),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => this.onMouseEnter());
+
+    fromEvent(nativeElement, 'focusout')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.onFocusOut());
+
+    fromEvent(nativeElement, 'mouseleave')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.onMouseLeave());
+
+    fromEvent(nativeElement, 'touchstart')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.onTouchStart());
+
+    // The tooltip may be created lazily, after the element is already focused or
+    // hovered (e.g. when validation errors appear on blur while the pointer still
+    // hovers the element). In that case the initial `focus`/`mouseenter` was
+    // missed, so show the tooltip immediately based on the live `:focus-visible`
+    // and `:hover` state.
+    if (nativeElement === document.activeElement && nativeElement.matches(':focus-visible')) {
+      this.isFocused = true;
+      this.show();
+    } else if (nativeElement.matches(':hover')) {
+      this.onMouseEnter();
+    }
+  }
+
+  private onFocus(event: FocusEvent): void {
+    if (event.target instanceof Element) {
+      if (event.target.matches(':focus-visible')) {
+        this.isFocused = true;
+        this.show();
+      }
+    }
+  }
+
+  private onFocusOut(): void {
+    this.isFocused = false;
+    this.isHovered = false;
+    this.hide();
+  }
+
+  private onMouseEnter(): void {
+    this.isHovered = true;
+    this.show();
+  }
+
+  private onMouseLeave(): void {
+    this.isHovered = false;
+    this.hide();
+  }
+
+  private onTouchStart(): void {
+    // On touch devices a tooltip is not useful and would obscure the content the
+    // user just tapped. Reset the hover/focus state so it is hidden immediately.
+    this.isFocused = false;
+    this.isHovered = false;
+    this.hide();
+  }
+
+  private getOrCreateOverlay(): OverlayRef {
+    this.overlayRef ??= getOverlay(
+      this.config.element,
+      this.config.overlay,
+      false,
+      this.config.placement,
+      false,
+      true,
+      this.config.scrollStrategy?.()
+    );
+    return this.overlayRef;
+  }
+
+  private show(): void {
+    const overlayRef = this.getOrCreateOverlay();
+    if (overlayRef.hasAttached()) {
       return;
     }
 
-    const toolTipPortal = new ComponentPortal(TooltipComponent, undefined, this.injector);
-    const tooltipRef: ComponentRef<TooltipComponent> = this.overlayRef.attach(toolTipPortal);
+    const toolTipPortal = new ComponentPortal(TooltipComponent, undefined, this.config.injector);
+    const tooltipRef: ComponentRef<TooltipComponent> = overlayRef.attach(toolTipPortal);
 
-    const positionStrategy = getPositionStrategy(this.overlayRef);
-    this.subscription?.unsubscribe();
-    this.subscription = positionStrategy?.positionChanges.subscribe(change =>
-      tooltipRef.instance.updateTooltipPosition(change, this.element)
+    const positionStrategy = getPositionStrategy(overlayRef);
+    this.positionSubscription?.unsubscribe();
+    this.positionSubscription = positionStrategy?.positionChanges.subscribe(change =>
+      tooltipRef.instance.updateTooltipPosition(change, this.config.element)
     );
   }
 
-  hide(): void {
-    this.overlayRef.detach();
-    this.subscription?.unsubscribe();
+  private hide(): void {
+    if (this.isFocused || this.isHovered) {
+      return;
+    }
+    this.overlayRef?.detach();
+    this.positionSubscription?.unsubscribe();
   }
 
   destroy(): void {
-    this.overlayRef.dispose();
-    this.subscription?.unsubscribe();
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.overlayRef?.dispose();
+    this.positionSubscription?.unsubscribe();
   }
 }
 
@@ -63,6 +188,7 @@ class TooltipRef {
 @Injectable()
 export class SiTooltipService {
   private overlay = inject(Overlay);
+  private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   createTooltip(config: {
     describedBy: string;
@@ -71,8 +197,12 @@ export class SiTooltipService {
     injector?: Injector;
     tooltip: () => SiTooltipContent;
     tooltipContext: () => unknown;
-    scrollStrategy?: ScrollStrategy;
+    scrollStrategy?: () => ScrollStrategy | undefined;
   }): TooltipRef {
+    if (!this.isBrowser) {
+      return new NoopTooltipRef();
+    }
+
     const injector = Injector.create({
       parent: config.injector,
       providers: [
@@ -87,19 +217,11 @@ export class SiTooltipService {
       ]
     });
 
-    return new TooltipRef(
-      getOverlay(
-        config.element,
-        this.overlay,
-        false,
-        config.placement,
-        false,
-        true,
-        config.scrollStrategy
-      ),
-      config.element,
-      injector
-    );
+    return new BrowserTooltipRef({
+      ...config,
+      injector,
+      overlay: this.overlay
+    });
   }
 }
 


### PR DESCRIPTION
We currently cannot attach tooltips dynamically
on our components if the host element is interactive element.

When having the tooltip as a service, we can do this.

Alternatives considered:
- extend the tooltip directive
- make the tooltip input a model

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1535/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1535/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1535/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1535/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1535/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1535/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1535/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1535/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1535/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1535/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->







