### PR TITLE
fix(form): prevent feedback icon from disappearing on hover in readonly inputs

### DIFF
--- a/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
+++ b/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
@@ -52,7 +52,7 @@
 
   &:is(.readonly, [readonly]) {
     &,
-    :is(:hover, :focus) {
+    &:is(:hover, :focus) {
       --border-color: #{semantic-tokens.$element-ui-4};
       background-color: variables.$input-bg;
     }


### PR DESCRIPTION
Icon disappears only when it has proper size e.g in case of numbered input component. in most of the case block size of feedback icon is `0` so it doesn't reproduce.

Steps to reproduce:

1. go to number input example https://element.siemens.io/element-examples/#/overview/si-number-input/si-number-input?q=number
2. change value to negative -42 which will highlight input as invalid with feedback icon
3. make component readonly from settings panel
4. hover on feedback icon. 

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1713/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1713/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1713/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1713/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1713/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1713/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
