### PR TITLE
feat(typeahead): make overlay scroll strategy configurable

### DIFF
--- a/api-goldens/element-ng/typeahead/index.api.md
+++ b/api-goldens/element-ng/typeahead/index.api.md
@@ -10,6 +10,7 @@ import * as i1 from '@siemens/element-ng/autocomplete';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
+import { ScrollStrategy } from '@angular/cdk/overlay';
 import { SimpleChanges } from '@angular/core';
 import { TemplateRef } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -52,6 +53,7 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
     readonly typeaheadProcess: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly typeaheadScrollable: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly typeaheadScrollableAdditionalHeight: _angular_core.InputSignal<number>;
+    readonly typeaheadScrollStrategy: _angular_core.InputSignal<ScrollStrategy | undefined>;
     readonly typeaheadSkipSortingMatches: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly typeaheadTokenize: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly typeaheadWaitMs: _angular_core.InputSignal<number>;

--- a/projects/element-ng/typeahead/si-typeahead.directive.ts
+++ b/projects/element-ng/typeahead/si-typeahead.directive.ts
@@ -2,7 +2,13 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ConnectionPositionPair, Overlay, OverlayRef } from '@angular/cdk/overlay';
+import {
+  ConnectionPositionPair,
+  Overlay,
+  OverlayConfig,
+  OverlayRef,
+  ScrollStrategy
+} from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import {
   booleanAttribute,
@@ -224,6 +230,12 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
    * @defaultValue false
    */
   readonly typeaheadFullWidth = input(false, { transform: booleanAttribute });
+
+  /**
+   * Optional CDK scroll strategy used for the typeahead overlay.
+   * If not provided, no strategy is set explicitly and CDK will apply its default behavior.
+   */
+  readonly typeaheadScrollStrategy = input<ScrollStrategy>();
 
   /**
    * This option will be shown at the end of the typeahead.
@@ -499,7 +511,8 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
   private loadComponent(): void {
     if (!this.overlayRef?.hasAttached()) {
       this.overlayRef?.dispose();
-      this.overlayRef = this.overlay.create({
+
+      const overlayConfig: OverlayConfig = {
         positionStrategy: this.overlay
           .position()
           .flexibleConnectedTo(this.elementRef.nativeElement)
@@ -507,7 +520,14 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
         minWidth: this.typeaheadFullWidth()
           ? this.elementRef.nativeElement.getBoundingClientRect().width + 2 // 2px border
           : 0
-      });
+      };
+
+      const scrollStrategy = this.typeaheadScrollStrategy();
+      if (scrollStrategy) {
+        overlayConfig.scrollStrategy = scrollStrategy;
+      }
+
+      this.overlayRef = this.overlay.create(overlayConfig);
     }
 
     if (this.overlayRef.hasAttached()) {


### PR DESCRIPTION
See https://material.angular.dev/cdk/overlay/overview#scroll-strategies, related to #1588

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1640/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1640/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1640/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1640/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1640/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1640/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->



