### PR TITLE
ci: redirect to coverage reports on coverage badge click

### DIFF
--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -30,7 +30,9 @@ jobs:
         with:
           name: coverage-reports
           path: coverage-reports
-      - run: cp coverage-reports/coverage-summary.json dist/design/coverage-summary.json
+      - run: |
+          cp coverage-reports/coverage-summary.json dist/design/coverage-summary.json
+          cp -r coverage-reports dist/design/coverage
       - uses: actions/upload-pages-artifact@v4
         with:
           path: 'dist/design'


### PR DESCRIPTION
currently clicking on coverage badge takes to 404 page as generated reports are never published.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1773/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1773/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1773/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1773/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1773/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1773/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1773/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1773/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1773/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1773/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
