### PR TITLE
feat(dashboards-ng): extend module-federation version range to include v21

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -129,6 +129,7 @@ export type LoadRemoteModuleScriptOptions = {
     remoteEntry?: string;
     remoteName: string;
     exposedModule: string;
+    nonce?: string;
 };
 
 // @public

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "projects/icon-viewer"
       ],
       "dependencies": {
-        "@angular-architects/module-federation": "20.0.0",
+        "@angular-architects/module-federation": "21.2.2",
         "@angular-architects/native-federation": "21.1.0",
         "@angular/cdk": "21.0.6",
         "@angular/common": "21.0.8",
@@ -392,362 +392,73 @@
       }
     },
     "node_modules/@angular-architects/module-federation": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-architects/module-federation/-/module-federation-20.0.0.tgz",
-      "integrity": "sha512-EonYL6P5Yu1kCV6yXW8uYhTGBGG3E77+FEWosDnbDlWXuj80mGOKYdqE5xNxSyLldTJIKfEgt7x8//bIOmkWbA==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@angular-architects/module-federation/-/module-federation-21.2.2.tgz",
+      "integrity": "sha512-aM6Oys+RGlUZ+GuVz1gx9LlJNMnb+niEtEsCQ3NmgoIMOZDBlfYnm+jbDO0F1TJWrTOBbAvfbKvJbLHfG25r8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@angular-architects/module-federation-runtime": "20.0.0",
+        "@angular-architects/module-federation-runtime": "~21.2.2",
         "callsite": "^1.0.0",
-        "node-fetch": "^2.6.7",
-        "semver": "^7.3.5",
-        "word-wrap": "^1.2.3"
+        "node-fetch": "^3.3.2",
+        "semver": "~7.7.1",
+        "word-wrap": "^1.2.5"
       }
     },
     "node_modules/@angular-architects/module-federation/node_modules/@angular-architects/module-federation-runtime": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-architects/module-federation-runtime/-/module-federation-runtime-20.0.0.tgz",
-      "integrity": "sha512-06qoytemnCY/MCRFvdbbX/jSflqNMVTMuddnprid0Wfuc2lVsSgCv2Xi0FZFKjvhDHb1xYpmMQNExxKoXdp80g==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@angular-architects/module-federation-runtime/-/module-federation-runtime-21.2.2.tgz",
+      "integrity": "sha512-Akl6fLcD2dYXqxW4pLVgytq7NKQ998g4OUjEgcLQnhqyvlu+qdPRUfSDPlTGUiIY01/J2M9ZXcIWmUJJ5tOT5Q==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": ">=20.0.0",
-        "@angular/core": ">=20.0.0",
-        "@module-federation/enhanced": "^0.9.0",
-        "@module-federation/runtime-core": "^0.6.21"
+        "@angular/common": "^21.2.0",
+        "@angular/core": "^21.2.0",
+        "@module-federation/enhanced": "^2.2.2",
+        "@module-federation/runtime-core": "^2.2.2"
       }
     },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.9.1.tgz",
