### PR TITLE
fix(filtered-search): trim whitespaces

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search-value.component.html
+++ b/projects/element-ng/filtered-search/si-filtered-search-value.component.html
@@ -112,6 +112,7 @@
         (backspaceOverflow)="backspaceOverflow()"
         (editValue)="edit('value')"
         (submitValue)="submitCriterion.emit($event)"
+        (typeaheadBlur)="blurCriterion.emit()"
       />
     }
   }

--- a/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
@@ -67,6 +67,7 @@ export class SiFilteredSearchValueComponent implements OnInit {
 
   readonly deleteCriterion = output<{ triggerSearch: boolean } | void>();
   readonly submitCriterion = output<{ freeText: string } | void>();
+  readonly blurCriterion = output<void>();
 
   protected readonly active = signal<boolean>(false);
   protected readonly icons = addIcons({ elementCancel });

--- a/projects/element-ng/filtered-search/si-filtered-search.component.html
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.html
@@ -2,7 +2,7 @@
   #scrollContainer
   class="search-container d-flex align-items-center overflow-auto py-2 w-100 ps-2 pe-2"
 >
-  @for (criterion of values(); track criterion) {
+  @for (criterion of values(); track criterion.value.name) {
     <si-filtered-search-value
       [editOnCreation]="autoEditCriteria"
       [definition]="criterion.config"
@@ -19,6 +19,7 @@
       [searchLabel]="searchLabel()"
       [onlySelectValue]="onlySelectValue()"
       [searchDebounceTime]="searchDebounceTime()"
+      (blurCriterion)="criterionBlur()"
       (submitCriterion)="focusNext($index, $event)"
       (deleteCriterion)="deleteCriterion($index, $event)"
       (valueChange)="valueChange($event, criterion)"

--- a/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
@@ -2192,7 +2192,7 @@ describe('SiFilteredSearchComponent', () => {
         await tick();
         await freeTextSearch.focus();
         await tick();
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
         expect(await freeTextSearch.getItems()).toEqual(['Bar']);
       });
 

--- a/projects/element-ng/filtered-search/si-filtered-search.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.ts
@@ -742,7 +742,13 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     }
   }
 
+  protected criterionBlur(): void {
+    this.trimWhitespaces();
+  }
+
   protected freeTextBlur(): void {
+    this.trimWhitespaces();
+
     queueMicrotask(() => {
       if (this.freeTextCriterion() && this.searchValue().length > 0) {
         this.createFreeTextPill(this.searchValue());
@@ -798,5 +804,37 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     ]);
     this.searchValue.set('');
     this.emitChangeEvent();
+  }
+
+  protected trimWhitespaces(): void {
+    const original = this.searchValue();
+    const trimmed = original.trim();
+    const searchChanged = trimmed !== original;
+    if (searchChanged) {
+      this.searchValue.set(trimmed);
+    }
+
+    let valuesChanged = false;
+    this.values.update(entries =>
+      entries.map(entry => {
+        const val = entry.value.value;
+        if (typeof val !== 'string') {
+          return entry;
+        }
+        const trimmedVal = val.trim();
+        if (trimmedVal === val) {
+          return entry;
+        }
+        valuesChanged = true;
+        return {
+          ...entry,
+          value: { ...entry.value, value: trimmedVal }
+        };
+      })
+    );
+
+    if (searchChanged || valuesChanged) {
+      this.emitChangeEvent();
+    }
   }
 }

--- a/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.html
+++ b/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.html
@@ -36,5 +36,6 @@
     (ngModelChange)="valueChange($event)"
     (typeaheadOnFullMatch)="valueTypeaheadFullMatch($event)"
     (typeaheadOnSelect)="valueTypeaheadSelect($event)"
+    (blur)="typeaheadBlur.emit()"
   />
 }

--- a/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
+++ b/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
@@ -9,6 +9,7 @@ import {
   ElementRef,
   OnChanges,
   OnInit,
+  output,
   signal,
   SimpleChanges,
   untracked,
@@ -40,6 +41,7 @@ export class SiFilteredSearchTypeaheadComponent
   protected override readonly valueInput = viewChild<ElementRef<HTMLInputElement>>('valueInput');
   protected readonly optionValue = signal<OptionCriterion | undefined>(undefined);
 
+  readonly typeaheadBlur = output<void>();
   // This must be a separate signal as it should only emit when the actual empty state changes.
   private readonly inputEmpty = computed(() => !this.criterionValue().value);
 
@@ -67,6 +69,10 @@ export class SiFilteredSearchTypeaheadComponent
   ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.criterionValue && this.criterionValue().value !== this.optionValue()?.value) {
       this.optionValue.set(undefined);
+    }
+
+    if (changes.definition) {
+      this.buildOptionValue();
     }
   }
 


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
Closes #1228

- add function to trim whitespaces that gets called on blur events
- add new custom blur event to make sure whitespaces are trimmed when user clicks outside of criterion<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1705/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1705/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1705/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1705/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-80%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1705/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1705/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->


