### PR TITLE
refactor(date-range-filter): use signal `model` for value input

### DIFF
--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
@@ -515,6 +515,7 @@ export class SiDateRangeFilterComponent implements OnChanges {
         : { point1: 'now', range: 'before', point2: item.offset };
     if (this.advancedMode()) {
       this.updateFromRange(newRange);
+      this.updateRange();
     } else {
       this.updateSimpleMode(newRange);
     }

--- a/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
@@ -15,10 +15,9 @@ const ONE_DAY = ONE_MINUTE * 60 * 24;
   imports: [SiRelativeDateComponent],
   template: `<si-relative-date
     [enableTimeSelection]="enableTimeSelection()"
-    [value]="value()"
     [unitLabel]="unitLabel"
     [valueLabel]="valueLabel"
-    (valueChange)="value.set($event)"
+    [(value)]="value"
   /> `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/projects/element-ng/date-range-filter/si-relative-date.component.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.ts
@@ -8,8 +8,8 @@ import {
   Component,
   computed,
   input,
+  model,
   OnChanges,
-  output,
   signal,
   SimpleChanges
 } from '@angular/core';
@@ -42,15 +42,12 @@ interface OffsetOption extends SelectOption<string> {
 })
 export class SiRelativeDateComponent implements OnChanges {
   /** @defaultValue 0 */
-  // eslint-disable-next-line @angular-eslint/prefer-signal-model
-  readonly value = input(0);
+  readonly value = model(0);
   /** @defaultValue false */
   readonly enableTimeSelection = input(false, { transform: booleanAttribute });
   readonly valueLabel = input.required<string>();
   readonly unitLabel = input.required<string>();
-  readonly valueChange = output<number>();
 
-  protected readonly internalValue = signal(0);
   protected readonly offset = signal(0);
   protected readonly unit = signal('days');
   private readonly fullOffsetList: OffsetOption[] = [
@@ -99,9 +96,7 @@ export class SiRelativeDateComponent implements OnChanges {
   );
 
   ngOnChanges(changes: SimpleChanges<this>): void {
-    const value = this.value();
-    if (changes.value && value !== this.internalValue()) {
-      this.internalValue.set(value);
+    if (changes.value) {
       this.calculateOffset();
     }
   }
@@ -116,7 +111,7 @@ export class SiRelativeDateComponent implements OnChanges {
 
     for (let i = offsetList.length - 1; i >= 0; i--) {
       const item = offsetList[i];
-      const raw = this.internalValue() / item.offset;
+      const raw = this.value() / item.offset;
       const rounded = Math.round(raw);
       if (rounded > 0 && Math.abs(raw - rounded) < 0.001) {
         this.offset.set(rounded);
@@ -131,15 +126,15 @@ export class SiRelativeDateComponent implements OnChanges {
   protected updateValue(offset: number): void {
     this.offset.set(offset);
     const item = this.offsetList().find(x => x.value === this.unit())!;
-    this.internalValue.set(offset * item.offset);
-    this.valueChange.emit(this.internalValue());
+    const nextValue = offset * item.offset;
+    this.value.set(nextValue);
   }
 
   protected changeUnit(newUnit: string): void {
     this.unit.set(newUnit);
     const item = this.offsetList().find(x => x.value === this.unit())!;
-    this.offset.set(Math.max(1, Math.round(this.internalValue() / item.offset)));
-    this.internalValue.set(this.offset() * item.offset);
-    this.valueChange.emit(this.internalValue());
+    const roundedOffset = Math.max(1, Math.round(this.value() / item.offset));
+    this.offset.set(roundedOffset);
+    this.value.set(roundedOffset * item.offset);
   }
 }


### PR DESCRIPTION
Use a `model` signal for the `value` input.
Remove the redundant `internalValue` signal.


<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1796/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1796/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1796/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1796/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1796/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1796/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1796/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1796/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1796/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1796/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