-      "integrity": "sha512-znN/Qm6M0U1t3iF10gu1hSxDkk18yz78yvk+AMB34UDzpXHiC1zbpIeV2CQNV5GCeafmCICmcn9y1qh7F54KTg==",
+    "node_modules/@angular-architects/module-federation/node_modules/@angular/common": {
+      "version": "21.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.5.tgz",
+      "integrity": "sha512-MTjCbsHBkF9W12CW9yYiTJdVfZv/qCqBCZ2iqhMpDA5G+ZJiTKP0IDTJVrx2N5iHfiJ1lnK719t/9GXROtEAvg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@module-federation/sdk": "0.9.1",
-        "@types/semver": "7.5.8",
-        "semver": "7.6.3"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "21.2.5",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/data-prefetch": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.9.1.tgz",
-      "integrity": "sha512-rS1AsgRvIMAWK8oMprEBF0YQ3WvsqnumjinvAZU1Dqut5DICmpQMTPEO1OrAKyjO+PQgEhmq13HggzN6ebGLrQ==",
+    "node_modules/@angular-architects/module-federation/node_modules/@angular/core": {
+      "version": "21.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.5.tgz",
+      "integrity": "sha512-JgHU134Adb1wrpyGC9ozcv3hiRAgaFTvJFn1u9OU/AVXyxu4meMmVh2hp5QhAvPnv8XQdKWWIkAY+dbpPE6zKA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@module-federation/runtime": "0.9.1",
-        "@module-federation/sdk": "0.9.1",
-        "fs-extra": "9.1.0"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/dts-plugin": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.9.1.tgz",
-      "integrity": "sha512-DezBrFaIKfDcEY7UhqyO1WbYocERYsR/CDN8AV6OvMnRlQ8u0rgM8qBUJwx0s+K59f+CFQFKEN4C8p7naCiHrw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@module-federation/error-codes": "0.9.1",
-        "@module-federation/managers": "0.9.1",
-        "@module-federation/sdk": "0.9.1",
-        "@module-federation/third-party-dts-extractor": "0.9.1",
-        "adm-zip": "^0.5.10",
-        "ansi-colors": "^4.1.3",
-        "axios": "^1.7.4",
-        "chalk": "3.0.0",
-        "fs-extra": "9.1.0",
-        "isomorphic-ws": "5.0.0",
-        "koa": "2.15.4",
-        "lodash.clonedeepwith": "4.5.0",
-        "log4js": "6.9.1",
-        "node-schedule": "2.1.1",
-        "rambda": "^9.1.0",
-        "ws": "8.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
-        "vue-tsc": ">=1.0.24"
+        "@angular/compiler": "21.2.5",
+        "rxjs": "^6.5.3 || ^7.4.0",
+        "zone.js": "~0.15.0 || ~0.16.0"
       },
       "peerDependenciesMeta": {
-        "vue-tsc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/enhanced": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.9.1.tgz",
-      "integrity": "sha512-c9siKVjcgT2gtDdOTqEr+GaP2X/PWAS0OV424ljKLstFL1lcS/BIsxWFDmxPPl5hDByAH+1q4YhC1LWY4LNDQw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.9.1",
-        "@module-federation/data-prefetch": "0.9.1",
-        "@module-federation/dts-plugin": "0.9.1",
-        "@module-federation/error-codes": "0.9.1",
-        "@module-federation/inject-external-runtime-core-plugin": "0.9.1",
-        "@module-federation/managers": "0.9.1",
-        "@module-federation/manifest": "0.9.1",
-        "@module-federation/rspack": "0.9.1",
-        "@module-federation/runtime-tools": "0.9.1",
-        "@module-federation/sdk": "0.9.1",
-        "btoa": "^1.2.1",
-        "upath": "2.0.1"
-      },
-      "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
-        "vue-tsc": ">=1.0.24",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
+        "@angular/compiler": {
           "optional": true
         },
-        "vue-tsc": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/error-codes": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.9.1.tgz",
-      "integrity": "sha512-q8spCvlwUzW42iX1irnlBTcwcZftRNHyGdlaoFO1z/fW4iphnBIfijzkigWQzOMhdPgzqN/up7XN+g5hjBGBtw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.9.1.tgz",
-      "integrity": "sha512-BPfzu1cqDU5BhM493enVF1VfxJWmruen0ktlHrWdJJlcddhZzyFBGaLAGoGc+83fS75aEllvJTEthw4kMViMQQ==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@module-federation/runtime-tools": "0.9.1"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/managers": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.9.1.tgz",
-      "integrity": "sha512-8hpIrvGfiODxS1qelTd7eaLRVF7jrp17RWgeH1DWoprxELANxm5IVvqUryB+7j+BhoQzamog9DL5q4MuNfGgIA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@module-federation/sdk": "0.9.1",
-        "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/manifest": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.9.1.tgz",
-      "integrity": "sha512-+GteKBXrAUkq49i2CSyWZXM4vYa+mEVXxR9Du71R55nXXxgbzAIoZj9gxjRunj9pcE8+YpAOyfHxLEdWngxWdg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@module-federation/dts-plugin": "0.9.1",
-        "@module-federation/managers": "0.9.1",
-        "@module-federation/sdk": "0.9.1",
-        "chalk": "3.0.0",
-        "find-pkg": "2.0.0"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/rspack": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.9.1.tgz",
-      "integrity": "sha512-ZJqG75dWHhyTMa9I0YPJEV2XRt0MFxnDiuMOpI92esdmwWY633CBKyNh1XxcLd629YVeTv03+whr+Fz/f91JEw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.9.1",
-        "@module-federation/dts-plugin": "0.9.1",
-        "@module-federation/inject-external-runtime-core-plugin": "0.9.1",
-        "@module-federation/managers": "0.9.1",
-        "@module-federation/manifest": "0.9.1",
-        "@module-federation/runtime-tools": "0.9.1",
-        "@module-federation/sdk": "0.9.1"
-      },
-      "peerDependencies": {
-        "@rspack/core": ">=0.7",
-        "typescript": "^4.9.0 || ^5.0.0",
-        "vue-tsc": ">=1.0.24"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "vue-tsc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/runtime": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.9.1.tgz",
-      "integrity": "sha512-jp7K06weabM5BF5sruHr/VLyalO+cilvRDy7vdEBqq88O9mjc0RserD8J+AP4WTl3ZzU7/GRqwRsiwjjN913dA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@module-federation/error-codes": "0.9.1",
-        "@module-federation/runtime-core": "0.9.1",
-        "@module-federation/sdk": "0.9.1"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/runtime-tools": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.9.1.tgz",
-      "integrity": "sha512-JQZ//ab+lEXoU2DHAH+JtYASGzxEjXB0s4rU+6VJXc8c+oUPxH3kWIwzjdncg2mcWBmC1140DCk+K+kDfOZ5CQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@module-federation/runtime": "0.9.1",
-        "@module-federation/webpack-bundler-runtime": "0.9.1"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/runtime/node_modules/@module-federation/runtime-core": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.9.1.tgz",
-      "integrity": "sha512-r61ufhKt5pjl81v7TkmhzeIoSPOaNtLynW6+aCy3KZMa3RfRevFxmygJqv4Nug1L0NhqUeWtdLejh4VIglNy5Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@module-federation/error-codes": "0.9.1",
-        "@module-federation/sdk": "0.9.1"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/sdk": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.9.1.tgz",
-      "integrity": "sha512-YQonPTImgnCqZjE/A+3N2g3J5ypR6kx1tbBzc9toUANKr/dw/S63qlh/zHKzWQzxjjNNVMdXRtTMp07g3kgEWg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.9.1.tgz",
-      "integrity": "sha512-KeIByP718hHyq+Mc53enZ419pZZ1fh9Ns6+/bYLkc3iCoJr/EDBeiLzkbMwh2AS4Qk57WW0yNC82xzf7r0Zrrw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0",
-        "resolve": "1.22.8"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.9.1.tgz",
-      "integrity": "sha512-CxySX01gT8cBowKl9xZh+voiHvThMZ471icasWnlDIZb14KasZoX1eCh9wpGvwoOdIk9rIRT7h70UvW9nmop6w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@module-federation/runtime": "0.9.1",
-        "@module-federation/sdk": "0.9.1"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@angular-architects/module-federation/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
+        "zone.js": {
           "optional": true
         }
       }
