### PR TITLE
refactor(dashboards-ng): remove $any cast from toolbar template

### DIFF
--- a/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.html
+++ b/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.html
@@ -26,8 +26,8 @@
           toggleItemLabel="toggle"
           viewType="expanded"
           [disabled]="disabled()"
-          [primaryActions]="primaryEditActions()"
-          [secondaryActions]="secondaryEditActions()"
+          [primaryActions]="primaryEditActionsComputed()"
+          [secondaryActions]="secondaryEditActionsComputed()"
         />
       } @else {
         <div>
@@ -41,17 +41,13 @@
               } @else {
                 @switch (action.type) {
                   @case ('action') {
-                    <!-- eslint-disable @angular-eslint/template/no-any -->
-                    <!-- This item has a patched action which will inject the grid. But our types do not reflect this. -->
-                    <!-- TODO: make our types reflect that this item has a patched action. -->
                     <button
                       type="button"
                       class="btn btn-secondary me-4"
-                      (click)="$any(action.action)()"
+                      (click)="action.action(grid())"
                     >
                       {{ action.label! | translate }}
                     </button>
-                    <!-- eslint-disable-enable @angular-eslint/template/no-any -->
                   }
                   @case ('router-link') {
                     <a

--- a/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.ts
+++ b/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.ts
@@ -12,6 +12,7 @@ import { SiResponsiveContainerDirective } from '@siemens/element-ng/resize-obser
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
 import { DashboardToolbarItem } from '../../model/si-dashboard-toolbar.model';
+import { SiGridComponent } from '../grid/si-grid.component';
 
 /**
  * The toolbar of the flexible dashboard is either `editable` or not. When not
@@ -85,6 +86,8 @@ export class SiDashboardToolbarComponent {
    */
   readonly showEditButtonLabel = input(false);
 
+  readonly grid = input.required<SiGridComponent>();
+
   /**
    * Emits on save button click.
    */
@@ -113,6 +116,14 @@ export class SiDashboardToolbarComponent {
     ...this.secondaryEditActions()
   ]);
 
+  protected readonly primaryEditActionsComputed = computed(() => {
+    return this.primaryEditActions().map(item => this.proxyMenuItemAction(item));
+  });
+
+  protected readonly secondaryEditActionsComputed = computed(() => {
+    return this.secondaryEditActions().map(item => this.proxyMenuItemAction(item));
+  });
+
   protected onEdit(): void {
     this.editable.set(true);
   }
@@ -136,4 +147,13 @@ export class SiDashboardToolbarComponent {
   protected readonly showEditButtonLabelDesktop = computed(() => {
     return this.showEditButtonLabel() && !this.dashboardToolbarContainer()?.xs();
   });
+
+  private proxyMenuItemAction(
+    item: MenuItem | DashboardToolbarItem
+  ): MenuItem | DashboardToolbarItem {
+    if (item.type === 'action' && typeof item.action === 'function') {
+      item.action = item.action.bind(this, this.grid());
+    }
+    return item;
+  }
 }

--- a/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.html
+++ b/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.html
@@ -9,6 +9,7 @@
     [disabled]="(grid.isLoading | async) ?? false"
     [hideEditButton]="hideEditButton()"
     [showEditButtonLabel]="showEditButtonLabel()"
+    [grid]="grid"
     (editableChange)="grid.edit()"
     (save)="grid.save()"
     (cancel)="grid.cancel()"

--- a/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.spec.ts
+++ b/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.spec.ts
@@ -65,6 +65,7 @@ export class SiDashboardToolbarStubComponent {
   readonly editable = input(false);
   readonly hideEditButton = input(false);
   readonly showEditButtonLabel = input(false);
+  readonly grid = input.required<SiGridComponent>();
 }
 
 @Component({

--- a/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.ts
+++ b/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.ts
@@ -25,7 +25,7 @@ import { MenuItem } from '@siemens/element-ng/common';
 import { SiDashboardComponent } from '@siemens/element-ng/dashboard';
 import { t } from '@siemens/element-translate-ng/translate';
 import { BehaviorSubject, combineLatest, of, Subject } from 'rxjs';
-import { map, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 
 import {
   Config,
@@ -323,10 +323,7 @@ export class SiFlexibleDashboardComponent implements OnInit, OnChanges, OnDestro
 
     if (secondaryMenuItems) {
       secondaryMenuItems
-        .pipe(
-          takeUntil(this.dashboardId$),
-          map(items => items.map(item => this.proxyMenuItemAction(item)))
-        )
+        .pipe(takeUntil(this.dashboardId$))
         .subscribe(items => this.secondaryEditActions$.next(items));
     }
   }
@@ -338,7 +335,7 @@ export class SiFlexibleDashboardComponent implements OnInit, OnChanges, OnDestro
     const next: (MenuItem | DashboardToolbarItem)[] = hideAddWidgetInstanceButton
       ? []
       : [this.addWidgetInstanceAction];
-    next.push(...items.map(item => this.proxyMenuItemAction(item)));
+    next.push(...items);
     this.primaryEditActions$.next(next);
   }
 
@@ -366,19 +363,6 @@ export class SiFlexibleDashboardComponent implements OnInit, OnChanges, OnDestro
         })
       ]
     });
-  }
-
-  private proxyMenuItemAction(
-    item: MenuItem | DashboardToolbarItem
-  ): MenuItem | DashboardToolbarItem {
-    if ('action' in item) {
-      if (typeof item.action === 'function') {
-        item.action = item.action.bind(this, this.grid());
-      } else {
-        return item;
-      }
-    }
-    return item;
   }
 
   private getWidget(id: string): Widget | undefined {


### PR DESCRIPTION
Pass the grid instance as an input to SiDashboardToolbarComponent so toolbar actions can invoke grid methods directly with proper typing.

Move proxyMenuItemAction into the toolbar component where actions are invoked, eliminating the $any() cast and associated eslint-disable comments from the template.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1652/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1652/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1652/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1652/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1652/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1652/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
