### PR TITLE
chore(demo): add bulk actions examples

### DIFF
--- a/projects/element-theme/src/styles/components/_datatable.scss
+++ b/projects/element-theme/src/styles/components/_datatable.scss
@@ -267,7 +267,6 @@ $datatable-ghost-cell-strip-radius: 0 !default;
     .datatable-group-header {
       border-block-end: 1px solid $datatable-header-border-color;
       inline-size: 100% !important; // stylelint-disable-line declaration-no-important
-      min-inline-size: fit-content;
 
       .datatable-body-cell-label {
         overflow: inherit;
@@ -275,7 +274,7 @@ $datatable-ghost-cell-strip-radius: 0 !default;
         inline-size: 100%;
       }
 
-      &.datatable-body-row:hover:not(.active) {
+      &.datatable-body-row:hover:not(.active):has(.datatable-row-group) {
         background-color: variables.$table-hover-bg;
 
         :is(.datatable-row-left, .datatable-row-right) {
@@ -289,6 +288,8 @@ $datatable-ghost-cell-strip-radius: 0 !default;
     }
 
     .datatable-group-header {
+      min-inline-size: fit-content;
+
       .datatable-group-cell {
         display: flex;
         align-items: center;
@@ -310,6 +311,10 @@ $datatable-ghost-cell-strip-radius: 0 !default;
           @include focus.make-outline-focus-inside();
         }
       }
+    }
+
+    .datatable-body-row:has(.datatable-row-group) {
+      min-inline-size: fit-content;
     }
   }
 

--- a/src/app/examples/datatable/datatable-bulk-actions-side-panel.html
+++ b/src/app/examples/datatable/datatable-bulk-actions-side-panel.html
@@ -19,7 +19,6 @@
         columnMode="force"
         [class.bulk-actions-mode]="checked().size > 0"
         [selectionType]="checked().size > 0 ? undefined : 'single'"
-        [summaryRow]="checked().size > 0"
         [summaryHeight]="tableConfig.rowHeightSmall"
         [rows]="rows()"
         [columns]="columns"
@@ -29,7 +28,25 @@
         [(selected)]="selectedRow"
         (siResizeObserver)="table.recalculate()"
         (selectedChange)="panelCollapsed.set(false)"
-      />
+      >
+        @if (checked().size > 0) {
+          <ng-template ngx-datatable-summary-row>
+            <div
+              class="d-flex align-items-center flex-grow-1"
+              [style.height.px]="tableConfig.rowHeightSmall"
+            >
+              <span class="text-secondary text-nowrap fw-normal"
+                >{{ checked().size }} of {{ rows().length }} selected</span
+              >
+              <div class="ms-auto">
+                <button type="button" class="btn btn-primary" (click)="acknowledge()">
+                  Acknowledge
+                </button>
+              </div>
+            </div>
+          </ng-template>
+        }
+      </ngx-datatable>
     </div>
 
     <si-side-panel-content>
@@ -111,16 +128,4 @@
     (click)="$event.stopPropagation()"
     (change)="toggleRow(row)"
   />
-</ng-template>
-
-<ng-template #bulkActionsTemplate>
-  <div class="d-flex align-items-center">
-    <span class="text-body text-nowrap fw-normal">{{ checked().size }} selected</span>
-    <div class="ms-auto">
-      <button type="button" class="btn btn-primary" (click)="acknowledge()"> Acknowledge </button>
-      <button type="button" class="btn btn-secondary ms-4" (click)="clearSelection()">
-        Clear
-      </button>
-    </div>
-  </div>
 </ng-template>

--- a/src/app/examples/datatable/datatable-bulk-actions-side-panel.html
+++ b/src/app/examples/datatable/datatable-bulk-actions-side-panel.html
@@ -1,0 +1,126 @@
+<div class="has-navbar-fixed-top si-layout-fixed-height h-100">
+  <si-application-header>
+    <si-header-brand>
+      <h1 class="application-name">Bulk actions with side panel detail</h1>
+    </si-header-brand>
+  </si-application-header>
+
+  <si-side-panel
+    mode="scroll"
+    size="regular"
+    [collapsed]="panelCollapsed()"
+    (closed)="closePanel()"
+  >
+    <div class="si-layout-fixed-height si-layout-main-padding">
+      <ngx-datatable
+        #table
+        class="table-element si-layout-fixed-height"
+        siDatatableInteraction
+        columnMode="force"
+        [class.bulk-actions-mode]="checked().size > 0"
+        [selectionType]="checked().size > 0 ? undefined : 'single'"
+        [summaryRow]="checked().size > 0"
+        [summaryHeight]="tableConfig.rowHeightSmall"
+        [rows]="rows()"
+        [columns]="columns"
+        [rowHeight]="tableConfig.rowHeightSmall"
+        [scrollbarV]="true"
+        [footerHeight]="0"
+        [(selected)]="selectedRow"
+        (siResizeObserver)="table.recalculate()"
+        (selectedChange)="panelCollapsed.set(false)"
+      />
+    </div>
+
+    <si-side-panel-content>
+      <div class="d-flex flex-column h-100">
+        @if (checked().size > 0) {
+          <si-empty-state icon="element-user-group" [heading]="checked().size + ' rows selected'" />
+        } @else if (selectedRow().length === 1) {
+          @let selectedRow = this.selectedRow()[0];
+          <div class="p-6">
+            <div class="mb-4">
+              <label for="detailName" class="form-label">Name</label>
+              <input
+                readonly
+                type="text"
+                class="form-control"
+                id="detailName"
+                [value]="selectedRow.name"
+              />
+            </div>
+            <div class="mb-4">
+              <label for="detailDepartment" class="form-label">Department</label>
+              <input
+                readonly
+                type="text"
+                class="form-control"
+                id="detailDepartment"
+                [value]="selectedRow.department"
+              />
+            </div>
+            <div class="mb-4">
+              <label for="detailRole" class="form-label">Role</label>
+              <input
+                readonly
+                type="text"
+                class="form-control"
+                id="detailRole"
+                [value]="selectedRow.role"
+              />
+            </div>
+            <div class="mb-0">
+              <label for="detailStatus" class="form-label">Status</label>
+              <input
+                readonly
+                type="text"
+                class="form-control"
+                id="detailStatus"
+                [value]="selectedRow.status"
+              />
+            </div>
+          </div>
+          <div class="mt-auto p-5">
+            <button type="button" class="btn btn-primary w-100" (click)="acknowledge()">
+              Acknowledge
+            </button>
+          </div>
+        }
+      </div>
+    </si-side-panel-content>
+  </si-side-panel>
+</div>
+
+<ng-template #checkboxHeaderTmpl>
+  <input
+    type="checkbox"
+    class="form-check-input"
+    aria-label="Select all"
+    [checked]="allChecked()"
+    [indeterminate]="someChecked()"
+    (change)="toggleAll()"
+  />
+</ng-template>
+
+<ng-template #checkboxCellTmpl let-row="row">
+  <input
+    type="checkbox"
+    class="form-check-input"
+    [attr.aria-label]="'Select ' + row.name"
+    [checked]="checked().has(row.id)"
+    (click)="$event.stopPropagation()"
+    (change)="toggleRow(row)"
+  />
+</ng-template>
+
+<ng-template #bulkActionsTemplate>
+  <div class="d-flex align-items-center">
+    <span class="text-body text-nowrap fw-normal">{{ checked().size }} selected</span>
+    <div class="ms-auto">
+      <button type="button" class="btn btn-primary" (click)="acknowledge()"> Acknowledge </button>
+      <button type="button" class="btn btn-secondary ms-4" (click)="clearSelection()">
+        Clear
+      </button>
+    </div>
+  </div>
+</ng-template>

--- a/src/app/examples/datatable/datatable-bulk-actions-side-panel.ts
+++ b/src/app/examples/datatable/datatable-bulk-actions-side-panel.ts
@@ -43,7 +43,6 @@ interface Employee {
     SiSidePanelContentComponent
   ],
   templateUrl: './datatable-bulk-actions-side-panel.html',
-  styleUrl: './datatable-bulk-actions.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SampleComponent implements OnInit {
@@ -51,9 +50,6 @@ export class SampleComponent implements OnInit {
   protected readonly panelCollapsed = signal(true);
   protected readonly selectedRow = signal<Employee[]>([]);
 
-  private readonly bulkActionsTemplate = viewChild.required('bulkActionsTemplate', {
-    read: TemplateRef<unknown>
-  });
   private readonly checkboxCellTemplate = viewChild.required('checkboxCellTmpl', {
     read: TemplateRef<unknown>
   });
@@ -106,13 +102,12 @@ export class SampleComponent implements OnInit {
         canAutoResize: false,
         headerTemplate: this.checkboxHeaderTemplate(),
         cellTemplate: this.checkboxCellTemplate(),
-        summaryTemplate: this.bulkActionsTemplate(),
         cellClass: 'bulk-actions'
       },
-      { name: 'Name', prop: 'name', summaryFunc: null },
-      { name: 'Department', prop: 'department', summaryFunc: null },
-      { name: 'Role', prop: 'role', summaryFunc: null },
-      { name: 'Status', prop: 'status', summaryFunc: null }
+      { name: 'Name', prop: 'name' },
+      { name: 'Department', prop: 'department' },
+      { name: 'Role', prop: 'role' },
+      { name: 'Status', prop: 'status' }
     ];
   }
 
