### PR TITLE
fix(buttons): selection buttons hover state and icon sizing

### DIFF
--- a/playwright/snapshots/selection-buttons.spec.ts-snapshots/buttons--selection-buttons--selection-button-icon-tooltip-focus-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/selection-buttons.spec.ts-snapshots/buttons--selection-buttons--selection-button-icon-tooltip-focus-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ecd609177a2c0a7057a8ffc38065251e7dd8316084df815eaf40966baddd785
-size 36545
+oid sha256:69217ad0e40cc7ad55508058846d4c272b73e701ccea1d2d366ab558b3f6298b
+size 38553

--- a/playwright/snapshots/selection-buttons.spec.ts-snapshots/buttons--selection-buttons--selection-button-icon-tooltip-focus-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/selection-buttons.spec.ts-snapshots/buttons--selection-buttons--selection-button-icon-tooltip-focus-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd13260c7807d79dd54be08efe9a78f8522d3e1e991f80d92d7e40f930a10926
-size 38714
+oid sha256:caa4177286faf4db64c3d253eb600473f201e205fab4de5e2d33f665159a6208
+size 40609

--- a/playwright/snapshots/selection-buttons.spec.ts-snapshots/buttons--selection-buttons--selection-button-icon-tooltip-hover-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/selection-buttons.spec.ts-snapshots/buttons--selection-buttons--selection-button-icon-tooltip-hover-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d5ae7a16240fe99aad8a02bc134b4d45335e76e1643cd90bc5d2cea75f3802fb
-size 36599
+oid sha256:c56c148ccdc738793c8e98d905629cffdb809632cea4eaf41bd9ae4e6d397fb9
+size 38747

--- a/playwright/snapshots/selection-buttons.spec.ts-snapshots/buttons--selection-buttons--selection-button-icon-tooltip-hover-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/selection-buttons.spec.ts-snapshots/buttons--selection-buttons--selection-button-icon-tooltip-hover-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:31f11b54bf74ae4262089a91c2cdf343b0c15005e194a0022669ae3ba027e340
-size 38840
+oid sha256:451f02b8cc4a7f41cabce194dc7dc8bae6764caf8269f3844f2aa9e4a1556fe6
+size 40896

--- a/playwright/snapshots/static.spec.ts-snapshots/buttons--selection-buttons-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/buttons--selection-buttons-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c5bdaa7c2759dd1a2c064e96d029ee2744bc22d27001f25891d54acf74e2ef9
-size 34984
+oid sha256:a9c8e0347a5daddcd8779547c8376dae510fa0d58d9051b45ce5037579a9fa36
+size 36978

--- a/playwright/snapshots/static.spec.ts-snapshots/buttons--selection-buttons-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/buttons--selection-buttons-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28f0c7547b2fd08e03f3c409eb870a75bb7d7d91f5affead2a03c334be2fffa2
-size 37262
+oid sha256:354c82c114e7f4967ffbf2a3dc0f12d9a3e330f426cc8022d878a6b8f0a90131
+size 39150

--- a/projects/element-theme/src/styles/bootstrap/_button-group.scss
+++ b/projects/element-theme/src/styles/bootstrap/_button-group.scss
@@ -126,20 +126,23 @@ $btn-size-sm: 24px !default;
         margin-inline: 0;
       }
     }
-
-    &:hover {
-      color: semantic-tokens.$element-ui-0-hover;
-    }
   }
 
