### PR TITLE
test(maps): disable a flaky test

### DIFF
--- a/playwright/e2e/element-examples/maps/static.spec.ts
+++ b/playwright/e2e/element-examples/maps/static.spec.ts
@@ -53,4 +53,4 @@ test('si-map/si-map-custom-style', ({ si }) => si.static(options));
 test('si-map/si-map-custom-zoom-levels', ({ si }) => si.static(options));
 test('si-map/si-map-default-style', ({ si }) => si.static(options));
 test('si-map/si-map-grouping', ({ si }) => si.static(options));
-test('si-map/si-map-labels', ({ si }) => si.static(options));
+test.fixme('si-map/si-map-labels', ({ si }) => si.static(options));


### PR DESCRIPTION
This test fails frequently after the recent `ol` update. The position of labels seems to be no longer stable.

---

- [x] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->
---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1606/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1606/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1606/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1606/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1606/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1606/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