@@ -757,6 +468,7 @@
       "resolved": "https://registry.npmjs.org/@angular-architects/native-federation/-/native-federation-21.1.0.tgz",
       "integrity": "sha512-XOkYPEdBSgIGYpCAb8M09kkDimVesr43YcTITTL7GYAmN2Upto+KOPNBCpkFEDrrbFMkVpoUXz7HJFQ6w1Iq8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.19.0",
         "@chialab/esbuild-plugin-commonjs": "^0.19.0",
@@ -2434,6 +2146,21 @@
         "@lmdb/lmdb-win32-x64": "3.5.1"
       }
     },
+    "node_modules/@angular-builders/custom-esbuild/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-builders/custom-esbuild/node_modules/rolldown": {
       "version": "1.0.0-rc.4",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.4.tgz",
@@ -2472,6 +2199,7 @@
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -2503,6 +2231,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2608,6 +2337,7 @@
       "integrity": "sha512-My42P8i/FrZgEsTnsCS9IXKMk7ikJwa14i0aBcHg3lMBAPrdpHVzgDS6/1SOO1HsoVYF/SiPjwnlL152xlm8/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
         "@angular-devkit/architect": "0.2100.5",
@@ -3259,6 +2989,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3486,6 +3217,7 @@
       "integrity": "sha512-moERVCTekQKOvR8RMuEOtWSO3VS1qrzA3keI1dPto/JVB8Nqp9w3R5ZpEoXHzh4zgEryosxmPgdi6UczJe2ouQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "21.3.1",
         "eslint-scope": "9.1.2"
@@ -4228,12 +3960,28 @@
         "@esbuild/win32-x64": "0.27.2"
       }
     },
+    "node_modules/@angular/build/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular/build/node_modules/sass": {
       "version": "1.97.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.1.tgz",
       "integrity": "sha512-uf6HoO8fy6ClsrShvMgaKUn14f2EHQLQRtpsZZLeU/Mv0Q1K5P0+x2uvH6Cub39TVVbWNSrraUhDAoFph6vh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -4366,6 +4114,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.0.6.tgz",
       "integrity": "sha512-5Gw8mXtKXvcvDMWEciPLRYB6Ja5vsikLAidZsdCEIF6Bc51GmoqT5Tk/Ke+ciCd5Hq9Aco/IcHxT1RC3470lZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -4382,6 +4131,7 @@
       "integrity": "sha512-UYFQqn9Ow1wFVSwdB/xfjmZo4Yb7CUNxilbeYDFIybesfxXSdjMJBbXLtV0+icIhjmqfSUm2gTls6WIrG8qv9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.2100.5",
         "@angular-devkit/core": "21.0.5",
@@ -4491,6 +4241,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.0.8.tgz",
       "integrity": "sha512-on1B4oc/pf7IlkbG08Et/cCDSX8dpZz9iwp3zMFN/0JvorspyL5YOovFJfjdpmjdlrIi+ToGImwyIkY9P8Mblw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4521,6 +4272,7 @@
       "integrity": "sha512-+i/wFvi5FTg47Ei+aiFf8j3iYfjQ79ieg8oJM86+Mw4bNwEKQqvWcpmKjoqcfmCescuw0sr2DXU6OEeX+yWeVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.4",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -4614,6 +4366,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.0.8.tgz",
       "integrity": "sha512-8dNolIQn8WHrD3PsqGuPrujxDX5hjpMbioifIByjjX9yaJy9on7AewVGb8m/DHVwWQ1eGVAGmvW9wt+h+nlzLg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4655,6 +4408,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.0.8.tgz",
       "integrity": "sha512-H03A50elawXO53xkz0Aytar5kYT14GLeaj6dLKc1kcR5NqvX9Y/R7z3bY52tvypAdIR8CmPT7ad07TlT4O9lkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -4685,6 +4439,7 @@
       "integrity": "sha512-b4R3lLq32CbRXZrwMct4K7rQ5yzL7EXihg1IfyHNSEcxuuzdtXw/M1xexIkEVtLIfA+SROAThISbYgSgWq6rwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.4",
         "@types/babel__core": "7.20.5",
@@ -4770,6 +4525,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.0.8.tgz",
       "integrity": "sha512-5rPyrP6n6ClO0ZEUXndS2/Xb7nZrbjjYWOxgfCb+ZTCiU7eyN6zhSmicKk2dLQxE1M15wbTa87dN6/Ytuq2uvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4792,6 +4548,7 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.0.8.tgz",
       "integrity": "sha512-LPR65wyWBSyR46fGeQtD92+TM635o0lh+N5k9qPZdMacogwViTrtBHWPfKYBtBUXLWEWXXKJfSbXvhh3w3uLxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4846,6 +4603,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -6493,6 +6251,7 @@
       "integrity": "sha512-eohl3hKTiVyD1ilYdw9T0OiB4hnjef89e3dMYKz+mVKDzj+5IteTseASUsOB+EU9Tf6VNTCjDePcP6wkDGmLKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -6603,6 +6362,7 @@
       "integrity": "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@commitlint/format": "^20.5.0",
         "@commitlint/lint": "^20.5.0",
@@ -6625,6 +6385,7 @@
       "integrity": "sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@commitlint/types": "^20.5.0",
         "conventional-changelog-conventionalcommits": "^9.2.0"
@@ -6920,6 +6681,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6963,6 +6725,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7630,6 +7393,7 @@
       "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -8033,6 +7797,7 @@
       "integrity": "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.0",
         "@inquirer/confirm": "^5.1.19",
@@ -8776,20 +8541,6 @@
         "semver": "7.6.3"
       }
     },