@@ -147,10 +142,6 @@ export class SampleComponent implements OnInit {
   closePanel(): void {
     this.panelCollapsed.set(true);
     this.selectedRow.set([]);
-  }
-
-  protected clearSelection(): void {
-    this.checked.set(new Set());
   }
 
   private updatePanel(): void {

--- a/src/app/examples/datatable/datatable-bulk-actions-side-panel.ts
+++ b/src/app/examples/datatable/datatable-bulk-actions-side-panel.ts
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  OnInit,
+  signal,
+  TemplateRef,
+  viewChild
+} from '@angular/core';
+import {
+  SiApplicationHeaderComponent,
+  SiHeaderBrandDirective
+} from '@siemens/element-ng/application-header';
+import { SI_DATATABLE_CONFIG, SiDatatableModule } from '@siemens/element-ng/datatable';
+import { SiEmptyStateComponent } from '@siemens/element-ng/empty-state';
+import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
+import { SiSidePanelComponent, SiSidePanelContentComponent } from '@siemens/element-ng/side-panel';
+import { NgxDatatableModule, TableColumn } from '@siemens/ngx-datatable';
+
+interface Employee {
+  id: number;
+  name: string;
+  department: string;
+  role: string;
+  status: string;
+}
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    NgxDatatableModule,
+    SiApplicationHeaderComponent,
+    SiDatatableModule,
+    SiEmptyStateComponent,
+    SiHeaderBrandDirective,
+    SiResizeObserverDirective,
+    SiSidePanelComponent,
+    SiSidePanelContentComponent
+  ],
+  templateUrl: './datatable-bulk-actions-side-panel.html',
+  styleUrl: './datatable-bulk-actions.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SampleComponent implements OnInit {
+  protected readonly tableConfig = SI_DATATABLE_CONFIG;
+  protected readonly panelCollapsed = signal(true);
+  protected readonly selectedRow = signal<Employee[]>([]);
+
+  private readonly bulkActionsTemplate = viewChild.required('bulkActionsTemplate', {
+    read: TemplateRef<unknown>
+  });
+  private readonly checkboxCellTemplate = viewChild.required('checkboxCellTmpl', {
+    read: TemplateRef<unknown>
+  });
+  private readonly checkboxHeaderTemplate = viewChild.required('checkboxHeaderTmpl', {
+    read: TemplateRef<unknown>
+  });
+
+  protected readonly checked = signal(new Set<number>());
+  protected readonly rows = signal<Employee[]>([]);
+  columns!: TableColumn[];
+
+  private readonly departments = ['Engineering', 'Marketing', 'Sales', 'Support'];
+  private readonly roles = ['Developer', 'Designer', 'Manager', 'Analyst'];
+  private readonly statuses = ['Active', 'Inactive', 'On Leave'];
+
+  protected readonly allChecked = computed(
+    () => this.rows().length > 0 && this.checked().size === this.rows().length
+  );
+  protected readonly someChecked = computed(
+    () => this.checked().size > 0 && this.checked().size < this.rows().length
+  );
+
+  constructor() {
+    const initial: Employee[] = [];
+    for (let i = 1; i <= 50; i++) {
+      initial.push({
+        id: i,
+        name: 'Employee ' + i,
+        department: this.departments[i % this.departments.length],
+        role: this.roles[i % this.roles.length],
+        status: this.statuses[i % this.statuses.length]
+      });
+    }
+    this.rows.set(initial);
+
+    effect(() => {
+      if (this.checked().size === 0 && this.selectedRow().length === 0) {
+        this.panelCollapsed.set(true);
+      }
+    });
+  }
+
+  ngOnInit(): void {
+    this.columns = [
+      {
+        name: '',
+        width: 50,
+        sortable: false,
+        resizeable: false,
+        canAutoResize: false,
+        headerTemplate: this.checkboxHeaderTemplate(),
+        cellTemplate: this.checkboxCellTemplate(),
+        summaryTemplate: this.bulkActionsTemplate(),
+        cellClass: 'bulk-actions'
+      },
+      { name: 'Name', prop: 'name', summaryFunc: null },
+      { name: 'Department', prop: 'department', summaryFunc: null },
+      { name: 'Role', prop: 'role', summaryFunc: null },
+      { name: 'Status', prop: 'status', summaryFunc: null }
+    ];
+  }
+
+  toggleAll(): void {
+    if (this.allChecked()) {
+      this.checked.set(new Set());
+    } else {
+      this.checked.set(new Set(this.rows().map(r => r.id)));
+    }
+    this.updatePanel();
+  }
+
+  toggleRow(row: Employee): void {
+    const next = new Set(this.checked());
+    if (next.has(row.id)) {
+      next.delete(row.id);
+    } else {
+      next.add(row.id);
+    }
+    this.checked.set(next);
+    this.updatePanel();
+  }
+
+  acknowledge(): void {
+    if (this.checked().size > 0) {
+      alert(`Acknowledged ${this.checked().size} items`);
+    } else if (this.selectedRow()) {
+      alert(`Acknowledged ${this.selectedRow()!.length} items`);
+    }
+  }
+
+  closePanel(): void {
+    this.panelCollapsed.set(true);
+    this.selectedRow.set([]);
+  }
+
+  protected clearSelection(): void {
+    this.checked.set(new Set());
+  }
+
+  private updatePanel(): void {
+    if (this.checked().size > 0) {
+      this.selectedRow.set([]);
+    }
+  }
+}

