### PR TITLE
refactor(filtered-search): extract free text input

### DIFF
--- a/api-goldens/element-ng/filtered-search/index.api.md
+++ b/api-goldens/element-ng/filtered-search/index.api.md
@@ -12,7 +12,6 @@ import { OnChanges } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
-import { TypeaheadOption } from '@siemens/element-ng/typeahead';
 
 // @public
 export interface CriterionDefinition {

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--data-entered-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--data-entered-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:466d4798ff64df16b6211cff4c35aab0b2dd68a4d3d755bf76103f0ebd1521a6
-size 17627
+oid sha256:423be33350c8c9c39882fd9ae612962b784d319636a87d44fdea31f3a93fa78f
+size 17631

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--data-entered-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--data-entered-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d2c2f399e866450f0b486f601a8b71eef432c628030e7d16a5ab1fbd98850c7
-size 17369
+oid sha256:e6313e6f174e31d1c584306b10c6d21105e127d9c4eb8b7b34e584140bebca67
+size 17425

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--empty-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--empty-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a06e08b7c47c1e6ed9b18eb44f5f5f0f44b66f7f0786d18fe000121175d3cb7
+oid sha256:2c74558577ac643b4cdcda6798042840dcb6972816ab6840050f72aa23b600d1
 size 14327

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--empty-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--empty-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe75ed05bc6dbbe7f493c77d7df13f0602361fd60ef9609993e2aa4cb4036c77
-size 14291
+oid sha256:c6bb305af0c74f677537ef6e77df70958acb160f71372760f12b1c90345d14a4
+size 14295

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-selected-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-selected-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e69d6fcb7daf595202f4a8d698670b3c8359a80921dd78866302067427a7dae3
-size 15532
+oid sha256:2d29a2a0abe4ab7d4cfe3a2db405b23d01ed30b3e1645ea5ca83b9026d757bf8
+size 15543

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-selected-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-selected-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c448e2832e1b06b1f597507f35ce044b9f0b65760049dce79d5a2379f67d590f
-size 15340
+oid sha256:a18b48c30759231ad3b1f9ce8e852fb2a6e56d8975aa29a710f184301d9b66bc
+size 15346

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-typeahead-open-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-typeahead-open-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66207d9d1cc2e3fb0cd03b2823bc47815c4389421c1fc1fd1b78ba97e5699ebc
-size 12838
+oid sha256:9301ac19d7c10661cb753da4946e8235fb2efb74433579a387dc9fbc42562cb4
+size 12858

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-typeahead-open-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-typeahead-open-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d376428b1b3700caec7d2578886b44aca328b14330991d99ac97e5b89efaa40d
-size 12449
+oid sha256:0b1cc8538ad26957b41f669c8e2b02c13267ca56565d9813eee46c978ec9755f
+size 12468

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-updated-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-updated-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47b0cf4d380b9d11063209fa75136bb5449fcede92cc3fd7588449e8eec26c93
-size 16060
+oid sha256:fd5c74ec356c4827bc101153d059b7101839ef0c49dc7013bdb6ce360e6dbc95
+size 16076

--- a/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-updated-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-filtered-search.spec.ts-snapshots/si-filtered-search--si-filtered-search-playground--freetext-updated-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:799b5a024458b89a1ddeb75fd5ba46ef1980c5dd8328f6787ff80d12660aeb53
-size 15827
+oid sha256:47da878eee84f59de005ae39746a11efdce99e220560a15849c96ebc6dc0a200
+size 15886

--- a/projects/element-ng/filtered-search/si-filtered-search-input.component.html
+++ b/projects/element-ng/filtered-search/si-filtered-search-input.component.html
@@ -1,0 +1,25 @@
+<input
+  #freeTextInputElement
+  type="text"
+  class="value-input ps-2 me-2 w-100"
+  typeaheadOptionField="translatedLabel"
+  typeaheadClearValueOnSelect
+  [siTypeahead]="dataSource()"
+  [typeaheadMinLength]="0"
+  [typeaheadOptionsLimit]="typeaheadOptionsLimit()"
+  [typeaheadScrollable]="true"
+  [typeaheadOptionsInScrollableView]="optionsInScrollableView()"
+  [typeaheadAutoSelectIndex]="searchValue() ? 0 : -1"
+  [typeaheadCreateOption]="typeaheadCreateOption()"
+  [disabled]="disabled()"
+  [placeholder]="placeholder()"
+  [attr.aria-label]="searchLabel() | translate"
+  [value]="searchValue()"
+  (focus)="inputFocus.emit()"
+  (input)="freeTextInputHandler($event)"
+  (blur)="freeTextBlurHandler()"
+  (keydown.backspace)="freeTextBackspaceHandler($event)"
+  (keydown.enter)="enterSubmit.emit()"
+  (typeaheadOnSelect)="typeaheadOnSelectCriterionHandler($event.option)"
+  (typeaheadOnCreateOption)="createFreeTextPillHandler($event)"
+/>

--- a/projects/element-ng/filtered-search/si-filtered-search-input.component.scss
+++ b/projects/element-ng/filtered-search/si-filtered-search-input.component.scss
@@ -1,0 +1,20 @@
+@use '@siemens/element-theme/src/styles/variables';
+
+input {
+  background: transparent;
+  border: 0;
+  padding-block: 0;
+
+  &:hover::placeholder {
+    opacity: 1;
+  }
+
+  &:disabled,
+  &:disabled ::placeholder {
+    color: variables.$element-text-disabled;
+  }
+
+  :host-context(si-filtered-search-value + :host) &::placeholder {
+    color: transparent;
+  }
+}

--- a/projects/element-ng/filtered-search/si-filtered-search-input.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search-input.component.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ElementRef,
+  input,
+  model,
+  output,
+  viewChild
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SiTypeaheadDirective, TypeaheadOption } from '@siemens/element-ng/typeahead';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
+import { Observable } from 'rxjs';
+
+import { InternalCriterionDefinition } from './si-filtered-search-helper';
+
+@Component({
+  selector: 'si-filtered-search-input',
+  imports: [FormsModule, SiTypeaheadDirective, SiTranslatePipe],
+  templateUrl: './si-filtered-search-input.component.html',
+  styleUrl: './si-filtered-search-input.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'w-100'
+  }
+})
+export class SiFilteredSearchInputComponent {
+  private static readonly criterionRegex = /(.+?):(.*)$/;
+
+  readonly dataSource = input.required<Observable<InternalCriterionDefinition[]>>();
+  readonly typeaheadOptionsLimit = input.required<number>();
+  readonly optionsInScrollableView = input.required<number>();
+  readonly disabled = input.required<boolean>();
+  readonly placeholder = input.required<string>();
+  readonly searchLabel = input.required<TranslatableString>();
+  readonly searchValue = model.required<string>();
+  readonly freeTextCriterion = input.required<boolean>();
+  readonly maxCriteriaReached = input.required<boolean>();
+  readonly allowFreeText = input.required<boolean>();
+  readonly searchForFreeTextLabel = input.required<TranslatableString>();
+  readonly disableSelectionByColonAndSemicolon = input.required<boolean>();
+  readonly onlySelectValue = input.required<boolean>();
+
+  readonly createCriterion = output<{ criterion: InternalCriterionDefinition; value?: string }>();
+  readonly createCriterionByName = output<{ criterionName: string; value?: string }>();
+  readonly backspaceOverflow = output();
+  readonly createFreeTextPill = output<string>();
+  readonly inputFocus = output();
+  readonly enterSubmit = output();
+
+  private readonly inputElement =
+    viewChild.required<ElementRef<HTMLInputElement>>('freeTextInputElement');
+
+  /** Public method to focus the input element */
+  focus(): void {
+    this.inputElement().nativeElement.focus();
+  }
+
+  protected readonly typeaheadCreateOption = computed(() =>
+    this.freeTextCriterion() && !this.maxCriteriaReached() && this.allowFreeText()
+      ? this.searchForFreeTextLabel()
+      : undefined
+  );
+
+  protected freeTextBackspaceHandler(event: Event): void {
+    if (!(event.target as HTMLInputElement).value) {
+      this.backspaceOverflow.emit();
+    }
+  }
+
+  protected freeTextInputHandler(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+
+    const match = value.match(SiFilteredSearchInputComponent.criterionRegex);
+    if (!this.disableSelectionByColonAndSemicolon() && !this.onlySelectValue() && match) {
+      const criterionName = match[1];
+      this.inputElement().nativeElement.value = '';
+      this.searchValue.set('');
+
+      this.createCriterionByName.emit({ criterionName: criterionName, value: match[2] });
+    } else {
+      this.searchValue.set(value);
+    }
+  }
+
+  protected freeTextBlurHandler(): void {
+    queueMicrotask(() => {
+      if (this.freeTextCriterion() && this.searchValue().length > 0) {
+        this.createFreeTextPill.emit(this.searchValue());
+      }
+    });
+  }
+
+  protected typeaheadOnSelectCriterionHandler(event: TypeaheadOption): void {
+    const criterion = event as InternalCriterionDefinition;
+    // Removes the focus border before creating a new criterion to prevent the impression of jumping content.
+    this.inputElement().nativeElement.blur();
+    this.createCriterion.emit({ criterion });
+    this.searchValue.set('');
+  }
+
+  protected createFreeTextPillHandler(query: string): void {
+    this.createFreeTextPill.emit(query);
+    this.searchValue.set('');
+  }
+}

