### PR TITLE
refactor(application-header): drop use of $any in template

### DIFF
--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.html
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.html
@@ -45,7 +45,7 @@
                     si-launchpad-app
                     routerLinkActive="active"
                     [routerLinkActiveOptions]="app.activeMatchOptions ?? { exact: false }"
-                    [enableFavoriteToggle]="enableFavorites() && !$any(app)._noFavorite"
+                    [enableFavoriteToggle]="enableFavorites() && !isFavoriteToggleDisabled(app)"
                     [external]="app.external"
                     [iconUrl]="app.iconUrl"
                     [iconClass]="app.iconClass"
@@ -69,7 +69,7 @@
                   <!--fallback for existing apps that do not have a type defined -->
                   <a
                     si-launchpad-app
-                    [enableFavoriteToggle]="enableFavorites() && !$any(app)._noFavorite"
+                    [enableFavoriteToggle]="enableFavorites() && !isFavoriteToggleDisabled(app)"
                     [favorite]="!!app.favorite"
                     [href]="app.href"
                     [target]="app.target ?? ''"

--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
@@ -155,4 +155,12 @@ export class SiLaunchpadFactoryComponent {
   protected isCategories(items: App[] | AppCategory[]): items is AppCategory[] {
     return items.some(item => 'apps' in item);
   }
+
+  protected isFavoriteToggleDisabled(app: App): boolean {
+    if ('_noFavorite' in app) {
+      return !!app._noFavorite;
+    } else {
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1661/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1661/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1661/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1661/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1661/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1661/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
