### PR TITLE
ci: use production config for examples build

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -41,7 +41,7 @@ jobs:
       - run: npm run prepare-brand
       - run: npm run build:all:update-translatable-keys # Output is needed in dist for providing default translations
       - run: git diff --exit-code "projects/**/*-translatable-keys.interface.ts"
-      - run: npm run build:examples -- --define="maptilerKey='$MAPTILER_KEY'" --define="maptilerUrl='$MAPTILER_URL'"
+      - run: npm run build:examples:prod -- --define="maptilerKey='$MAPTILER_KEY'" --define="maptilerUrl='$MAPTILER_URL'"
       - run: npm run dashboards-demo:build-all -- --progress=false
       - run: npm run dashboards-demo:build-all:esm
 

--- a/angular.json
+++ b/angular.json
@@ -93,12 +93,6 @@
                   "with": "src/environments/environment.local-maps.ts"
                 }
               ]
-            },
-            "aot": {
-              "aot": true,
-              "sourceMap": false,
-              "tsConfig": "src/tsconfig.app.prod.json",
-              "outputPath": "dist/element-examples-aot"
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "lint:playwright:eslint": "eslint -c playwright/eslint.config.js playwright",
     "build:examples": "ng build",
     "build:examples:prod": "ng build --configuration production",
-    "build:examples:aot": "ng build --configuration aot",
     "build:all": "npm run translate:build && npm run lib:build && npm run schematics:build && npm run live-preview:build && npm run charts:build && npm run native-charts:build && npm run dashboards:build && npm run maps:build",
     "build:all:update-translatable-keys": "npm exec update-translatable-keys",
     "release:copy-license": "cpy LICENSE.md projects/element-theme/ && cpy LICENSE.md projects/element-translate-cli/",


### PR DESCRIPTION
also remove `aot` config from `angular.json` as it is now by default.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1736/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1736/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1736/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1736/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-90%25-success?style=flat)

- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1736/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1736/pages/coverage/element-translate-ng/)

<!-- preview-links:end -->
