### PR TITLE
test(datepicker): do not bind `disabled` when using `formControl`

### DIFF
--- a/projects/element-ng/datepicker/si-timepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.spec.ts
@@ -12,7 +12,6 @@ import { SiTimepickerComponent as TestComponent } from './index';
   imports: [TestComponent, ReactiveFormsModule],
   template: `
     <si-timepicker
-      [disabled]="disabled()"
       [formControl]="time"
       [min]="min()"
       [max]="max()"
@@ -27,7 +26,6 @@ import { SiTimepickerComponent as TestComponent } from './index';
 })
 class WrapperComponent {
   readonly picker = viewChild.required<TestComponent>(TestComponent);
-  readonly disabled = signal(false);
   readonly time = new FormControl<Date | string | undefined>(undefined);
   readonly readonly = signal(false);
   readonly showMinutes = signal(true);
@@ -281,11 +279,8 @@ describe('SiTimepickerComponent', () => {
     });
 
     it('should disable component', () => {
-      fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
       component.time.setValue('2021-01-12 18:23:58.435');
-      component.disabled.set(true);
-      fixture.changeDetectorRef.markForCheck();
+      component.time.disable();
       fixture.detectChanges();
       expect(getHours().disabled).toBeTruthy();
       expect(getMinutes().disabled).toBeTruthy();


### PR DESCRIPTION
This is causing a warning in unit tests.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1725/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1725/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1725/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1725/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-59%25-yellow?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1725/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1725/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
