### PR TITLE
fix(dashboards-ng): prevent unnecessary widgetRef config updates

### DIFF
--- a/projects/dashboards-ng/src/components/grid/si-grid.component.ts
+++ b/projects/dashboards-ng/src/components/grid/si-grid.component.ts
@@ -419,7 +419,13 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
     const layout = this.gridStackWrapper().getLayout();
     const widgets = widgetConfigs.map(widget => {
       const position = layout.find(p => p.id === widget.id);
-      if (position) {
+      if (
+        position &&
+        (widget.x !== position.x ||
+          widget.y !== position.y ||
+          widget.width !== position.width ||
+          widget.height !== position.height)
+      ) {
         return {
           ...widget,
           x: position.x,

--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
@@ -20,6 +20,7 @@ import { firstValueFrom, take, toArray } from 'rxjs';
 import { TestingModule } from '../../../test/testing.module';
 import { WidgetConfig } from '../../model/widgets.model';
 import { SiGridService } from '../../services/si-grid.service';
+import { SiWidgetHostComponent } from '../widget-host/si-widget-host.component';
 import { SiGridstackWrapperComponent } from './si-gridstack-wrapper.component';
 
 @Component({
@@ -124,6 +125,47 @@ describe('SiGridstackWrapperComponent', () => {
 
       expect(host.gridStackWrapper()!.unmount).toHaveBeenCalled();
       expect(host.gridStackWrapper()!.unmount).toHaveBeenCalledWith([TEST_WIDGET_CONFIG_1]);
+    });
+
+    it('should not trigger ngOnChanges on SiWidgetHostComponent when widget config reference is unchanged', async () => {
+      const widgetHosts = fixture.debugElement.queryAll(By.directive(SiWidgetHostComponent));
+      const ngOnChangesSpy = widgetHosts.map(widgetHost =>
+        spyOn(widgetHost.componentInstance, 'ngOnChanges').and.callThrough()
+      );
+
+      // Re-assign the same config references inside a new array
+      host.widgets = [TEST_WIDGET_CONFIG_0, TEST_WIDGET_CONFIG_1];
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      // to avoid injector destroyed error
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      ngOnChangesSpy.forEach(spy => expect(spy).not.toHaveBeenCalled());
+    });
+
+    it('should only trigger ngOnChanges on the resized widget, not on unchanged ones', async () => {
+      const widgetHosts = fixture.debugElement.queryAll(By.directive(SiWidgetHostComponent));
+      const widget0Host = widgetHosts.find(
+        wh => wh.componentInstance.widgetConfig().id === TEST_WIDGET_CONFIG_0.id
+      )!;
+      const widget1Host = widgetHosts.find(
+        wh => wh.componentInstance.widgetConfig().id === TEST_WIDGET_CONFIG_1.id
+      )!;
+      const spy0 = spyOn(widget0Host.componentInstance, 'ngOnChanges').and.callThrough();
+      const spy1 = spyOn(widget1Host.componentInstance, 'ngOnChanges').and.callThrough();
+
+      // Simulate resize of widget 0 by creating a new reference with updated dimensions
+      const resizedConfig0: WidgetConfig = { ...TEST_WIDGET_CONFIG_0, width: 8, height: 3 };
+      host.widgets = [resizedConfig0, TEST_WIDGET_CONFIG_1];
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      // to avoid injector destroyed error
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(spy0).toHaveBeenCalledTimes(1);
+      expect(spy1).not.toHaveBeenCalled();
     });
   });
 

--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.ts
@@ -10,6 +10,8 @@ import {
   inject,
   input,
   inputBinding,
+  IterableDiffer,
+  IterableDiffers,
   NgZone,
   OnChanges,
   OnInit,
@@ -18,7 +20,8 @@ import {
   signal,
   SimpleChanges,
   viewChild,
-  ViewContainerRef
+  ViewContainerRef,
+  WritableSignal
 } from '@angular/core';
 import { GridItemHTMLElement, GridStack, GridStackNode, GridStackOptions } from 'gridstack';
 
@@ -89,33 +92,22 @@ export class SiGridstackWrapperComponent implements OnInit, OnChanges {
 
   private ngZone = inject(NgZone);
   private elementRef = inject(ElementRef);
-  private readonly widgetConfigsMap = computed(
-    () => new Map(this.widgetConfigs().map(w => [w.id, w]))
-  );
+  private iterableDiffers = inject(IterableDiffers);
+  private widgetConfigsDiffer?: IterableDiffer<WidgetConfig>;
+  private readonly widgetConfigSignals = new Map<string, WritableSignal<WidgetConfig>>();
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.widgetConfigs) {
-      const { currentValue, previousValue, firstChange } = changes.widgetConfigs;
+      const { currentValue, firstChange } = changes.widgetConfigs;
 
       this.grid?.batchUpdate(true);
       if (firstChange) {
         this.markedForRender = currentValue;
+        this.widgetConfigsDiffer = this.iterableDiffers
+          .find(currentValue)
+          .create((_, item: WidgetConfig) => item.id);
       } else {
-        const currentIds = new Set(currentValue.map((item: WidgetConfig) => item.id));
-        const previousIds = new Set(previousValue.map((item: WidgetConfig) => item.id));
-        // Get newly added items
-        const toBeAdded = currentValue.filter((item: WidgetConfig) => !previousIds.has(item.id));
-
-        // Get deleted items
-        const toBeRemoved = previousValue.filter((item: WidgetConfig) => !currentIds.has(item.id));
-
-        if (toBeAdded) {
-          this.mount(toBeAdded);
-        }
-
-        if (toBeRemoved) {
-          this.unmount(toBeRemoved);
-        }
+        this.diffWidgetConfigs(currentValue);
       }
 
       this.updateLayout(currentValue);
@@ -148,6 +140,8 @@ export class SiGridstackWrapperComponent implements OnInit, OnChanges {
     this.hookEvents(this.grid);
 
     this.mount(this.markedForRender);
+    // Run initial diff to prime the differ with the current state
+    this.widgetConfigsDiffer?.diff(this.markedForRender);
   }
 
   mount(items: WidgetConfig[]): void {
@@ -199,11 +193,12 @@ export class SiGridstackWrapperComponent implements OnInit, OnChanges {
   }
 
   private addToView(item: WidgetConfig): void {
-    // we use computed here to dynamically bind the widgetConfig to the SiWidgetHostComponent
-    const config = computed(() => this.widgetConfigsMap().get(item.id)!);
+    const configSignal = signal(item);
+    this.widgetConfigSignals.set(item.id, configSignal);
+
     const componentRef = this.gridstackContainer()!.createComponent(SiWidgetHostComponent, {
       bindings: [
-        inputBinding('widgetConfig', config),
+        inputBinding('widgetConfig', configSignal),
         outputBinding<string>('remove', widgetId => {
           this.widgetInstanceRemove.emit(widgetId);
         }),
@@ -237,8 +232,34 @@ export class SiGridstackWrapperComponent implements OnInit, OnChanges {
       this.grid.removeWidget(toRemove);
       const gridItemToRemove = this.gridItemsMap().get(widgetId);
       gridItemToRemove?.component.destroy();
+      this.widgetConfigSignals.delete(widgetId);
       this.gridItemsMap().delete(widgetId);
       this.gridItems.set(Array.from(this.gridItemsMap().values()));
+    }
+  }
+
+  /**
+   * Uses IterableDiffer to detect added, removed, and identity-changed items.
+   * Only widgets whose object reference changed get their signal updated.
+   */
+  private diffWidgetConfigs(configs: WidgetConfig[]): void {
+    const changes = this.widgetConfigsDiffer?.diff(configs);
+    if (changes) {
+      const toMount: WidgetConfig[] = [];
+      const toUnmount: WidgetConfig[] = [];
+
+      changes.forEachAddedItem(record => toMount.push(record.item));
+      changes.forEachRemovedItem(record => toUnmount.push(record.item));
+      changes.forEachIdentityChange(record =>
+        this.widgetConfigSignals.get(record.item.id)?.set(record.item)
+      );
+
+      if (toMount.length) {
+        this.mount(toMount);
+      }
+      if (toUnmount.length) {
+        this.unmount(toUnmount);
+      }
     }
   }
 


### PR DESCRIPTION
When `widgetConfigs` input changes `ngOnChanges` fires on every `SiWidgetHostComponent` even if a specific widget's config hasn't changed. Use Angular's `IterableDiffer` to detect changes before propagating config to widgetRef, avoiding unnecessary re-renders of widget instances.


- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1598/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1598/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1598/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1598/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1598/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1598/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->

