### PR TITLE
test(element): drop TestHostComponent from copyright, inline notification and side panel tests

### DIFF
--- a/projects/element-ng/copyright-notice/si-copyright-notice.component.spec.ts
+++ b/projects/element-ng/copyright-notice/si-copyright-notice.component.spec.ts
@@ -2,26 +2,18 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { inputBinding, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CopyrightDetails, SI_COPYRIGHT_DETAILS } from '@siemens/element-ng/copyright-notice';
 
 import { SiCopyrightNoticeComponent } from './si-copyright-notice.component';
 
-@Component({
-  imports: [SiCopyrightNoticeComponent],
-  template: `<si-copyright-notice />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
-})
-class WrapperComponent {}
 describe('SiCopyrightNoticeComponent', () => {
-  let component: WrapperComponent;
-  let fixture: ComponentFixture<WrapperComponent>;
+  let fixture: ComponentFixture<SiCopyrightNoticeComponent>;
   let element: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WrapperComponent],
       providers: [
         {
           provide: SI_COPYRIGHT_DETAILS,
@@ -34,94 +26,77 @@ describe('SiCopyrightNoticeComponent', () => {
       ]
     }).compileComponents();
 
-    fixture = TestBed.createComponent(WrapperComponent);
-    component = fixture.componentInstance;
+    fixture = TestBed.createComponent(SiCopyrightNoticeComponent);
     element = fixture.nativeElement;
   });
 
   it('should create', () => {
     fixture.detectChanges();
-    expect(component).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
   it('should fetch from injector and assign default company', () => {
     fixture.detectChanges();
-    const copyrightElement = element.querySelector<HTMLElement>('si-copyright-notice');
-    expect(copyrightElement).toBeTruthy();
 
-    expect(copyrightElement?.innerText).toContain('Sample Company');
-    expect(copyrightElement?.innerText).toContain('2012');
-    expect(copyrightElement?.innerText).toContain('-');
+    expect(element.innerText).toContain('Sample Company');
+    expect(element.innerText).toContain('2012');
+    expect(element.innerText).toContain('-');
   });
 
   it('should print the correct last updated year when globally injected', () => {
     fixture.detectChanges();
-    const copyrightEl = element.querySelector<HTMLElement>('si-copyright-notice');
-    expect(copyrightEl).toBeTruthy();
 
-    expect(copyrightEl?.innerText).toContain('-');
-    expect(copyrightEl?.innerText).toContain('2019');
+    expect(element.innerText).toContain('-');
+    expect(element.innerText).toContain('2019');
   });
 });
 
-@Component({
-  imports: [SiCopyrightNoticeComponent],
-  template: `<si-copyright-notice [copyright]="copyrightInfo" />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
-})
-class WrapperWithInputComponent {
-  copyrightInfo: CopyrightDetails | undefined = {
-    startYear: 2020,
-    company: 'My Company',
-    lastUpdateYear: 2021
-  };
-}
 describe('SiCopyrightNoticeComponentWithInput', () => {
-  let component: WrapperWithInputComponent;
-  let fixture: ComponentFixture<WrapperWithInputComponent>;
+  let fixture: ComponentFixture<SiCopyrightNoticeComponent>;
   let element: HTMLElement;
+  let copyright: WritableSignal<CopyrightDetails | undefined>;
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(WrapperWithInputComponent);
-    component = fixture.componentInstance;
+    copyright = signal({
+      startYear: 2020,
+      company: 'My Company',
+      lastUpdateYear: 2021
+    });
+    fixture = TestBed.createComponent(SiCopyrightNoticeComponent, {
+      bindings: [inputBinding('copyright', copyright)]
+    });
     element = fixture.nativeElement;
   });
 
   it('should initialize component', () => {
     fixture.detectChanges();
-    expect(component).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
   it('should reflect input changes', () => {
     fixture.detectChanges();
-    const copyrightEl = element.querySelector<HTMLElement>('si-copyright-notice');
-    expect(copyrightEl).toBeTruthy();
 
-    expect(copyrightEl?.innerText).toContain('My Company');
-    expect(copyrightEl?.innerText).toContain('2020');
-    expect(copyrightEl?.innerText).toContain('-');
+    expect(element.innerText).toContain('My Company');
+    expect(element.innerText).toContain('2020');
+    expect(element.innerText).toContain('-');
   });
 
   it('should print the correct last updated year', () => {
     fixture.detectChanges();
-    const copyrightEl = element.querySelector<HTMLElement>('si-copyright-notice');
-    expect(copyrightEl).toBeTruthy();
 
-    expect(copyrightEl?.innerText).toContain('-');
-    expect(copyrightEl?.innerText).toContain('2021');
+    expect(element.innerText).toContain('-');
+    expect(element.innerText).toContain('2021');
   });
 
   it('should print default copyright notice when no input is given', () => {
-    component.copyrightInfo = undefined;
+    copyright.set(undefined);
     fixture.detectChanges();
-    const copyrightEl = element.querySelector<HTMLElement>('si-copyright-notice')!;
-    expect(copyrightEl).toBeTruthy();
 
-    expect(
-      window.getComputedStyle(copyrightEl.querySelector('.company')!, ':after').content
-    ).toContain('ExampleOrg');
-    expect(copyrightEl.innerText).toContain('©');
-    expect(copyrightEl.innerText).toContain(new Date().getFullYear() + '');
-    expect(copyrightEl.innerText).not.toContain('-');
+    expect(window.getComputedStyle(element.querySelector('.company')!, ':after').content).toContain(
+      'ExampleOrg'
+    );
+    expect(element.innerText).toContain('©');
+    expect(element.innerText).toContain(new Date().getFullYear() + '');
+    expect(element.innerText).not.toContain('-');
   });
 });

