### PR TITLE
test(tabs): wait for tooltip to be visible

### DIFF
--- a/playwright/e2e/element-examples/si-tabs.spec.ts
+++ b/playwright/e2e/element-examples/si-tabs.spec.ts
@@ -81,6 +81,8 @@ test.describe('si-tabs', () => {
     await page.keyboard.press('Tab');
     await page.keyboard.press('ArrowRight');
     await expect(page.getByRole('menuitem', { name: 'Settings' })).toBeFocused();
+    // Make sure the tooltip is also there. It may appear delayed.
+    await expect(page.getByRole('tooltip', { name: 'Settings' })).toBeVisible();
     await si.runVisualAndA11yTests('tabs-toolbar-focused');
   });
 });


### PR DESCRIPTION
The tooltip may appear delayed due to animations, and its usage of `setTimeout` internally.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1693/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1693/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1693/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1693/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-88%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1693/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1693/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->

