### PR TITLE
refactor(dashboards-ng): correct typos in dashboards-related components and tests

### DIFF
--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
@@ -231,7 +231,7 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
     if (this.view() === 'list') {
       this.setupWidgetInstanceEditor();
     } else {
-      if (this.isEditorWizdard(this.widgetInstanceEditor)) {
+      if (this.isEditorWizard(this.widgetInstanceEditor)) {
         this.widgetInstanceEditor.next();
         this.editorWizardState.set(this.widgetInstanceEditor.state);
       }
@@ -239,7 +239,7 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
   }
 
   protected onPrevious(): void {
-    if (this.isEditorWizdard(this.widgetInstanceEditor) && this.editorWizardState()?.hasPrevious) {
+    if (this.isEditorWizard(this.widgetInstanceEditor) && this.editorWizardState()?.hasPrevious) {
       this.widgetInstanceEditor.previous();
       this.editorWizardState.set(this.widgetInstanceEditor.state);
     } else if (!this.widgetConfigModified) {
@@ -310,7 +310,7 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
           );
         }
 
-        if (this.isEditorWizdard(this.widgetInstanceEditor)) {
+        if (this.isEditorWizard(this.widgetInstanceEditor)) {
           this.editorWizardState.set(this.widgetInstanceEditor.state);
 
           if (this.widgetInstanceEditor.stateChange) {
@@ -380,7 +380,7 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
     }
   }
 
-  private isEditorWizdard(
+  private isEditorWizard(
     editor?: WidgetInstanceEditor | WidgetInstanceEditorWizard
   ): editor is WidgetInstanceEditorWizard {
     return !!editor && 'state' in editor;

--- a/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.ts
@@ -174,7 +174,7 @@ export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy 
           }) as Subscription
         );
       }
-      if (this.isEditorWizdard(this.widgetInstanceEditor)) {
+      if (this.isEditorWizard(this.widgetInstanceEditor)) {
         this.editorWizardState.set(this.widgetInstanceEditor.state);
 
         if (this.widgetInstanceEditor.stateChange) {
@@ -220,14 +220,14 @@ export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy 
   }
 
   protected onNext(): void {
-    if (this.isEditorWizdard(this.widgetInstanceEditor)) {
+    if (this.isEditorWizard(this.widgetInstanceEditor)) {
       this.widgetInstanceEditor.next();
       this.editorWizardState.set(this.widgetInstanceEditor.state);
     }
   }
 
   protected onPrevious(): void {
-    if (this.isEditorWizdard(this.widgetInstanceEditor) && this.editorWizardState()?.hasPrevious) {
+    if (this.isEditorWizard(this.widgetInstanceEditor) && this.editorWizardState()?.hasPrevious) {
       this.widgetInstanceEditor.previous();
       this.editorWizardState.set(this.widgetInstanceEditor.state);
     }
@@ -255,7 +255,7 @@ export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy 
     this.subscriptions = [];
   }
 
-  private isEditorWizdard(
+  private isEditorWizard(
     editor?: WidgetInstanceEditor | WidgetInstanceEditorWizard
   ): editor is WidgetInstanceEditorWizard {
     return !!editor && 'state' in editor;

--- a/projects/dashboards-ng/src/model/si-widget-storage.spec.ts
+++ b/projects/dashboards-ng/src/model/si-widget-storage.spec.ts
@@ -17,24 +17,24 @@ describe('SiDefaultWidgetStorage', () => {
 
   describe('#load()', () => {
     it('with dashboardId should return widget config observable', () => {
-      const widgitConfigs$ = widgetStorage.load('id');
-      expect(widgitConfigs$).toBeDefined();
+      const widgetConfigs$ = widgetStorage.load('id');
+      expect(widgetConfigs$).toBeDefined();
     });
     it('without dashboardId should return widget config observable', () => {
-      const widgitConfigs$ = widgetStorage.load();
-      expect(widgitConfigs$).toBeDefined();
+      const widgetConfigs$ = widgetStorage.load();
+      expect(widgetConfigs$).toBeDefined();
     });
     it('with different ids should return different objects', () => {
-      const widgitConfigs$ = widgetStorage.load();
-      const widgitConfigs1$ = widgetStorage.load('1');
-      const widgitConfigs2$ = widgetStorage.load('2');
-      expect(widgitConfigs$).not.toBe(widgitConfigs1$);
-      expect(widgitConfigs$).not.toBe(widgitConfigs2$);
+      const widgetConfigs$ = widgetStorage.load();
+      const widgetConfigs1$ = widgetStorage.load('1');
+      const widgetConfigs2$ = widgetStorage.load('2');
+      expect(widgetConfigs$).not.toBe(widgetConfigs1$);
+      expect(widgetConfigs$).not.toBe(widgetConfigs2$);
     });
     it('with same ids should return same objects', () => {
-      const widgitConfigs1$ = widgetStorage.load('1');
-      const widgitConfigs2$ = widgetStorage.load('1');
-      expect(widgitConfigs1$).toBe(widgitConfigs2$);
+      const widgetConfigs1$ = widgetStorage.load('1');
+      const widgetConfigs2$ = widgetStorage.load('1');
+      expect(widgetConfigs1$).toBe(widgetConfigs2$);
     });
   });
 });


### PR DESCRIPTION
Fixed some typos around dashboards-ng projects

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1701/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1701/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1701/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1701/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1701/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1701/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1701/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1701/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1701/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1701/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

