### PR TITLE
refactor: use typed SimpleChanges<this> in ngOnChanges

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -100,6 +100,13 @@ export const tsConfig = defineConfig({
         'source': 'string',
         'content': 'Copyright (c) Siemens 2016 - 2026\nSPDX-License-Identifier: MIT'
       }
+    ],
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'TSTypeReference:not([typeArguments]) > Identifier[name="SimpleChanges"]',
+        message: 'Use SimpleChanges<this> instead of plain SimpleChanges'
+      }
     ]
   }
 });

--- a/projects/charts-ng/cartesian/si-chart-cartesian.component.ts
+++ b/projects/charts-ng/cartesian/si-chart-cartesian.component.ts
@@ -86,7 +86,7 @@ export class SiChartCartesianComponent extends SiChartBaseComponent implements O
   readonly zoomMode = input<boolean>();
 
   // Used to toggle different chart types
-  override ngOnChanges(changes: SimpleChanges): void {
+  override ngOnChanges(changes: SimpleChanges<unknown>): void {
     if (changes.zoomMode) {
       this.setZoomMode();
     }

--- a/projects/charts-ng/common/si-chart-base.component.ts
+++ b/projects/charts-ng/common/si-chart-base.component.ts
@@ -353,7 +353,7 @@ export class SiChartBaseComponent implements AfterViewInit, OnChanges, OnInit, O
     this.updateCustomLegendMultiLineInfo();
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<unknown>): void {
     if (changes.options?.currentValue) {
       this.actualOptions = this.options()!;
     }

--- a/projects/charts-ng/gauge/si-chart-gauge.component.ts
+++ b/projects/charts-ng/gauge/si-chart-gauge.component.ts
@@ -377,7 +377,7 @@ export class SiChartGaugeComponent extends SiChartBaseComponent implements OnCha
     };
   }
 