--- a/src/app/examples/datatable/datatable-bulk-actions.html
+++ b/src/app/examples/datatable/datatable-bulk-actions.html
@@ -1,0 +1,80 @@
+<div class="p-5 clearfix si-layout-fixed-height h-100">
+  <ngx-datatable
+    class="table-element si-layout-fixed-height"
+    siDatatableInteraction
+    columnMode="force"
+    [class.bulk-actions-mode]="checked().size > 0"
+    [selectionType]="checked().size > 0 ? undefined : 'single'"
+    [summaryRow]="checked().size > 0"
+    [summaryHeight]="tableConfig.rowHeightSmall"
+    [rows]="rows()"
+    [columns]="columns"
+    [rowHeight]="tableConfig.rowHeightSmall"
+    [scrollbarV]="true"
+    [footerHeight]="0"
+    [(selected)]="selected"
+  />
+</div>
+
+<ng-template #checkboxHeaderTmpl>
+  <input
+    type="checkbox"
+    class="form-check-input"
+    aria-label="Select all"
+    [checked]="allChecked()"
+    [indeterminate]="someChecked()"
+    (change)="toggleAll()"
+  />
+</ng-template>
+
+<ng-template #checkboxCellTmpl let-row="row">
+  <input
+    type="checkbox"
+    class="form-check-input"
+    [attr.aria-label]="'Select ' + row.name"
+    [checked]="checked().has(row.id)"
+    (click)="$event.stopPropagation()"
+    (change)="toggleRow(row)"
+  />
+</ng-template>
+
+<ng-template #bulkActionsTemplate>
+  <div class="d-flex align-items-center" (siResizeObserver)="onResize($event)">
+    <span class="text-body text-nowrap fw-normal">{{ checked().size }} selected</span>
+    <div class="d-flex gap-2 ms-auto">
+      @if (collapsed()) {
+        <button
+          type="button"
+          class="btn btn-icon btn-tertiary"
+          aria-label="Actions"
+          [cdkMenuTriggerFor]="allActionsMenu"
+        >
+          <si-icon [icon]="icons.elementOptionsVertical" />
+        </button>
+      } @else {
+        <button
+          type="button"
+          class="btn btn-tertiary dropdown-toggle"
+          [class.show]="statusMenuOpen()"
+          [cdkMenuTriggerFor]="statusMenu"
+          (cdkMenuOpened)="statusMenuOpen.set(true)"
+          (cdkMenuClosed)="statusMenuOpen.set(false)"
+        >
+          Change status
+          <i aria-hidden="true" class="dropdown-caret icon element-down-2"></i>
+        </button>
+        <button type="button" class="btn btn-tertiary" (click)="delete()"> Delete </button>
+        <button type="button" class="btn btn-tertiary" (click)="export()"> Export </button>
+        <button type="button" class="btn btn-tertiary" (click)="clear()"> Clear </button>
+      }
+    </div>
+  </div>
+</ng-template>
+
+<ng-template #allActionsMenu>
+  <si-menu-factory [items]="allActions" />
+</ng-template>
+
+<ng-template #statusMenu>
+  <si-menu-factory [items]="statusMenuItems" />
+</ng-template>

