### PR TITLE
docs(icons): update to v49 changes

### DIFF
--- a/docs/fundamentals/icons.md
+++ b/docs/fundamentals/icons.md
@@ -96,16 +96,68 @@ e.g., event states or severity symbols.
 
 ## Code ---
 
-All icons start with the `element-` prefix and can be copied directly from the
-internal icon catalog.
+Icons are available as SVGs or as an icon font.
+Prefer SVGs unless you are working in an existing project that already uses the icon font. Stay consistent within a project.
+SVGs were introduced to reduce bundle size, as the icon font is already above 100KB while typically only a few icons are used.
 
-To use the icons within your HTML template, add the `<i>`-tag and define the
-desired icon name as CSS class. Besides the icon class, all other text utility
-classes such size and color can be used. The CSS class `icon` applies the default
-icon size.
+A list of icons can be found in the [icon overview](../icons.md).
 
-There is also a specific [si-icon](../components/status-notifications/icon.md)
-component, which can be used to show icons. It supports stacking of icons to build
-compositions and also supports SVG-based icons.
+### SVG
+
+!!! info "Content Security Policy considerations"
+
+    Element embedds icons as `data:image/svg+xml` URLs.
+    Thus you need to allow the `data:` scheme ONLY for `img-src` in addition to the [Angular recommended values](https://angular.dev/best-practices/security#content-security-policy).
+    ```http
+      Content-Security-Policy: <...>; img-src 'self' data:;
+    ```
+
+Use the `si-icon` component to include SVG icons:
+
+```ts
+import { Component } from '@angular/core';
+import { elementUser } from '@siemens/element-icons';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
+
+@Component({
+  selector: 'app-sample',
+  imports: [SiIconComponent],
+  template: `<si-icon class="icon" [icon]="icons.elementUser" />`
+})
+export class SampleComponent {
+  // addIcons returns a map of all names added to the library for typesafe use in the template.
+  protected readonly icons = addIcons({ elementUser });
+}
+```
+
+`addIcons` registers icons for use for as long as the component is alive.
+The `icons` object enables type-safe use of added icons in the template.
+You can also provide icon names as strings in camelCase (`elementUser`) or kebab-case (`element-user`).
+If an icon is not found, the icon font class is rendered as a fallback (only works if the icon font is still loaded).
+
+### Icon font
+
+Use the CSS classes `element-*` to use the icon font with an `<i>` tag.
+
+### Styling
+
+Use the `icon` classes for the correct icon size:
+
+- `.icon-sm` (16px): Used in dense UI or compact contexts, such as labels or inline helper actions
+- `.icon` (20px): The most common size and pairs well with body and body-bold text.
+- `.icon-lg` (24px): Used for more prominent contexts, such as large buttons, and pairs well with `body-lg` and `body-bold-lg` text.
+
+Besides the `icon` classes, all other text utility classes (such as color utilities) can be used.
+
+### Stacking
+
+Use stacking with the `si-icon` component to combine multiple icons into a single symbol, such as event states or severities:
+
+```html
+<span class="icon icon-stack">
+  <si-icon class="status-danger" [icon]="icons.elementAlarmFilled" />
+  <si-icon class="text-secondary" [icon]="icons.elementAlarmTick" />
+</span>
+```
 
 <si-docs-component example="icons/icons"></si-docs-component>

--- a/playwright/snapshots/static.spec.ts-snapshots/icons--icons-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/icons--icons-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:feca893241434a9f9180cb94fb8d02628b9f84684b4ba0bca2da20f650b6f7dd
-size 8536
+oid sha256:aabe81a659c95f532e1d66f2db4e456efbb979b30f6078e4bc4a514a87bbef38
+size 16457

--- a/playwright/snapshots/static.spec.ts-snapshots/icons--icons-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/icons--icons-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3933f79d65effe036edae693dacb4fe46edcdbf87ea03326407d861b4d3e11c8
-size 8722
+oid sha256:368bf47200d3cd86f879f1cd056dde96b4a440ec22b54f9cb093204bdb946912
+size 16425

--- a/src/app/examples/icons/icons.html
+++ b/src/app/examples/icons/icons.html
@@ -1,4 +1,31 @@
-<i class="icon element-user"></i>
-<i class="si-display-xl element-plant"></i>
-<i class="si-display-xl element-security text-secondary"></i>
-<i class="si-display-xl element-alchemy-flask text-primary"></i>
+<h3>SVG with si-icon</h3>
+<div class="d-flex gap-6 align-items-center">
+  <si-icon class="icon-sm" [icon]="icons.elementUser" />
+  <si-icon class="icon" [icon]="icons.elementUser" />
+  <si-icon class="icon-lg" [icon]="icons.elementUser" />
+  <!-- Direct usage with strings. NOT RECOMMENDED! -->
+  <si-icon class="icon-sm" icon="element-account" />
+  <si-icon class="icon" icon="element-account" />
+  <!-- Icon names can also be provided as camelCase -->
+  <si-icon class="icon-lg" icon="elementAccount" />
+</div>
+
+<h3>Icon-only action</h3>
+<button class="btn btn-primary btn-icon btn-sm" type="button" aria-label="Cancel">
+  <si-icon [icon]="icons.elementCancel" />
+</button>
+
+<h3>Stacking</h3>
+<div class="d-flex gap-6 align-items-center">
+  <span class="icon icon-stack">
+    <si-icon class="status-danger" [icon]="icons.elementAlarmFilled" />
+    <si-icon class="text-secondary" [icon]="icons.elementAlarmTick" />
+  </span>
+</div>
+
+<h3>Icon font</h3>
+<div class="d-flex gap-6 align-items-center">
+  <i class="icon-sm element-user"></i>
+  <i class="icon element-user"></i>
+  <i class="icon-lg element-user"></i>
+</div>

--- a/src/app/examples/icons/icons.ts
+++ b/src/app/examples/icons/icons.ts
@@ -3,11 +3,28 @@
  * SPDX-License-Identifier: MIT
  */
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  elementAccount,
+  elementAlarmFilled,
+  elementAlarmTick,
+  elementCancel,
+  elementUser
+} from '@siemens/element-icons';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 
 @Component({
   selector: 'app-sample',
+  imports: [SiIconComponent],
   templateUrl: './icons.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'p-5' }
 })
-export class SampleComponent {}
+export class SampleComponent {
+  icons = addIcons({
+    elementUser,
+    elementAccount,
+    elementAlarmFilled,
+    elementAlarmTick,
+    elementCancel
+  });
+}


### PR DESCRIPTION
v49 had many changes around icons we did not yet document.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1596/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1596/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1596/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1596/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1596/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1596/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->




