### PR TITLE
refactor(element-ng): add `@siemens/element-icons` to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32408,6 +32408,7 @@
         "@angular/router": "21",
         "@ngx-formly/bootstrap": "^6.2.2",
         "@ngx-formly/core": "^6.2.2",
+        "@siemens/element-icons": "1",
         "@siemens/element-theme": "48.9.0",
         "@siemens/element-translate-ng": "48.9.0",
         "@siemens/ngx-datatable": "25",

--- a/projects/element-ng/package.json
+++ b/projects/element-ng/package.json
@@ -45,6 +45,7 @@
     "@angular/router": "21",
     "@ngx-formly/bootstrap": "^6.2.2",
     "@ngx-formly/core": "^6.2.2",
+    "@siemens/element-icons": "1",
     "@siemens/element-translate-ng": "48.9.0",
     "@siemens/element-theme": "48.9.0",
     "@siemens/ngx-datatable": "25",


### PR DESCRIPTION
This adds the forgotten line the `package.json`.
No breaking change note required, as this was already included in be23170793cc2e37b5abd34a6f0d8b8823e7f7b4

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
