### PR TITLE
refactor(datepicker): avoid frequent template expressions re-evaluati…

### DIFF
--- a/projects/element-ng/datepicker/components/si-calendar-body.component.html
+++ b/projects/element-ng/datepicker/components/si-calendar-body.component.html
@@ -12,15 +12,7 @@
         class="si-calendar-cell"
         [attr.data-row]="rowIndex"
         [attr.data-col]="colIndex"
-        [class.range-hover]="
-          previewRange() && selection().previewRangeHover(col, activeHover(), startDate())
-        "
-        [class.range-hover-end]="
-          previewRange() && selection().previewRangeHoverEnd(col, activeHover(), startDate())
-        "
-        [class.range]="selection().inRange(col, startDate(), endDate())"
-        [class.range-start]="selection().isRangeSelected(col, startDate())"
-        [class.range-end]="selection().isRangeSelected(col, endDate())"
+        [class]="cellRangeClasses()[rowIndex][colIndex]"
       >
         <button
           siCalendarDateCell

--- a/projects/element-ng/datepicker/components/si-calendar-body.component.ts
+++ b/projects/element-ng/datepicker/components/si-calendar-body.component.ts
@@ -201,6 +201,40 @@ export class SiCalendarBodyComponent {
       : new SingleSelectionStrategy(this.compareAdapter())
   );
 
+  protected readonly cellRangeClasses = computed(() => {
+    const sel = this.selection();
+    const rows = this.rows();
+    const previewRange = this.previewRange();
+    // Only track hover if it's actually needed for the preview logic.
+    // This prevents unnecessary re-computations during mouse movement
+    // when range selection or preview is disabled.
+    const hover = previewRange && this.enableRangeSelection() ? this.activeHover() : undefined;
+    const start = this.startDate();
+    const end = this.endDate();
+
+    return rows.map(row =>
+      row.map(col => {
+        const classes: string[] = [];
+        if (previewRange && sel.previewRangeHover(col, hover, start)) {
+          classes.push('range-hover');
+        }
+        if (previewRange && sel.previewRangeHoverEnd(col, hover, start)) {
+          classes.push('range-hover-end');
+        }
+        if (sel.inRange(col, start, end)) {
+          classes.push('range');
+        }
+        if (sel.isRangeSelected(col, start)) {
+          classes.push('range-start');
+        }
+        if (sel.isRangeSelected(col, end)) {
+          classes.push('range-end');
+        }
+        return classes;
+      })
+    );
+  });
+
   /**
    * Focus calendar cell which is marked as active cell.
    */


### PR DESCRIPTION
…on in si-calendar-body

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1806/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1806/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1806/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1806/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1806/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1806/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1806/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1806/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1806/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1806/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


