### PR TITLE
fix(launchpad): align external icon size and spacing with design specs

### DIFF
--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b70e2e88e40b64db8e610f80be4204521c6ce078a4d6e200ed7fdc416d776351
-size 32641
+oid sha256:13898f42cc467d3ad45db06097e33b27594ab10b86d9c8c53809bab02fa13b0a
+size 32713

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87ba5d14ac8d9944edfb94b4019d56deadb4b092a01b06aa56d0058e2c4ad536
-size 31831
+oid sha256:81cde2ebdee99aabd0667047da45be8657a4c4eab8dc2109ead35a59d6c95027
+size 31829

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3d4172f5cac2fdc1a98013fdce0e05ac47910e8ee9ab65db3f3d1f9d4f3ee7ca
-size 41434
+oid sha256:cc3c7b70d36fedd3863c4227520a90c1cb03150119211c380e085cb9691a8fdb
+size 41692

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2eb4368055421820a16f19ffc089e5df8c9d52417ada392683f611fa28d8261f
-size 40535
+oid sha256:fce6ff63d3f0baeedb177b358a4d54c8b947b672aa56517d2ea7d7e6e751ee9c
+size 40829

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db2041a9db2401ea91e2a8ff46ff80d1729650aa2c45b7c418d7179fc10f5c20
-size 43043
+oid sha256:b90b9c0f10b49ce64bc4153ebae334c8cc47e8accfe3bf47533a49164e63dbb9
+size 43322

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2af654ac9bd273755913717255c8689b0d5d30a65e93df84b1f533d0e39603b
-size 42182
+oid sha256:66739bbb01f2e47db6cfb99f52ab1c9b32385c554ce372f9ab50255b2393a4ca
+size 42464

--- a/projects/element-ng/application-header/launchpad/si-launchpad-app.component.html
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-app.component.html
@@ -4,13 +4,13 @@
   <si-icon class="app-icon" [icon]="iconClass()!" />
 }
 <div class="app-text">
-  <div class="si-h4 d-flex align-items-center mw-100">
+  <div class="si-h4 d-flex align-items-center mw-100 gap-1">
     <span class="text-truncate">
       <ng-content select="[app-name]" />
     </span>
     @if (external()) {
       <si-icon
-        class="icon external-icon ms-1 mt-1"
+        class="icon"
         [icon]="icons.elementExport"
         [attr.aria-label]="externalLinkText() | translate"
       />
@@ -22,7 +22,7 @@
 </div>
 @if (enableFavoriteToggle()) {
   <si-icon
-    class="favorite-icon"
+    class="icon favorite-icon"
     [class.is-favorite]="favorite()"
     [icon]="favorite() ? icons.elementFavoritesFilled : icons.elementFavorites"
     (click)="favoriteClicked($event)"

--- a/projects/element-ng/application-header/launchpad/si-launchpad-app.component.scss
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-app.component.scss
@@ -59,16 +59,10 @@
 }
 
 .favorite-icon {
-  font-size: 20px;
   position: absolute;
-  inset-inline-end: 14px;
-  inset-block-start: 14px;
-  padding: map.get(variables.$spacers, 1);
+  inset-inline-end: map.get(variables.$spacers, 6);
+  inset-block-start: map.get(variables.$spacers, 6);
   color: variables.$element-text-primary;
-}
-
-.external-icon {
-  font-size: 16px;
 }
 
 .is-favorite {


### PR DESCRIPTION
Fixed wrong spacing and sizing of external icon.

Additionally simplified favourite icon css to properly match design specs.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
