### PR TITLE
chore(e2e): add manual override for networking in Linux

### DIFF
--- a/e2e-local.sh
+++ b/e2e-local.sh
@@ -36,10 +36,10 @@ DISPLAY=$LOCAL_ADDRESS:0
 
 case "$OS" in
   Linux*)
-    if [ -z "$LOCAL_ADDRESS" ]; then
+    if [ x"$LOCAL_ADDRESS" = "x" ]; then
       LOCAL_ADDRESS=localhost
     fi
-    if [ -z "$NETWORK_MODE" ]; then
+    if [ x"$NETWORK_MODE" = "x" ]; then
       NETWORK_MODE=host
     fi
     ;;


### PR DESCRIPTION
When setting up Playwright tests in Windows using WSL, I found that the docker container has trouble connecting to localhost:4200. To be able to pass another address a slight change needs to be made to e2e-local.sh

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