--- a/projects/element-ng/filtered-search/si-filtered-search.component.html
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.html
@@ -25,36 +25,27 @@
     />
   }
   <!-- criterion input -->
-  <input
-    #freeTextInputElement
-    type="text"
-    class="value-input ps-2 me-2 flex-grow-1"
-    typeaheadOptionField="translatedLabel"
-    typeaheadClearValueOnSelect
-    [siTypeahead]="dataSource"
-    [typeaheadMinLength]="0"
+  <si-filtered-search-input
+    [dataSource]="dataSource"
     [typeaheadOptionsLimit]="typeaheadOptionsLimit()"
-    [typeaheadScrollable]="true"
-    [typeaheadOptionsInScrollableView]="optionsInScrollableView()"
-    [typeaheadAutoSelectIndex]="searchValue() ? 0 : -1"
-    [typeaheadCreateOption]="
-      freeTextCriterion() &&
-      (!maxCriteria() || values().length < maxCriteria()!) &&
-      allowFreeTextCache()
-        ? searchForFreeTextLabel()
-        : undefined
-    "
+    [optionsInScrollableView]="optionsInScrollableView()"
     [disabled]="disabled()"
     [placeholder]="placeholder()"
-    [attr.aria-label]="searchLabel() | translate"
-    [value]="searchValue()"
-    (focus)="freeTextFocus()"
-    (input)="freeTextInput($event)"
-    (blur)="freeTextBlur()"
-    (keydown.backspace)="freeTextBackspace($event)"
-    (keydown.enter)="submit()"
-    (typeaheadOnSelect)="typeaheadOnSelectCriterion($event.option)"
-    (typeaheadOnCreateOption)="createFreeTextPill($event)"
+    [searchLabel]="searchLabel()"
+    [freeTextCriterion]="!!freeTextCriterion()"
+    [maxCriteriaReached]="!!maxCriteria() && values().length >= maxCriteria()!"
+    [allowFreeText]="allowFreeTextCache()"
+    [searchForFreeTextLabel]="searchForFreeTextLabel()"
+    [disableSelectionByColonAndSemicolon]="disableSelectionByColonAndSemicolon()"
+    [onlySelectValue]="onlySelectValue()"
+    [(searchValue)]="searchValue"
+    (createCriterion)="onCreateCriterion($event)"
+    (createCriterionByName)="onCreateCriterionByName($event)"
+    (backspaceOverflow)="freeTextBackspace()"
+    (createFreeTextPill)="createFreeTextPill($event)"
+    (searchValueChange)="onSearchValueChange($event)"
+    (inputFocus)="freeTextFocus()"
+    (enterSubmit)="submit()"
   />
 </div>
 <!-- clear all searchCriteria -->

