### PR TITLE
docs(si-tree-view): provide better tree view example

### DIFF
--- a/playwright/snapshots/static.spec.ts-snapshots/si-tree-view--si-tree-view-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-tree-view--si-tree-view-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61f3c264358f5e86af4fcde3221535954ade16b0f7b90908e6d356c57f0c8c8e
-size 8956
+oid sha256:bd677378f7a68079596355d49db9d8b898f2a7913b36ff9fe2d1f382eba67496
+size 14964

--- a/playwright/snapshots/static.spec.ts-snapshots/si-tree-view--si-tree-view-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-tree-view--si-tree-view-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ebfc527b9f2241287633ad9dc300b428f5d0479368b98b3ca115eb2e772dc445
-size 8550
+oid sha256:671f34ae92a900f10aeaf08859c242cb73ab4fe827aa49029b5b705ac3141e5b
+size 13717

--- a/playwright/snapshots/static.spec.ts-snapshots/si-tree-view--si-tree-view.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-tree-view--si-tree-view.yaml
@@ -1,7 +1,5 @@
 - tree "Company locations":
-  - treeitem "Company1 SI" [level=1]:
-    - text: ""
-    - paragraph: SI
-  - treeitem "Company2 GG" [level=1]:
-    - text: ""
-    - paragraph: GG
+  - treeitem "Discovered Devices 2" [level=1]
+  - treeitem "Geographical" [level=1]
+  - treeitem "Infrastructure" [level=1]
+  - treeitem "Assigned Devices 5" [level=1]

--- a/src/app/examples/si-tree-view/si-tree-view.ts
+++ b/src/app/examples/si-tree-view/si-tree-view.ts
@@ -13,14 +13,12 @@ import { MenuItemsProvider, SiTreeViewComponent, TreeItem } from '@siemens/eleme
   host: { class: 'p-5' }
 })
 export class SampleComponent {
-  
-  private contextClasses: { [key: string]: string[] }  =
-  {
-    'device' : ['Option 1', 'Option 2', 'Option 3'],
-    'geo'  : ['Option A', 'Option B', 'Option C'],
-    'infra'  : ['Analyze', 'Map', 'Restructure'],
-    'discDevices' : ['Assign all', 'Forget all'],
-    'assignedDevices' : ['Remove all', 'Update'],
+  private contextClasses: { [key: string]: string[] } = {
+    'device': ['Option 1', 'Option 2', 'Option 3'],
+    'geo': ['Option A', 'Option B', 'Option C'],
+    'infra': ['Analyze', 'Map', 'Restructure'],
+    'discDevices': ['Assign all', 'Forget all'],
+    'assignedDevices': ['Remove all', 'Update']
   };
 
   private getRandomNumber(max: number): number {
@@ -36,13 +34,16 @@ export class SampleComponent {
   }
 
   private getRandomIcon(): string {
-    return this.getRandomBoolean() ? (this.getRandomBoolean() ? 'element-light' : 'element-light-on') : '';
+    return this.getRandomBoolean()
+      ? this.getRandomBoolean()
+        ? 'element-light'
+        : 'element-light-on'
+      : '';
   }
 
-  menuItems: MenuItemsProvider = item => 
-  {
+  menuItems: MenuItemsProvider = item => {
     const key = item.dataField2 as string;
-    if(!key) return [];
+    if (!key) return [];
     const options = this.contextClasses[key] || [];
     return options.map(option => ({
       title: option,
@@ -66,16 +67,16 @@ export class SampleComponent {
           label: 'Automation station',
           dataField1: '[AS_TRA_155]',
           icon: 'element-automation-station',
-          dataField2: "device",
+          dataField2: 'device',
           state: 'leaf'
         },
         {
           label: 'Unknown device',
           dataField1: '[X3_456_dfsda]',
           icon: 'element-device-alt',
-          dataField2: "device",
+          dataField2: 'device',
           state: 'leaf'
-        },
+        }
       ]
     },
     {
@@ -110,14 +111,14 @@ export class SampleComponent {
     },
     {
       label: 'Infrastructure',
-      dataField2: "infra",
-      icon: 'element-box',
+      dataField2: 'infra',
+      icon: 'element-box'
       //state: 'leaf'
     },
     {
       label: 'Assigned Devices',
       icon: 'element-assigned',
-      dataField2: "assignedDevices",
+      dataField2: 'assignedDevices',
       badge: '5',
       badgeColor: 'info',
       stateIndicatorColor: 'green',
@@ -126,7 +127,7 @@ export class SampleComponent {
           label: 'Automation station',
           dataField1: '[AS_TRA_152]',
           icon: 'element-automation-station',
-          dataField2: "device",
+          dataField2: 'device',
           stateIndicatorColor: 'green',
           children: [
             {
@@ -166,42 +167,41 @@ export class SampleComponent {
                 {
                   label: 'Cooling coil',
                   state: 'leaf',
-                  stateIndicatorColor: 'green',
+                  stateIndicatorColor: 'green'
                 },
                 {
                   label: 'Heating coil',
                   state: 'leaf'
-                },
+                }
               ]
-            },
+            }
           ]
         },
         {
           label: 'Automation station',
           dataField1: '[AS_TRA_155]',
           icon: 'element-automation-station',
-          dataField2: "device",
+          dataField2: 'device'
         },
         {
           label: 'Automation station',
           dataField1: '[AS_TRA_TX]',
           icon: 'element-automation-station',
-          dataField2: "device",
+          dataField2: 'device'
         },
         {
           label: 'POL687 VVS11',
           dataField1: '[SaturnCB-AS01]',
           icon: 'element-automation-station',
-          dataField2: "device",
+          dataField2: 'device'
         },
         {
           label: 'PXC AS02',
           dataField1: '[TPSite ‘S02]',
           icon: 'element-automation-station',
-          dataField2: "device",
-        },
+          dataField2: 'device'
+        }
       ]
-    },
-    
+    }
   ];
 }

