### PR TITLE
refactor(sass): use modern CSS if() syntax

### DIFF
--- a/projects/element-theme/src/styles/bootstrap/_modals.scss
+++ b/projects/element-theme/src/styles/bootstrap/_modals.scss
@@ -209,7 +209,7 @@
 // scss-docs-start modal-fullscreen-loop
 @each $breakpoint in map.keys(variables.$grid-breakpoints) {
   $infix: breakpoints.breakpoint-infix($breakpoint, variables.$grid-breakpoints);
-  $postfix: if($infix != '', $infix + '-down', '');
+  $postfix: if(sass($infix != ''): $infix + '-down'; else: '');
 
   @include breakpoints.media-breakpoint-down($breakpoint) {
     .modal-fullscreen#{$postfix} {

--- a/projects/element-theme/src/styles/bootstrap/mixins/_breakpoints.scss
+++ b/projects/element-theme/src/styles/bootstrap/mixins/_breakpoints.scss
@@ -28,7 +28,7 @@
   @if not $n {
     @error "breakpoint `#{$name}` not found in `#{$breakpoints}`";
   }
-  @return if($n < list.length($breakpoint-names), list.nth($breakpoint-names, $n + 1), null);
+  @return if(sass($n < list.length($breakpoint-names)): list.nth($breakpoint-names, $n + 1));
 }
 
 // Minimum breakpoint width. Null for the smallest (first) breakpoint.
@@ -37,7 +37,7 @@
 //    576px
 @function breakpoint-min($name, $breakpoints: variables.$grid-breakpoints) {
   $min: map.get($breakpoints, $name);
-  @return if($min != 0, $min, null);
+  @return if(sass($min != 0): $min);
 }
 
 // Maximum breakpoint width.
@@ -51,7 +51,7 @@
 //    767.98px
 @function breakpoint-max($name, $breakpoints: variables.$grid-breakpoints) {
   $max: map.get($breakpoints, $name);
-  @return if($max and $max > 0, $max - 0.02, null);
+  @return if(sass($max and $max > 0): $max - 0.02);
 }
 
 // Returns a blank string if smallest breakpoint, otherwise returns the name with a dash in front.
@@ -62,7 +62,7 @@
 //    >> breakpoint-infix(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
 //    "-sm"
 @function breakpoint-infix($name, $breakpoints: variables.$grid-breakpoints) {
-  @return if(breakpoint-min($name, $breakpoints) == null, '', '-#{$name}');
+  @return if(sass(breakpoint-min($name, $breakpoints) == null): '' ; else: '-#{$name}');
 }
 
 // Media of at least the minimum breakpoint width. No query for the smallest breakpoint.

--- a/projects/element-theme/src/styles/bootstrap/mixins/_grid.scss
+++ b/projects/element-theme/src/styles/bootstrap/mixins/_grid.scss
@@ -27,9 +27,7 @@
 @mixin make-col-ready($gutter: variables.$grid-gutter-width) {
   // Add box sizing if only the grid is loaded
   box-sizing: if(
-    meta.variable-exists(include-column-box-sizing) and $include-column-box-sizing,
-    border-box,
-    null
+    sass(meta.variable-exists(include-column-box-sizing) and $include-column-box-sizing): border-box
   );
   // Prevent columns from becoming too narrow when at smaller grid tiers by
   // always setting `width: 100%;`. This works because we set the width
@@ -60,7 +58,7 @@
 
 @mixin make-col-offset($size, $columns: variables.$grid-columns) {
   $num: functions.divide($size, $columns);
-  margin-inline-start: if($num == 0, 0, math.percentage($num));
+  margin-inline-start: if(sass($num == 0): 0; else: math.percentage($num));
 }
 
 // Row columns

--- a/projects/element-theme/src/styles/bootstrap/mixins/_utilities.scss
+++ b/projects/element-theme/src/styles/bootstrap/mixins/_utilities.scss
@@ -25,26 +25,30 @@
 
     // Use custom class if present
     $property-class: if(
-      map.has-key($utility, class),
-      map.get($utility, class),
-      list.nth($properties, 1)
+      sass(map.has-key($utility, class)): map.get($utility, class) ; else: list.nth($properties, 1)
     );
-    $property-class: if($property-class == null, '', $property-class);
+    $property-class: if(
+      sass($property-class == null): '' ; else: $property-class
+    );
 
     // State params to generate pseudo-classes
-    $state: if(map.has-key($utility, state), map.get($utility, state), ());
+    $state: if(
+      sass(map.has-key($utility, state)): map.get($utility, state) ; else: ()
+    );
 
     $infix: if(
-      $property-class == '' and string.slice($infix, 1, 1) == '-',
-      string.slice($infix, 2),
-      $infix
+      sass($property-class == '' and string.slice($infix, 1, 1) == '-'): string.slice($infix, 2)
+        ;
+        else: $infix
     );
 
     // Don't prefix if value key is null (eg. with shadow class)
     $property-class-modifier: if(
-      $key,
-      if($property-class == '' and $infix == '', '', '-') + $key,
-      ''
+      sass($key): if(
+          sass($property-class == '' and $infix == ''): '' ; else: '-'
+        ) +
+        $key;
+        else: ''
     );
 
     $is-css-var: map.get($utility, css-var);
@@ -69,14 +73,22 @@
                 --#{variables.$variable-prefix}#{$local-var}: #{$value};
               }
             }
-            #{$property}: $value if(variables.$enable-important-utilities, !important, null);
+            @if variables.$enable-important-utilities {
+              #{$property}: $value !important;
+            } @else {
+              #{$property}: $value;
+            }
           }
         }
 
         @each $pseudo in $state {
           .#{$property-class + $infix + $property-class-modifier}-#{$pseudo}:#{$pseudo} {
             @each $property in $properties {
-              #{$property}: $value if(variables.$enable-important-utilities, !important, null);
+              @if variables.$enable-important-utilities {
+                #{$property}: $value !important;
+              } @else {
+                #{$property}: $value;
+              }
             }
           }
         }


### PR DESCRIPTION
The Sass if() syntax is deprecated in favor of the modern CSS syntax.

More info: https://sass-lang.com/d/if-function

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
