### PR TITLE
fix(landing-page): resolve backgroundImageUrl from libraries relative path

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -23,11 +23,6 @@
               "src/favicon.png",
               "src/app/examples",
               {
-                "glob": "*",
-                "input": "projects/element-ng/assets/images",
-                "output": "assets/images"
-              },
-              {
                 "glob": "**/*",
                 "input": "src/assets/",
                 "ignore": ["**/i18n/*.json", "**/i18n/"],

--- a/projects/element-ng/landing-page/si-landing-page.component.html
+++ b/projects/element-ng/landing-page/si-landing-page.component.html
@@ -16,11 +16,7 @@
   />
 }
 <div class="landing-page">
-  <div
-    class="landing-page-background d-none d-md-block"
-    [style.background-image]="'url(' + backgroundImageUrl() + ')'"
-  >
-  </div>
+  <div class="landing-page-background d-none d-md-block"> </div>
   <div class="landing-page-content">
     <div class="landing-page-content-inner">
       @if (!isFullHeightSection) {

--- a/projects/element-ng/landing-page/si-landing-page.component.scss
+++ b/projects/element-ng/landing-page/si-landing-page.component.scss
@@ -26,6 +26,10 @@ $margin-bottom-footer: map.get(all-variables.$spacers, 9);
 }
 
 .landing-page-background {
+  background-image: var(
+    --si-landing-page-background-image,
+    url('../assets/images/landing-page-steel.webp')
+  );
   background-size: cover;
   background-position: center;
 

--- a/projects/element-ng/landing-page/si-landing-page.component.ts
+++ b/projects/element-ng/landing-page/si-landing-page.component.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input, TemplateRef, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  TemplateRef,
+  signal
+} from '@angular/core';
 import { CopyrightDetails, SiCopyrightNoticeComponent } from '@siemens/element-ng/copyright-notice';
 import { SiInlineNotificationComponent } from '@siemens/element-ng/inline-notification';
 import {
@@ -62,7 +69,10 @@ import { LandingPageWarning } from './si-landing-page.model';
   ],
   templateUrl: './si-landing-page.component.html',
   styleUrl: './si-landing-page.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[style.--si-landing-page-background-image]': 'backgroundImageCssUrl()'
+  }
 })
 export class SiLandingPageComponent {
   /**
@@ -85,11 +95,15 @@ export class SiLandingPageComponent {
   readonly links = input<Link[]>([]);
 
   /**
-   * URL to custom background image
-   *
-   * @defaultValue './assets/images/landing-page-steel.webp'
+   * URL to custom background image. When not set, the default image shipped
+   * with the library is used (resolved via CSS).
    */
-  readonly backgroundImageUrl = input('./assets/images/landing-page-steel.webp');
+  readonly backgroundImageUrl = input<string>();
+
+  protected readonly backgroundImageCssUrl = computed(() => {
+    const url = this.backgroundImageUrl();
+    return url ? `url(${url})` : null;
+  });
 
   /**
    * URL to custom brand image.


### PR DESCRIPTION
Currently apps need to explicitly copy assets from node_modules into project assets for default path to work.
With this they will no longer need to do that.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1716/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1716/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1716/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1716/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-80%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1716/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1716/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
