### PR TITLE
refactor(native-charts-ng): deprecate SiNativeChartsNgModule

### DIFF
--- a/api-goldens/native-charts-ng/index.api.md
+++ b/api-goldens/native-charts-ng/index.api.md
@@ -7,7 +7,7 @@
 import * as i0 from '@angular/core';
 import * as i1 from '@siemens/native-charts-ng/gauge';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 class SiNativeChartsNgModule {
 }
 export { SiNativeChartsNgModule }

--- a/projects/native-charts-ng/public-api.module.ts
+++ b/projects/native-charts-ng/public-api.module.ts
@@ -5,6 +5,9 @@
 import { NgModule } from '@angular/core';
 import { SiNChartGaugeComponent } from '@siemens/native-charts-ng/gauge';
 
+/**
+ * @deprecated Both SimplNativeChartsNgModule and SiNativeChartsNgModule are deprecated and will be removed in v52.
+ */
 @NgModule({
   imports: [SiNChartGaugeComponent],
   exports: [SiNChartGaugeComponent]
@@ -14,4 +17,5 @@ export class SiNativeChartsNgModule {}
 /**
  * @deprecated Use {@link SiNativeChartsNgModule} instead. The `Simpl` prefix is deprecated and will be removed in v51.
  */
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { SiNativeChartsNgModule as SimplNativeChartsNgModule };


### PR DESCRIPTION
DEPRECATED: `SiNativeChartsNgModule` is deprecated, import individual components instead. Separate entry points are available for each component, allowing applications to import components from specific entry points.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1656/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1656/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1656/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1656/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1656/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1656/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1656/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1656/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1656/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1656/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->







