### PR TITLE
ci(github): add line break before generated pr description

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -269,6 +269,7 @@ jobs:
         run: |
           cat > pr-preview-description.md <<'EOF'
           <!-- preview-links:start -->
+
           ---
 
           [Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-${{ github.event.pull_request.number }}/pages/).


### PR DESCRIPTION
GitHub renders text before a horizontal line as a heading:
```md
My description
---
```

The new change adds an extra line break so the text is not rendered as a heading unintentionally.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1624/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1624/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1624/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1624/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1624/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1624/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
