### PR TITLE
fix(maps): add extraProperties to map feature point to match MapPointMetaData interface

### DIFF
--- a/projects/maps-ng/src/components/si-map/services/map.service.ts
+++ b/projects/maps-ng/src/components/si-map/services/map.service.ts
@@ -204,7 +204,10 @@ export class MapService {
           marker: point.marker,
           label: alwaysShowLabels ? ({ text: point.name } as LabelOptions) : undefined,
           group: point.group,
+          // TODO: Remove extraProps in v50
+          // For backward compatibility, extraProps is still supported, but extraProperties should be used going forward
           extraProps: point.extraProperties,
+          extraProperties: point.extraProperties,
           click: point.click
         })
     );

--- a/src/app/examples/si-map/si-map-custom-popover-onhover.ts
+++ b/src/app/examples/si-map/si-map-custom-popover-onhover.ts
@@ -16,8 +16,8 @@ import { environment } from 'src/environments/environment';
     <table>
       <thead><th>label</th><th>value</th></thead>
       <tr>
-        <td>{{ $any(mapPoint()).extraProps?.label ?? 'N/A' }}</td>
-        <td>{{ $any(mapPoint()).extraProps?.value ?? 'N/A' }}</td>
+        <td>{{ mapPoint().extraProperties?.label ?? 'N/A' }}</td>
+        <td>{{ mapPoint().extraProperties?.value ?? 'N/A' }}</td>
       </tr>
     </table>
   `,

--- a/src/app/examples/si-map/si-map-custom-popover.ts
+++ b/src/app/examples/si-map/si-map-custom-popover.ts
@@ -16,8 +16,8 @@ import { environment } from 'src/environments/environment';
     <table>
       <thead><th>label</th><th>value</th></thead>
       <tr>
-        <td>{{ $any(mapPoint()).extraProps?.label ?? 'N/A' }}</td>
-        <td>{{ $any(mapPoint()).extraProps?.value ?? 'N/A' }}</td>
+        <td>{{ mapPoint().extraProperties?.label ?? 'N/A' }}</td>
+        <td>{{ mapPoint().extraProperties?.value ?? 'N/A' }}</td>
       </tr>
     </table>
   `,


### PR DESCRIPTION
`extraProperties` is stored as `extraProps` which is not a known property on `MapPointMetaData` forcing consumers to use `any` as type to access `extraProps`. This fix allows consumers to use valid `extraProperties` without using type casting.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1660/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1660/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1660/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1660/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1660/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1660/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