-  override ngOnChanges(changes: SimpleChanges): void {
+  override ngOnChanges(changes: SimpleChanges<unknown>): void {
     if (this.chart && (changes.palette || changes.colors || changes.segments)) {
       this.updateColors();
     }

--- a/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.ts
+++ b/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.ts
@@ -231,7 +231,7 @@ export class SiFlexibleDashboardComponent implements OnInit, OnChanges, OnDestro
     secondary: []
   };
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.dashboardId) {
       const dashboard = this.dashboard();
       if (dashboard.isExpanded) {

--- a/projects/dashboards-ng/src/components/grid/si-grid.component.ts
+++ b/projects/dashboards-ng/src/components/grid/si-grid.component.ts
@@ -184,7 +184,7 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
     return !this.initialLoad && this.visibleWidgetInstances$.value.length === 0;
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     // Reload widgets if the dashboardId changes. Do not load on inital
     // dashboardId property binding as first load will be done in ngOnInit()
     if (changes.dashboardId && !changes.dashboardId.firstChange) {

--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.ts
@@ -96,7 +96,7 @@ export class SiGridstackWrapperComponent implements OnInit, OnChanges {
   private widgetConfigsDiffer?: IterableDiffer<WidgetConfig>;
   private readonly widgetConfigSignals = new Map<string, WritableSignal<WidgetConfig>>();
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.widgetConfigs) {
       const { currentValue, firstChange } = changes.widgetConfigs;
 

--- a/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper-base.component.ts
+++ b/projects/dashboards-ng/src/components/web-component-wrapper/si-web-component-wrapper-base.component.ts
@@ -40,7 +40,7 @@ export abstract class SiWebComponentWrapperBaseComponent<
   private renderer2 = inject(Renderer2);
   private document = inject(DOCUMENT);
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.config && this.webComponent) {
       this.webComponent.config = this.config();
     }

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
@@ -138,7 +138,7 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
     return widgetConfig.accentLine ? 'accent-' + widgetConfig.accentLine : '';
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.widgetConfig) {
       if (this.widgetRef) {
         if (isSignal(this.widgetRef.instance.config)) {

--- a/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
+++ b/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
@@ -33,8 +33,8 @@ export abstract class SiHeaderActionIconItemBase
       : undefined;
   });
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if ('badge' in changes) {
+  ngOnChanges(changes: SimpleChanges<this>): void {
+    if (changes.badge) {
       if (changes.badge.currentValue && !changes.badge.previousValue) {
         this.collapsibleActions?.badgeCount.update(count => count + 1);
       } else if (!changes.badge.currentValue && changes.badge.previousValue) {

--- a/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list.directive.ts
+++ b/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list.directive.ts
@@ -88,7 +88,7 @@ export class SiAutoCollapsableListDirective implements AfterViewInit, OnChanges,
     }
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.siAutoCollapsableList) {
       const siAutoCollapsableList = this.siAutoCollapsableList();
       if (!siAutoCollapsableList && this.resizeSubscription) {

--- a/projects/element-ng/avatar/si-avatar-background-color.directive.ts
+++ b/projects/element-ng/avatar/si-avatar-background-color.directive.ts
@@ -45,7 +45,7 @@ export class SiAvatarBackgroundColorDirective implements OnChanges {
 
   protected readonly backgroundStyle = signal<string | undefined>('var(--element-data-17)');
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.color) {
       this.setColor(this.color());
     }

--- a/projects/element-ng/circle-status/si-circle-status.component.ts
+++ b/projects/element-ng/circle-status/si-circle-status.component.ts
@@ -112,7 +112,7 @@ export class SiCircleStatusComponent implements OnChanges, OnDestroy {
 
   private blinkService = inject(BlinkService);
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (this.blinkService && changes.blink) {
       this.blinkSubs?.unsubscribe();
 

--- a/projects/element-ng/dashboard/si-dashboard.component.ts
+++ b/projects/element-ng/dashboard/si-dashboard.component.ts
@@ -110,7 +110,7 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
       .subscribe(cards => this.subscribeToCards(cards));
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.enableExpandInteractions) {
       this.initCards();
     }

--- a/projects/element-ng/dashboard/widgets/si-widget-base.directive.ts
+++ b/projects/element-ng/dashboard/widgets/si-widget-base.directive.ts
@@ -61,7 +61,7 @@ export abstract class SiWidgetBaseDirective<T> implements OnInit, OnChanges {
 
   protected loadingTimer?: ReturnType<typeof setTimeout>;
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (
       !this.disableAutoLoadingIndicator() &&
       !changes.value?.firstChange &&

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
@@ -352,7 +352,7 @@ export class SiDateRangeFilterComponent implements OnChanges {
     () => this.basicMode() === 'input' || this.enableTimeSelection()
   );
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (
       changes.enableTimeSelection ||
       changes.datepickerConfig ||

--- a/projects/element-ng/date-range-filter/si-relative-date.component.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.ts
@@ -100,7 +100,7 @@ export class SiRelativeDateComponent implements OnChanges {
       : this.fullOffsetList.filter(item => item.offset >= ONE_DAY)
   );
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     const value = this.value();
     if (changes.value && value !== this.internalValue()) {
       this.internalValue.set(value);

--- a/projects/element-ng/datepicker/components/si-month-selection.component.ts
+++ b/projects/element-ng/datepicker/components/si-month-selection.component.ts
@@ -91,7 +91,7 @@ export class SiMonthSelectionComponent extends SiInitialFocusComponent implement
     return maxDate && (isSameYear(focusedDate, maxDate) || isAfterYear(focusedDate, maxDate));
   });
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (
       changes.maxDate ||
       changes.minDate ||

--- a/projects/element-ng/datepicker/components/si-year-selection.component.ts
+++ b/projects/element-ng/datepicker/components/si-year-selection.component.ts
@@ -92,7 +92,7 @@ export class SiYearSelectionComponent extends SiInitialFocusComponent implements
     );
   });
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.startDate || changes.focusedDate || changes.maxDate || changes.minDate) {
       this.initView();
     }

--- a/projects/element-ng/datepicker/si-date-input.directive.ts
+++ b/projects/element-ng/datepicker/si-date-input.directive.ts
@@ -120,7 +120,7 @@ export class SiDateInputDirective
   readonly errormessageId = input(`${this.id()}-errormessage`);
 
   /** @internal */
-  validatorOnChange = (): void => {};
+  validatorOnChange: () => void = () => {};
   /**
    * Date form input validator function, validating text format, min and max value.
    */
@@ -143,7 +143,7 @@ export class SiDateInputDirective
   protected readonly locale = inject(LOCALE_ID).toString();
   private format = '';
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.siDatepickerConfig && !changes.siDatepickerConfig.currentValue) {
       this.siDatepickerConfig.set({});
     }

--- a/projects/element-ng/datepicker/si-date-range.component.ts
+++ b/projects/element-ng/datepicker/si-date-range.component.ts
@@ -242,7 +242,7 @@ export class SiDateRangeComponent
     positionTopEnd
   ];
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.siDatepickerConfig) {
       this.siDatepickerConfig.set({
         ...changes.siDatepickerConfig.currentValue,

--- a/projects/element-ng/datepicker/si-datepicker-overlay.component.ts
+++ b/projects/element-ng/datepicker/si-datepicker-overlay.component.ts
@@ -159,7 +159,7 @@ export class SiDatepickerOverlayComponent implements OnChanges, OnInit, OnDestro
 
   protected readonly completeAnimation = signal(false);
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.config) {
       const config = this.config();
 

--- a/projects/element-ng/datepicker/si-datepicker.component.ts
+++ b/projects/element-ng/datepicker/si-datepicker.component.ts
@@ -322,7 +322,7 @@ export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
     this.time.valueChanges.subscribe((newTime?: Date) => this.timeSelected(newTime));
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     const config = this.config();
     if (changes.date && !config.enableDateRange) {
       if (this.date() && !isValid(this.date())) {
@@ -475,11 +475,11 @@ export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
       // eslint-disable-next-line @angular-eslint/no-lifecycle-call
       this.ngOnChanges({
         date: new SimpleChange(previousValue, date, previousValue === undefined)
-      });
+      } as SimpleChanges<this>);
       //this.dateChange.emit(date);
     } else if (!validForMinDate || !validForMaxDate) {
       // eslint-disable-next-line @angular-eslint/no-lifecycle-call
-      this.ngOnChanges({ date: new SimpleChange(undefined, date, true) });
+      this.ngOnChanges({ date: new SimpleChange(undefined, date, true) } as SimpleChanges<this>);
     }
 
     this.cdRef.markForCheck();

--- a/projects/element-ng/file-uploader/si-file-uploader.component.ts
+++ b/projects/element-ng/file-uploader/si-file-uploader.component.ts
@@ -352,7 +352,7 @@ export class SiFileUploaderComponent implements OnChanges {
   private cdRef = inject(ChangeDetectorRef);
   private http? = inject(HttpClient, { optional: true });
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.maxFiles || changes.disableUpload) {
       this.updateStates();
     }

--- a/projects/element-ng/filtered-search/si-filtered-search.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.ts
@@ -415,7 +415,7 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     );
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.criteria) {
       this.initCriteria();
     }

--- a/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.ts
+++ b/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.ts
@@ -47,7 +47,7 @@ export class SiFilteredSearchMultiSelectComponent
     () => Array.isArray(this.criterionValue().value) && this.criterionValue().value!.length > 1
   );
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (
       changes.criterionValue &&
       this.criterionValue().value?.length !== this.optionValue().length

--- a/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
+++ b/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
@@ -64,7 +64,7 @@ export class SiFilteredSearchTypeaheadComponent
     return '';
   });
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.criterionValue && this.criterionValue().value !== this.optionValue()?.value) {
       this.optionValue.set(undefined);
     }

--- a/projects/element-ng/form/si-form-item/si-form-item.component.ts
+++ b/projects/element-ng/form/si-form-item/si-form-item.component.ts
@@ -159,7 +159,7 @@ export class SiFormItemComponent
   /** @internal */
   readonly required = computed(() => this.requiredInput() || this.hasRequiredValidator());
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.formErrorMapper) {
       this.updateValidationMessages();
     }

