### PR TITLE
fix(charts): visualize datasets in si-chart-cartesian and si-chart

### DIFF
--- a/playwright/e2e/element-examples/charts/static.spec.ts
+++ b/playwright/e2e/element-examples/charts/static.spec.ts
@@ -18,6 +18,7 @@ test('si-charts/cartesian/line-basic', ({ si }) => si.static(options));
 test('si-charts/cartesian/line-live', ({ si }) => si.static(options));
 test('si-charts/cartesian/scatter-basic', ({ si }) => si.static(options));
 test('si-charts/cartesian/scatter-line-combined', ({ si }) => si.static(options));
+test('si-charts/cartesian/scatter-dataset', ({ si }) => si.static(options));
 test('si-charts/cartesian/scatter-live', ({ si }) => si.static(options));
 test('si-charts/circle/donut', ({ si }) => si.static(options));
 test('si-charts/circle/pie-basic', ({ si }) => si.static(options));

--- a/playwright/snapshots/charts/static.spec.ts-snapshots/si-charts--cartesian--scatter-dataset-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/charts/static.spec.ts-snapshots/si-charts--cartesian--scatter-dataset-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6426a84970320eb20ffdd6e49b0012c48207b26db017227d6b1b6371a148737d
+size 16283

--- a/playwright/snapshots/charts/static.spec.ts-snapshots/si-charts--cartesian--scatter-dataset-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/charts/static.spec.ts-snapshots/si-charts--cartesian--scatter-dataset-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7738bd458fa9d124ba40cf5407fbf14eabbbd15e12b570d8d933e221423f098b
+size 16271

--- a/projects/charts-ng/cartesian/si-chart-cartesian.component.ts
+++ b/projects/charts-ng/cartesian/si-chart-cartesian.component.ts
@@ -31,7 +31,8 @@ import {
   MarkAreaComponent,
   MarkLineComponent,
   MarkPointComponent,
-  AxisPointerComponent
+  AxisPointerComponent,
+  DatasetComponent
 } from 'echarts/components';
 import { LegacyGridContainLabel } from 'echarts/features';
 
@@ -47,6 +48,7 @@ echarts.use([
   ScatterChart,
   CandlestickChart,
   HeatmapChart,
+  DatasetComponent,
   LegendComponent,
   GridComponent,
   DataZoomComponent,

--- a/projects/charts-ng/chart/si-chart.component.ts
+++ b/projects/charts-ng/chart/si-chart.component.ts
@@ -27,7 +27,8 @@ import {
   MarkAreaComponent,
   MarkLineComponent,
   MarkPointComponent,
-  AxisPointerComponent
+  AxisPointerComponent,
+  DatasetComponent
 } from 'echarts/components';
 import { LegacyGridContainLabel } from 'echarts/features';
 
@@ -41,6 +42,7 @@ echarts.use([
   GaugeChart,
   SankeyChart,
   SunburstChart,
+  DatasetComponent,
   LegendComponent,
   GridComponent,
   DataZoomComponent,

--- a/src/app/examples/si-charts/cartesian/scatter-dataset.ts
+++ b/src/app/examples/si-charts/cartesian/scatter-dataset.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { SiChartCartesianComponent } from '@siemens/charts-ng/cartesian';
+import { ChartXAxis, ChartYAxis } from '@siemens/charts-ng/common';
+import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
+
+import { ChartBase, ChartData } from './chart-base';
+
+@Component({
+  selector: 'app-sample',
+  imports: [SiChartCartesianComponent, SiResizeObserverDirective],
+  templateUrl: './chart.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SampleComponent extends ChartBase {
+  chartData: ChartData = {
+    title: 'Scatter chart with dataset',
+    xAxis: { type: 'value' } as ChartXAxis,
+    yAxis: { type: 'value' } as ChartYAxis,
+    series: [
+      {
+        type: 'scatter',
+        name: 'Series A'
+      },
+      {
+        type: 'scatter',
+        name: 'Series B',
+        symbol: 'diamond',
+        datasetIndex: 1
+      }
+    ],
+    additionalOptions: {
+      dataset: [
+        {
+          source: [
+            [10, 20],
+            [15, 35],
+            [20, 25],
+            [30, 40],
+            [25, 15],
+            [12, 28],
+            [18, 32],
+            [22, 18],
+            [28, 42],
+            [35, 30]
+          ]
+        },
+        {
+          source: [
+            [8, 30],
+            [14, 22],
+            [19, 38],
+            [24, 12],
+            [32, 28],
+            [11, 36],
+            [16, 16],
+            [27, 34],
+            [33, 20],
+            [38, 26]
+          ]
+        }
+      ]
+    },
+    showLegend: true
+  };
+}


### PR DESCRIPTION
fixes #1761

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->

Visualize data provided by dataset:

<img width="1280" height="476" alt="image" src="https://github.com/user-attachments/assets/fd21ea7d-bd1c-4101-b74e-8653c9b9c376" />

<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1765/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1765/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1765/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1765/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1765/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1765/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1765/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1765/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1765/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1765/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

