### PR TITLE
build(gh-actions): generate coverage in test job

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -81,6 +81,27 @@ jobs:
       - run: npm run charts:test -- --watch=false --progress=false
       - run: npm run dashboards:test -- --watch=false --progress=false
       - run: npm run maps:test -- --watch=false --progress=false
+      - name: Generate coverage summary
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: 'dist/coverage/*/cobertura-coverage.xml'
+          badge: true
+          format: markdown
+          output: both
+          hide_branch_rate: true
+          hide_complexity: true
+          indicators: false
+          file_coverage_mode: changes
+      - name: Generate coverage summary JSON
+        run: |
+          # Extract coverage percentage from markdown and create JSON badge
+          TOTAL_COVERAGE=$(grep -E "(Summary|Total)" code-coverage-results.md | grep -oE '[0-9]+(\.[0-9]+)?%' | head -1 | sed 's/%//')
+          echo "Extracted coverage: $TOTAL_COVERAGE%"
+          echo "{\"schemaVersion\": 1, \"label\": \"coverage\", \"message\": \"$TOTAL_COVERAGE%\", \"color\": \"brightgreen\"}" > dist/coverage/coverage-summary.json
+      - name: Extract coverage badge
+        run: |
+          # Extract only the badge line and total coverage line
+          head -n 2 code-coverage-results.md > dist/coverage/coverage-badge.md
       - uses: actions/upload-artifact@v7
         with:
           name: coverage-reports
@@ -152,7 +173,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - build
-      - test
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
@@ -160,37 +180,6 @@ jobs:
         with:
           name: dist
           path: dist
-      - uses: actions/download-artifact@v8
-        with:
-          name: coverage-reports
-          path: dist/coverage
-      - name: Generate coverage summary
-        uses: irongut/CodeCoverageSummary@v1.3.0
-        with:
-          filename: 'dist/coverage/*/cobertura-coverage.xml'
-          badge: true
-          format: markdown
-          output: both
-          hide_branch_rate: true
-          hide_complexity: true
-          indicators: false
-          file_coverage_mode: changes
-      - name: Generate coverage summary JSON
-        run: |
-          # Extract coverage percentage from markdown and create JSON badge
-          TOTAL_COVERAGE=$(grep -E "(Summary|Total)" code-coverage-results.md | grep -oE '[0-9]+(\.[0-9]+)?%' | head -1 | sed 's/%//')
-          echo "Extracted coverage: $TOTAL_COVERAGE%"
-          echo "{\"schemaVersion\": 1, \"label\": \"coverage\", \"message\": \"$TOTAL_COVERAGE%\", \"color\": \"brightgreen\"}" > coverage-summary.json
-      - name: Extract coverage badge
-        run: |
-          # Extract only the badge line and total coverage line
-          head -n 2 code-coverage-results.md > coverage-badge.md
-      - name: Upload coverage badge
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-badge
-          path: coverage-badge.md
-          retention-days: 1
       - uses: actions/setup-node@v6
         with:
           node-version: lts/krypton
@@ -217,8 +206,6 @@ jobs:
       - run: mv dist/element-examples/ dist/design/
       - run: mv dist/dashboards-demo/ dist/design/
       - run: mv dist/dashboards-demo-esm/ dist/design/
-      - run: mv coverage-summary.json dist/design/
-      - run: mv dist/coverage/ dist/design/
       - uses: actions/upload-artifact@v7
         with:
           name: pages
@@ -236,6 +223,7 @@ jobs:
     needs:
       - e2e-merge-reports
       - documentation
+      - test
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -247,8 +235,8 @@ jobs:
           path: playwright-report
       - uses: actions/download-artifact@v8
         with:
-          name: coverage-badge
-          path: coverage-badge
+          name: coverage-reports
+          path: coverage-reports
       - uses: aws-actions/configure-aws-credentials@v6.0.0
         with:
           role-to-assume: arn:aws:iam::974483672234:role/simpl-element-preview
@@ -257,6 +245,7 @@ jobs:
       - run: |
           aws s3 cp --quiet --no-progress --recursive ./pages s3://${{ env.BUCKET_NAME }}/pr-${{ github.event.pull_request.number }}/pages
           aws s3 cp --quiet --no-progress --recursive ./playwright-report s3://${{ env.BUCKET_NAME }}/pr-${{ github.event.pull_request.number }}/playwright-report
+          aws s3 cp --quiet --no-progress --recursive ./coverage-reports s3://${{ env.BUCKET_NAME }}/pr-${{ github.event.pull_request.number }}/pages/coverage
       - name: Build PR description block
         run: |
           cat > pr-preview-description.md <<'EOF'
@@ -271,7 +260,7 @@ jobs:
           **Coverage Reports:**
 
           EOF
-          cat coverage-badge/coverage-badge.md >> pr-preview-description.md
+          cat coverage-reports/coverage-badge.md >> pr-preview-description.md
           cat >> pr-preview-description.md <<'EOF'
           - [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-${{ github.event.pull_request.number }}/pages/coverage/element-ng/)
           - [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-${{ github.event.pull_request.number }}/pages/coverage/element-translate-ng/)

--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -25,6 +25,11 @@ jobs:
         with:
           name: pages
           path: dist/design
+      - uses: actions/download-artifact@v8
+        with:
+          name: coverage-reports
+          path: coverage-reports
+      - run: cp coverage-reports/coverage-summary.json dist/design/coverage-summary.json
       - uses: actions/upload-pages-artifact@v4
         with:
           path: 'dist/design'


### PR DESCRIPTION
The main goal of this change is, to remove the dependency from documentation to test.
then they can run in parallel reducing pipeline duration.


---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->
---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1603/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1603/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1603/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1603/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1603/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1603/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->