--- a/projects/element-ng/list-details/si-list-details.component.ts
+++ b/projects/element-ng/list-details/si-list-details.component.ts
@@ -148,7 +148,7 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
 
   private animationDone?: () => void;
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.detailsActive) {
       this.transferFocus();
     }

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
@@ -221,7 +221,7 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges, OnDest
 
   @HostBinding('style.opacity') protected opacity = '0';
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.detailsActive) {
       this.updateDetailsFocusable();
       this.doAnimation(changes.detailsActive.currentValue);

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical.component.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical.component.ts
@@ -239,7 +239,7 @@ export class SiNavbarVerticalComponent implements OnChanges, OnInit {
       });
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.collapsed) {
       this.preferCollapse = this.collapsed();
     }

--- a/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.ts
+++ b/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.ts
@@ -288,7 +288,7 @@ export class SiNavbarPrimaryComponent implements OnChanges, HeaderWithDropdowns 
   }
 
   /** @internal */
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.appItems || changes.appCategoryItems) {
       const appItems = this.appItems();
       const appCategoryItems = this.appCategoryItems();

--- a/projects/element-ng/number-input/si-number-input.component.ts
+++ b/projects/element-ng/number-input/si-number-input.component.ts
@@ -177,7 +177,7 @@ export class SiNumberInputComponent
   private autoUpdateSubs?: Subscription;
   private changeDetectorRef = inject(ChangeDetectorRef);
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.value) {
       this.writeValueToInput(this.value());
     }

