### PR TITLE
test(element-ng): migrate schematics to vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lib:test-vitest": "cross-env TZ=utc ng run element-ng:test-vitest",
     "lib:test:browser": "cross-env TZ=utc HEADLESS=0 ng test element-ng",
     "schematics:build": "tsc -p projects/element-ng/tsconfig.schematics.json",
-    "schematics:test": "tsx --tsconfig projects/element-ng/tsconfig.schematics.spec.json node_modules/jasmine/bin/jasmine.js --config=projects/element-ng/jasmine.json",
+    "schematics:test": "vitest run --config projects/element-ng/vitest.config.schematics.ts",
     "translate:test": "ng test element-translate-ng",
     "translate:build": "ng build element-translate-ng && cpy LICENSE.md \"./dist/@siemens/element-translate-ng/\"",
     "docs:build": "uv run mkdocs build --strict",

--- a/projects/element-ng/jasmine.json
+++ b/projects/element-ng/jasmine.json
@@ -1,6 +1,0 @@
-{
-  "spec_dir": "./projects/element-ng/schematics",
-  "spec_files": ["**/*.spec.ts", "!*/files/**/*"],
-  "stopSpecOnExpectationFailure": false,
-  "random": true
-}

--- a/projects/element-ng/schematics/ng-update/index.spec.ts
+++ b/projects/element-ng/schematics/ng-update/index.spec.ts
@@ -27,14 +27,14 @@ describe('ng-update migration', () => {
   });
 
   it('should log migration start message', async () => {
-    const logSpy = jasmine.createSpy('log');
+    const logSpy = vi.fn();
     runner.logger.subscribe(logSpy);
 
     await runner.runSchematic('migration-v49', {}, appTree);
 
     expect(logSpy).toHaveBeenCalledWith(
-      jasmine.objectContaining({
-        message: jasmine.stringContaining('Starting update from version 48 to 49')
+      expect.objectContaining({
+        message: expect.stringContaining('Starting update from version 48 to 49')
       })
     );
   });

--- a/projects/element-ng/schematics/vitest-setup.ts
+++ b/projects/element-ng/schematics/vitest-setup.ts
@@ -1,0 +1,5 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import 'tsx/cjs';

--- a/projects/element-ng/tsconfig.schematics.spec.json
+++ b/projects/element-ng/tsconfig.schematics.spec.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.schematics.json",
-  "compilerOptions": { "types": ["jasmine", "node"] },
+  "compilerOptions": { "types": ["vitest/globals", "node"] },
   "exclude": ["schematics/*/files/**/*"]
 }

--- a/projects/element-ng/vitest.config.schematics.ts
+++ b/projects/element-ng/vitest.config.schematics.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    root: path.dirname(fileURLToPath(import.meta.url)),
+    include: ['schematics/**/*.spec.ts'],
+    exclude: ['schematics/*/files/**/*'],
+    globals: true,
+    setupFiles: ['schematics/vitest-setup.ts'],
+    testTimeout: 60000
+  }
+});


### PR DESCRIPTION
Since we move away form karma / jasmine, we should also replace jasmine in the schematics test to reduce the amount of test frameworks in use.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1681/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1681/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1681/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1681/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-88%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1681/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1681/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
