### PR TITLE
fix(card): use correct spacing in `si-action-card`

### DIFF
--- a/playwright/snapshots/si-action-card.spec.ts-snapshots/si-card--si-action-card--hover-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-action-card.spec.ts-snapshots/si-card--si-action-card--hover-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f2f3d77b5838f35052590c32c5060a1a3d8ed583545940fed895c08ac5eda62
-size 121951
+oid sha256:781b0bd16730b0b864f18d08be4d4ac03297c79478e2adb7fe74e5cef3471a05
+size 125850

--- a/playwright/snapshots/si-action-card.spec.ts-snapshots/si-card--si-action-card--hover-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-action-card.spec.ts-snapshots/si-card--si-action-card--hover-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbb29c3328c82fcaef2b5300e1d53724e86310b052826071980c914fe0247dd1
-size 116347
+oid sha256:e19efc29bea31265df77a271257d58dda3906a05738ac86a84da39e5a99ea02b
+size 119862

--- a/playwright/snapshots/si-action-card.spec.ts-snapshots/si-card--si-action-card-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-action-card.spec.ts-snapshots/si-card--si-action-card-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f2f3d77b5838f35052590c32c5060a1a3d8ed583545940fed895c08ac5eda62
-size 121951
+oid sha256:781b0bd16730b0b864f18d08be4d4ac03297c79478e2adb7fe74e5cef3471a05
+size 125850

--- a/playwright/snapshots/si-action-card.spec.ts-snapshots/si-card--si-action-card-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-action-card.spec.ts-snapshots/si-card--si-action-card-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbb29c3328c82fcaef2b5300e1d53724e86310b052826071980c914fe0247dd1
-size 116347
+oid sha256:e19efc29bea31265df77a271257d58dda3906a05738ac86a84da39e5a99ea02b
+size 119862

--- a/projects/element-theme/src/styles/bootstrap/_card.scss
+++ b/projects/element-theme/src/styles/bootstrap/_card.scss
@@ -127,6 +127,7 @@ button.card {
   background-color: variables.$card-cap-bg;
   line-height: typography.$si-font-size-h5;
 
+  + * .card-body, // for action cards, where we wrap the content
   + .card-body {
     margin-block-start: map.get(spacers.$spacers, 2) * -1;
     padding-block-start: map.get(spacers.$spacers, 2);


### PR DESCRIPTION
In action cards, the spacing between header and body was previously too large.
This was caused by an extra wrapping of the content so a selector did no longer match.
This fix allows wrapping the `card-body`.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->
---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1615/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1615/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1615/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1615/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1615/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1615/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