-    "node_modules/@module-federation/bridge-react-webpack-plugin/node_modules/@module-federation/sdk": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.2.3.tgz",
-      "integrity": "sha512-DUXqwxQRqxlBz7XWW5mEsdTvYEZPWVAgwfh9JtLW1fkxfdG+Czzzs1sXGz8MPF76H3PGzbRdzeCEfiANlANWiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@module-federation/bridge-react-webpack-plugin/node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -8819,20 +8570,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@module-federation/cli/node_modules/@module-federation/sdk": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.2.3.tgz",
-      "integrity": "sha512-DUXqwxQRqxlBz7XWW5mEsdTvYEZPWVAgwfh9JtLW1fkxfdG+Czzzs1sXGz8MPF76H3PGzbRdzeCEfiANlANWiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
       }
     },
     "node_modules/@module-federation/cli/node_modules/ansi-styles": {
@@ -8904,20 +8641,6 @@
         }
       }
     },
-    "node_modules/@module-federation/data-prefetch/node_modules/@module-federation/sdk": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.2.3.tgz",
-      "integrity": "sha512-DUXqwxQRqxlBz7XWW5mEsdTvYEZPWVAgwfh9JtLW1fkxfdG+Czzzs1sXGz8MPF76H3PGzbRdzeCEfiANlANWiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@module-federation/data-prefetch/node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -8961,20 +8684,6 @@
       },
       "peerDependenciesMeta": {
         "vue-tsc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@module-federation/dts-plugin/node_modules/@module-federation/sdk": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.2.3.tgz",
-      "integrity": "sha512-DUXqwxQRqxlBz7XWW5mEsdTvYEZPWVAgwfh9JtLW1fkxfdG+Czzzs1sXGz8MPF76H3PGzbRdzeCEfiANlANWiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
           "optional": true
         }
       }
@@ -9048,6 +8757,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.2.3.tgz",
       "integrity": "sha512-9jANnDfa06aVsvwy/HXrmo89a5lcXEQg6ud3qKzfSEYZheXrWWEk5+3wWI0OoTmLr8VufleEYLtrg6AnxF9ZHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/bridge-react-webpack-plugin": "2.2.3",
         "@module-federation/cli": "2.2.3",
@@ -9086,20 +8796,6 @@
         }
       }
     },
-    "node_modules/@module-federation/enhanced/node_modules/@module-federation/sdk": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.2.3.tgz",
-      "integrity": "sha512-DUXqwxQRqxlBz7XWW5mEsdTvYEZPWVAgwfh9JtLW1fkxfdG+Czzzs1sXGz8MPF76H3PGzbRdzeCEfiANlANWiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@module-federation/error-codes": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.2.3.tgz",
@@ -9124,20 +8820,6 @@
         "@module-federation/sdk": "2.2.3",
         "find-pkg": "2.0.0",
         "fs-extra": "9.1.0"
-      }
-    },
-    "node_modules/@module-federation/managers/node_modules/@module-federation/sdk": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.2.3.tgz",
-      "integrity": "sha512-DUXqwxQRqxlBz7XWW5mEsdTvYEZPWVAgwfh9JtLW1fkxfdG+Czzzs1sXGz8MPF76H3PGzbRdzeCEfiANlANWiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
       }
     },
     "node_modules/@module-federation/managers/node_modules/fs-extra": {
@@ -9166,20 +8848,6 @@
         "@module-federation/sdk": "2.2.3",
         "chalk": "3.0.0",
         "find-pkg": "2.0.0"
-      }
-    },
-    "node_modules/@module-federation/manifest/node_modules/@module-federation/sdk": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.2.3.tgz",
-      "integrity": "sha512-DUXqwxQRqxlBz7XWW5mEsdTvYEZPWVAgwfh9JtLW1fkxfdG+Czzzs1sXGz8MPF76H3PGzbRdzeCEfiANlANWiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
       }
     },
     "node_modules/@module-federation/manifest/node_modules/ansi-styles": {
@@ -9239,20 +8907,6 @@
         }
       }
     },