--- a/src/app/examples/datatable/datatable-bulk-actions.html
+++ b/src/app/examples/datatable/datatable-bulk-actions.html
@@ -5,7 +5,6 @@
     columnMode="force"
     [class.bulk-actions-mode]="checked().size > 0"
     [selectionType]="checked().size > 0 ? undefined : 'single'"
-    [summaryRow]="checked().size > 0"
     [summaryHeight]="tableConfig.rowHeightSmall"
     [rows]="rows()"
     [columns]="columns"
@@ -13,7 +12,47 @@
     [scrollbarV]="true"
     [footerHeight]="0"
     [(selected)]="selected"
-  />
+  >
+    @if (checked().size > 0) {
+      <ng-template ngx-datatable-summary-row>
+        <div
+          class="d-flex align-items-center justify-content-between flex-grow-1"
+          siAutoCollapsableList
+          [style.height.px]="tableConfig.rowHeightSmall"
+        >
+          <div class="text-secondary text-nowrap fw-normal" siAutoCollapsableListItem
+            >{{ checked().size }} of {{ rows().length }} selected</div
+          >
+
+          <button
+            type="button"
+            class="btn btn-icon btn-tertiary"
+            aria-label="Actions"
+            siAutoCollapsableListOverflowItem
+            [cdkMenuTriggerFor]="allActionsMenu"
+          >
+            <si-icon [icon]="icons.elementOptionsVertical" />
+          </button>
+
+          <div class="d-flex gap-2" siAutoCollapsableListItem>
+            <button
+              type="button"
+              class="btn btn-tertiary dropdown-toggle"
+              [class.show]="statusMenuOpen()"
+              [cdkMenuTriggerFor]="statusMenu"
+              (cdkMenuOpened)="statusMenuOpen.set(true)"
+              (cdkMenuClosed)="statusMenuOpen.set(false)"
+            >
+              Change status
+              <i aria-hidden="true" class="dropdown-caret icon element-down-2"></i>
+            </button>
+            <button type="button" class="btn btn-tertiary" (click)="delete()"> Delete </button>
+            <button type="button" class="btn btn-tertiary" (click)="export()"> Export </button>
+          </div>
+        </div>
+      </ng-template>
+    }
+  </ngx-datatable>
 </div>
 
 <ng-template #checkboxHeaderTmpl>