--- a/projects/element-ng/inline-notification/si-inline-notification.component.spec.ts
+++ b/projects/element-ng/inline-notification/si-inline-notification.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { inputBinding, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { StatusType } from '@siemens/element-ng/common';
 import { Link } from '@siemens/element-ng/link';
@@ -12,35 +12,17 @@ import { of } from 'rxjs';
 
 import { SiInlineNotificationComponent } from './index';
 
-@Component({
-  imports: [SiInlineNotificationComponent],
-  template: `
-    <si-inline-notification
-      [severity]="severity"
-      [heading]="heading"
-      [message]="message"
-      [action]="action"
-      [translationParams]="translationParams"
-    />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
-})
-class TestHostComponent {
-  severity!: StatusType;
-  heading = '';
-  message = '';
-  action!: Link;
-  translationParams!: { [key: string]: any };
-}
-
 describe('SiInlineNotificationComponent', () => {
-  let fixture: ComponentFixture<TestHostComponent>;
-  let component: TestHostComponent;
+  let fixture: ComponentFixture<SiInlineNotificationComponent>;
   let element: HTMLElement;
+  let severity: WritableSignal<StatusType>;
+  let heading: WritableSignal<string>;
+  let message: WritableSignal<string>;
+  let action: WritableSignal<Link | undefined>;
+  let translationParams: WritableSignal<{ [key: string]: any } | undefined>;
 
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [TestHostComponent],
       providers: [
         provideMockTranslateServiceBuilder(
           () =>
@@ -56,17 +38,29 @@ describe('SiInlineNotificationComponent', () => {
   );
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(TestHostComponent);
-    component = fixture.componentInstance;
+    severity = signal('info');
+    heading = signal('');
+    message = signal('');
+    action = signal(undefined);
+    translationParams = signal(undefined);
+    fixture = TestBed.createComponent(SiInlineNotificationComponent, {
+      bindings: [
+        inputBinding('severity', severity),
+        inputBinding('heading', heading),
+        inputBinding('message', message),
+        inputBinding('action', action),
+        inputBinding('translationParams', translationParams)
+      ]
+    });
     element = fixture.nativeElement;
   });
 
   it('should display the correct data', () => {
-    component.severity = 'danger';
-    component.heading = 'MSG.HEADING';
-    component.message = 'MSG.MESSAGE';
-    component.action = { title: 'MSG.ACTION' };
-    component.translationParams = { param: 'something' };
+    severity.set('danger');
+    heading.set('MSG.HEADING');
+    message.set('MSG.MESSAGE');
+    action.set({ title: 'MSG.ACTION' });
+    translationParams.set({ param: 'something' });
     fixture.detectChanges();
 
     expect(element.querySelector<HTMLElement>('.alert strong')!.innerText).toBe(
@@ -82,8 +76,8 @@ describe('SiInlineNotificationComponent', () => {
   });
 
   it('should display empty title', () => {
-    component.severity = 'info';
-    component.message = 'There is no Title';
+    severity.set('info');
+    message.set('There is no Title');
     fixture.detectChanges();
     expect(element.querySelector('.alert strong')!).toBeNull();
   });

--- a/projects/element-ng/result-details-list/si-result-details-list.component.spec.ts
+++ b/projects/element-ng/result-details-list/si-result-details-list.component.spec.ts
@@ -2,37 +2,30 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { inputBinding, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ResultDetailStep, SiResultDetailsListComponent } from '.';
 
-@Component({
-  imports: [SiResultDetailsListComponent],
-  template: `<si-result-details-list [steps]="steps" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
-})
-export class TestHostComponent {
-  steps: ResultDetailStep[] = [];
-}
-
 describe('SiResultDetailsListComponent', () => {
-  let fixture: ComponentFixture<TestHostComponent>;
-  let component: TestHostComponent;
+  let fixture: ComponentFixture<SiResultDetailsListComponent>;
   let element: HTMLElement;
+  let steps: WritableSignal<ResultDetailStep[]>;
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(TestHostComponent);
-    component = fixture.componentInstance;
+    steps = signal([]);
+    fixture = TestBed.createComponent(SiResultDetailsListComponent, {
+      bindings: [inputBinding('steps', steps)]
+    });
     element = fixture.nativeElement;
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
   it('should show the steps', () => {
-    component.steps = [
+    steps.set([
       {
         description: 'Test volume flow sensor',
         state: 'failed'
@@ -58,70 +51,70 @@ describe('SiResultDetailsListComponent', () => {
         description: 'Test valve fully operational',
         state: 'failed'
       }
-    ];
+    ]);
     fixture.detectChanges();
 
-    expect(element.querySelectorAll('.result-description').length).toEqual(component.steps.length);
+    expect(element.querySelectorAll('.result-description').length).toEqual(steps().length);
   });
 
   it('should show step values if provided', () => {
-    component.steps = [
+    steps.set([
       {
         description: 'Test maximum volume flow',
         state: 'passed',
         value: '3.7 m3/h'
       }
-    ];
+    ]);
     fixture.detectChanges();
 
     expect(element.querySelectorAll('.result-value').length).toEqual(1);
   });
 
   it('should show no test step values if none provided', () => {
-    component.steps = [
+    steps.set([
       {
         description: 'Test maximum volume flow',
         state: 'passed'
       }
-    ];
+    ]);
     fixture.detectChanges();
 
     expect(element.querySelectorAll('.result-value').length).toEqual(0);
   });
 
   it('should show step errors if provided', () => {
-    component.steps = [
+    steps.set([
       {
         description: 'Test maximum volume flow',
         state: 'failed',
         errorMessage: 'an error message'
       }
-    ];
+    ]);
     fixture.detectChanges();
 
     expect(element.querySelectorAll('.text-danger').length).toEqual(1);
   });
 
   it('should show no step errors if none provided', () => {
-    component.steps = [
+    steps.set([
       {
         description: 'Test maximum volume flow',
         state: 'passed'
       }
-    ];
+    ]);
     fixture.detectChanges();
 
     expect(element.querySelectorAll('.result-error').length).toEqual(0);
   });
 
   it('should show detail text if provided', () => {
-    component.steps = [
+    steps.set([
       {
         description: 'Test maximum volume flow',
         state: 'passed',
         detail: 'Test this detail'
       }
-    ];
+    ]);
     fixture.detectChanges();
     expect(element.querySelectorAll('.result-detail').length).toEqual(1);
   });

--- a/projects/element-ng/side-panel/si-side-panel-content.component.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.spec.ts
@@ -2,41 +2,30 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { inputBinding, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { SiSidePanelModule } from './si-side-panel.module';
+import { SiSidePanelContentComponent } from './si-side-panel-content.component';
 import { SiSidePanelService } from './si-side-panel.service';
 
-@Component({
-  imports: [SiSidePanelModule],
-  template: `<si-side-panel-content heading="Title" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
-})
-class TestHostComponent {}
-
 describe('SiSidePanelContentComponent', () => {
-  let component: TestHostComponent;
-  let fixture: ComponentFixture<TestHostComponent>;
+  let fixture: ComponentFixture<SiSidePanelContentComponent>;
   let element: HTMLElement;
   let sidePanelService: SiSidePanelService;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [SiSidePanelModule, TestHostComponent]
-    }).compileComponents();
-  });
+  let heading: WritableSignal<string>;
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(TestHostComponent);
-    component = fixture.componentInstance;
+    heading = signal('Title');
+    fixture = TestBed.createComponent(SiSidePanelContentComponent, {
+      bindings: [inputBinding('heading', heading)]
+    });
     fixture.detectChanges();
     element = fixture.nativeElement;
     sidePanelService = TestBed.inject(SiSidePanelService);
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
   it('should toggle side panel on click', () => {


### PR DESCRIPTION

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->
---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1585/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1585/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1585/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1585/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1585/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1585/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
