### PR TITLE
refactor(tooltip): use `transition-delay` instead of `setTimeout`

### DIFF
--- a/projects/element-ng/tooltip/si-tooltip.component.scss
+++ b/projects/element-ng/tooltip/si-tooltip.component.scss
@@ -5,7 +5,8 @@ $transition-duration: variables.element-transition-duration(0.15s);
 %transition {
   transition:
     opacity $transition-duration ease-out,
-    transform $transition-duration ease-out;
+    transform $transition-duration ease-out,
+    visibility 0s;
 }
 
 :host {
@@ -17,13 +18,19 @@ $transition-duration: variables.element-transition-duration(0.15s);
     opacity: 0;
     transform: scale(0.8);
   }
+}
 
-  .tooltip {
-    @extend %transition;
+.tooltip {
+  @extend %transition;
+  transition-delay: 500ms;
 
-    @starting-style {
-      opacity: 0;
-      transform: scale(0.8);
-    }
+  @starting-style {
+    opacity: 0;
+    transform: scale(0.8);
+    visibility: hidden;
+  }
+
+  :host(.is-focus) & {
+    transition-delay: 0s;
   }
 }

--- a/projects/element-ng/tooltip/si-tooltip.component.ts
+++ b/projects/element-ng/tooltip/si-tooltip.component.ts
@@ -16,6 +16,7 @@ import { SI_TOOLTIP_CONFIG } from './si-tooltip.model';
   templateUrl: './si-tooltip.component.html',
   styleUrl: './si-tooltip.component.scss',
   host: {
+    '[class.is-focus]': 'config.trigger() === "focus"',
     'animate.leave': 'tooltip-leave'
   }
 })

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -31,7 +31,6 @@ describe('SiTooltipDirective', () => {
     });
 
     beforeEach(() => {
-      jasmine.clock().install();
       fixture = TestBed.createComponent(TestHostComponent);
       component = fixture.componentInstance;
       button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
@@ -39,21 +38,14 @@ describe('SiTooltipDirective', () => {
       fixture.detectChanges();
     });
 
-    afterEach(() => {
-      jasmine.clock().uninstall();
-    });
-
     it('should open on focus', () => {
       button.dispatchEvent(new Event('focus'));
-      // Focus should be immediate (no delay) but still need to tick for setTimeout(0)
-      jasmine.clock().tick(0);
       fixture.detectChanges();
 
       expect(document.querySelector('.tooltip')).toBeTruthy();
       expect(document.querySelector('.tooltip')?.innerHTML).toContain('test tooltip');
 
       button.dispatchEvent(new Event('focusout'));
-      jasmine.clock().tick(500);
 
       expect(document.querySelector('.tooltip')).toBeFalsy();
     });
@@ -69,11 +61,8 @@ describe('SiTooltipDirective', () => {
 
     it('should show tooltip on mouse over', () => {
       button.dispatchEvent(new MouseEvent('mouseenter'));
-      // hover should have 500ms delay
-      expect(document.querySelector('.tooltip')).toBeFalsy();
-
-      jasmine.clock().tick(500);
       fixture.detectChanges();
+      // tooltip DOM is created immediately, CSS transition-delay handles visual delay
       expect(document.querySelector('.tooltip')).toBeTruthy();
 
       button.dispatchEvent(new MouseEvent('mouseleave'));
@@ -82,7 +71,6 @@ describe('SiTooltipDirective', () => {
 
     it('should update tooltip content while open', () => {
       button.dispatchEvent(new Event('focus'));
-      jasmine.clock().tick(0);
       fixture.detectChanges();
       expect(document.querySelector('.tooltip')?.innerHTML).toContain('test tooltip');
 
@@ -110,24 +98,17 @@ describe('SiTooltipDirective', () => {
     }
 
     beforeEach(() => {
-      jasmine.clock().install();
       fixture = TestBed.createComponent(TestHostComponent);
       button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
       spyOn(button, 'matches').and.returnValue(true);
       fixture.detectChanges();
     });
 
-    afterEach(() => {
-      jasmine.clock().uninstall();
-    });
-
     it('should render the template', async () => {
       button.dispatchEvent(new Event('focus'));
-      jasmine.clock().tick(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')?.innerHTML).toContain('Template content');
       button.dispatchEvent(new Event('focusout'));
-      jasmine.clock().tick(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).toBeFalsy();
     });
@@ -137,11 +118,9 @@ describe('SiTooltipDirective', () => {
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       button.dispatchEvent(new Event('focus'));
-      jasmine.clock().tick(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')?.innerHTML).toContain('Template content test');
       button.dispatchEvent(new Event('focusout'));
-      jasmine.clock().tick(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).toBeFalsy();
     });

--- a/projects/element-ng/tooltip/si-tooltip.directive.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.ts
@@ -62,57 +62,41 @@ export class SiTooltipDirective implements OnDestroy {
   protected describedBy = `__tooltip_${SiTooltipDirective.idCounter++}`;
 
   private tooltipRef?: TooltipRef;
-  private showTimeout?: ReturnType<typeof setTimeout>;
   private tooltipService = inject(SiTooltipService);
   private elementRef = inject(ElementRef);
   private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   ngOnDestroy(): void {
-    this.clearShowTimeout();
     this.tooltipRef?.destroy();
   }
 
-  private clearShowTimeout(): void {
-    if (this.showTimeout) {
-      clearTimeout(this.showTimeout);
-      this.showTimeout = undefined;
-    }
-  }
-
-  private showTooltip(immediate = false): void {
+  private showTooltip(trigger: 'hover' | 'focus'): void {
     const siTooltip = this.siTooltip();
     if (this.isDisabled() || !siTooltip) {
       return;
     }
 
-    this.clearShowTimeout();
-
-    const delay = immediate ? 0 : 500;
-
-    this.showTimeout = setTimeout(() => {
-      this.tooltipRef ??= this.tooltipService.createTooltip({
-        describedBy: this.describedBy,
-        element: this.elementRef,
-        placement: this.placement(),
-        tooltip: this.siTooltip,
-        tooltipContext: this.tooltipContext
-      });
-      this.tooltipRef.show();
-    }, delay);
+    this.tooltipRef ??= this.tooltipService.createTooltip({
+      describedBy: this.describedBy,
+      element: this.elementRef,
+      placement: this.placement(),
+      tooltip: this.siTooltip,
+      tooltipContext: this.tooltipContext
+    });
+    this.tooltipRef.show(trigger);
   }
 
   protected focusIn(event: FocusEvent): void {
     if (this.isBrowser && (event.target as Element).matches(':focus-visible')) {
-      this.showTooltip(true);
+      this.showTooltip('focus');
     }
   }
 
   protected show(): void {
-    this.showTooltip(false);
+    this.showTooltip('hover');
   }
 
   protected hide(): void {
-    this.clearShowTimeout();
     this.tooltipRef?.hide();
   }
 }

--- a/projects/element-ng/tooltip/si-tooltip.model.ts
+++ b/projects/element-ng/tooltip/si-tooltip.model.ts
@@ -7,10 +7,13 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 export type SiTooltipContent = TranslatableString | TemplateRef<any> | Type<any> | null | undefined;
 
+export type TooltipTrigger = 'hover' | 'focus';
+
 export interface SiTooltipConfig {
   id: string;
   tooltip: () => SiTooltipContent;
   tooltipContext: () => unknown;
+  trigger: () => TooltipTrigger;
 }
 
 export const SI_TOOLTIP_CONFIG = new InjectionToken<SiTooltipConfig>('SiTooltipConfig');

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -4,12 +4,12 @@
  */
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { ComponentRef, ElementRef, inject, Injectable, Injector } from '@angular/core';
+import { ComponentRef, ElementRef, inject, Injectable, Injector, signal, WritableSignal } from '@angular/core';
 import { getOverlay, getPositionStrategy, positions } from '@siemens/element-ng/common';
 import { Subscription } from 'rxjs';
 
 import { TooltipComponent } from './si-tooltip.component';
-import { SI_TOOLTIP_CONFIG, SiTooltipContent } from './si-tooltip.model';
+import { SI_TOOLTIP_CONFIG, SiTooltipContent, TooltipTrigger } from './si-tooltip.model';
 
 /**
  * TooltipRef is attached to a specific element.
@@ -21,12 +21,15 @@ class TooltipRef {
   constructor(
     private overlayRef: OverlayRef,
     private element: ElementRef,
-    private injector?: Injector
+    private trigger: WritableSignal<TooltipTrigger>,
+    private injector: Injector
   ) {}
 
   private subscription?: Subscription;
 
-  show(): void {
+  show(trigger: TooltipTrigger = 'focus'): void {
+    this.trigger.set(trigger);
+
     if (this.overlayRef.hasAttached()) {
       return;
     }
@@ -72,6 +75,7 @@ export class SiTooltipService {
     tooltip: () => SiTooltipContent;
     tooltipContext: () => unknown;
   }): TooltipRef {
+    const trigger = signal<TooltipTrigger>('focus');
     const injector = Injector.create({
       parent: config.injector,
       providers: [
@@ -80,7 +84,8 @@ export class SiTooltipService {
           useValue: {
             id: config.describedBy,
             tooltip: config.tooltip,
-            tooltipContext: config.tooltipContext
+            tooltipContext: config.tooltipContext,
+            trigger
           }
         }
       ]
@@ -89,6 +94,7 @@ export class SiTooltipService {
     return new TooltipRef(
       getOverlay(config.element, this.overlay, false, config.placement),
       config.element,
+      trigger,
       injector
     );
   }


### PR DESCRIPTION
Simplifies the tooltip by using a `transition-delay` instead of `setTimeout` to delay displaying a toast.

@dr-itz what is your opinion here?

Makes the code easier, but now always creates a tooltip instantly when hovering.
I guess this has a negative impact on performance.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1699/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1699/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1699/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1699/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-88%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1699/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1699/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