@@ -36,39 +75,6 @@
     (click)="$event.stopPropagation()"
     (change)="toggleRow(row)"
   />
-</ng-template>
-
-<ng-template #bulkActionsTemplate>
-  <div class="d-flex align-items-center" (siResizeObserver)="onResize($event)">
-    <span class="text-body text-nowrap fw-normal">{{ checked().size }} selected</span>
-    <div class="d-flex gap-2 ms-auto">
-      @if (collapsed()) {
-        <button
-          type="button"
-          class="btn btn-icon btn-tertiary"
-          aria-label="Actions"
-          [cdkMenuTriggerFor]="allActionsMenu"
-        >
-          <si-icon [icon]="icons.elementOptionsVertical" />
-        </button>
-      } @else {
-        <button
-          type="button"
-          class="btn btn-tertiary dropdown-toggle"
-          [class.show]="statusMenuOpen()"
-          [cdkMenuTriggerFor]="statusMenu"
-          (cdkMenuOpened)="statusMenuOpen.set(true)"
-          (cdkMenuClosed)="statusMenuOpen.set(false)"
-        >
-          Change status
-          <i aria-hidden="true" class="dropdown-caret icon element-down-2"></i>
-        </button>
-        <button type="button" class="btn btn-tertiary" (click)="delete()"> Delete </button>
-        <button type="button" class="btn btn-tertiary" (click)="export()"> Export </button>
-        <button type="button" class="btn btn-tertiary" (click)="clear()"> Clear </button>
-      }
-    </div>
-  </div>
 </ng-template>
 
 <ng-template #allActionsMenu>