-    "node_modules/@module-federation/rspack/node_modules/@module-federation/sdk": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.2.3.tgz",
-      "integrity": "sha512-DUXqwxQRqxlBz7XWW5mEsdTvYEZPWVAgwfh9JtLW1fkxfdG+Czzzs1sXGz8MPF76H3PGzbRdzeCEfiANlANWiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@module-federation/runtime": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.2.3.tgz",
@@ -9265,31 +8919,14 @@
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.6.21.tgz",
-      "integrity": "sha512-CLQiPP3kpcPbgPkiu/A1VURI2v4geFnEdizlB1tq0c6eDZqb5aLzvp87ZCGDVSuwY7DCq6jh1k+CM2WGge/2xA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.2.3.tgz",
+      "integrity": "sha512-muGMkv1AQIkCQy8mIa6lmgHu3qTasl/se+bZHERulD3gddK6ninM/Hc7mHyUVNO9rVhb+5Fv7QiCYahH4pRrIg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@module-federation/error-codes": "0.9.0",
-        "@module-federation/sdk": "0.9.0"
-      }
-    },
-    "node_modules/@module-federation/runtime-core/node_modules/@module-federation/error-codes": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.9.0.tgz",
-      "integrity": "sha512-dNqIs5cQfE4p+WIdiZ64cTSRJ5KjGaV+epvZkGttrNjXW9XAAtE7zgpo7cMQ8GWA3wCGaKnFw7Dn48XcU5ZMNw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@module-federation/runtime-core/node_modules/@module-federation/sdk": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.9.0.tgz",
-      "integrity": "sha512-84MklxE6Z79gCAr+6HCyqOpF95pqSah+fGnhLz+g4ePcWf98J73bWfrdOWFO/UfxMRneXKBZBNbpDVvPLgaFeQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "isomorphic-rslog": "0.0.7"
+        "@module-federation/error-codes": "2.2.3",
+        "@module-federation/sdk": "2.2.3"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
@@ -9297,22 +8934,13 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.2.3.tgz",
       "integrity": "sha512-nc7N2oGCwrn+WBou+K3owSILt57ibBxEBA1tppwypuSr7/GPNoOCyLJ9C/nBcPJf5NcHce4GYJES5+pO4f4C+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "2.2.3",
         "@module-federation/webpack-bundler-runtime": "2.2.3"
       }
     },
-    "node_modules/@module-federation/runtime/node_modules/@module-federation/runtime-core": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.2.3.tgz",
-      "integrity": "sha512-muGMkv1AQIkCQy8mIa6lmgHu3qTasl/se+bZHERulD3gddK6ninM/Hc7mHyUVNO9rVhb+5Fv7QiCYahH4pRrIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "2.2.3",
-        "@module-federation/sdk": "2.2.3"
-      }
-    },
-    "node_modules/@module-federation/runtime/node_modules/@module-federation/sdk": {
+    "node_modules/@module-federation/sdk": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.2.3.tgz",
       "integrity": "sha512-DUXqwxQRqxlBz7XWW5mEsdTvYEZPWVAgwfh9JtLW1fkxfdG+Czzzs1sXGz8MPF76H3PGzbRdzeCEfiANlANWiw==",
@@ -9377,20 +9005,6 @@
       "dependencies": {
         "@module-federation/runtime": "2.2.3",
         "@module-federation/sdk": "2.2.3"
-      }
-    },
-    "node_modules/@module-federation/webpack-bundler-runtime/node_modules/@module-federation/sdk": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.2.3.tgz",
-      "integrity": "sha512-DUXqwxQRqxlBz7XWW5mEsdTvYEZPWVAgwfh9JtLW1fkxfdG+Czzzs1sXGz8MPF76H3PGzbRdzeCEfiANlANWiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -10020,7 +9634,6 @@
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
@@ -10049,6 +9662,7 @@
       "resolved": "https://registry.npmjs.org/@ngx-formly/bootstrap/-/bootstrap-6.3.12.tgz",
       "integrity": "sha512-2HPqyC7DJjz5mwgNw+hkzXVmyaD4BfykWgUiF9peeNmhmYqF0z1JoGRotbdtzuwGeaGVkX86dPEt2pHJDeS3Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -10062,6 +9676,7 @@
       "resolved": "https://registry.npmjs.org/@ngx-formly/core/-/core-6.3.12.tgz",
       "integrity": "sha512-88MOfn9dM1B33t04jl8x0Glh0Ed0lUKMkhYajicRH7ZHTmwIdla1SQjiblp2C+EcCFvsY7XAU2/JUZQdl56aUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -10075,6 +9690,7 @@
       "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-16.0.4.tgz",
       "integrity": "sha512-s8llTL2SJvROhqttxvEs7Cg+6qSf4kvZPFYO+cTOY1d8DWTjlutRkWAleZcPPoeX927Dm7ALfL07G7oYDJ7z6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -10435,6 +10051,7 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -11811,7 +11428,6 @@
       "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.4.6.tgz",
       "integrity": "sha512-rRc6sbKWxhomxxJeqi4QS3S/2T6pKf4JwC/VHXs7KXw7lHXHa3yxPynmn3xHstL0H6VLaM5xQj87Wh7lQYRAPg==",
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "@rspack/binding-darwin-arm64": "1.4.6",
         "@rspack/binding-darwin-x64": "1.4.6",
@@ -11836,8 +11452,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
       "version": "1.4.6",
@@ -11850,8 +11465,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
       "version": "1.4.6",
@@ -11864,8 +11478,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
       "version": "1.4.6",
@@ -11878,8 +11491,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
       "version": "1.4.6",
@@ -11892,8 +11504,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
       "version": "1.4.6",
@@ -11906,8 +11517,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-wasm32-wasi": {
       "version": "1.4.6",
@@ -11918,7 +11528,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.11"
       }
@@ -11934,8 +11543,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
       "version": "1.4.6",
@@ -11948,8 +11556,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
       "version": "1.4.6",
@@ -11962,8 +11569,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/core": {
       "version": "1.4.6",
@@ -11992,15 +11598,13 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.15.0.tgz",
       "integrity": "sha512-CFJSF+XKwTcy0PFZ2l/fSUpR4z247+Uwzp1sXVkdIfJ/ATsnqf0Q01f51qqSEA6MYdQi6FKos9FIcu3dCpQNdg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rspack/core/node_modules/@module-federation/runtime": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.15.0.tgz",
       "integrity": "sha512-dTPsCNum9Bhu3yPOcrPYq0YnM9eCMMMNB1wuiqf1+sFbQlNApF0vfZxooqz3ln0/MpgE0jerVvFsLVGfqvC9Ug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.15.0",
         "@module-federation/runtime-core": "0.15.0",