--- a/projects/element-ng/phone-number/si-phone-number-input.component.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.ts
@@ -225,7 +225,7 @@ export class SiPhoneNumberInputComponent
   private onChange: (val: string) => void = () => {};
   private onTouched: () => void = () => {};
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.country) {
       this.writeCountry();
     }

--- a/projects/element-ng/photo-upload/si-photo-upload.component.ts
+++ b/projects/element-ng/photo-upload/si-photo-upload.component.ts
@@ -366,7 +366,7 @@ export class SiPhotoUploadComponent implements OnChanges, OnDestroy {
   private readonly modalService = inject(SiModalService);
   private readonly autoBackgroundColorDirective = inject(SiAvatarBackgroundColorDirective);
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.readonly) {
       this.resetErrorMessage();
       this.resetFileInputValue();
@@ -386,7 +386,7 @@ export class SiPhotoUploadComponent implements OnChanges, OnDestroy {
     }
     if (
       changes.croppedPhoto &&
-      changes.croppedPhoto.previousValue?.length > 0 &&
+      (changes.croppedPhoto?.previousValue?.length ?? 0) > 0 &&
       changes.croppedPhoto.previousValue !== changes.croppedPhoto.currentValue
     ) {
       this.setPhoto(this.croppedPhoto());

--- a/projects/element-ng/search-bar/si-search-bar.component.ts
+++ b/projects/element-ng/search-bar/si-search-bar.component.ts
@@ -142,9 +142,9 @@ export class SiSearchBarComponent implements OnInit, OnDestroy, ControlValueAcce
     this.disabledNgControl.set(disabled);
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.value) {
-      this.writeSearchValue(changes.value.currentValue);
+      this.writeSearchValue(changes.value.currentValue ?? '');
     }
   }
 

