### PR TITLE
fix(filtered-search): only emit `doSearch` once for each change

### DIFF
--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-selected-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-selected-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb2f3f3cdf1011c00f9c3bc5cc4575d5b9ef18f79af8b9020f0f752cb169bf12
-size 9824
+oid sha256:e69d6fcb7daf595202f4a8d698670b3c8359a80921dd78866302067427a7dae3
+size 15532

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-selected-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-selected-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7944d9c1cd83aba3aa27b49fa506c78a5e8390d6da54562029fac8c07c81f0a
-size 9562
+oid sha256:c448e2832e1b06b1f597507f35ce044b9f0b65760049dce79d5a2379f67d590f
+size 15340

--- a/projects/element-ng/filtered-search/si-filtered-search.component.html
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.html
@@ -30,6 +30,7 @@
     type="text"
     class="value-input ps-2 me-2 flex-grow-1"
     typeaheadOptionField="translatedLabel"
+    typeaheadClearValueOnSelect
     [siTypeahead]="dataSource"
     [typeaheadMinLength]="0"
     [typeaheadOptionsLimit]="typeaheadOptionsLimit()"

--- a/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
@@ -1431,6 +1431,25 @@ describe('SiFilteredSearchComponent', () => {
       });
     });
 
+    it('should emit doSearch once when creating criterion from selection', async () => {
+      component.criteria.set([{ name: 'company', label: 'Company' }]);
+      component.searchCriteria.set({ criteria: [], value: '' });
+      const spy = spyOn(component, 'doSearch');
+
+      const filteredSearch = await loader.getHarness(SiFilteredSearchHarness);
+      const freeTextSearch = await filteredSearch.freeTextSearch();
+      await freeTextSearch.focus();
+      await tick();
+      await freeTextSearch.select({ text: 'Company' });
+      await tick();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith({
+        criteria: [{ name: 'company', value: '' }],
+        value: ''
+      });
+    });
+
     it('and disableFreeTextSearch should emit criteria but no free text values while typing', async () => {
       component.disableFreeTextSearch = true;
       component.searchCriteria.set({

--- a/projects/element-ng/filtered-search/si-filtered-search.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.ts
@@ -552,17 +552,13 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
 
   protected typeaheadOnSelectCriterion(event: TypeaheadOption): void {
     const criterion = event as InternalCriterionDefinition;
-
-    // Timeout is needed otherwise siTypeahead will overwrite the value
-    setTimeout(() => {
-      // Removes the focus border before creating a new criterion to prevent the impression of jumping content.
-      this.freeTextInputElement().nativeElement.blur();
-      this.searchValue = '';
-      this.addCriterion(criterion);
-      // The user selected a criterion so we remove the free text search value and add the criterion.
-      this.allowedCriteriaCache = undefined;
-      this.typeaheadInputChange.next('');
-    }, 0);
+    // Removes the focus border before creating a new criterion to prevent the impression of jumping content.
+    this.freeTextInputElement().nativeElement.blur();
+    this.addCriterion(criterion);
+    // The user selected a criterion so we remove the free text search value and add the criterion.
+    this.allowedCriteriaCache = undefined;
+    this.typeaheadInputChange.next('');
+    this.searchValue = '';
   }
 
   protected validateCriterionLabel(criterion: InternalCriterionDefinition): boolean {

--- a/src/app/examples/si-filtered-search/si-filtered-search-playground.html
+++ b/src/app/examples/si-filtered-search/si-filtered-search-playground.html
@@ -77,8 +77,8 @@
         [optionsInScrollableView]="configForm.value.optionsInScrollableView!"
         [maxCriteria]="configForm.value.maxCriteria"
         [maxCriteriaOptions]="configForm.value.maxCriteriaOptions!"
-        (doSearch)="logEvent('doSearch:', $event)"
-        (searchCriteriaChange)="logEvent('searchCriteriaChange:', $event)"
+        (doSearch)="doSearch($event)"
+        (searchCriteriaChange)="searchCriteriaChange($event)"
       />
     </div>
   </div>

--- a/src/app/examples/si-filtered-search/si-filtered-search-playground.ts
+++ b/src/app/examples/si-filtered-search/si-filtered-search-playground.ts
@@ -64,4 +64,14 @@ export class SampleComponent implements OnInit {
       this.logEvent((error as Error).message);
     }
   }
+
+  doSearch(event: SearchCriteria): void {
+    this.logEvent('doSearch:', event);
+    this.searchCriteria = event;
+  }
+
+  searchCriteriaChange(event: SearchCriteria): void {
+    this.logEvent('searchCriteriaChange:', event);
+    this.searchCriteria = event;
+  }
 }


### PR DESCRIPTION
Previously, when creating a new criteria by selecting it from the typeahead, `doSearch` emits twice.
With this change, it only emits once the correct value.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