@@ -12012,7 +11616,6 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.15.0.tgz",
       "integrity": "sha512-RYzI61fRDrhyhaEOXH3AgIGlHiot0wPFXu7F43cr+ZnTi+VlSYWLdlZ4NBuT9uV6JSmH54/c+tEZm5SXgKR2sQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.15.0",
         "@module-federation/sdk": "0.15.0"
@@ -12023,7 +11626,6 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.15.0.tgz",
       "integrity": "sha512-kzFn3ObUeBp5vaEtN1WMxhTYBuYEErxugu1RzFUERD21X3BZ+b4cWwdFJuBDlsmVjctIg/QSOoZoPXRKAO0foA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.15.0",
         "@module-federation/webpack-bundler-runtime": "0.15.0"
@@ -12033,15 +11635,13 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.15.0.tgz",
       "integrity": "sha512-PWiYbGcJrKUD6JZiEPihrXhV3bgXdll4bV7rU+opV7tHaun+Z0CdcawjZ82Xnpb8MCPGmqHwa1MPFeUs66zksw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rspack/core/node_modules/@module-federation/webpack-bundler-runtime": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.15.0.tgz",
       "integrity": "sha512-i+3wu2Ljh2TmuUpsnjwZVupOVqV50jP0ndA8PSP4gwMKlgdGeaZ4VH5KkHAXGr2eiYUxYLMrJXz1+eILJqeGDg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.15.0",
         "@module-federation/sdk": "0.15.0"
@@ -12052,7 +11652,6 @@
       "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.0.1.tgz",
       "integrity": "sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -12226,6 +11825,7 @@
       "integrity": "sha512-uNBIilq5bGnln3D7Nbm3/K+Ot++eGj4rygU0DCw//IZiTQU/iSyF3UAsN++iRetu/OMs+97T/RoGPjD22ryiZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.0.5",
         "@angular-devkit/schematics": "21.0.5",
@@ -12777,7 +12377,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@siemens/element-icons/-/element-icons-1.1.0.tgz",
       "integrity": "sha512-WVA64Uj4gytVRfYie2S4mUYbaoMKiV4Xv6YqMRjXXzlU6aw5E6JwttvepMb4D1QBEgUwnFoQ24SfQHvmOBsd2A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@siemens/element-ng": {
       "resolved": "projects/element-ng",
@@ -12842,6 +12443,7 @@
       "resolved": "https://registry.npmjs.org/@siemens/ngx-datatable/-/ngx-datatable-26.0.0.tgz",
       "integrity": "sha512-pi9Ksprec+sdGtndtf9odDHE870nB2AaWxuWIAkBnTtlif2EeXvYcuXPDgDgcieq3TyVerb/tZZ3mul0otGQeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -13560,6 +13162,7 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -13613,6 +13216,7 @@
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -13938,6 +13542,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -14407,6 +14012,7 @@
       "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -14488,6 +14094,7 @@
       "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.56.1",
@@ -14556,6 +14163,7 @@
       "integrity": "sha512-gjjrFC4+kPVK/fN9URDJWrssU5Gqh8Az8pKG/NSfQ2V+ky8b/y1BgBg0Ug13+hOGp5pzInonmGRPn7vOgSLgzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@blazediff/core": "1.9.1",
         "@vitest/mocker": "4.1.1",
@@ -14579,6 +14187,7 @@
       "integrity": "sha512-dtVSBZZha2k/7P7EAXXrEAoxuIKl8Yv9f2Dk4GN/DGfmhf4DQvkvu+57okR2wq/gan1xppKjL/aBxK/kbYrbGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.1",
         "@vitest/mocker": "4.1.1",
@@ -14986,6 +14595,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -14999,6 +14609,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -15010,6 +14621,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -15116,6 +14728,7 @@
       "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-34.3.1.tgz",
       "integrity": "sha512-PwlrPudsFOzGumphi2y9ihWeaUlIwKhOra/MXu2LjeV2U8DgLLcYS8CartE5Hszhn1poJHawwI9HWrxlKliwdw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ag-charts-types": "12.3.1"
       }
@@ -15149,6 +14762,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15237,6 +14851,7 @@
       "integrity": "sha512-VGQWTyuPAEO/AnZuqHxGBJMYSiZ0tbrHx/OgPCRTKHfbrFU4x+zivS84h9UWoDpDtius1RyD+ZReFjTAEWptiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-devkit/core": ">= 21.0.0 < 22.0.0",
         "@angular-devkit/schematics": ">= 21.0.0 < 22.0.0",
@@ -15523,6 +15138,7 @@
       "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -15864,6 +15480,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -15969,20 +15586,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/cache-content-type": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
-      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mime-types": "^2.1.18",
-        "ylru": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/cacheable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.0.tgz",
@@ -16024,6 +15627,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -16624,17 +16228,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
-    },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
@@ -16902,6 +16495,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -16958,6 +16552,7 @@
       "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17017,20 +16612,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
-      }
-    },
-    "node_modules/cookies": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
-      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "depd": "~2.0.0",
-        "keygrip": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/copy-anything": {
@@ -17138,6 +16719,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -17430,6 +17012,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/date-format": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
@@ -17455,13 +17046,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -17532,17 +17116,11 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -17562,6 +17140,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -17782,6 +17361,7 @@
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
       "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "6.0.0"
