### PR TITLE
fix(charts): add missing echarts imports

### DIFF
--- a/projects/charts-ng/chart/si-chart.component.ts
+++ b/projects/charts-ng/chart/si-chart.component.ts
@@ -15,7 +15,8 @@ import {
   PieChart,
   GaugeChart,
   SankeyChart,
-  SunburstChart
+  SunburstChart,
+  CustomChart
 } from 'echarts/charts';
 import {
   LegendComponent,
@@ -28,7 +29,9 @@ import {
   MarkLineComponent,
   MarkPointComponent,
   AxisPointerComponent,
-  DatasetComponent
+  DatasetComponent,
+  PolarComponent,
+  SingleAxisComponent
 } from 'echarts/components';
 import { LegacyGridContainLabel } from 'echarts/features';
 
@@ -43,6 +46,7 @@ echarts.use([
   SankeyChart,
   SunburstChart,
   DatasetComponent,
+  CustomChart,
   LegendComponent,
   GridComponent,
   DataZoomComponent,
@@ -53,6 +57,8 @@ echarts.use([
   MarkLineComponent,
   MarkPointComponent,
   AxisPointerComponent,
+  PolarComponent,
+  SingleAxisComponent,
   LegacyGridContainLabel
 ]);
 


### PR DESCRIPTION
Fixes #1761<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1770/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1770/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1770/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1770/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1770/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1770/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1770/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1770/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1770/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1770/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
