### PR TITLE
docs(native-charts): render microcharts in public entrypoint

### DIFF
--- a/.docs-composerrc.mts
+++ b/.docs-composerrc.mts
@@ -9,7 +9,7 @@ export const config: Config = {
     'projects/element-ng',
     'projects/charts-ng',
     'projects/dashboards-ng',
-    'projects/native-charts-ng',
+    { packageDir: 'projects/native-charts-ng', publicEntrypoint: 'docs.ts' },
     'projects/element-translate-ng',
     'projects/maps-ng'
   ],

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # generated typedoc documentation
 /src/assets/typedoc
 # icon preview documentation
+docs/api
 docs/_src/fonts
 docs/_src/style
 docs/_src/icon-viewer


### PR DESCRIPTION
Related to https://github.com/siemens/element/pull/1665#issuecomment-4082581102

By default the publicEntrypoint looks for `'src/index.ts' | 'src/public-api.ts' | 'public-api.ts'`. 

Since none of the files existed before it simply skipped the step. Now that it will find a file it can either be set to an empty string or array which would enforce skipping the step again or to have it more explicit like done here simply provide the `docs.ts`.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1679/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1679/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1679/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1679/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-91%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1679/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1679/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->


