### PR TITLE
refactor(dashboards-ng): use typed factory keys in widgetFactoryRegistry

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -141,7 +141,7 @@ export const provideDashboardToolbarItems: (toolbarItems?: {
     secondary?: DashboardToolbarItem[];
 }) => Provider;
 
-// @public
+// @public (undocumented)
 export type SetupComponentFn = <T>(factory: WidgetComponentFactory, componentName: string, host: ViewContainerRef, injector: Injector, envInjector: EnvironmentInjector) => Observable<ComponentRef<T>>;
 
 // @public (undocumented)
@@ -337,16 +337,6 @@ export interface WidgetConfigStatus {
     invalid: boolean;
     modified: boolean;
 }
-
-// @public (undocumented)
-export const widgetFactoryRegistry: {
-    _factories: {
-        [key: string]: SetupComponentFn;
-    };
-    register(name: string, factoryFn: SetupComponentFn): void;
-    getFactoryFn(name: string): SetupComponentFn;
-    hasFactoryFn(name: string): boolean;
-};
 
 // @public
 export interface WidgetImage {

--- a/projects/dashboards-ng/src/widget-loader.spec.ts
+++ b/projects/dashboards-ng/src/widget-loader.spec.ts
@@ -33,13 +33,13 @@ describe('widget-loader', () => {
 
 describe('widgetFactoryRegistry', () => {
   it('#hasFactoryFn() should return false for a not existing factory function', () => {
-    expect(widgetFactoryRegistry.hasFactoryFn('nothing')).toBe(false);
+    expect(widgetFactoryRegistry.hasFactoryFn('module-federation')).toBe(false);
   });
 
   it('#register() should add a factory function to the registry', () => {
     const factoryFn = {} as SetupComponentFn;
-    widgetFactoryRegistry.register('my-function', factoryFn);
-    expect(widgetFactoryRegistry.hasFactoryFn('my-function')).toBe(true);
-    expect(widgetFactoryRegistry.getFactoryFn('my-function')).toBe(factoryFn);
+    widgetFactoryRegistry.register('module-federation', factoryFn);
+    expect(widgetFactoryRegistry.hasFactoryFn('module-federation')).toBe(true);
+    expect(widgetFactoryRegistry.getFactoryFn('module-federation')).toBe(factoryFn);
   });
 });

--- a/projects/dashboards-ng/src/widget-loader.ts
+++ b/projects/dashboards-ng/src/widget-loader.ts
@@ -14,12 +14,16 @@ import { Observable, ReplaySubject, Subject, throwError } from 'rxjs';
 import { SiWebComponentEditorWrapperComponent } from './components/web-component-wrapper/si-web-component-editor-wrapper.component';
 import { SiWebComponentWrapperComponent } from './components/web-component-wrapper/si-web-component-wrapper.component';
 import {
+  FederatedBridgeModule,
+  FederatedModule,
   WebComponent,
   WidgetComponentFactory,
   WidgetComponentTypeFactory,
   WidgetInstance,
   WidgetInstanceEditor
 } from './model/widgets.model';
+
+type WidgetFactoryType = FederatedModule['factoryType'] | FederatedBridgeModule['factoryType'];
 
 export type SetupComponentFn = <T>(
   factory: WidgetComponentFactory,
@@ -29,18 +33,19 @@ export type SetupComponentFn = <T>(
   envInjector: EnvironmentInjector
 ) => Observable<ComponentRef<T>>;
 
+/** @internal */
 export const widgetFactoryRegistry = {
-  _factories: {} as { [key: string]: SetupComponentFn },
+  _factories: {} as { [key in WidgetFactoryType]?: SetupComponentFn },
 
-  register(name: string, factoryFn: SetupComponentFn) {
+  register(name: WidgetFactoryType, factoryFn: SetupComponentFn) {
     this._factories[name] = factoryFn;
   },
 
-  getFactoryFn(name: string) {
+  getFactoryFn(name: WidgetFactoryType) {
     return this._factories[name];
   },
 
-  hasFactoryFn(name: string) {
+  hasFactoryFn(name: WidgetFactoryType) {
     return this._factories[name] !== undefined;
   }
 };


### PR DESCRIPTION
This ensures that factory functions are mapped to valid factoryTypes.
Not a breaking change as it is intended to be used internally.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1807/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1807/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1807/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1807/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1807/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1807/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1807/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1807/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1807/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1807/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
