### PR TITLE
refactor(date-range-filter): reduce change detections to update values

### DIFF
--- a/projects/element-ng/date-range-filter/si-relative-date.component.html
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.html
@@ -1,14 +1,14 @@
 <si-number-input
   class="form-control mb-4"
   [aria-label]="valueLabel()"
-  [ngModel]="offset()"
-  (ngModelChange)="updateValue($event)"
+  [value]="offset()"
+  (valueChange)="updateValue($event ?? 0)"
 />
 <si-select
   class="form-control"
   min="0"
   [ariaLabel]="unitLabel()"
   [options]="offsetList()"
-  [ngModel]="unit()"
-  (ngModelChange)="changeUnit($event)"
+  [value]="unit()"
+  (valueChange)="changeUnit($event)"
 />

--- a/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
@@ -14,7 +14,7 @@ const ONE_DAY = ONE_MINUTE * 60 * 24;
 @Component({
   imports: [SiRelativeDateComponent],
   template: `<si-relative-date
-    [enableTimeSelection]="enableTimeSelection"
+    [enableTimeSelection]="enableTimeSelection()"
     [value]="value()"
     [unitLabel]="unitLabel"
     [valueLabel]="valueLabel"
@@ -24,9 +24,9 @@ const ONE_DAY = ONE_MINUTE * 60 * 24;
 })
 class TestHostComponent {
   readonly value = signal(0);
-  enableTimeSelection = false;
-  unitLabel = t(() => $localize`:@@SI_DATE_RANGE_FILTER.UNIT:Unit`);
-  valueLabel = t(() => $localize`:@@SI_DATE_RANGE_FILTER.UNIT:Unit`);
+  readonly enableTimeSelection = signal(false);
+  readonly unitLabel = t(() => $localize`:@@SI_DATE_RANGE_FILTER.UNIT:Unit`);
+  readonly valueLabel = t(() => $localize`:@@SI_DATE_RANGE_FILTER.UNIT:Unit`);
 }
 
 describe('SiRelativeDateComponent', () => {
@@ -42,12 +42,6 @@ describe('SiRelativeDateComponent', () => {
     btn?.dispatchEvent(new Event('mousedown'));
     btn?.dispatchEvent(new Event('mouseup'));
   };
-
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [SiRelativeDateComponent, TestHostComponent]
-    })
-  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
@@ -101,7 +95,6 @@ describe('SiRelativeDateComponent', () => {
     element.querySelector<HTMLElement>('si-select .select')?.click();
     await fixture.whenStable();
     document.querySelector<HTMLElement>('.dropdown-menu [data-id=weeks]')?.click();
-    await fixture.whenStable();
 
     inputAction('.inc');
     await fixture.whenStable();
@@ -111,7 +104,7 @@ describe('SiRelativeDateComponent', () => {
   });
 
   it('handles time selection', async () => {
-    component.enableTimeSelection = true;
+    component.enableTimeSelection.set(true);
     await fixture.whenStable();
 
     element.querySelector<HTMLElement>('si-select .select')?.click();

--- a/projects/element-ng/date-range-filter/si-relative-date.component.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.ts
@@ -13,7 +13,6 @@ import {
   signal,
   SimpleChanges
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 import { SiNumberInputComponent } from '@siemens/element-ng/number-input';
 import {
   SelectOption,
@@ -32,7 +31,6 @@ interface OffsetOption extends SelectOption<string> {
 @Component({
   selector: 'si-relative-date',
   imports: [
-    FormsModule,
     SiNumberInputComponent,
     SiSelectComponent,
     SiSelectSingleValueDirective,


### PR DESCRIPTION
`ngModel` require an extra cycle to propagate changes which requires extra ticks or setTimeouts in the test cases, this isn't necessary when we directly use the value + changes.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1686/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1686/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1686/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1686/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-88%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1686/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1686/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->