--- a/projects/element-ng/filtered-search/si-filtered-search.component.scss
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.scss
@@ -27,15 +27,6 @@ $filtered-search-criteria-margin: map.get(variables.$spacers, 2);
 
   &.disabled {
     color: variables.$element-text-disabled;
-
-    input,
-    ::placeholder {
-      color: variables.$element-text-disabled;
-    }
-  }
-
-  si-filtered-search-value + input::placeholder {
-    color: transparent;
   }
 }
 
@@ -44,20 +35,6 @@ $filtered-search-criteria-margin: map.get(variables.$spacers, 2);
   border-end-start-radius: 4px;
   background-color: var(--filter-search-background-color);
   gap: map.get(variables.$spacers, 2);
-}
-
-input {
-  background: transparent;
-  border: 0;
-  padding-block: 0;
-
-  &:hover::placeholder {
-    opacity: 1;
-  }
-
-  :host(.disabled) &::placeholder {
-    opacity: variables.$element-action-disabled-opacity;
-  }
 }
 
 .clear-button-container {

--- a/projects/element-ng/filtered-search/si-filtered-search.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectorRef,
   Component,
   computed,
   DestroyRef,
@@ -22,18 +21,16 @@ import {
   viewChildren
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { FormsModule } from '@angular/forms';
 import { elementCancel, elementSearch } from '@siemens/element-icons';
 import { BackgroundColorVariant, isRTL } from '@siemens/element-ng/common';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
-import { SiTypeaheadDirective, TypeaheadOption } from '@siemens/element-ng/typeahead';
 import {
   injectSiTranslateService,
   SiTranslatePipe,
   t,
   TranslatableString
 } from '@siemens/element-translate-ng/translate';
-import { BehaviorSubject, Observable, Subject, switchMap } from 'rxjs';
+import { merge, Observable, Subject, switchMap } from 'rxjs';
 import { debounceTime, map } from 'rxjs/operators';
 
 import {
@@ -42,6 +39,7 @@ import {
   InternalCriterionDefinition,
   toInternalCriteria
 } from './si-filtered-search-helper';
+import { SiFilteredSearchInputComponent } from './si-filtered-search-input.component';
 import { SiFilteredSearchValueComponent } from './si-filtered-search-value.component';
 import {
   CriterionDefinition,
@@ -54,10 +52,9 @@ import {
 @Component({
   selector: 'si-filtered-search',
   imports: [
-    FormsModule,
     SiIconComponent,
-    SiTypeaheadDirective,
     SiTranslatePipe,
+    SiFilteredSearchInputComponent,
     SiFilteredSearchValueComponent
   ],
   templateUrl: './si-filtered-search.component.html',
@@ -68,8 +65,6 @@ import {
   }
 })
 export class SiFilteredSearchComponent implements OnInit, OnChanges {
-  private static readonly criterionRegex = /(.+?):(.*)$/;
-
   /**
    * Output callback event that provides an object describing the
    * selected criteria and additional filter text.
@@ -311,8 +306,7 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
    */
   readonly interceptDisplayedCriteria = output<DisplayedCriteriaEventArgs>();
 
-  private readonly freeTextInputElement =
-    viewChild.required<ElementRef<HTMLInputElement>>('freeTextInputElement');
+  private readonly freeTextInput = viewChild.required(SiFilteredSearchInputComponent);
 
   private readonly scrollContainer = viewChild.required('scrollContainer', { read: ElementRef });
 
@@ -328,14 +322,12 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
   protected internalCriterionDefinitions: InternalCriterionDefinition[] = [];
 
   protected readonly icons = addIcons({ elementCancel, elementSearch });
-  /** Used to trigger a renewed search */
-  private typeaheadInputChange = new BehaviorSubject<string>('');
   /** Used to debounce the Search emissions */
   private searchEmitQueue = new Subject<SearchCriteria | undefined>();
   private readonly destroyRef = inject(DestroyRef);
-  private readonly cdRef = inject(ChangeDetectorRef);
   private readonly translateService = injectSiTranslateService();
   private readonly locale = inject(LOCALE_ID).toString();
+  private readonly freeTextFocused = new Subject<void>();
 
   protected readonly allowFreeTextCache = signal<boolean>(true);
   // Angular also calls ngOnChanges if we emitted a change and then two-way-databinding writes back our own change.
@@ -377,6 +369,11 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
   );
 
   constructor() {
+    const typeaheadInputChange = merge(
+      toObservable(this.searchValue),
+      this.freeTextFocused.pipe(map(() => this.searchValue()))
+    );
+
     const criteriaRestrictions = toObservable(
       computed(() => ({
         maxCriteria: this.maxCriteria(),
@@ -388,7 +385,7 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     this.dataSource = toObservable(this.lazyCriterionProvider).pipe(
       switchMap(lazyCriterionProvider => {
         if (lazyCriterionProvider) {
-          return this.typeaheadInputChange.pipe(
+          return typeaheadInputChange.pipe(
             switchMap(value =>
               this.lazyCriterionProvider()!(value, this.searchCriteria()).pipe(
                 debounceTime(this.lazyLoadingDebounceTime()),
@@ -424,9 +421,6 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
       changes.criteria
     ) {
       this.initValue();
-      // Update typeahead since the criteria input can change while the free text input is focused.
-      // This is necessary since the criteria are set as a result of an API call response.
-      this.typeaheadInputChange.next(this.freeTextInputElement().nativeElement.value ?? '');
     }
   }
 
@@ -525,7 +519,6 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     this.values.set([]);
     this.searchValue.set('');
     this.emitChangeEvent();
-    this.typeaheadInputChange.next(this.searchValue());
     this.submit();
   }
 
@@ -540,16 +533,14 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     this.valueComponents().forEach(component => {
       component.closeOverlay();
     });
-    this.cdRef.detectChanges();
 
     this.values.update(v => v.filter((_, i) => i !== index));
     this.emitChangeEvent();
     if (this.values().length !== index) {
       this.valueComponents()[index + 1].edit('value');
     } else {
-      this.freeTextInputElement().nativeElement.focus();
+      this.freeTextInput().focus();
     }
-    this.typeaheadInputChange.next(this.searchValue());
     if (event?.triggerSearch) {
       this.submit();
     }
@@ -559,16 +550,6 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     if (!this.doSearchOnInputChange()) {
       this.doSearch.emit(this.searchCriteria()!);
     }
-  }
-
-  protected typeaheadOnSelectCriterion(event: TypeaheadOption): void {
-    const criterion = event as InternalCriterionDefinition;
-    // Removes the focus border before creating a new criterion to prevent the impression of jumping content.
-    this.freeTextInputElement().nativeElement.blur();
-    this.addCriterion(criterion);
-    // The user selected a criterion so we remove the free text search value and add the criterion.
-    this.typeaheadInputChange.next('');
-    this.searchValue.set('');
   }
 
   protected validateCriterionLabel(criterion: InternalCriterionDefinition): boolean {
@@ -691,63 +672,41 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     const scrollDirection = isRTL() ? -1 : 1;
     const position = scrollDirection * this.scrollContainer().nativeElement.scrollWidth;
     this.scrollContainer().nativeElement.scrollLeft = position;
-    this.typeaheadInputChange.next(this.freeTextInputElement().nativeElement.value);
+    this.freeTextFocused.next();
   }
 
-  protected freeTextBackspace(event: Event): void {
-    if (!(event.target as HTMLInputElement).value) {
-      // edit last criterion if a user presses backspace in empty search input.
-      const valueComponents = this.valueComponents();
-      if (valueComponents.length) {
-        valueComponents[valueComponents.length - 1].edit('value');
-      }
+  protected freeTextBackspace(): void {
+    // edit last criterion if a user presses backspace in empty search input.
+    const valueComponents = this.valueComponents();
+    if (valueComponents.length) {
+      valueComponents[valueComponents.length - 1].edit('value');
     }
   }
 
-  protected freeTextInput(event: Event): void {
-    const value = (event.target as HTMLInputElement).value;
-
-    const match = value.match(SiFilteredSearchComponent.criterionRegex);
-    if (!this.disableSelectionByColonAndSemicolon() && !this.onlySelectValue() && match) {
-      const criterionName = match[1];
-      if (this.searchValue() === '') {
-        // The value was empty before, so we must make angular detect a change here.
-        // Otherwise, the entire value which was pasted will remain in the input.
-        // This happens if the user pasts something like: 'key:value'
-        this.searchValue.set(value);
-        this.cdRef.detectChanges();
-      }
-      this.searchValue.set('');
-
-      const nameLowerCase = criterionName.toLocaleLowerCase();
-      const criterion = this.internalCriterionDefinitions.find(
-        ic => ic.translatedLabel.toLocaleLowerCase() === nameLowerCase
-      ) ?? {
-        name: criterionName,
-        label: criterionName,
-        translatedLabel: criterionName
-      };
-
-      this.typeaheadInputChange.next('');
-      this.addCriterion(criterion, match[2]);
-    } else {
-      this.searchValue.set(value);
-
-      // Only emit a change event if free text pills are not enabled and the free text search is enabled.
-      if (!this.disableFreeTextSearch() && !this.freeTextCriterion()) {
-        this.emitChangeEvent();
-      }
-
-      this.typeaheadInputChange.next(value);
-    }
+  protected onCreateCriterion(event: {
+    criterion: InternalCriterionDefinition;
+    value?: string;
+  }): void {
+    this.addCriterion(event.criterion, event.value);
   }
 
-  protected freeTextBlur(): void {
-    queueMicrotask(() => {
-      if (this.freeTextCriterion() && this.searchValue().length > 0) {
-        this.createFreeTextPill(this.searchValue());
-      }
-    });
+  protected onCreateCriterionByName(event: { criterionName: string; value?: string }): void {
+    const nameLowerCase = event.criterionName.toLocaleLowerCase();
+    const criterion = this.internalCriterionDefinitions.find(
+      ic => ic.translatedLabel.toLocaleLowerCase() === nameLowerCase
+    ) ?? {
+      name: event.criterionName,
+      label: event.criterionName,
+      translatedLabel: event.criterionName
+    };
+    this.addCriterion(criterion, event.value);
+  }
+
+  protected onSearchValueChange(value: string): void {
+    // Only emit a change event if free text pills are not enabled and the free text search is enabled.
+    if (value && !this.disableFreeTextSearch() && !this.freeTextCriterion()) {
+      this.emitChangeEvent();
+    }
   }
 
   protected valueChange(
@@ -764,7 +723,7 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
       next.edit();
     } else {
       this.searchValue.set(event?.freeText ?? this.searchValue());
-      this.freeTextInputElement().nativeElement.focus();
+      this.freeTextInput().focus();
     }
   }
 
@@ -796,7 +755,6 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
         config: freeTextDefinition
       }
     ]);
-    this.searchValue.set('');
     this.emitChangeEvent();
   }
 }


### PR DESCRIPTION
This extracts to search-input to a separate component. The goal is to keep the root component free of interaction logic.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1667/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1667/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1667/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1667/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1667/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1667/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1667/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1667/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1667/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1667/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->