@@ -17797,6 +17377,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -17833,6 +17414,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -18271,6 +17853,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -18292,6 +17875,7 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -18361,6 +17945,7 @@
       "integrity": "sha512-WRHj7OZS/INutQ/gKN5C1ZGnMhkQ3oKZQAA2I7rl5yM8keBtSd9oj/qlJaHuwh5873FhMPqYlttcadF0YsTN7g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.57.1",
         "natural-orderby": "^5.0.0"
@@ -18571,6 +18156,7 @@
       "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "eslint": ">=2.0.0"
       }
@@ -19327,6 +18913,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -19515,7 +19124,8 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-7.5.0.tgz",
       "integrity": "sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/flat": {
       "version": "5.0.2",
@@ -19581,6 +19191,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -19731,16 +19353,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/generator-function": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -20140,6 +19752,7 @@
       "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.44.tgz",
       "integrity": "sha512-9p2TghluF2LTChFMLWsDRD5N78SZDsILdUk4gyqYxBXluCyxoPiOq+Fqt7DKM+LUd33+OgRkdrc+cPR93AypCQ==",
       "license": "(MIT AND Apache-2.0)",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -20176,7 +19789,8 @@
           "url": "https://www.venmo.com/adumesny"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -20474,47 +20088,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/http-assert": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
-      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "deep-equal": "~1.0.1",
-        "http-errors": "~1.8.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-assert/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-assert/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -20967,6 +20540,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -21099,26 +20673,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -21260,6 +20814,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -21363,16 +20918,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-rslog": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.7.tgz",
-      "integrity": "sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14.17.6"
       }
     },
     "node_modules/isomorphic-ws": {
@@ -21502,7 +21047,8 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.13.0.tgz",
       "integrity": "sha512-vsYjfh7lyqvZX5QgqKc4YH8phs7g96Z8bsdIFNEU3VqXhlHaq+vov/Fgn/sr6MiUczdZkyXRC3TX369Ll4Nzbw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jasmine/node_modules/jasmine-core": {
       "version": "6.1.0",
@@ -21558,6 +21104,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -21713,6 +21260,7 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -22197,20 +21745,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/keygrip": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tsscmp": "1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -22238,112 +21772,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/koa": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.4.tgz",
-      "integrity": "sha512-7fNBIdrU2PEgLljXoPWoyY4r1e+ToWCmzS/wwMPbUNs7X+5MMET1ObhJBlUkF5uZG9B6QhM2zS1TsH6adegkiQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "accepts": "^1.3.5",
-        "cache-content-type": "^1.0.0",
-        "content-disposition": "~0.5.2",
-        "content-type": "^1.0.4",
-        "cookies": "~0.9.0",
-        "debug": "^4.3.2",
-        "delegates": "^1.0.0",
-        "depd": "^2.0.0",
-        "destroy": "^1.0.4",
-        "encodeurl": "^1.0.2",
-        "escape-html": "^1.0.3",
-        "fresh": "~0.5.2",
-        "http-assert": "^1.3.0",
-        "http-errors": "^1.6.3",
-        "is-generator-function": "^1.0.7",
-        "koa-compose": "^4.1.0",
-        "koa-convert": "^2.0.0",
-        "on-finished": "^2.3.0",
-        "only": "~0.0.2",
-        "parseurl": "^1.3.2",
-        "statuses": "^1.5.0",
-        "type-is": "^1.6.16",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
-      }
-    },
-    "node_modules/koa-compose": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
-      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/koa-convert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
-      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "co": "^4.6.0",
-        "koa-compose": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/koa/node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/koa/node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/koa/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/koa/node_modules/http-errors/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/launch-editor": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.12.0.tgz",
@@ -22367,6 +21795,7 @@
       "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -22532,6 +21961,7 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -22999,6 +22429,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -23066,6 +22497,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -23661,6 +23093,7 @@
       "integrity": "sha512-IZGxuF226GF0d8FOZIfPvHsyBl53PrDEg/IB2+CVamsm3r4+gUw3mBp27eygpowBpdVLG0Sm2IbUiH4aSspzyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@rollup/plugin-json": "^6.1.0",
@@ -24209,6 +23642,7 @@
       "resolved": "https://registry.npmjs.org/ngx-image-cropper/-/ngx-image-cropper-9.1.6.tgz",
       "integrity": "sha512-b250YJ+jZovfqIj8vdEOrpEFay34be5f1Hpvg6Db68VMlvdyyuzboJdR0gCupbXtVcG6qQ86L7YG+SYxXJwApw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -24240,6 +23674,26 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -24257,23 +23711,21 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-forge": {
@@ -26487,6 +25939,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26669,6 +26122,7 @@
       "resolved": "https://registry.npmjs.org/ol/-/ol-10.8.0.tgz",
       "integrity": "sha512-kLk7jIlJvKyhVMAjORTXKjzlM6YIByZ1H/d0DBx3oq8nSPCG6/gbLr5RxukzPgwbhnAqh+xHNCmrvmFKhVMvoQ==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@types/rbush": "4.0.0",
         "earcut": "^3.0.0",
@@ -26687,6 +26141,7 @@
       "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-4.0.38.tgz",
       "integrity": "sha512-fJmMcUYV8tfNhaHTl93eV1esBo1L8QHdOjJsBzapomgpmXiW7PGv91i6tmvXU4mL2z0gFrupuzs8BMLGi6T0QQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "peerDependencies": {
         "ol": ">= 5.3.0"
       }
