### PR TITLE
docs(examples): rename tabs arrow example to tabs menu

### DIFF
--- a/src/app/examples/si-tabs/si-tabs-menu.html
+++ b/src/app/examples/si-tabs/si-tabs-menu.html
@@ -32,10 +32,10 @@
   <si-tab heading="Eleven">
     <p class="mt-4">Content Eleven</p>
   </si-tab>
-  <si-tab icon="element-favorites-filled" heading="Favorites">
+  <si-tab heading="Twelve">
     <p class="mt-4">Some content</p>
   </si-tab>
-  <si-tab icon="element-alarm-filled" heading="notifications" badgeColor="danger" badgeContent="5">
+  <si-tab heading="Thirteen">
     <p class="mt-4">Some other content</p>
   </si-tab>
 </si-tabset>

--- a/src/app/examples/si-tabs/si-tabs-menu.ts
+++ b/src/app/examples/si-tabs/si-tabs-menu.ts
@@ -8,7 +8,7 @@ import { SiTabComponent, SiTabsetComponent } from '@siemens/element-ng/tabs';
 @Component({
   selector: 'app-sample',
   imports: [SiTabsetComponent, SiTabComponent],
-  templateUrl: './si-tabs-arrow.html',
+  templateUrl: './si-tabs-menu.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'p-5' }
 })


### PR DESCRIPTION
Rename to tabs-menu as the arrow is no more valid. also remove the combination of text and icons in the tabs as per ux guidelines

- [ ] I confirm that this MR follows the [contribution guidelines](https://github.com/siemens/element/blob/main/CONTRIBUTING.md).
<!-- preview-links:start -->
---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1607/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1607/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1607/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1607/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1607/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1607/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