--- a/src/app/examples/si-tree-view/si-tree-view.ts
+++ b/src/app/examples/si-tree-view/si-tree-view.ts
@@ -50,7 +50,7 @@ export class SampleComponent {
       badge: this.getRandomNumber(10),
       badgeColor: this.getRandomBadgeColor(),
       icon: this.getRandomIcon(),
-      action: () => alert(`Performed action \"${option}\"`),
+      action: () => alert(`Performed action "${option}"`),
       disabled: false
     }));
   };

--- a/src/app/examples/si-tree-view/si-tree-view.ts
+++ b/src/app/examples/si-tree-view/si-tree-view.ts
@@ -13,95 +13,76 @@ import { MenuItemsProvider, SiTreeViewComponent, TreeItem } from '@siemens/eleme
   host: { class: 'p-5' }
 })
 export class SampleComponent {
-  menuItems: MenuItemsProvider = item =>
-    Math.random() < 0.5 || item.level === 0
-      ? [
-          {
-            title: 'Item One',
-            badge: 5,
-            badgeColor: 'danger',
-            action: () => alert('action one'),
-            disabled: true
-          },
-          { title: '-' },
-          {
-            title: 'Item Two',
-            items: [
-              {
-                title: 'Item Three',
-                icon: 'element-play',
-                action: (param: any) => alert('action three at ' + param)
-              }
-            ]
-          }
-        ]
-      : [];
+  
+  private contextClasses: { [key: string]: string[] }  =
+  {
+    'device' : ['Option 1', 'Option 2', 'Option 3'],
+    'geo'  : ['Option A', 'Option B', 'Option C'],
+    'infra'  : ['Analyze', 'Map', 'Restructure'],
+    'discDevices' : ['Assign all', 'Forget all'],
+    'assignedDevices' : ['Remove all', 'Update'],
+  };
+
+  private getRandomNumber(max: number): number {
+    return this.getRandomBoolean() ? Math.ceil(Math.random() * max) : 0;
+  }
+
+  private getRandomBoolean(): boolean {
+    return Math.random() < 0.5;
+  }
+
+  private getRandomBadgeColor(): string {
+    return this.getRandomBoolean() ? 'warning' : 'info';
+  }
+
+  private getRandomIcon(): string {
+    return this.getRandomBoolean() ? (this.getRandomBoolean() ? 'element-light' : 'element-light-on') : '';
+  }
+
+  menuItems: MenuItemsProvider = item => 
+  {
+    const key = item.dataField2 as string;
+    if(!key) return [];
+    const options = this.contextClasses[key] || [];
+    return options.map(option => ({
+      title: option,
+      badge: this.getRandomNumber(10),
+      badgeColor: this.getRandomBadgeColor(),
+      icon: this.getRandomIcon(),
+      action: () => alert(`Performed action \"${option}\"`),
+      disabled: false
+    }));
+  };
 
   treeItems: TreeItem[] = [
     {
-      label: 'Company1',
-      dataField1: 'SI',
-      stateIndicatorColor: 'red',
-      icon: 'element-project',
+      label: 'Discovered Devices',
+      dataField2: 'discDevices',
+      badge: '2',
+      badgeColor: 'info',
+      icon: 'element-show',
       children: [
         {
-          label: 'Milano',
-          dataField1: 'MIL',
-          state: 'leaf',
-          badge: '1',
-          badgeColor: 'info'
-        },
-        {
-          label: 'Chicago',
-          dataField1: 'CHI',
-          stateIndicatorColor: 'red',
+          label: 'Automation station',
+          dataField1: '[AS_TRA_155]',
+          icon: 'element-automation-station',
+          dataField2: "device",
           state: 'leaf'
         },
         {
-          label: 'Pune',
-          dataField1: 'PUN',
+          label: 'Unknown device',
+          dataField1: '[X3_456_dfsda]',
+          icon: 'element-device-alt',
+          dataField2: "device",
           state: 'leaf'
         },
-        {
-          label: 'Zug',
-          dataField1: 'ZUG',
-          children: [
-            {
-              label: 'Example Location 1',
-              state: 'leaf'
-            },
-            {
-              label: 'Example Location 2',
-              state: 'leaf'
-            },
-            {
-              label: 'Example Location 3',
-              state: 'leaf'
-            },
-            {
-              label: 'Example Location 4',
-              state: 'leaf'
-            },
-            {
-              label: 'Example Location 5',
-              state: 'leaf'
-            },
-            {
-              label: 'Example Location 6',
-              state: 'leaf'
-            },
-            {
-              label: 'Example Location 7',
-              state: 'leaf'
-            }
-          ]
-        }
       ]
     },
     {
-      label: 'Company2',
-      dataField1: 'GG',
-      icon: 'element-project',
+      label: 'Geographical',
+      icon: 'element-map-location',
+      dataField2: 'geo',
+      stateIndicatorColor: 'red',
       children: [
         {
           label: 'Mountain View',
@@ -111,6 +92,7 @@ export class SampleComponent {
         {
           label: 'Zurich',
           dataField1: 'ZRH',
+          dataField2: 'geo',
           stateIndicatorColor: 'red',
           state: 'leaf'
         },
@@ -125,6 +107,101 @@ export class SampleComponent {
           state: 'leaf'
         }
       ]
-    }
+    },
+    {
+      label: 'Infrastructure',
+      dataField2: "infra",
+      icon: 'element-box',
+      //state: 'leaf'
+    },
+    {
+      label: 'Assigned Devices',
+      icon: 'element-assigned',
+      dataField2: "assignedDevices",
+      badge: '5',
+      badgeColor: 'info',
+      stateIndicatorColor: 'green',
+      children: [
+        {
+          label: 'Automation station',
+          dataField1: '[AS_TRA_152]',
+          icon: 'element-automation-station',
+          dataField2: "device",
+          stateIndicatorColor: 'green',
+          children: [
+            {
+              label: 'Infrastructure',
+              icon: 'element-box',
+              state: 'leaf'
+            },
+            {
+              label: 'I/O Bus',
+              icon: 'element-network',
+              state: 'leaf'
+            },
+            {
+              label: 'KNX PL-Link Bus',
+              icon: 'element-network-backbone',
+              state: 'leaf'
+            },
+            {
+              label: 'Room 1',
+              icon: 'element-room',
+              state: 'leaf'
+            },
+            {
+              label: 'Room segment 1',
+              icon: 'element-room-segment',
+              state: 'leaf'
+            },
+            {
+              label: 'HVAC',
+              icon: 'element-ahu-plant',
+              stateIndicatorColor: 'green',
+              children: [
+                {
+                  label: 'Supply air VAV',
+                  state: 'leaf'
+                },
+                {
+                  label: 'Cooling coil',
+                  state: 'leaf',
+                  stateIndicatorColor: 'green',
+                },
+                {
+                  label: 'Heating coil',
+                  state: 'leaf'
+                },
+              ]
+            },
+          ]
+        },
+        {
+          label: 'Automation station',
+          dataField1: '[AS_TRA_155]',
+          icon: 'element-automation-station',
+          dataField2: "device",
+        },
+        {
+          label: 'Automation station',
+          dataField1: '[AS_TRA_TX]',
+          icon: 'element-automation-station',
+          dataField2: "device",
+        },
+        {
+          label: 'POL687 VVS11',
+          dataField1: '[SaturnCB-AS01]',
+          icon: 'element-automation-station',
+          dataField2: "device",
+        },
+        {
+          label: 'PXC AS02',
+          dataField1: '[TPSite ‘S02]',
+          icon: 'element-automation-station',
+          dataField2: "device",
+        },
+      ]
+    },
+    
   ];
 }


### PR DESCRIPTION
Bring the si-tree-view example closer to the Figma design. Context menu content is given with dummy options and randomized content.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
