### PR TITLE
refactor(dashboards-demo): convert sort property to signal in ListWidgetComponent

### DIFF
--- a/projects/dashboards-demo/src/app/widgets/charts/list-widget.component.ts
+++ b/projects/dashboards-demo/src/app/widgets/charts/list-widget.component.ts
@@ -2,7 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input, TemplateRef, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+  TemplateRef,
+  ViewChild
+} from '@angular/core';
 import { WidgetConfig, WidgetInstance } from '@siemens/dashboards-ng';
 import { ContentActionBarMainItem } from '@siemens/element-ng/content-action-bar';
 import {
@@ -17,7 +24,7 @@ import { Link, SiLinkDirective } from '@siemens/element-ng/link';
   selector: 'app-list-widget',
   imports: [SiEmptyStateComponent, SiListWidgetBodyComponent, SiLinkDirective],
   template: `
-    <si-list-widget-body search [sort]="sort" [value]="listWidgetValue">
+    <si-list-widget-body search [sort]="sort()" [value]="listWidgetValue">
       <si-empty-state
         empty-state
         icon="element-info"
@@ -88,17 +95,17 @@ export class ListWidgetComponent implements WidgetInstance {
   primaryActions!: ContentActionBarMainItem[];
   protected link?: Link = { href: 'https://github.com/siemens/element/issues' };
 
-  sort?: SortOrder;
+  protected readonly sort = signal<SortOrder | undefined>(undefined);
 
   constructor() {
     this.setupSortAction();
   }
 
   private doSort(): void {
-    if (this.sort === 'ASC') {
-      this.sort = 'DSC';
+    if (this.sort() === 'ASC') {
+      this.sort.set('DSC');
     } else {
-      this.sort = 'ASC';
+      this.sort.set('ASC');
     }
     this.setupSortAction();
   }
@@ -115,7 +122,7 @@ export class ListWidgetComponent implements WidgetInstance {
         }
       ];
     }
-    if (this.sort === 'ASC') {
+    if (this.sort() === 'ASC') {
       this.primaryActions[0].label = 'Sort ascending';
       this.primaryActions[0].icon = 'element-sort-up';
     } else {


### PR DESCRIPTION
clicking on sort button is currently not updating the list as it is not triggering change detection. using signal ensure it always trigger change detection to reflect correctly sorted list

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1772/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1772/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1772/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1772/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1772/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1772/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1772/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1772/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1772/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1772/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