--- a/projects/element-ng/side-panel/si-side-panel.component.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel.component.spec.ts
@@ -129,7 +129,7 @@ describe('SiSidePanelComponent', () => {
     const spy = spyOn(service, 'open');
     component.collapsed.set(false);
     component.sidePanel().ngOnChanges({
-      collapsed: new SimpleChange(null, component.collapsed, false)
+      collapsed: new SimpleChange(undefined, component.collapsed(), false)
     });
 
     expect(spy).toHaveBeenCalled();

--- a/projects/element-ng/side-panel/si-side-panel.component.ts
+++ b/projects/element-ng/side-panel/si-side-panel.component.ts
@@ -236,7 +236,7 @@ export class SiSidePanelComponent implements OnInit, OnDestroy, OnChanges {
     });
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.collapsed) {
       if (this.collapsed()) {
         this.service.close();

--- a/projects/element-ng/split/si-split-part.component.ts
+++ b/projects/element-ng/split/si-split-part.component.ts
@@ -200,7 +200,7 @@ export class SiSplitPartComponent implements OnChanges {
     return !this.collapsedState();
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.collapseToMinSize && this.collapseToMinSize) {
       this.collapsedSize.set(this.minSize ?? 40);
     } else {

--- a/projects/element-ng/split/si-split.component.ts
+++ b/projects/element-ng/split/si-split.component.ts
@@ -106,7 +106,7 @@ export class SiSplitComponent implements AfterContentInit, OnChanges {
   // Using 10, as the sum of all fractional sizes is 1, so we need to scale them up as fr-values should be >= 1.
   private fractionalSizeToExpandedSizeFactor = 10;
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.sizes && !changes.sizes.firstChange) {
       this.sizes.forEach((size, index) => {
         const part = this.parts.get(index);

--- a/projects/element-ng/status-bar/si-status-bar.component.ts
+++ b/projects/element-ng/status-bar/si-status-bar.component.ts
@@ -175,7 +175,7 @@ export class SiStatusBarComponent implements DoCheck, OnDestroy, OnChanges {
       .subscribe(() => this.resizeHandler());
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (this.blinkService && changes.blink) {
       this.blinkSubs?.unsubscribe();
       if (this.blink()) {

--- a/projects/element-ng/status-toggle/si-status-toggle.component.ts
+++ b/projects/element-ng/status-toggle/si-status-toggle.component.ts
@@ -70,8 +70,8 @@ export class SiStatusToggleComponent implements ControlValueAccessor, OnInit, On
   protected readonly animated = signal(false);
   protected readonly isDisabled = computed(() => this.disabled() || this.internalDisabled());
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.value || changes.values) {
+  ngOnChanges(changes: SimpleChanges<this>): void {
+    if (changes.value) {
       this.setValue(this.value(), true, false);
     }
   }

--- a/projects/element-ng/tree-view/si-tree-view.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.ts
@@ -479,7 +479,7 @@ export class SiTreeViewComponent
     return this.itemsVirtualized;
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     // Compact mode change the CSS margins so it is necessary to
     // re-calc the tree item height
     if (changes.compactMode || changes.enableDataField1 || changes.enableDataField2) {

--- a/projects/element-ng/typeahead/si-typeahead.directive.ts
+++ b/projects/element-ng/typeahead/si-typeahead.directive.ts
@@ -412,7 +412,7 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
   }
 
   // Every time the main input changes, detect whether it is async and if it is not make an observable out of the array.
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.siTypeahead) {
       this.sourceSubscription?.unsubscribe();
       this.loadingSubscription?.unsubscribe();

--- a/projects/live-preview/components/si-live-preview-iframe/si-live-preview-iframe.component.ts
+++ b/projects/live-preview/components/si-live-preview-iframe/si-live-preview-iframe.component.ts
@@ -88,7 +88,7 @@ export class SiLivePreviewIframeComponent implements OnInit, OnChanges {
   protected plainUrl = '';
   protected plainUrlShort = '';
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (!this.previewIframe()) {
       return;
     }

--- a/projects/live-preview/components/si-live-preview-qr/si-live-preview-qr.component.ts
+++ b/projects/live-preview/components/si-live-preview-qr/si-live-preview-qr.component.ts
@@ -28,7 +28,7 @@ export class SiLivePreviewQrComponent implements AfterViewInit, OnDestroy, OnCha
 
   private unlisten?: () => void;
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.url && changes.urlShort) {
       this.generateQr();
     }

--- a/projects/live-preview/components/si-live-preview-renderer/si-live-preview-renderer.component.ts
+++ b/projects/live-preview/components/si-live-preview-renderer/si-live-preview-renderer.component.ts
@@ -122,7 +122,7 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
   private defaultRoutes = this.activatedRoute.routeConfig?.children ?? [];
   private cdRef = inject(ChangeDetectorRef);
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.exampleUrl?.currentValue) {
       this.loadFromUrl();
     }

--- a/projects/live-preview/components/si-live-preview-renderer/webcomponent/si-live-preview-web.component.ts
+++ b/projects/live-preview/components/si-live-preview-renderer/webcomponent/si-live-preview-web.component.ts
@@ -34,7 +34,7 @@ export class SiLivePreviewWebComponent implements OnChanges {
   private reactRoot: any;
   private vueRoot: any;
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     this.reactRoot?.unmount();
     this.vueRoot?.unmount();
     if (

--- a/projects/live-preview/components/si-live-preview/si-live-preview.component.ts
+++ b/projects/live-preview/components/si-live-preview/si-live-preview.component.ts
@@ -122,7 +122,7 @@ export class SiLivePreviewComponent implements OnInit, AfterViewInit, OnChanges 
     this.webcomponentsList = this.config.componentLoader.webcomponentsList;
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     this.activeTab = this.activeTab !== 'typescript' ? 'template' : this.activeTab;
     if (changes.template?.currentValue) {
       this.skipInitialLoad = !!changes.template.isFirstChange;
@@ -131,10 +131,11 @@ export class SiLivePreviewComponent implements OnInit, AfterViewInit, OnChanges 
       this.templateVue = '';
       this.templateJs = '';
     } else {
-      this.skipInitialLoad =
+      this.skipInitialLoad = !!(
         changes.templateReact?.currentValue ??
         changes.templateVue?.currentValue ??
-        changes.templateJs?.currentValue;
+        changes.templateJs?.currentValue
+      );
     }
     if (changes.example?.currentValue) {
       this.loadFromUrl(changes.example.firstChange && this.skipInitialLoad);

--- a/projects/maps-ng/src/components/si-map/si-map.component.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.ts
@@ -364,7 +364,7 @@ export class SiMapComponent implements AfterViewInit, OnChanges, OnDestroy, Afte
     return name === POINTS_LAYER || name === GEOJSON_LAYER;
   };
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (!this.map) {
       return;
     }

--- a/projects/native-charts-ng/gauge/si-nchart-gauge.component.ts
+++ b/projects/native-charts-ng/gauge/si-nchart-gauge.component.ts
@@ -208,7 +208,7 @@ export class SiNChartGaugeComponent implements OnInit, OnChanges {
     maximumFractionDigits: this.axisNumberOfDecimals()
   });
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     let calc = false;
     if (changes.minNumberOfDecimals || changes.maxNumberOfDecimals) {
       this.numberFormat = new Intl.NumberFormat(this.locale, {


### PR DESCRIPTION
Migrate all `ngOnChanges` signatures from `SimpleChanges` to `SimpleChanges<this>` for improved type safety. This ensures property names in change checks are validated against actual component/directive inputs at compile time.

- Add ESLint rule to enforce `SimpleChanges<T>` over plain SimpleChanges

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1625/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1625/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1625/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1625/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1625/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1625/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->




