### PR TITLE
fix(schematics): prevent directoryExists from returning true for file path

### DIFF
--- a/projects/element-ng/schematics/utils/ts-compiler-host.ts
+++ b/projects/element-ng/schematics/utils/ts-compiler-host.ts
@@ -55,6 +55,9 @@ export const createTreeAwareCompilerHost = (
   host.directoryExists = path => {
     const treePath = toTreePath(path);
     if (treePath) {
+      if (tree.exists(treePath) && tree.get(treePath) !== null) {
+        return false;
+      }
       const dir = tree.getDir(treePath);
       if (dir.subfiles.length || dir.subdirs.length) {
         return true;


### PR DESCRIPTION
The custom `host.directoryExists` in `createTreeAwareCompilerHost` was calling `tree.getDir(treePath)` for every path that resolved within the `Tree` — including paths that point to files. `tree.getDir()` throws a `PathIsFileException` when given a file path, which caused schematics to crash during TypeScript compilation.

Added an early `return false` before `tree.getDir()` using `tree.get(treePath)`, which returns a `FileEntry` for files and `null` for everything else — making it the correct way to detect files in the tree, even empty ones

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->
---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1613/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1613/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1613/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1613/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1613/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1613/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->

