### PR TITLE
ci: remove aot job, enable AOT by default, and move api-goldens test to test job

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -74,6 +74,7 @@ jobs:
       - run: npm run lint:scss
       - run: npm run lint:ng
       - run: npm run lint:playwright:eslint
+      - run: npm run api-goldens:test
       - run: npm run translate:test -- --watch=false --progress=false --coverage
       - run: npm run lib:test -- --watch=false --progress=false --code-coverage
       - run: npm run schematics:test
@@ -85,28 +86,6 @@ jobs:
           name: coverage-reports
           path: dist/coverage
           retention-days: 30
-
-  aot:
-    runs-on: ubuntu-24.04
-    needs:
-      - build
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/krypton
-          cache: 'npm'
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist
-          path: dist
-      - run: npm config set //code.siemens.com/api/v4/packages/npm/:_authToken $SIEMENS_NPM_TOKEN
-        env:
-          SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
-      - run: npm ci --prefer-offline --no-audit --include=optional
-      - run: npm run prepare-brand
-      - run: npm run build:examples:aot -- --define="maptilerKey='$MAPTILER_KEY'" --define="maptilerUrl='$MAPTILER_URL'"
-      - run: npm run api-goldens:test
 
   e2e:
     runs-on: ubuntu-24.04

--- a/angular.json
+++ b/angular.json
@@ -18,7 +18,7 @@
             "index": "src/index.html",
             "browser": "src/main.ts",
             "tsConfig": "src/tsconfig.app.json",
-            "aot": false,
+            "aot": true,
             "assets": [
               "src/favicon.png",
               "src/app/examples",

--- a/projects/live-preview/components/si-live-preview-renderer/si-live-preview-renderer.component.ts
+++ b/projects/live-preview/components/si-live-preview-renderer/si-live-preview-renderer.component.ts
@@ -267,7 +267,10 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
   // patches the template into the loaded component (if any), returns the template to use
   private updateDynamicTemplate(): void {
     if (this.componentTsSampleComponent) {
-      const ann = this.getAnnotation(this.componentTsSampleComponent, Component);
+      const ann = this.componentTsSampleComponent?.decorators
+        ? this.getAnnotationInAot(this.componentTsSampleComponent)
+        : this.getAnnotation(this.componentTsSampleComponent, Component);
+
       if (ann) {
         const supportsLandscape = ann.providers?.includes(LandscapeSupportService);
         this.supportsLandscapeMode.emit(supportsLandscape);
@@ -290,6 +293,10 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
 
   private getAnnotation(obj: any, type: any): any {
     return obj?.__annotations__?.find((a: any) => a instanceof type);
+  }
+
+  private getAnnotationInAot(obj: any): any {
+    return obj.decorators?.[0]?.args?.[0];
   }
 
   private createAbstractComponentClass(ionic: boolean): any {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,8 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
+// Import angular compiler to enable JIT compilation in the live preview even in AOT mode.
+import '@angular/compiler';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
 


### PR DESCRIPTION

- Enable AOT compilation in angular.json for the examples app
- Import @angular/compiler in main.ts to preserve JIT for live preview
- Add AOT-aware decorator extraction in live preview renderer
- Move api-goldens:test from removed aot job into the test job
- Remove the now-redundant standalone aot CI job


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->
---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1597/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1597/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1597/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1597/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1597/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1597/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->