-  .btn-check:checked + .btn,
-  label.btn:has(.btn-check:checked) {
-    background: semantic-tokens.$element-action-secondary-active;
-    border-color: semantic-tokens.$element-action-secondary-border-hover;
+  .btn-check + .btn:hover,
+  label:has(.btn-check:not(:checked)):hover > * {
     color: semantic-tokens.$element-ui-0-hover;
-    z-index: 2;
+  }
 
-    &:hover {
+  .btn-check:checked {
+    + .btn {
+      background: semantic-tokens.$element-action-secondary-active;
+      border-color: semantic-tokens.$element-action-secondary-border-hover;
+      color: semantic-tokens.$element-ui-0-hover;
+      z-index: 2;
+    }
+
+    + .btn:hover,
+    &:hover + .btn {
       color: semantic-tokens.$element-text-primary;
     }
   }

--- a/src/app/examples/buttons/selection-buttons.html
+++ b/src/app/examples/buttons/selection-buttons.html
@@ -40,9 +40,7 @@
         aria-label="One pane"
         checked
       />
-      <span class="btn btn-icon">
-        <si-icon class="icon" icon="element-layout-pane-1" />
-      </span>
+      <si-icon class="btn btn-icon" icon="element-layout-pane-1" />
     </label>
 
     <label>
@@ -53,9 +51,7 @@
         siTooltip="Two panes"
         aria-label="Two panes"
       />
-      <span class="btn btn-icon">
-        <si-icon class="icon" icon="element-layout-pane-2" />
-      </span>
+      <si-icon class="btn btn-icon" icon="element-layout-pane-2" />
     </label>
 
     <label>
@@ -66,9 +62,7 @@
         siTooltip="Three panes"
         aria-label="Three panes"
       />
-      <span class="btn btn-icon">
-        <si-icon class="icon" icon="element-layout-pane-3" />
-      </span>
+      <si-icon class="btn btn-icon" icon="element-layout-pane-3" />
     </label>
   </div>
 </div>
@@ -105,37 +99,27 @@
 <div class="btn-group mb-6" role="group" aria-label="Category filter">
   <label>
     <input type="checkbox" class="btn-check" siTooltip="Garden" aria-label="Garden" checked />
-    <span class="btn btn-icon">
-      <si-icon class="icon" icon="element-garden" />
-    </span>
+    <si-icon class="btn btn-icon" icon="element-garden" />
   </label>
 
   <label>
     <input type="checkbox" class="btn-check" siTooltip="Mobile" aria-label="Mobile" />
-    <span class="btn btn-icon">
-      <si-icon class="icon" icon="element-smartphone" />
-    </span>
+    <si-icon class="btn btn-icon" icon="element-smartphone" />
   </label>
 
   <label>
     <input type="checkbox" class="btn-check" siTooltip="Cloud" aria-label="Cloud" checked />
-    <span class="btn btn-icon">
-      <si-icon class="icon" icon="element-cloud" />
-    </span>
+    <si-icon class="btn btn-icon" icon="element-cloud" />
   </label>
 
   <label>
     <input type="checkbox" class="btn-check" siTooltip="AI" aria-label="AI" />
-    <span class="btn btn-icon">
-      <si-icon class="icon" icon="element-ai" />
-    </span>
+    <si-icon class="btn btn-icon" icon="element-ai" />
   </label>
 
   <label>
     <input type="checkbox" class="btn-check" siTooltip="Network" aria-label="Network" />
-    <span class="btn btn-icon">
-      <si-icon class="icon" icon="element-network" />
-    </span>
+    <si-icon class="btn btn-icon" icon="element-network" />
   </label>
 </div>
 
@@ -259,16 +243,12 @@
         siTooltip="Heating"
         aria-label="Heating"
       />
-      <span class="btn btn-lg btn-icon">
-        <si-icon class="icon" icon="element-sun" />
-      </span>
+      <si-icon class="btn btn-lg btn-icon" icon="element-sun" />
     </label>
 
     <label>
       <input type="radio" class="btn-check" name="btnradio7" siTooltip="Water" aria-label="Water" />
-      <span class="btn btn-lg btn-icon">
-        <si-icon class="icon" icon="element-water" />
-      </span>
+      <si-icon class="btn btn-lg btn-icon" icon="element-water" />
     </label>
 
     <label>
@@ -279,9 +259,7 @@
         siTooltip="Cooling"
         aria-label="Cooling"
       />
-      <span class="btn btn-lg btn-icon">
-        <si-icon class="icon" icon="element-cooling-state" />
-      </span>
+      <si-icon class="btn btn-lg btn-icon" icon="element-cooling-state" />
     </label>
   </div>
 
@@ -294,16 +272,12 @@
         siTooltip="Heating"
         aria-label="Heating"
       />
-      <span class="btn btn-icon">
-        <si-icon class="icon" icon="element-sun" />
-      </span>
+      <si-icon class="btn btn-icon" icon="element-sun" />
     </label>
 
     <label>
       <input type="radio" class="btn-check" name="btnradio8" siTooltip="Water" aria-label="Water" />
-      <span class="btn btn-icon">
-        <si-icon class="icon" icon="element-water" />
-      </span>
+      <si-icon class="btn btn-icon" icon="element-water" />
     </label>
 
     <label>
@@ -314,9 +288,7 @@
         siTooltip="Cooling"
         aria-label="Cooling"
       />
-      <span class="btn btn-icon">
-        <si-icon class="icon" icon="element-cooling-state" />
-      </span>
+      <si-icon class="btn btn-icon" icon="element-cooling-state" />
     </label>
   </div>
 
@@ -329,16 +301,12 @@
         siTooltip="Heating"
         aria-label="Heating"
       />
-      <span class="btn btn-sm btn-icon">
-        <si-icon class="icon" icon="element-sun" />
-      </span>
+      <si-icon class="btn btn-sm btn-icon" icon="element-sun" />
     </label>
 
     <label>
       <input type="radio" class="btn-check" name="btnradio9" siTooltip="Water" aria-label="Water" />
-      <span class="btn btn-sm btn-icon">
-        <si-icon class="icon" icon="element-water" />
-      </span>
+      <si-icon class="btn btn-sm btn-icon" icon="element-water" />
     </label>
 
     <label>
@@ -349,9 +317,7 @@
         siTooltip="Cooling"
         aria-label="Cooling"
       />
-      <span class="btn btn-sm btn-icon">
-        <si-icon class="icon" icon="element-cooling-state" />
-      </span>
+      <si-icon class="btn btn-sm btn-icon" icon="element-cooling-state" />
     </label>
   </div>
 </div>


### PR DESCRIPTION
Fixes hover state for selection buttons using a wrapping `<label>` tag and icon size for the large variant.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1568/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1568/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1568/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1568/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1568/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1568/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1568/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1568/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1568/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1568/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

