### PR TITLE
fix(filtered-search): only emit criteriaValueChange once after option…

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
@@ -521,10 +521,16 @@ describe('SiFilteredSearchComponent', () => {
       expect(component.lazyValueProvider).toHaveBeenCalledWith('foo', '');
 
       const spy = vi.spyOn(component, 'doSearch');
+      const changeSpy = vi.spyOn(component, 'searchCriteriaChange');
       await criteriaValue?.select({ text: 'Foo' });
       await tick();
 
       expect(spy).toHaveBeenCalledWith({
+        criteria: [{ name: 'foo', value: 'fO' }],
+        value: ''
+      });
+      expect(changeSpy).toHaveBeenCalledTimes(1);
+      expect(changeSpy).toHaveBeenCalledWith({
         criteria: [{ name: 'foo', value: 'fO' }],
         value: ''
       });
@@ -1598,17 +1604,25 @@ describe('SiFilteredSearchComponent', () => {
   it('should allow setting a custom value after an value option was selected', async () => {
     component.criteria.set([{ name: 'country', options: ['Germany'] }]);
     const spy = vi.spyOn(component, 'doSearch');
+    const changeSpy = vi.spyOn(component, 'searchCriteriaChange');
     const filteredSearch = await loader.getHarness(SiFilteredSearchHarness);
     const freeText = await filteredSearch.freeTextSearch();
     await freeText.focus();
     await tick();
     await freeText.select({ text: 'country' });
     await tick();
+    changeSpy.mockClear();
     const [criterion] = await filteredSearch.getCriteria();
     await criterion.clickLabel();
     await criterion.value().then(async value => {
       await value?.focus();
       await value?.select({ text: 'Germany' });
+    });
+    vi.advanceTimersToNextFrame();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
+    expect(changeSpy).toHaveBeenCalledWith({
+      value: '',
+      criteria: [{ name: 'country', value: 'Germany' }]
     });
     await filteredSearch.clickSearchButton();
     expect(spy).toHaveBeenCalledWith({
@@ -1620,6 +1634,7 @@ describe('SiFilteredSearchComponent', () => {
       await value!.focus();
       await value!.sendKeys('-North');
     });
+    vi.advanceTimersToNextFrame();
     await filteredSearch.clickSearchButton();
     expect(spy).toHaveBeenCalledWith({
       value: '',
@@ -1708,8 +1723,9 @@ describe('SiFilteredSearchComponent', () => {
       const filteredSearch = await loader.getHarness(SiFilteredSearchHarness);
       const criteria = await filteredSearch.getCriteria();
       const criteriaValue = await criteria[0].value();
-      await criteriaValue?.click();
-      await criteriaValue?.sendKeys(';');
+      await criteriaValue!.click();
+      await criteriaValue!.sendKeys(';');
+      vi.advanceTimersToNextFrame();
       expect(
         await filteredSearch.freeTextSearch().then(freeTextSearch => freeTextSearch.isFocused())
       ).toBe(true);

--- a/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.html
+++ b/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.html
@@ -21,7 +21,7 @@
     typeaheadScrollable
     [type]="inputType()"
     [step]="step()"
-    [ngModel]="valueLabel()"
+    [value]="valueLabel()"
     [siTypeahead]="options() ?? []"
     [typeaheadProcess]="!onlySelectValue()"
     [typeaheadMinLength]="0"
@@ -33,7 +33,7 @@
     (keydown)="valueFilterKeys($event)"
     (keydown.backspace)="valueBackspace()"
     (keydown.enter)="valueEnter()"
-    (ngModelChange)="valueChange($event)"
+    (typeaheadOnInput)="valueChange($event)"
     (typeaheadOnFullMatch)="valueTypeaheadFullMatch($event)"
     (typeaheadOnSelect)="valueTypeaheadSelect($event)"
   />

--- a/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
+++ b/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
@@ -14,7 +14,6 @@ import {
   untracked,
   viewChild
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 import { SiTypeaheadDirective, TypeaheadMatch } from '@siemens/element-ng/typeahead';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
@@ -25,7 +24,7 @@ import { SiFilteredSearchValueBase } from '../si-filtered-search-value.base';
 
 @Component({
   selector: 'si-filtered-search-typeahead',
-  imports: [SiTypeaheadDirective, FormsModule, SiTranslatePipe],
+  imports: [SiTypeaheadDirective, SiTranslatePipe],
   templateUrl: './si-filtered-search-typeahead.component.html',
   styleUrl: './si-filtered-search-typeahead.component.scss',
   providers: [
@@ -76,7 +75,7 @@ export class SiFilteredSearchTypeaheadComponent
   }
 
   protected valueChange(newValue: string | string[]): void {
-    if (typeof newValue === 'string') {
+    if (typeof newValue === 'string' && this.criterionValue().value !== newValue) {
       const match = newValue.match(/(.+?);(.*)$/);
       let value: string;
       if (!this.disableSelectionByColonAndSemicolon() && match) {
@@ -94,13 +93,7 @@ export class SiFilteredSearchTypeaheadComponent
   protected valueTypeaheadFullMatch(match: TypeaheadMatch): void {
     const option = match.option as TypeaheadOptionCriterion;
     this.optionValue.set(option);
-    // Usually, we already emitted a change in onCriterionValueInputChange using the text entered by the user.
-    // In case of a fullMatch, we should check if the value is different from label.
-    // If it is different, we must emit another event using the value instead of the label.
-    // TODO: prevent the emit of the label matching the option. This is currently not possible due to the order events.
-    if (option.value !== option.translatedLabel) {
-      this.criterionValue.update(v => ({ ...v, value: option.value }));
-    }
+    this.criterionValue.update(v => ({ ...v, value: option.value }));
   }
 
   protected valueTypeaheadSelect(match: TypeaheadMatch): void {


### PR DESCRIPTION
… selection

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1808/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1808/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1808/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1808/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1808/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1808/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1808/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1808/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1808/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1808/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

