### PR TITLE
refactor(tree-view): resolve circular dependency using injection token

### DIFF
--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.directive.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.directive.ts
@@ -20,8 +20,8 @@ import {
 } from '@angular/core';
 
 import { TREE_ITEM_CONTEXT } from '../si-tree-view-item-context';
-import { SiTreeViewComponent } from '../si-tree-view.component';
 import { TreeItem, TreeItemContext } from '../si-tree-view.model';
+import { SI_TREE_VIEW } from '../si-tree-view.token';
 
 @Directive({
   selector: '[siTreeViewItem]'
@@ -29,7 +29,7 @@ import { TreeItem, TreeItemContext } from '../si-tree-view.model';
 export class SiTreeViewItemDirective implements AfterViewInit, OnDestroy {
   private templateRef = inject(TemplateRef);
   private viewContainerRef = inject(ViewContainerRef);
-  private parent = inject(SiTreeViewComponent);
+  private parent = inject(SI_TREE_VIEW);
   private differs = inject(IterableDiffers);
   private cdRef = inject(ChangeDetectorRef);
   private differ: IterableDiffer<TreeItem> | null = null;

--- a/projects/element-ng/tree-view/si-tree-view.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.ts
@@ -58,6 +58,7 @@ import {
   TreeViewIconSet
 } from './si-tree-view.model';
 import { SiTreeViewService } from './si-tree-view.service';
+import { SI_TREE_VIEW } from './si-tree-view.token';
 import {
   addChildItems,
   childrenLoaded,
@@ -109,7 +110,8 @@ const rootDefaults: TreeItem = {
     SiTreeViewConverterService,
     SiTreeViewItemHeightService,
     SiTreeViewService,
-    SiTreeViewVirtualizationService
+    SiTreeViewVirtualizationService,
+    { provide: SI_TREE_VIEW, useExisting: SiTreeViewComponent }
   ],
   host: {
     '(document:keyup.shift)': 'onKeyUpShift()',

--- a/projects/element-ng/tree-view/si-tree-view.token.ts
+++ b/projects/element-ng/tree-view/si-tree-view.token.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { InjectionToken } from '@angular/core';
+
+import type { SiTreeViewComponent } from './si-tree-view.component';
+
+export const SI_TREE_VIEW = new InjectionToken<SiTreeViewComponent>('SI_TREE_VIEW');


### PR DESCRIPTION
## Summary

- Introduce `SI_TREE_VIEW` injection token to break the circular runtime import between `SiTreeViewComponent` and `SiTreeViewItemDirective`
- The directive now injects the tree-view via the token instead of importing the component class directly
- The component provides itself under the token using `useExisting`

This change is needed to prepare the vitest migration, which does not tolerate circular dependencies at the module level.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1706/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1706/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1706/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1706/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-81%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1706/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1706/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->

