### PR TITLE
Revert "chore(element-ng): narrow @siemens/ngx-datatable peer dependency to v25

### DIFF
--- a/projects/element-ng/package.json
+++ b/projects/element-ng/package.json
@@ -48,7 +48,7 @@
     "@siemens/element-icons": "1",
     "@siemens/element-translate-ng": "49.0.0",
     "@siemens/element-theme": "49.0.0",
-    "@siemens/ngx-datatable": "25",
+    "@siemens/ngx-datatable": "22 - 25",
     "ag-grid-community": "^34.3.1",
     "flag-icons": "^7.3.2",
     "google-libphonenumber": "^3.2.40",


### PR DESCRIPTION
This reverts commit 14aea41f1c849eb7fba960d5fedc20a9cde3a186.

> Describe in detail what your merge request does and why. Add relevant
> screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->
---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1594/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1594/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1594/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1594/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1594/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1594/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