--- a/src/app/examples/datatable/datatable-bulk-actions.scss
+++ b/src/app/examples/datatable/datatable-bulk-actions.scss
@@ -1,0 +1,21 @@
+::ng-deep {
+  .datatable-summary-row {
+    position: sticky;
+    inset-block-start: 0;
+    z-index: 1;
+  }
+
+  .datatable-summary-row .datatable-body-cell {
+    inline-size: 100% !important; // stylelint-disable-line declaration-no-important
+
+    &:not(.bulk-actions) {
+      display: none !important; // stylelint-disable-line declaration-no-important
+    }
+  }
+
+  .bulk-actions-mode {
+    .datatable-body-row:not(.datatable-summary-row *):hover {
+      background-color: revert !important; // stylelint-disable-line declaration-no-important
+    }
+  }
+}

--- a/src/app/examples/datatable/datatable-bulk-actions.scss
+++ b/src/app/examples/datatable/datatable-bulk-actions.scss
@@ -1,21 +1,7 @@
 ::ng-deep {
   .datatable-summary-row {
-    position: sticky;
-    inset-block-start: 0;
-    z-index: 1;
-  }
-
-  .datatable-summary-row .datatable-body-cell {
-    inline-size: 100% !important; // stylelint-disable-line declaration-no-important
-
-    &:not(.bulk-actions) {
-      display: none !important; // stylelint-disable-line declaration-no-important
-    }
-  }
-
-  .bulk-actions-mode {
-    .datatable-body-row:not(.datatable-summary-row *):hover {
-      background-color: revert !important; // stylelint-disable-line declaration-no-important
+    .datatable-body-row {
+      min-inline-size: inherit !important; // stylelint-disable-line declaration-no-important
     }
   }
 }

--- a/src/app/examples/datatable/datatable-bulk-actions.scss
+++ b/src/app/examples/datatable/datatable-bulk-actions.scss
@@ -1,7 +1,0 @@
-::ng-deep {
-  .datatable-summary-row {
-    .datatable-body-row {
-      min-inline-size: inherit !important; // stylelint-disable-line declaration-no-important
-    }
-  }
-}

--- a/src/app/examples/datatable/datatable-bulk-actions.ts
+++ b/src/app/examples/datatable/datatable-bulk-actions.ts
@@ -42,7 +42,6 @@ interface Employee {
     SiAutoCollapsableListModule
   ],
   templateUrl: './datatable-bulk-actions.html',
-  styleUrl: './datatable-bulk-actions.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SampleComponent implements OnInit {

--- a/src/app/examples/datatable/datatable-bulk-actions.ts
+++ b/src/app/examples/datatable/datatable-bulk-actions.ts
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { CdkMenuTrigger } from '@angular/cdk/menu';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  OnInit,
+  signal,
+  TemplateRef,
+  viewChild
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { elementDown2, elementOptionsVertical } from '@siemens/element-icons';
+import { SI_DATATABLE_CONFIG, SiDatatableModule } from '@siemens/element-ng/datatable';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
+import { MenuItem, SiMenuFactoryComponent } from '@siemens/element-ng/menu';
+import { ElementDimensions, SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
+import { NgxDatatableModule, TableColumn } from '@siemens/ngx-datatable';
+
+type Status = 'Active' | 'Inactive' | 'On Leave';
+
+interface Employee {
+  id: number;
+  name: string;
+  department: string;
+  role: string;
+  status: Status;
+}
+
+const COLLAPSED_BREAKPOINT = 400;
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    NgxDatatableModule,
+    SiDatatableModule,
+    SiIconComponent,
+    SiMenuFactoryComponent,
+    SiResizeObserverDirective,
+    CdkMenuTrigger,
+    FormsModule
+  ],
+  templateUrl: './datatable-bulk-actions.html',
+  styleUrl: './datatable-bulk-actions.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SampleComponent implements OnInit {
+  protected readonly icons = addIcons({ elementDown2, elementOptionsVertical });
+  protected readonly tableConfig = SI_DATATABLE_CONFIG;
+  protected readonly collapsed = signal(false);
+  protected readonly statusMenuOpen = signal(false);
+
+  private readonly bulkActionsTemplate = viewChild.required('bulkActionsTemplate', {
+    read: TemplateRef<unknown>
+  });
+  private readonly checkboxCellTemplate = viewChild.required('checkboxCellTmpl', {
+    read: TemplateRef<unknown>
+  });
+  private readonly checkboxHeaderTemplate = viewChild.required('checkboxHeaderTmpl', {
+    read: TemplateRef<unknown>
+  });
+
+  protected readonly checked = signal(new Set<number>());
+  protected readonly rows = signal<Employee[]>([]);
+  columns!: TableColumn[];
+
+  private readonly departments = ['Engineering', 'Marketing', 'Sales', 'Support'];
+  private readonly roles = ['Developer', 'Designer', 'Manager', 'Analyst'];
+  private readonly statuses: Status[] = ['Active', 'Inactive', 'On Leave'];
+
+  protected readonly allActions: MenuItem[] = [
+    { type: 'action', label: 'Delete', action: () => this.delete() },
+    { type: 'action', label: 'Export', action: () => this.export() },
+    {
+      type: 'group',
+      label: 'Change status',
+      children: this.statuses.map(status => ({
+        type: 'action',
+        label: status,
+        action: () => this.changeStatus(status)
+      }))
+    }
+  ];
+
+  protected readonly statusMenuItems: MenuItem[] = this.statuses.map(status => ({
+    type: 'action',
+    label: status,
+    action: () => this.changeStatus(status)
+  }));
+
+  protected readonly allChecked = computed(
+    () => this.rows().length > 0 && this.checked().size === this.rows().length
+  );
+  protected readonly someChecked = computed(
+    () => this.checked().size > 0 && this.checked().size < this.rows().length
+  );
+
+  protected readonly selected = signal<Employee[]>([]);
+
+  constructor() {
+    const initial: Employee[] = [];
+    for (let i = 1; i <= 50; i++) {
+      initial.push({
+        id: i,
+        name: 'Employee ' + i,
+        department: this.departments[i % this.departments.length],
+        role: this.roles[i % this.roles.length],
+        status: this.statuses[i % this.statuses.length]
+      });
+    }
+    this.rows.set(initial);
+  }
+
+  ngOnInit(): void {
+    this.columns = [
+      {
+        name: '',
+        width: 50,
+        sortable: false,
+        resizeable: false,
+        canAutoResize: false,
+        headerTemplate: this.checkboxHeaderTemplate(),
+        cellTemplate: this.checkboxCellTemplate(),
+        summaryTemplate: this.bulkActionsTemplate(),
+        cellClass: 'bulk-actions'
+      },
+      { name: 'Name', prop: 'name', summaryFunc: null },
+      { name: 'Department', prop: 'department', summaryFunc: null },
+      { name: 'Role', prop: 'role', summaryFunc: null },
+      { name: 'Status', prop: 'status', summaryFunc: null }
+    ];
+  }
+
+  protected toggleAll(): void {
+    if (this.allChecked()) {
+      this.checked.set(new Set());
+    } else {
+      this.checked.set(new Set(this.rows().map(r => r.id)));
+    }
+  }
+
+  protected toggleRow(row: Employee): void {
+    const next = new Set(this.checked());
+    if (next.has(row.id)) {
+      next.delete(row.id);
+    } else {
+      next.add(row.id);
+    }
+    this.checked.set(next);
+  }
+
+  protected delete(): void {
+    this.rows.set(this.rows().filter(row => !this.checked().has(row.id)));
+    this.checked.set(new Set());
+  }
+
+  protected export(): void {
+    alert(`Exporting ${this.checked().size} items`);
+  }
+
+  protected onResize(dimensions: ElementDimensions): void {
+    this.collapsed.set(dimensions.width < COLLAPSED_BREAKPOINT);
+  }
+
+  private changeStatus(status: Status): void {
+    this.rows.set(this.rows().map(row => (this.checked().has(row.id) ? { ...row, status } : row)));
+  }
+
+  protected clear(): void {
+    this.checked.set(new Set());
+    this.selected.set([]);
+  }
+}

