### PR TITLE
refactor(charts-ng): filter out empty strings from echarts color palette and avoid warnings

### DIFF
--- a/projects/charts-ng/common/si-chart-base.component.ts
+++ b/projects/charts-ng/common/si-chart-base.component.ts
@@ -767,9 +767,9 @@ export class SiChartBaseComponent implements AfterViewInit, OnChanges, OnInit, O
     if (paletteValue) {
       const palette = this.getThemeCustomValue(['colorPalettes', paletteValue], null);
       if (palette) {
-        this.actualOptions.color = palette;
+        this.actualOptions.color = Array.isArray(palette) ? palette.filter(Boolean) : palette;
         if (this.customLegendAction()) {
-          this.fetchSeriesColors(palette);
+          this.fetchSeriesColors(this.actualOptions.color);
         }
       }
     }


### PR DESCRIPTION

<img width="1011" height="482" alt="image" src="https://github.com/user-attachments/assets/86038fc1-d7b9-4ccd-95bd-0c7faa8524bf" />

Echarts does not like empty strings in color array

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1630/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1630/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1630/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1630/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1630/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1630/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->

