### PR TITLE
feat(element-theme): add btn-font-weight-normal class for ghost and tertiary buttons

### DIFF
--- a/projects/element-theme/src/styles/bootstrap/_buttons.scss
+++ b/projects/element-theme/src/styles/bootstrap/_buttons.scss
@@ -28,7 +28,7 @@ button {
 
 :is(.btn, .btn-close) {
   line-height: bootstrap-variables.$btn-line-height;
-  font-weight: typography.$si-font-weight-h5;
+  font-weight: typography.$si-font-weight-semibold;
   padding-block: calc(bootstrap-variables.$btn-padding-y - var(--btn-border-width, 0px));
   padding-inline: calc(bootstrap-variables.$btn-padding-x - var(--btn-border-width, 0px));
   font-size: bootstrap-variables.$btn-font-size;
@@ -317,4 +317,16 @@ button {
   &:focus {
     --btn-border-color: #{semantic-tokens.$element-ui-1};
   }
+}
+
+:is(
+  .btn-primary-ghost,
+  .btn-secondary-ghost,
+  .btn-tertiary-ghost,
+  .btn-ghost,
+  .btn-tertiary,
+  .btn-tertiary-warning,
+  .btn-tertiary-danger
+).btn-font-weight-normal {
+  font-weight: typography.$si-font-weight-normal;
 }


### PR DESCRIPTION
Adds a `btn-font-weight-normal` class that sets the font-weight to normal (400) on ghost and tertiary buttons, instead of the default semibold (600). This is needed for internal component construction (content action bar, tree select).

A general typography class like `si-body` was considered but is not suitable because buttons determine their height through their own `line-height` and `font-size` values per size variant (`btn-lg`, `btn-sm`), which differ from the typography scale. Applying `si-body` would override these sizing properties and break button dimensions. A dedicated class that only adjusts `font-weight` avoids this issue.

```html
<!-- Default: semibold (600) — unchanged -->
<button class="btn btn-tertiary">Action</button>

<!-- Normal weight (400) -->
<button class="btn btn-tertiary btn-font-weight-normal">Action</button>
<button class="btn btn-tertiary-danger btn-font-weight-normal">Action</button>
<button class="btn btn-ghost btn-font-weight-normal">Action</button>
<button class="btn btn-primary-ghost btn-font-weight-normal">Action</button>

<!-- Works with any size -->
<button class="btn btn-tertiary btn-lg btn-font-weight-normal">Large</button>
<button class="btn btn-ghost btn-sm btn-font-weight-normal">Small</button>

<!-- Has no effect on non-ghost/tertiary buttons (specificity won't match) -->
<button class="btn btn-primary btn-font-weight-normal">Still semibold</button>
<button class="btn btn-secondary btn-font-weight-normal">Still semibold</button>
```

Resolves https://github.com/siemens/element/issues/1805

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1795/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1795/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1795/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1795/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1795/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1795/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1795/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1795/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1795/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1795/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


