### PR TITLE
feat(threshold): add useAliasForStepValues input to display alias labels

### DIFF
--- a/api-goldens/element-ng/threshold/index.api.md
+++ b/api-goldens/element-ng/threshold/index.api.md
@@ -7,15 +7,15 @@
 import * as _angular_core from '@angular/core';
 import { OnChanges } from '@angular/core';
 import { SelectOption } from '@siemens/element-ng/select';
-import * as _siemens_element_translate_ng_translate from '@siemens/element-translate-ng/translate';
+import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public (undocumented)
 export class SiThresholdComponent implements OnChanges {
-    readonly addAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
+    readonly addAriaLabel: _angular_core.InputSignal<TranslatableString>;
     readonly canAddRemoveSteps: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly deleteAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
+    readonly deleteAriaLabel: _angular_core.InputSignal<TranslatableString>;
     readonly horizontalLayout: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly inputAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
+    readonly inputAriaLabel: _angular_core.InputSignal<TranslatableString>;
     readonly maxSteps: _angular_core.InputSignal<number>;
     readonly maxValue: _angular_core.InputSignal<number>;
     readonly minValue: _angular_core.InputSignal<number>;
@@ -23,10 +23,11 @@ export class SiThresholdComponent implements OnChanges {
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly readonlyConditions: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly showDecIncButtons: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly statusAriaLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
+    readonly statusAriaLabel: _angular_core.InputSignal<TranslatableString>;
     readonly stepSize: _angular_core.InputSignal<number>;
     readonly thresholdSteps: _angular_core.ModelSignal<ThresholdStep[]>;
     readonly unit: _angular_core.InputSignal<string>;
+    readonly useAliasForStepValues: _angular_core.InputSignalWithTransform<boolean, unknown>;
     get valid(): boolean;
     readonly validation: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly validChange: _angular_core.OutputEmitterRef<boolean>;
@@ -38,6 +39,7 @@ export class SiThresholdModule {
 
 // @public
 export interface ThresholdStep {
+    aliasLabel?: TranslatableString;
     optionValue: string;
     valid?: boolean;
     value?: number;

--- a/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--horizontal-noaddremove.yaml
+++ b/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--horizontal-noaddremove.yaml
@@ -37,7 +37,9 @@
 - checkbox "Validate" [checked]
 - text: Validate
 - checkbox "Can wrap" [checked]
-- text: Can wrap Max. steps
+- text: Can wrap
+- checkbox "Use alias for step values"
+- text: Use alias for step values Max. steps
 - spinbutton "Max. steps"
 - text: Min. value
 - spinbutton "Min. value"

--- a/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--horizontal-readonly.yaml
+++ b/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--horizontal-readonly.yaml
@@ -28,7 +28,9 @@
 - checkbox "Validate" [checked]
 - text: Validate
 - checkbox "Can wrap" [checked]
-- text: Can wrap Max. steps
+- text: Can wrap
+- checkbox "Use alias for step values"
+- text: Use alias for step values Max. steps
 - spinbutton "Max. steps"
 - text: Min. value
 - spinbutton "Min. value"

--- a/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--horizontal.yaml
+++ b/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--horizontal.yaml
@@ -54,7 +54,9 @@
 - checkbox "Validate" [checked]
 - text: Validate
 - checkbox "Can wrap" [checked]
-- text: Can wrap Max. steps
+- text: Can wrap
+- checkbox "Use alias for step values"
+- text: Use alias for step values Max. steps
 - spinbutton "Max. steps"
 - text: Min. value
 - spinbutton "Min. value"

--- a/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--vertical-noaddremove.yaml
+++ b/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--vertical-noaddremove.yaml
@@ -37,7 +37,9 @@
 - checkbox "Validate" [checked]
 - text: Validate
 - checkbox "Can wrap"
-- text: Can wrap Max. steps
+- text: Can wrap
+- checkbox "Use alias for step values"
+- text: Use alias for step values Max. steps
 - spinbutton "Max. steps"
 - text: Min. value
 - spinbutton "Min. value"

--- a/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--vertical-readonly.yaml
+++ b/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--vertical-readonly.yaml
@@ -28,7 +28,9 @@
 - checkbox "Validate" [checked]
 - text: Validate
 - checkbox "Can wrap"
-- text: Can wrap Max. steps
+- text: Can wrap
+- checkbox "Use alias for step values"
+- text: Use alias for step values Max. steps
 - spinbutton "Max. steps"
 - text: Min. value
 - spinbutton "Min. value"

--- a/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--vertical.yaml
+++ b/playwright/snapshots/si-threshold.spec.ts-snapshots/si-threshold--si-threshold--vertical.yaml
@@ -54,7 +54,9 @@
 - checkbox "Validate" [checked]
 - text: Validate
 - checkbox "Can wrap"
-- text: Can wrap Max. steps
+- text: Can wrap
+- checkbox "Use alias for step values"
+- text: Use alias for step values Max. steps
 - spinbutton "Max. steps"
 - text: Min. value
 - spinbutton "Min. value"

--- a/projects/element-ng/threshold/si-threshold.component.html
+++ b/projects/element-ng/threshold/si-threshold.component.html
@@ -2,7 +2,7 @@
   <div class="ths-step">
     @if (!$first) {
       <div class="ths-value d-flex align-items-center">
-        @if (canAddRemoveSteps() && !readonly() && !readonlyConditions()) {
+        @if (showAddRemoveButtons()) {
           <button
             type="button"
             class="btn btn-circle btn-ghost m-4"
@@ -11,8 +11,7 @@
           >
             <si-icon [icon]="icons.elementDelete" />
           </button>
-        }
-        @if (!canAddRemoveSteps() || readonly() || readonlyConditions()) {
+        } @else {
           <div class="py-4 my-4">&#8203;</div>
         }
         <div class="line">
@@ -21,22 +20,31 @@
           <div class="segment" [class]="colors()[$index]"></div>
         </div>
         <div class="d-flex align-items-center text-nowrap m-4">
-          <si-number-input
-            #valueInput="ngModel"
-            class="form-control text-end"
-            [class.is-invalid]="step.valid === false"
-            [aria-label]="inputAriaLabel() | translate"
-            [readonly]="readonly()"
-            [ngModelOptions]="{ standalone: true }"
-            [min]="minValue()"
-            [max]="maxValue()"
-            [step]="stepSize()"
-            [unit]="unit()"
-            [showButtons]="showDecIncButtons()"
-            [required]="true"
-            [(ngModel)]="step.value"
-            (ngModelChange)="stepChange()"
-          />
+          @if (useAliasForStepValues()) {
+            <input
+              type="text"
+              readonly
+              class="form-control"
+              [value]="step.aliasLabel ?? '' | translate"
+            />
+          } @else {
+            <si-number-input
+              #valueInput="ngModel"
+              class="form-control text-end"
+              [class.is-invalid]="step.valid === false"
+              [aria-label]="inputAriaLabel() | translate"
+              [readonly]="readonly()"
+              [ngModelOptions]="{ standalone: true }"
+              [min]="minValue()"
+              [max]="maxValue()"
+              [step]="stepSize()"
+              [unit]="unit()"
+              [showButtons]="showDecIncButtons()"
+              [required]="true"
+              [(ngModel)]="step.value"
+              (ngModelChange)="stepChange()"
+            />
+          }
         </div>
       </div>
     }
@@ -47,7 +55,7 @@
       />
     }
     <div class="ths-option d-flex align-items-center">
-      @if (canAddRemoveSteps() && !readonly() && !readonlyConditions()) {
+      @if (showAddRemoveButtons()) {
         <button
           type="button"
           class="btn btn-circle btn-secondary m-4"
@@ -57,8 +65,7 @@
         >
           <si-icon [icon]="icons.elementPlus" />
         </button>
-      }
-      @if (!canAddRemoveSteps() || readonly() || readonlyConditions()) {
+      } @else {
         <div class="py-4 my-4">&#8203;</div>
       }
       <div class="line" [class]="colors()[$index]">

--- a/projects/element-ng/threshold/si-threshold.component.spec.ts
+++ b/projects/element-ng/threshold/si-threshold.component.spec.ts
@@ -29,6 +29,7 @@ import { SiThresholdComponent, ThresholdStep } from './index';
       [stepSize]="stepSize"
       [showDecIncButtons]="showDecIncButtons"
       [validation]="validation"
+      [useAliasForStepValues]="useAliasForStepValues"
       [(thresholdSteps)]="thresholdSteps"
       (validChange)="valid = $event"
       (thresholdStepsChange)="thresholdStepsChange($event)"
@@ -52,6 +53,7 @@ class TestHostComponent {
   validation!: boolean;
   valid = true;
   wrap = false;
+  useAliasForStepValues = false;
 
   thresholdStepsChange(steps: ThresholdStep[]): void {}
 }
@@ -232,5 +234,50 @@ describe('SiThresholdComponent', () => {
       .map(option => option.nativeElement.innerText);
 
     expect(readonlyOptions).toEqual(['Poor', 'Average', 'Good', 'Average', 'Poor']);
+  });
+
+  describe('useAliasForStepValues', () => {
+    beforeEach(async () => {
+      component.useAliasForStepValues = true;
+      component.thresholdSteps = [
+        { value: undefined, optionValue: 'poor' },
+        { value: 15, optionValue: 'average', aliasLabel: 'Low' },
+        { value: 20, optionValue: 'good', aliasLabel: 'Medium' },
+        { value: 30, optionValue: 'poor', aliasLabel: 'High' }
+      ];
+      await runOnPushChangeDetection(fixture);
+    });
+
+    it('should hide add and delete buttons', () => {
+      expect(element.querySelectorAll('[aria-label="Add step"]').length).toBe(0);
+      expect(element.querySelectorAll('[aria-label="Delete step"]').length).toBe(0);
+    });
+
+    it('should show readonly text inputs instead of number inputs', () => {
+      const numberInputs = element.querySelectorAll('si-number-input');
+      expect(numberInputs.length).toBe(0);
+
+      const textInputs = element.querySelectorAll<HTMLInputElement>('.ths-value input[readonly]');
+      expect(textInputs.length).toBe(3);
+    });
+
+    it('should display alias labels in readonly inputs', () => {
+      const textInputs = element.querySelectorAll<HTMLInputElement>('.ths-value input[readonly]');
+      expect(textInputs[0].value).toBe('Low');
+      expect(textInputs[1].value).toBe('Medium');
+      expect(textInputs[2].value).toBe('High');
+    });
+
+    it('should display empty value when aliasLabel is not set', async () => {
+      component.thresholdSteps = [
+        { value: undefined, optionValue: 'poor' },
+        { value: 15, optionValue: 'average' }
+      ];
+      await runOnPushChangeDetection(fixture);
+
+      const textInputs = element.querySelectorAll<HTMLInputElement>('.ths-value input[readonly]');
+      expect(textInputs.length).toBe(1);
+      expect(textInputs[0].value).toBe('');
+    });
   });
 });

--- a/projects/element-ng/threshold/si-threshold.component.ts
+++ b/projects/element-ng/threshold/si-threshold.component.ts
@@ -23,7 +23,7 @@ import {
   SiSelectSimpleOptionsDirective,
   SiSelectSingleValueDirective
 } from '@siemens/element-ng/select';
-import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiReadonlyThresholdOptionComponent } from './si-readonly-threshold-option.component';
 
@@ -37,6 +37,8 @@ export interface ThresholdStep {
   optionValue: string;
   /** When set to `false`, input fields are highlighted as invalid */
   valid?: boolean;
+  /** Optional alias label for the threshold step, used when `useAliasForStepValues` is `true` */
+  aliasLabel?: TranslatableString;
 }
 
 @Component({
@@ -176,6 +178,14 @@ export class SiThresholdComponent implements OnChanges {
    */
   readonly statusAriaLabel = input(t(() => $localize`:@@SI_THRESHOLD.STATUS:Status`));
 
+  /**
+   * When enabled, numeric step inputs are replaced with readonly text fields displaying the `aliasLabel` of each step.
+   * Add/remove step buttons are also hidden.
+   *
+   * @defaultValue false
+   */
+  readonly useAliasForStepValues = input(false, { transform: booleanAttribute });
+
   /** Fired when validation status changes */
   readonly validChange = output<boolean>();
 
@@ -197,6 +207,14 @@ export class SiThresholdComponent implements OnChanges {
   }
 
   private readonly numberInputs = viewChildren(SiNumberInputComponent);
+
+  protected readonly showAddRemoveButtons = computed(
+    () =>
+      !this.useAliasForStepValues() &&
+      this.canAddRemoveSteps() &&
+      !this.readonly() &&
+      !this.readonlyConditions()
+  );
 
   ngOnChanges(): void {
     this.validate();

--- a/src/app/examples/si-threshold/si-threshold.html
+++ b/src/app/examples/si-threshold/si-threshold.html
@@ -15,6 +15,7 @@
       [stepSize]="stepSize"
       [showDecIncButtons]="showDecIncButtons"
       [validation]="validation"
+      [useAliasForStepValues]="useAliasForStepValues"
       (validChange)="valid = $event"
     />
   </div>
@@ -58,6 +59,11 @@
       <div class="col-sm-3">
         <si-form-item label="Can wrap">
           <input type="checkbox" class="form-check-input" [(ngModel)]="wrap" />
+        </si-form-item>
+      </div>
+      <div class="col-sm-3">
+        <si-form-item label="Use alias for step values">
+          <input type="checkbox" class="form-check-input" [(ngModel)]="useAliasForStepValues" />
         </si-form-item>
       </div>
     </div>

--- a/src/app/examples/si-threshold/si-threshold.ts
+++ b/src/app/examples/si-threshold/si-threshold.ts
@@ -66,15 +66,15 @@ export class SampleComponent {
   ];
 
   readonly thresholdSteps: ThresholdStep[] = [
-    { value: undefined, optionValue: 'unhealthy' },
-    { value: 10, optionValue: 'poor' },
-    { value: 15, optionValue: 'average' },
-    { value: 20, optionValue: 'good' },
-    { value: 23, optionValue: 'very-good' },
-    { value: 26, optionValue: 'good' },
-    { value: 28, optionValue: 'average' },
-    { value: 33, optionValue: 'poor' },
-    { value: 40, optionValue: 'unhealthy' }
+    { value: undefined, optionValue: 'unhealthy', aliasLabel: 'No value' },
+    { value: 10, optionValue: 'poor', aliasLabel: 'Ten' },
+    { value: 15, optionValue: 'average', aliasLabel: 'Fifteen' },
+    { value: 20, optionValue: 'good', aliasLabel: 'Twenty' },
+    { value: 23, optionValue: 'very-good', aliasLabel: 'Twenty-three' },
+    { value: 26, optionValue: 'good', aliasLabel: 'Twenty-six' },
+    { value: 28, optionValue: 'average', aliasLabel: 'Twenty-eight' },
+    { value: 33, optionValue: 'poor', aliasLabel: 'Thirty-three' },
+    { value: 40, optionValue: 'unhealthy', aliasLabel: 'Forty' }
   ];
 
   canAddRemove = true;
@@ -90,4 +90,5 @@ export class SampleComponent {
   validation = true;
   valid = true;
   wrap = false;
+  useAliasForStepValues = false;
 }


### PR DESCRIPTION
Add a `useAliasForStepValues` input that replaces numeric step inputs with readonly text fields showing alias labels. When enabled, add/delete step buttons are hidden. Adds `aliasLabel` property to `ThresholdStep`.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1728/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1728/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1728/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1728/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-48%25-critical?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1728/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1728/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->




