### PR TITLE
feat(modal): migrate .modal-backdrop to use CSS starting-style instea…

### DIFF
--- a/projects/element-ng/modal/si-modal.component.html
+++ b/projects/element-ng/modal/si-modal.component.html
@@ -1,9 +1,5 @@
-@if (showBackdropClass() !== undefined) {
-  <div
-    class="modal-backdrop"
-    [class.fade]="modalRef.data.animated !== false"
-    [class.show]="showBackdropClass()"
-  ></div>
+@if (showBackdropVisible()) {
+  <div class="modal-backdrop" animate.leave="backdrop-leave"></div>
 }
 @if (init) {
   <div

--- a/projects/element-ng/modal/si-modal.component.ts
+++ b/projects/element-ng/modal/si-modal.component.ts
@@ -25,6 +25,7 @@ import { ModalRef } from './modalref';
   templateUrl: './si-modal.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
+    '[style.--element-animations-enabled]': 'modalRef.data.animated === false ? 0 : null',
     '(mousedown)': 'clickStarted($event)',
     '(mouseup)': 'onClickStop($event)',
     '(window:keydown.esc)': 'onEsc($event)'
@@ -38,12 +39,11 @@ export class SiModalComponent implements OnInit, AfterViewInit, OnDestroy {
   protected readonly titleId = this.modalRef.data?.ariaLabelledBy ?? '';
   protected init = false;
   protected readonly show = signal(false);
-  protected readonly showBackdropClass = signal<boolean | undefined>(undefined);
+  protected readonly showBackdropVisible = signal(false);
 
   private clickStartInDialog = false;
   private origBodyOverflow?: string;
   private showTimer: any;
-  private backdropTimer: any;
   private backdropGhostClickPrevention = true;
   private readonly document = inject(DOCUMENT);
 
@@ -86,23 +86,13 @@ export class SiModalComponent implements OnInit, AfterViewInit, OnDestroy {
 
   /** @internal */
   showBackdrop(): void {
-    if (this.modalRef?.data.animated !== false) {
-      this.showBackdropClass.set(false);
-      this.backdropTimer = setTimeout(() => {
-        this.showBackdropClass.set(true);
-      }, 16);
-    } else {
-      this.showBackdropClass.set(true);
-    }
+    this.showBackdropVisible.set(true);
     this.origBodyOverflow = this.document.body.style.overflow;
     this.document.body.style.overflow = 'hidden';
   }
 
   private hideBackdrop(): void {
-    clearTimeout(this.backdropTimer);
-    if (this.showBackdropClass() !== undefined) {
-      this.showBackdropClass.set(false);
-    }
+    this.showBackdropVisible.set(false);
     if (this.origBodyOverflow !== undefined) {
       this.document.body.style.overflow = this.origBodyOverflow;
       this.origBodyOverflow = undefined;

--- a/projects/element-theme/src/styles/bootstrap/mixins/_backdrop.scss
+++ b/projects/element-theme/src/styles/bootstrap/mixins/_backdrop.scss
@@ -1,4 +1,5 @@
-// Shared between modals and offcanvases
+@use '../variables';
+
 @mixin overlay-backdrop($zindex, $backdrop-bg, $backdrop-opacity) {
   position: fixed;
   inset-block-start: 0;
@@ -7,13 +8,14 @@
   inline-size: 100vw;
   block-size: 100vh;
   background-color: $backdrop-bg;
+  opacity: $backdrop-opacity;
+  transition: variables.$transition-fade;
 
-  // Fade for backdrop
-  &.fade {
+  @starting-style {
     opacity: 0;
   }
 
-  &.show {
-    opacity: $backdrop-opacity;
+  &.backdrop-leave {
+    opacity: 0;
   }
 }


### PR DESCRIPTION
…d of using timers

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1776/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1776/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1776/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1776/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1776/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1776/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1776/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1776/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1776/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1776/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


