### PR TITLE
chore(github): replace PR guidelines checkbox with reminder text

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
-> Describe in detail what your merge request does and why. Add relevant
-> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.
+<!-- Describe in detail what your merge request does and why. Add relevant
+screenshots and reference related issues via `Closes #XY` or `Related to #XY`.
 
----
-
-- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
+Please make sure your PR follows the contribution guidelines
+https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->


### PR DESCRIPTION
### Replace contribution guidelines checkbox in PR template

The contribution guidelines checkbox in the PR template has become a low-signal step for regular contributors and adds noise to every PR body.

For new contributors, a reminder can still be useful during PR creation.

Three options:

### Option 1: 🎉  Remove checkbox

`Please make sure your PR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).`

### Option 2: 🚀  HTML comment

As the reminder doesn't serve a purpose in the description but rather when creating we could make it an HTML comment that is then hidden once created. Although a mardown link does not work in this case, so it would be like this:

`<!-- Please make sure your PR follows the contribution guidelines. -->`

### Option 3: 👀  Remove it entirely


<!-- preview-links:start -->
---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1553/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1553/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1553/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1553/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1553/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1553/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
