### PR TITLE
build(gh-actions): set environments for jobs

### DIFF
--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -13,6 +13,7 @@ jobs:
       MAPTILER_KEY: ${{ secrets.MAPTILER_KEY }}
 
   publish-documentation:
+    environment: github-pages
     runs-on: ubuntu-24.04
     permissions:
       pages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ jobs:
       MAPTILER_KEY: ${{ secrets.MAPTILER_KEY }}
 
   publish:
+    environment: release
     runs-on: ubuntu-24.04
     needs:
       - build-and-test


### PR DESCRIPTION
This ensures that only authorized jobs can do release and deploy to pages.

(cherry picked from commit bd3e6318553fe7c9f99dd9535b9128e939009ad8)

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