@@ -26696,6 +26151,7 @@
       "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-13.4.0.tgz",
       "integrity": "sha512-nme+Ko+hBKpdWwPr3tBIvOxlO/qLCStVgsPL39SQtIoVNM+mFq2dkX6ty6jrGcgyXS/QvyAOImUEN8VWSViFXw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^24.4.1",
         "mapbox-to-css-font": "^3.2.0"
@@ -26708,6 +26164,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -26751,12 +26208,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/only": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
-      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
-      "peer": true
     },
     "node_modules/open": {
       "version": "10.2.0",
@@ -27225,6 +26676,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -27536,6 +26988,7 @@
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -27602,6 +27055,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -27767,6 +27221,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0"
       },
@@ -27780,6 +27235,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -27811,6 +27267,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -28109,29 +27566,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.26.0"
-      },
-      "peerDependencies": {
-        "react": "^19.1.0"
       }
     },
     "node_modules/read-package-up": {
@@ -28675,6 +28109,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -28801,6 +28236,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -28809,6 +28245,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -28829,6 +28266,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -28924,7 +28362,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT",
-      "peer": true
+      "optional": true
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -28996,6 +28434,7 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -29387,7 +28826,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -29603,6 +29041,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/shallow-clone": {
@@ -30261,6 +29700,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -30490,6 +29930,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -30544,6 +29985,7 @@
       "integrity": "sha512-H88kCC+6Vtzj76NsC8rv6x/LW8slBzIbyeSjsKVlS+4qaEJoDrcJR4L+8JdrR2ORdTscrBzYWiiT2jq6leYR1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.1",
         "is-plain-object": "^5.0.0",
@@ -30990,6 +30432,7 @@
       "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
       "devOptional": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -31227,6 +30670,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -31241,12 +30685,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/traverse": {
       "version": "0.6.8",
@@ -31375,17 +30813,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.6.x"
-      }
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -31393,6 +30822,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -31932,6 +31362,7 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -31977,6 +31408,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -31991,6 +31423,7 @@
       "integrity": "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.57.2",
         "@typescript-eslint/parser": "8.57.2",
@@ -32581,6 +32014,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -32592,6 +32026,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -33151,6 +32586,7 @@
       "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.1",
         "@vitest/mocker": "4.1.1",
@@ -33269,17 +32705,20 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/web-worker": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
       "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
       "license": "Apache-2.0"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
       "version": "5.104.0",
@@ -33287,6 +32726,7 @@
       "integrity": "sha512-5DeICTX8BVgNp6afSPYXAFjskIgWGlygQH58bcozPOXgo2r/6xx39Y1+cULZ3gTxUYQP88jmwLj2anu4Xaq84g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -33393,6 +32833,7 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -33912,16 +33353,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -34090,6 +33521,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -34280,16 +33712,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ylru": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
-      "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -34355,6 +33777,7 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -34416,7 +33839,7 @@
       "version": "49.2.0",
       "license": "MIT",
       "peerDependencies": {
-        "@angular-architects/module-federation": "^20.0.0",
+        "@angular-architects/module-federation": "^20.0.0 || ^21.0.0",
         "@angular-architects/native-federation": "^21.1.0",
         "@angular/common": "21",
         "@angular/core": "21",
@@ -34441,6 +33864,7 @@
       "name": "@siemens/element-ng",
       "version": "49.2.0",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@angular/cdk": "21",
         "@angular/common": "21",
@@ -34485,7 +33909,8 @@
     "projects/element-theme": {
       "name": "@siemens/element-theme",
       "version": "49.2.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "projects/element-translate-cli": {
       "name": "@siemens/element-translate-cli",
@@ -34502,6 +33927,7 @@
       "name": "@siemens/element-translate-ng",
       "version": "49.2.0",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@angular/common": "21",
         "@angular/core": "21",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "projects/icon-viewer"
   ],
   "dependencies": {
-    "@angular-architects/module-federation": "20.0.0",
+    "@angular-architects/module-federation": "21.2.2",
     "@angular-architects/native-federation": "21.1.0",
     "@angular/cdk": "21.0.6",
     "@angular/common": "21.0.8",

--- a/projects/dashboards-ng/package.json
+++ b/projects/dashboards-ng/package.json
@@ -23,7 +23,7 @@
     "@siemens/element-ng": "49.2.0",
     "@siemens/element-theme": "49.2.0",
     "gridstack": "^12.3.3",
-    "@angular-architects/module-federation": "^20.0.0",
+    "@angular-architects/module-federation": "^20.0.0 || ^21.0.0",
     "@angular-architects/native-federation": "^21.1.0",
     "@module-federation/enhanced": "^2.0.0"
   },

--- a/projects/dashboards-ng/src/model/widgets.model.ts
+++ b/projects/dashboards-ng/src/model/widgets.model.ts
@@ -399,6 +399,11 @@ export type LoadRemoteModuleScriptOptions = {
   remoteEntry?: string;
   remoteName: string;
   exposedModule: string;
+  /**
+   * Optional nonce value applied to the script element for Content Security Policy (CSP) support.
+   * Supported in Module Federation v21.2.0+; safely ignored by earlier versions.
+   */
+  nonce?: string;
 };
 
 export type LoadRemoteModuleEsmOptions = {


### PR DESCRIPTION
Add optional `nonce` property to `LoadRemoteModuleScriptOptions` for Content Security Policy support, available in Module Federation v21.2.0+. The property is safely ignored by earlier versions.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1720/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1720/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1720/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1720/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-59%25-yellow?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1720/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1720/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->

