### PR TITLE
refactor(dashboard): change SiWidgetBaseComponent from @Component to @Directive

### DIFF
--- a/api-goldens/element-ng/dashboard/index.api.md
+++ b/api-goldens/element-ng/dashboard/index.api.md
@@ -8,7 +8,6 @@ import { AccentLineType } from '@siemens/element-ng/common';
 import { ActivatedRoute } from '@angular/router';
 import { AfterViewInit } from '@angular/core';
 import * as _angular_core from '@angular/core';
-import { ChangeDetectorRef } from '@angular/core';
 import { ContentActionBarMainItem } from '@siemens/element-ng/content-action-bar';
 import { ElementRef } from '@angular/core';
 import { EntityStatusType } from '@siemens/element-ng/common';
@@ -67,13 +66,13 @@ export class SiDashboardService {
 }
 
 // @public
-export class SiLinkWidgetComponent extends SiWidgetBaseComponent<Link[]> {
+export class SiLinkWidgetComponent extends SiWidgetBaseDirective<Link[]> {
     readonly numberOfLinks: _angular_core.InputSignal<number>;
     readonly showLinkIcons: _angular_core.InputSignalWithTransform<boolean, unknown>;
 }
 
 // @public
-export class SiListWidgetBodyComponent extends SiWidgetBaseComponent<SiListWidgetItem[]> implements OnChanges {
+export class SiListWidgetBodyComponent extends SiWidgetBaseDirective<SiListWidgetItem[]> implements OnChanges {
     readonly compareFn: _angular_core.InputSignal<(a: SiListWidgetItem, b: SiListWidgetItem) => number | undefined>;
     readonly filterFn: _angular_core.InputSignal<(item: SiListWidgetItem, searchTerm: string) => boolean | undefined>;
     readonly link: _angular_core.InputSignal<Link | undefined>;
@@ -84,7 +83,7 @@ export class SiListWidgetBodyComponent extends SiWidgetBaseComponent<SiListWidge
 }
 
 // @public
-export class SiListWidgetComponent extends SiWidgetBaseComponent<SiListWidgetItem[]> implements OnChanges {
+export class SiListWidgetComponent extends SiWidgetBaseDirective<SiListWidgetItem[]> implements OnChanges {
     readonly accentLine: _angular_core.InputSignal<AccentLineType | undefined>;
     readonly compareFn: _angular_core.InputSignal<(a: SiListWidgetItem, b: SiListWidgetItem) => number | undefined>;
     readonly filterFn: _angular_core.InputSignal<(item: SiListWidgetItem, searchTerm: string) => boolean | undefined>;
@@ -112,17 +111,17 @@ export interface SiListWidgetItem {
 }
 
 // @public
-export class SiListWidgetItemComponent extends SiWidgetBaseComponent<SiListWidgetItem> {
+export class SiListWidgetItemComponent extends SiWidgetBaseDirective<SiListWidgetItem> {
 }
 
 // @public (undocumented)
-export class SiTimelineWidgetBodyComponent extends SiWidgetBaseComponent<SiTimelineWidgetItem[]> {
+export class SiTimelineWidgetBodyComponent extends SiWidgetBaseDirective<SiTimelineWidgetItem[]> {
     readonly numberOfItems: _angular_core.InputSignal<number>;
     readonly showDescription: _angular_core.InputSignal<boolean>;
 }
 
 // @public (undocumented)
-export class SiTimelineWidgetComponent extends SiWidgetBaseComponent<SiTimelineWidgetItem[]> implements OnChanges {
+export class SiTimelineWidgetComponent extends SiWidgetBaseDirective<SiTimelineWidgetItem[]> implements OnChanges {
     readonly accentLine: _angular_core.InputSignal<AccentLineType | undefined>;
     readonly heading: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly link: _angular_core.InputSignal<Link | undefined>;
@@ -146,13 +145,13 @@ export interface SiTimelineWidgetItem {
 }
 
 // @public
-export class SiTimelineWidgetItemComponent extends SiWidgetBaseComponent<SiTimelineWidgetItem> implements OnInit, OnChanges {
+export class SiTimelineWidgetItemComponent extends SiWidgetBaseDirective<SiTimelineWidgetItem> implements OnInit, OnChanges {
     readonly ariaLabelDropdown: TranslatableString;
     readonly showDescription: _angular_core.InputSignal<boolean>;
 }
 
 // @public
-export class SiValueWidgetBodyComponent extends SiWidgetBaseComponent<TranslatableString> implements OnInit {
+export class SiValueWidgetBodyComponent extends SiWidgetBaseDirective<TranslatableString> implements OnInit {
     readonly description: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly icon: _angular_core.InputSignal<string | undefined>;
     readonly status: _angular_core.InputSignal<EntityStatusType | undefined>;

--- a/projects/element-ng/dashboard/widgets/si-link-widget/si-link-widget.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-link-widget/si-link-widget.component.ts
@@ -8,7 +8,7 @@ import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
-import { SiWidgetBaseComponent } from '../si-widget-base.component';
+import { SiWidgetBaseDirective } from '../si-widget-base.directive';
 
 /**
  * The `<si-link-widget>` supports an easy composition of links and actions
@@ -20,7 +20,7 @@ import { SiWidgetBaseComponent } from '../si-widget-base.component';
   templateUrl: './si-link-widget.component.html',
   host: { class: 'si-link-widget' }
 })
-export class SiLinkWidgetComponent extends SiWidgetBaseComponent<Link[]> {
+export class SiLinkWidgetComponent extends SiWidgetBaseDirective<Link[]> {
   /**
    * Option to enable trailing link arrow icons for each link.
    *

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.ts
@@ -8,7 +8,7 @@ import { Link } from '@siemens/element-ng/link';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
-import { SiWidgetBaseComponent } from '../si-widget-base.component';
+import { SiWidgetBaseDirective } from '../si-widget-base.directive';
 import { SiListWidgetItem, SiListWidgetItemComponent } from './si-list-widget-item.component';
 
 /** Defines the sort order. */
@@ -26,7 +26,7 @@ export type SortOrder = 'ASC' | 'DSC';
   host: { class: '' }
 })
 export class SiListWidgetBodyComponent
-  extends SiWidgetBaseComponent<SiListWidgetItem[]>
+  extends SiWidgetBaseDirective<SiListWidgetItem[]>
   implements OnChanges
 {
   /** Optional footer link for the list widget */

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-item.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-item.component.ts
@@ -8,7 +8,7 @@ import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
-import { SiWidgetBaseComponent } from '../si-widget-base.component';
+import { SiWidgetBaseDirective } from '../si-widget-base.directive';
 
 /**
  * Interface for objects to configure the the list widget.
@@ -46,7 +46,7 @@ export interface SiListWidgetItem {
     role: 'listitem'
   }
 })
-export class SiListWidgetItemComponent extends SiWidgetBaseComponent<SiListWidgetItem> {
+export class SiListWidgetItemComponent extends SiWidgetBaseDirective<SiListWidgetItem> {
   protected readonly isLink = computed(() => {
     return typeof this.value()?.label === 'object';
   });

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget.component.ts
@@ -11,7 +11,7 @@ import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
-import { SiWidgetBaseComponent } from '../si-widget-base.component';
+import { SiWidgetBaseDirective } from '../si-widget-base.directive';
 import { SiListWidgetBodyComponent, SortOrder } from './si-list-widget-body.component';
 import { SiListWidgetItem } from './si-list-widget-item.component';
 
@@ -32,7 +32,7 @@ import { SiListWidgetItem } from './si-list-widget-item.component';
   host: { class: 'si-list-widget' }
 })
 export class SiListWidgetComponent
-  extends SiWidgetBaseComponent<SiListWidgetItem[]>
+  extends SiWidgetBaseDirective<SiListWidgetItem[]>
   implements OnChanges
 {
   protected readonly icons = addIcons({ elementRight2, elementSortDown, elementSortUp });

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-body.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-body.component.ts
@@ -4,7 +4,7 @@
  */
 import { Component, computed, input } from '@angular/core';
 
-import { SiWidgetBaseComponent } from '../si-widget-base.component';
+import { SiWidgetBaseDirective } from '../si-widget-base.directive';
 import {
   SiTimelineWidgetItem,
   SiTimelineWidgetItemComponent
@@ -16,7 +16,7 @@ import {
   templateUrl: './si-timeline-widget-body.component.html',
   styleUrl: './si-timeline-widget-body.component.scss'
 })
-export class SiTimelineWidgetBodyComponent extends SiWidgetBaseComponent<SiTimelineWidgetItem[]> {
+export class SiTimelineWidgetBodyComponent extends SiWidgetBaseDirective<SiTimelineWidgetItem[]> {
   /**
    * Number of skeleton progress indication items.
    *

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.ts
@@ -10,7 +10,7 @@ import { SiIconComponent } from '@siemens/element-ng/icon';
 import { MenuItem, SiMenuModule } from '@siemens/element-ng/menu';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
-import { SiWidgetBaseComponent } from '../si-widget-base.component';
+import { SiWidgetBaseDirective } from '../si-widget-base.directive';
 
 /** Base for action items in the timeline widget. */
 export interface TimelineWidgetActionBase {
@@ -118,7 +118,7 @@ export interface SiTimelineWidgetItem {
   }
 })
 export class SiTimelineWidgetItemComponent
-  extends SiWidgetBaseComponent<SiTimelineWidgetItem>
+  extends SiWidgetBaseDirective<SiTimelineWidgetItem>
   implements OnInit, OnChanges
 {
   /**

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget.component.ts
@@ -12,7 +12,7 @@ import { Link, SiLinkDirective } from '@siemens/element-ng/link';
 import { MenuItem } from '@siemens/element-ng/menu';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
-import { SiWidgetBaseComponent } from '../si-widget-base.component';
+import { SiWidgetBaseDirective } from '../si-widget-base.directive';
 import { SiTimelineWidgetBodyComponent } from './si-timeline-widget-body.component';
 import { SiTimelineWidgetItem } from './si-timeline-widget-item.component';
 
@@ -28,7 +28,7 @@ import { SiTimelineWidgetItem } from './si-timeline-widget-item.component';
   templateUrl: './si-timeline-widget.component.html'
 })
 export class SiTimelineWidgetComponent
-  extends SiWidgetBaseComponent<SiTimelineWidgetItem[]>
+  extends SiWidgetBaseDirective<SiTimelineWidgetItem[]>
   implements OnChanges
 {
   /**

--- a/projects/element-ng/dashboard/widgets/si-value-widget/si-value-widget-body.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-value-widget/si-value-widget-body.component.ts
@@ -7,7 +7,7 @@ import { EntityStatusType } from '@siemens/element-ng/common';
 import { SiIconComponent, SiStatusIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
-import { SiWidgetBaseComponent } from '../si-widget-base.component';
+import { SiWidgetBaseDirective } from '../si-widget-base.directive';
 
 /**
  * The body of the `<si-value-widget>`. Useful for compositions.
@@ -18,7 +18,7 @@ import { SiWidgetBaseComponent } from '../si-widget-base.component';
   templateUrl: './si-value-widget-body.component.html'
 })
 export class SiValueWidgetBodyComponent
-  extends SiWidgetBaseComponent<TranslatableString>
+  extends SiWidgetBaseDirective<TranslatableString>
   implements OnInit
 {
   /**

--- a/projects/element-ng/dashboard/widgets/si-widget-base.directive.ts
+++ b/projects/element-ng/dashboard/widgets/si-widget-base.directive.ts
@@ -4,10 +4,8 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectorRef,
-  Component,
   computed,
-  inject,
+  Directive,
   input,
   OnChanges,
   OnInit,
@@ -16,16 +14,14 @@ import {
 } from '@angular/core';
 
 /**
- * The SiWidgetBaseComponent<T> implements the timing for the skeleton loading
+ * The SiWidgetBaseDirective<T> implements the timing for the skeleton loading
  * indicator of widgets. It supports a generic value input property that represents
  * the main value to be displayed by a widget. When the value is not set, the `showLoadingIndicator`
  * changes after the `initialLoadingIndicatorDebounceTime` delay to `true` and subclasses
  * should show the skeleton loading indicator.
  */
-@Component({
-  template: ''
-})
-export abstract class SiWidgetBaseComponent<T> implements OnInit, OnChanges {
+@Directive()
+export abstract class SiWidgetBaseDirective<T> implements OnInit, OnChanges {
   /**
    * The main value to be displayed. If no value is set,
    * the skeleton indicates the loading of the value. Disable
@@ -63,7 +59,6 @@ export abstract class SiWidgetBaseComponent<T> implements OnInit, OnChanges {
    */
   readonly initialLoadingIndicatorDebounceTime = input(300);
 
-  protected cdRef = inject(ChangeDetectorRef);
   protected loadingTimer?: ReturnType<typeof setTimeout>;
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
Since it has an empty template and is only used as an abstract base class, @Directive() is semantically more accurate. Also removes the unused ChangeDetectorRef injection.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->
---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1592/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1592/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1592/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1592/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1592/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1592/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->