--- a/src/app/examples/datatable/datatable-bulk-actions.ts
+++ b/src/app/examples/datatable/datatable-bulk-actions.ts
@@ -17,8 +17,8 @@ import { elementDown2, elementOptionsVertical } from '@siemens/element-icons';
 import { SI_DATATABLE_CONFIG, SiDatatableModule } from '@siemens/element-ng/datatable';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { MenuItem, SiMenuFactoryComponent } from '@siemens/element-ng/menu';
-import { ElementDimensions, SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
 import { NgxDatatableModule, TableColumn } from '@siemens/ngx-datatable';
+import { SiAutoCollapsableListModule } from 'projects/element-ng/auto-collapsable-list';
 
 type Status = 'Active' | 'Inactive' | 'On Leave';
 
@@ -30,8 +30,6 @@ interface Employee {
   status: Status;
 }
 
-const COLLAPSED_BREAKPOINT = 400;
-
 @Component({
   selector: 'app-sample',
   imports: [
@@ -39,9 +37,9 @@ const COLLAPSED_BREAKPOINT = 400;
     SiDatatableModule,
     SiIconComponent,
     SiMenuFactoryComponent,
-    SiResizeObserverDirective,
     CdkMenuTrigger,
-    FormsModule
+    FormsModule,
+    SiAutoCollapsableListModule
   ],
   templateUrl: './datatable-bulk-actions.html',
   styleUrl: './datatable-bulk-actions.scss',
@@ -123,14 +121,12 @@ export class SampleComponent implements OnInit {
         resizeable: false,
         canAutoResize: false,
         headerTemplate: this.checkboxHeaderTemplate(),
-        cellTemplate: this.checkboxCellTemplate(),
-        summaryTemplate: this.bulkActionsTemplate(),
-        cellClass: 'bulk-actions'
+        cellTemplate: this.checkboxCellTemplate()
       },
-      { name: 'Name', prop: 'name', summaryFunc: null },
-      { name: 'Department', prop: 'department', summaryFunc: null },
-      { name: 'Role', prop: 'role', summaryFunc: null },
-      { name: 'Status', prop: 'status', summaryFunc: null }
+      { name: 'Name', prop: 'name' },
+      { name: 'Department', prop: 'department' },
+      { name: 'Role', prop: 'role' },
+      { name: 'Status', prop: 'status' }
     ];
   }
 
@@ -161,16 +157,7 @@ export class SampleComponent implements OnInit {
     alert(`Exporting ${this.checked().size} items`);
   }
 
-  protected onResize(dimensions: ElementDimensions): void {
-    this.collapsed.set(dimensions.width < COLLAPSED_BREAKPOINT);
-  }
-
   private changeStatus(status: Status): void {
     this.rows.set(this.rows().map(row => (this.checked().has(row.id) ? { ...row, status } : row)));
-  }
-
-  protected clear(): void {
-    this.checked.set(new Set());
-    this.selected.set([]);
   }
 }


### PR DESCRIPTION
Show cases how to show bulk actions within table using existing `summaryRow` feature of datatable.

Two examples are added:

1. bulk-actions => demonstrate use of secondary buttons and menu dropdowns for bulk actions and responsive behavior by collapsing actions into three dots menu when space is less. 
2. bulk-actions-side-panel => demonstrate displaying row details in side panel on row click and bulk actions on top when rows are checked with checkbox.

NOTE: 
summary-row requires certain css overrides for rendering actions.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1777/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1777/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1777/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1777/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1777/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1777/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1777/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1777/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1777/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1777/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->















