### PR TITLE
fix(live-preview): hide StackBlitz button without element-theme dependency

### DIFF
--- a/projects/live-preview/components/stackblitz/si-stackblitz-button.component.ts
+++ b/projects/live-preview/components/stackblitz/si-stackblitz-button.component.ts
@@ -13,7 +13,7 @@ import { SI_STACKBLITZ_CONFIG } from './stackblitz.provider';
   host: {
     'title': 'Open Stackblitz',
     'attr.aria-label': 'Open in Stackblitz',
-    '[class.d-none]': '!config',
+    '[style.display]': '!config ? "none" : null',
     '[disabled]': 'disabled()',
     '(click)': 'openStackblitz()'
   }


### PR DESCRIPTION
The StackBlitz button visibility no longer relies on the d-none utility class from element-theme.
Use a style binding so the button is hidden when no StackBlitz config is provided, even in projects that do not include Element theme styles.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1764/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1764/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1764/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1764/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1764/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1764/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1764/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1764/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1764/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1764/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

