### PR TITLE
feat(markdown-renderer): add optional syntax highlighting support

### DIFF
--- a/api-goldens/element-ng/markdown-renderer/index.api.md
+++ b/api-goldens/element-ng/markdown-renderer/index.api.md
@@ -4,19 +4,22 @@
 
 ```ts
 
+import * as _angular_core from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
-import * as i0 from '@angular/core';
 
 // @public
 export const getMarkdownRenderer: (sanitizer: DomSanitizer, options?: MarkdownRendererOptions, doc?: Document, isBrowser?: boolean) => ((text: string) => Node);
 
 // @public (undocumented)
-export type MarkdownRendererOptions = Record<string, never>;
+export interface MarkdownRendererOptions {
+    syntaxHighlighter?: (code: string, language?: string) => string | undefined;
+}
 
 // @public
 export class SiMarkdownRendererComponent {
     constructor();
-    readonly text: i0.InputSignal<string | undefined>;
+    readonly syntaxHighlighter: _angular_core.InputSignal<((code: string, language?: string) => string | undefined) | undefined>;
+    readonly text: _angular_core.InputSignal<string | undefined>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/api-goldens/element-ng/markdown-renderer/index.api.md
+++ b/api-goldens/element-ng/markdown-renderer/index.api.md
@@ -8,7 +8,10 @@ import { DomSanitizer } from '@angular/platform-browser';
 import * as i0 from '@angular/core';
 
 // @public
-export const getMarkdownRenderer: (sanitizer: DomSanitizer) => ((text: string) => Node);
+export const getMarkdownRenderer: (sanitizer: DomSanitizer, options?: MarkdownRendererOptions, doc?: Document, isBrowser?: boolean) => ((text: string) => Node);
+
+// @public (undocumented)
+export type MarkdownRendererOptions = Record<string, never>;
 
 // @public
 export class SiMarkdownRendererComponent {

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "eslint-plugin-perfectionist": "5.9.0",
         "eslint-plugin-prefer-arrow": "1.2.3",
         "eslint-plugin-tsdoc": "0.5.2",
+        "highlight.js": "11.11.1",
         "http-server": "14.1.1",
         "husky": "9.1.7",
         "ng-packagr": "21.0.1",
@@ -14558,6 +14559,16 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/cli-highlight/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/cli-highlight/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -17911,13 +17922,13 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/homedir-polyfill": {

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "eslint-plugin-perfectionist": "5.9.0",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-tsdoc": "0.5.2",
+    "highlight.js": "11.11.1",
     "http-server": "14.1.1",
     "husky": "9.1.7",
     "ng-packagr": "21.0.1",

--- a/playwright/e2e/element-examples/static.spec.ts
+++ b/playwright/e2e/element-examples/static.spec.ts
@@ -111,7 +111,7 @@ test('typography/type-styles', ({ si }) => si.static());
 test('typography/display-styles', ({ si }) => si.static());
 test('typography/typography', ({ si }) => si.static());
 test('si-markdown-renderer/si-markdown-renderer', ({ si }) =>
-  si.static({ disabledA11yRules: ['link-in-text-block'] }));
+  si.static({ disabledA11yRules: ['link-in-text-block', 'color-contrast'] }));
 test('si-chat-messages/si-ai-message', ({ si }) => si.static());
 test('si-chat-messages/si-user-message', ({ si }) => si.static());
 test('si-chat-messages/si-chat-message', ({ si }) => si.static());

--- a/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-ai-message-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-ai-message-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ef537fcdb4bdf2010c69e492639696ffb7a5c6b90268cedf3eb1a03a8b091650
-size 14065
+oid sha256:e468b677795c5ebf95fcf35b04c7a9c0830cd81cc05e72415c9ff9a787430800
+size 14052

--- a/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-ai-message-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-ai-message-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d658adc4170aab7747ccfc062501489d14a49da294f3589744555a18f28168a
-size 13747
+oid sha256:4ff193f2e6d511f5889ded8da42cae2014092d4a7068597e95efddda2fc2d212
+size 13737

--- a/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-user-message-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-user-message-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f35a2a7dd7483fb7baff2137b550b8c59f877c56f7ced2d58cb6b70f0781b6a
-size 15359
+oid sha256:3eff70e341c0936fe7931c5729725bdd5e238dc8307460195fd90fe9f5fed318
+size 15354

--- a/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-user-message-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-user-message-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e074fcc1d95efe6772b45b105a1e108c24b8915da2ffe7ce622d90cd731b4c80
-size 14984
+oid sha256:7d0dda2042e334aad645d664f7bc285ca194cc6a83b4f87b67bb40907a637b34
+size 14981

--- a/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9099595741c83cc68b109c3e10c580a16baa955edada83be763a4e0463c4b562
-size 142664
+oid sha256:44d26e9299c91d7588e8bb6b4c4ea36412b8e3f868d61e5e547f040de234b56f
+size 484298

--- a/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44d26e9299c91d7588e8bb6b4c4ea36412b8e3f868d61e5e547f040de234b56f
-size 484298
+oid sha256:bcc30dd5d87ee6ebd10c43e081da97010e321a1d2a6e6c3ad01494af3c933991
+size 485477

--- a/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44169fc478745ec3948eb36eb49e9bba080d83989df561e9f1bb6f6b44343cd7
-size 480324
+oid sha256:a567d3866cae2739eead20cde17766e1a5dc7789b1ee5e3bb11810c4c678a44f
+size 481968

--- a/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc2d2cd0d352ea4b212b3a2fe92921e49a29df13bf23e7560e248301c282fa54
-size 139173
+oid sha256:44169fc478745ec3948eb36eb49e9bba080d83989df561e9f1bb6f6b44343cd7
+size 480324

--- a/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer.yaml
@@ -1,5 +1,5 @@
-- heading "AI Assistant Response" [level=2]:
-  - strong: AI Assistant Response
+- heading "Sample Markdown Content" [level=2]:
+  - strong: Sample Markdown Content
 - paragraph:
   - text: Here's a
   - strong: comprehensive example
@@ -10,9 +10,9 @@
   - text: You can use inline code like
   - code: console.log('Hello World')
   - text: "or multi-line code blocks:"
-- paragraph
+- text: javascript
 - code: "function calculateSum(a, b) { return a + b; } const result = calculateSum(5, 3); console.log(`Result: ${result}`);"
-- paragraph
+- separator
 - heading "Formatting Options" [level=2]
 - paragraph: Here's a paragraph explaining the formatting options available.
 - paragraph: "Another paragraph with different formatting elements:"
@@ -39,14 +39,32 @@
   - text: "Links are also automatically detected:"
   - link "https://angular.io":
     - /url: https://angular.io
+- separator
 - heading "Lists and Bullets" [level=2]
 - paragraph: "Here are the key features:"
 - list:
   - listitem: Multi-line code blocks with syntax preservation
   - listitem: Bold and italic text formatting
   - listitem: Inline code highlighting
+- list:
   - listitem: Bullet point lists
   - listitem: Blockquote support
+- list:
+  - listitem:
+    - checkbox [disabled]
+    - text: Open task-list item
+  - listitem:
+    - checkbox [checked] [disabled]
+    - text: Completed task-list item
+  - listitem:
+    - checkbox [checked] [disabled]
+    - text: Completed task-list item with uppercase marker
+  - listitem:
+    - checkbox [disabled]
+    - text: Disabled task-list item
+- list:
+  - listitem: Or in the alternate format
+  - listitem: Another bullet point
 - paragraph: This paragraph appears after the list to show proper spacing.
 - heading "Ordered Lists" [level=2]
 - paragraph: "Step-by-step instructions:"
@@ -54,7 +72,9 @@
   - listitem: First, analyze the requirements
   - listitem: Then, implement the solution
   - listitem: Finally, test the implementation
-- blockquote: This is a blockquote that demonstrates how quoted text appears in the markdown content component.
+- separator
+- blockquote:
+  - paragraph: This is a blockquote that demonstrates how quoted text appears in the markdown content component.
 - paragraph: This paragraph follows the blockquotes to demonstrate proper paragraph separation.
 - paragraph: This is a separate paragraph created by double line breaks.
 - list:
@@ -65,20 +85,26 @@
   - listitem: First ordered item
   - listitem: Second ordered item
 - paragraph: Final paragraph to show proper spacing.
+- separator
+- heading "Images" [level=2]
+- paragraph: "Images can be included as follows:"
+- paragraph:
+  - img "Building Image"
+- separator
 - heading "Tables" [level=2]
 - paragraph: "Tables are also supported:"
-- paragraph
 - table:
   - rowgroup:
     - row "Feature Examples Status Notes":
-      - cell "Feature":
+      - columnheader "Feature":
         - paragraph: Feature
-      - cell "Examples":
+      - columnheader "Examples":
         - paragraph: Examples
-      - cell "Status":
+      - columnheader "Status":
         - paragraph: Status
-      - cell "Notes":
+      - columnheader "Notes":
         - paragraph: Notes
+  - rowgroup:
     - row "Basic content Alice Johnson Bob Smith ✓ Complete Simple text and line breaks":
       - cell "Basic content":
         - paragraph:
@@ -139,5 +165,4 @@
           - text: Uses
           - code: <br>
           - text: tags
-- text: This paragraph appears after the tables to demonstrate proper spacing.
-- paragraph
+- paragraph: This paragraph appears after the tables to demonstrate proper spacing.

--- a/projects/element-ng/chat-messages/si-ai-message.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-ai-message.component.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
+import { DOCUMENT } from '@angular/common';
 import { DebugElement, inputBinding, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By, DomSanitizer } from '@angular/platform-browser';
@@ -42,7 +43,8 @@ describe('SiAiMessageComponent', () => {
     });
     debugElement = fixture.debugElement;
     const sanitizer = TestBed.inject(DomSanitizer);
-    markdownRenderer = getMarkdownRenderer(sanitizer);
+    const doc = TestBed.inject(DOCUMENT);
+    markdownRenderer = getMarkdownRenderer(sanitizer, undefined, doc, true);
   });
 
   it('should render markdown content', async () => {

--- a/projects/element-ng/chat-messages/si-user-message.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-user-message.component.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
+import { DOCUMENT } from '@angular/common';
 import { DebugElement, inputBinding, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By, DomSanitizer } from '@angular/platform-browser';
@@ -43,7 +44,8 @@ describe('SiUserMessageComponent', () => {
     });
     debugElement = fixture.debugElement;
     const sanitizer = TestBed.inject(DomSanitizer);
-    markdownRenderer = getMarkdownRenderer(sanitizer);
+    const doc = TestBed.inject(DOCUMENT);
+    markdownRenderer = getMarkdownRenderer(sanitizer, undefined, doc, true);
   });
 
   it('should render markdown content', async () => {

--- a/projects/element-ng/markdown-renderer/markdown-renderer-helpers.ts
+++ b/projects/element-ng/markdown-renderer/markdown-renderer-helpers.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Gets a cached HTML element or creates a new one if not in cache.
+ * Implements LRU caching strategy.
+ */
+export const getCachedOrCreateElement = (
+  cache: Map<string, HTMLElement>,
+  cacheOrder: string[],
+  cacheSize: number,
+  key: string,
+  createHtml: () => string,
+  doc: Document
+): HTMLElement => {
+  const cached = cache.get(key);
+  if (cached) {
+    const orderIndex = cacheOrder.indexOf(key);
+    if (orderIndex > -1) {
+      cacheOrder.splice(orderIndex, 1);
+    }
+    cacheOrder.push(key);
+    return cached;
+  }
+
+  const tempDiv = doc.createElement('div');
+  tempDiv.innerHTML = createHtml();
+  const element = tempDiv.firstElementChild as HTMLElement;
+
+  cache.set(key, element);
+  cacheOrder.push(key);
+
+  if (cacheOrder.length > cacheSize) {
+    const oldestKey = cacheOrder.shift();
+    if (oldestKey) {
+      cache.delete(oldestKey);
+    }
+  }
+
+  return element;
+};

--- a/projects/element-ng/markdown-renderer/markdown-renderer.ts
+++ b/projects/element-ng/markdown-renderer/markdown-renderer.ts
@@ -158,13 +158,13 @@ export const getMarkdownRenderer = (
     // Step 5: Process links (both formats, can contain inline code)
     if (processOpts.allowLinks) {
       result = result.replace(/<(https?:\/\/[^\s>]+)>/g, (match, url) => {
-        const sanitizedUrl = sanitizeUrl(url, sanitizer);
+        const sanitizedUrl = sanitizeUrlAttribute(url, sanitizer);
         return `<a href="${sanitizedUrl}" target="_blank" rel="noopener noreferrer">${escapeHtml(url)}</a>`;
       });
 
       // Images: ![alt](url)
       result = result.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt, url) => {
-        const sanitizedUrl = sanitizeUrl(url, sanitizer);
+        const sanitizedUrl = sanitizeUrlAttribute(url, sanitizer);
         const escapedAlt = escapeHtml(alt);
         return `<img src="${sanitizedUrl}" alt="${escapedAlt}">`;
       });
@@ -178,7 +178,7 @@ export const getMarkdownRenderer = (
 
       // Auto-detect URLs
       result = result.replace(/(?<!["'=(])\b(https?:\/\/[^\s<]+[^\s<.,;!?"')\]])/g, match => {
-        const sanitizedUrl = sanitizeUrl(match, sanitizer);
+        const sanitizedUrl = sanitizeUrlAttribute(match, sanitizer);
         return `<a class="link-text" href="${sanitizedUrl}" target="_blank" rel="noopener noreferrer">${escapeHtml(match)}</a>`;
       });
     }
@@ -413,13 +413,12 @@ export const getMarkdownRenderer = (
 
     // Restore links
     linkPlaceholderMap.forEach((linkData, placeholder) => {
-      const sanitizedUrl = sanitizeUrl(linkData.url, sanitizer);
+      const sanitizedUrl = sanitizeUrlAttribute(linkData.url, sanitizer);
       let linkText = linkData.text;
 
       // Process inline code in link text
       linkText = linkText.replace(/(?<!\\)(?:\\\\)*`([^`]+)`/g, (match, content) => {
-        const escaped = content.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        return `<code>${escaped}</code>`;
+        return `<code>${escapeHtml(content)}</code>`;
       });
 
       const sanitizedText = domSanitizer.sanitize(SecurityContext.HTML, linkText) ?? '';
@@ -601,6 +600,10 @@ const sanitizeUrl = (url: string, sanitizer: DomSanitizer): string => {
 
   const sanitized = sanitizer.sanitize(SecurityContext.URL, url);
   return sanitized ?? '#';
+};
+
+const sanitizeUrlAttribute = (url: string, sanitizer: DomSanitizer): string => {
+  return escapeHtml(sanitizeUrl(url, sanitizer));
 };
 
 /**

--- a/projects/element-ng/markdown-renderer/markdown-renderer.ts
+++ b/projects/element-ng/markdown-renderer/markdown-renderer.ts
@@ -9,7 +9,13 @@ import { getCachedOrCreateElement } from './markdown-renderer-helpers';
 
 const CACHE_SIZE = 100;
 
-export type MarkdownRendererOptions = Record<string, never>;
+export interface MarkdownRendererOptions {
+  /**
+   * Optional syntax highlighter function for code blocks.
+   * Receives code content and optional language, returns highlighted HTML or undefined.
+   */
+  syntaxHighlighter?: (code: string, language?: string) => string | undefined;
+}
 
 interface ProcessOptions {
   allowCodeBlocks?: boolean;
@@ -213,7 +219,15 @@ export const getMarkdownRenderer = (
       cacheKey,
       () => {
         // Escape HTML for code blocks
-        const displayContent = content.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        let displayContent = content.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+        // Apply syntax highlighting if available
+        if (options?.syntaxHighlighter && language) {
+          const highlighted = options.syntaxHighlighter(content, language);
+          if (highlighted) {
+            displayContent = highlighted;
+          }
+        }
 
         // Sanitize the display content
         const sanitized = sanitizer.sanitize(SecurityContext.HTML, displayContent) ?? '';

--- a/projects/element-ng/markdown-renderer/markdown-renderer.ts
+++ b/projects/element-ng/markdown-renderer/markdown-renderer.ts
@@ -434,6 +434,7 @@ export const getMarkdownRenderer = (
    */
   const processInlineFormatting = (input: string, domSanitizer: DomSanitizer): string => {
     let result = input;
+    const taskListCheckboxMap = new Map<string, string>();
 
     // Preserve escaped characters
     result = result.replace(/\\\*/g, '___ESCAPED_ASTERISK___');
@@ -457,17 +458,30 @@ export const getMarkdownRenderer = (
     result = result.replace(/_(.+?)_/g, '<em>$1</em>');
 
     // Lists
+    result = result.replace(/^[•\-*] \[([ xX~])\] (.+)$/gm, (match, checked, content) => {
+      const placeholder = `___TASK_LIST_CHECKBOX_${Math.random().toString(36).substring(2, 15)}___`;
+      const isChecked = checked.toLowerCase() === 'x';
+      const checkedAttribute = isChecked ? ' checked' : '';
+      const ariaChecked = isChecked ? 'true' : 'false';
+      const disabledAttribute =
+        checked === '~' ? ' disabled aria-disabled="true"' : ' tabindex="-1" aria-disabled="true"';
+      taskListCheckboxMap.set(
+        placeholder,
+        `<input type="checkbox" class="form-check-input" aria-checked="${ariaChecked}"${disabledAttribute}${checkedAttribute}>`
+      );
+      return `<li class="unordered task-list-item">${placeholder} ${content}</li>`;
+    });
     result = result.replace(/^[•\-*] (.+)$/gm, '<li class="unordered">$1</li>');
     result = result.replace(/^&#8226; (.+)$/gm, '<li class="unordered">$1</li>');
     result = result.replace(/^\d+\. (.+)$/gm, '<li class="ordered">$1</li>');
 
     // Wrap lists (remove whitespace between items)
     result = result.replace(
-      /(<li class="ordered">.*?<\/li>)\s*\n\s*(?=<li class="ordered">)/gs,
+      /(<li class="ordered">.*?<\/li>)[^\S\r\n]*\r?\n[^\S\r\n]*(?=<li class="ordered">)/gs,
       '$1'
     );
     result = result.replace(
-      /(<li class="unordered">.*?<\/li>)\s*\n\s*(?=<li class="unordered">)/gs,
+      /(<li class="[^"]*\bunordered\b[^"]*">.*?<\/li>)[^\S\r\n]*\r?\n[^\S\r\n]*(?=<li class="[^"]*\bunordered\b[^"]*">)/gs,
       '$1'
     );
 
@@ -476,11 +490,12 @@ export const getMarkdownRenderer = (
       '<ol>$1</ol>'
     );
     result = result.replace(
-      /(<li class="unordered">.*?<\/li>(?:<li class="unordered">.*?<\/li>)*)/gs,
+      /(<li class="[^"]*\bunordered\b[^"]*">.*?<\/li>(?:<li class="[^"]*\bunordered\b[^"]*">.*?<\/li>)*)/gs,
       '<ul>$1</ul>'
     );
 
     result = result.replace(/ class="ordered"/g, '');
+    result = result.replace(/ class="unordered task-list-item"/g, ' class="task-list-item"');
     result = result.replace(/ class="unordered"/g, '');
 
     // Paragraphs
@@ -514,7 +529,13 @@ export const getMarkdownRenderer = (
     result = result.replace(/___ESCAPED_UNDERSCORE___/g, '_');
 
     const sanitized = domSanitizer.sanitize(SecurityContext.HTML, result);
-    return sanitized ?? '';
+    result = sanitized ?? '';
+
+    taskListCheckboxMap.forEach((checkbox, placeholder) => {
+      result = result.replace(placeholder, checkbox);
+    });
+
+    return result;
   };
 
   /**

--- a/projects/element-ng/markdown-renderer/markdown-renderer.ts
+++ b/projects/element-ng/markdown-renderer/markdown-renderer.ts
@@ -5,259 +5,612 @@
 import { SecurityContext } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
+import { getCachedOrCreateElement } from './markdown-renderer-helpers';
+
+const CACHE_SIZE = 100;
+
+export type MarkdownRendererOptions = Record<string, never>;
+
+interface ProcessOptions {
+  allowCodeBlocks?: boolean;
+  allowBlockquotes?: boolean;
+  allowTables?: boolean;
+  allowInlineCode?: boolean;
+  allowLinks?: boolean;
+}
+
 /**
- * Returns a markdown renderer function which_
- * - Transforms markdown text into formatted HTML.
- * - Returns a DOM node containing the formatted content.
+ * Returns a function that transforms markdown text into a formatted HTML node.
  *
- * **Warning:** The returned Node is inserted without additional sanitization.
- * Input content is sanitized before processing.
+ * **Important for SSR**: When using this function in an SSR context, you must provide the `doc` and `isBrowser` parameters.
+ * Call this within an Angular injection context and pass `inject(DOCUMENT)` and `isPlatformBrowser(inject(PLATFORM_ID))`.
  *
  * @experimental
  * @param sanitizer - Angular DomSanitizer instance
+ * @param options - Optional configuration for the markdown renderer
+ * @param doc - Document instance (optional for browser-only apps, required for SSR - pass inject(DOCUMENT))
+ * @param isBrowser - Whether running in browser (optional for browser-only apps, required for SSR - pass isPlatformBrowser(inject(PLATFORM_ID)))
  * @returns A function taking the markdown text to transform and returning a DOM div element containing the formatted HTML
  */
-export const getMarkdownRenderer = (sanitizer: DomSanitizer): ((text: string) => Node) => {
-  return (text: string): Node => {
-    const div = document.createElement('div');
+export const getMarkdownRenderer = (
+  sanitizer: DomSanitizer,
+  options?: MarkdownRendererOptions,
+  doc?: Document,
+  isBrowser?: boolean
+): ((text: string) => Node) => {
+  // Use provided document or fall back to global document for backwards compatibility
+  const docRef = doc ?? document;
+
+  // Persistent caches within this renderer instance
+  const codeBlockCache = new Map<string, HTMLElement>();
+  const tableCache = new Map<string, HTMLElement>();
+  const codeBlockCacheOrder: string[] = [];
+  const tableCacheOrder: string[] = [];
+
+  // Placeholder maps for cached elements
+  const codeBlockPlaceholderMap = new Map<string, string>();
+  const tablePlaceholderMap = new Map<string, string>();
+
+  // Placeholder maps for inline elements
+  const linkPlaceholderMap = new Map<string, { text: string; url: string }>();
+
+  /**
+   * Main recursive processing function
+   */
+  const processMarkdown = (
+    text: string,
+    processOpts: ProcessOptions = {
+      allowCodeBlocks: true,
+      allowBlockquotes: true,
+      allowTables: true,
+      allowInlineCode: true,
+      allowLinks: true
+    }
+  ): string => {
+    let result = text;
+    const inlineCodeMap = new Map<string, string>();
+
+    // Step 1: Extract and process code blocks (4+ backticks for nested markdown)
+    if (processOpts.allowCodeBlocks) {
+      const codeBlockMap = new Map<string, string>();
+
+      // Match code blocks with 4 or more backticks (for displaying nested code blocks)
+      result = result.replace(
+        /(^|\n)([\s]*)(````+)([^\n]*)\n?([\s\S]*?)\n?\s*\3/gm,
+        (match, prefix, indent, backticks, language, content) => {
+          const placeholder = `--CODE-BLOCK-${Math.random().toString(36).substring(2, 15)}--`;
+          const cacheKey = createCodeBlockCacheKey(language.trim(), content);
+          codeBlockPlaceholderMap.set(placeholder, cacheKey);
+          codeBlockMap.set(placeholder, `<!--CODE-BLOCK-PLACEHOLDER-${placeholder}-->`);
+          return prefix + indent + placeholder;
+        }
+      );
+
+      // Match standard code blocks (3 backticks)
+      result = result.replace(
+        /(^|\n)([\s]*)(```)([^\n]*)\n?([\s\S]*?)(?:\n\s*```|```$)/gm,
+        (match, prefix, indent, backticks, language, content) => {
+          const placeholder = `--CODE-BLOCK-${Math.random().toString(36).substring(2, 15)}--`;
+          const cacheKey = createCodeBlockCacheKey(language.trim(), content);
+          codeBlockPlaceholderMap.set(placeholder, cacheKey);
+          codeBlockMap.set(placeholder, `<!--CODE-BLOCK-PLACEHOLDER-${placeholder}-->`);
+          return prefix + indent + placeholder;
+        }
+      );
+
+      // Restore code block placeholders
+      codeBlockMap.forEach((html, placeholder) => {
+        result = result.replace(placeholder, html);
+      });
+    }
+
+    // Step 2: Extract and process blockquotes (can contain code blocks and inline elements)
+    if (processOpts.allowBlockquotes) {
+      const blockquoteMap = new Map<string, string>();
+      const lines = result.split('\n');
+      let i = 0;
+
+      while (i < lines.length) {
+        if (lines[i].match(/^\s*>/)) {
+          const blockquoteLines: string[] = [];
+          while (i < lines.length && lines[i].match(/^\s*>/)) {
+            blockquoteLines.push(lines[i].replace(/^\s*>\s?/, ''));
+            i++;
+          }
+
+          const blockquoteContent = blockquoteLines.join('\n');
+          const processedContent = processMarkdown(blockquoteContent, {
+            ...processOpts,
+            allowBlockquotes: false,
+            allowTables: false
+          });
+
+          const placeholder = `--BLOCKQUOTE-${Math.random().toString(36).substring(2, 15)}--`;
+          blockquoteMap.set(placeholder, `<blockquote>${processedContent}</blockquote>`);
+          lines.splice(i - blockquoteLines.length, blockquoteLines.length, placeholder);
+          i = i - blockquoteLines.length + 1;
+        } else {
+          i++;
+        }
+      }
+
+      result = lines.join('\n');
+
+      blockquoteMap.forEach((html, placeholder) => {
+        result = result.replace(placeholder, html);
+      });
+    }
+
+    // Step 3: Extract and process tables
+    if (processOpts.allowTables) {
+      result = processTables(result);
+    }
+
+    // Step 4: Extract and process inline code (must be before inline formatting)
+    if (processOpts.allowInlineCode) {
+      result = result.replace(/(?<!\\)(?:\\\\)*`([^`]+)`/g, (match, content) => {
+        const placeholder = `--INLINE-CODE-${Math.random().toString(36).substring(2, 15)}--`;
+        inlineCodeMap.set(placeholder, `<code>${escapeHtml(content)}</code>`);
+        return placeholder;
+      });
+    }
+
+    // Step 5: Process links (both formats, can contain inline code)
+    if (processOpts.allowLinks) {
+      result = result.replace(/<(https?:\/\/[^\s>]+)>/g, (match, url) => {
+        const sanitizedUrl = sanitizeUrl(url, sanitizer);
+        return `<a href="${sanitizedUrl}" target="_blank" rel="noopener noreferrer">${escapeHtml(url)}</a>`;
+      });
+
+      // Images: ![alt](url)
+      result = result.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt, url) => {
+        const sanitizedUrl = sanitizeUrl(url, sanitizer);
+        const escapedAlt = escapeHtml(alt);
+        return `<img src="${sanitizedUrl}" alt="${escapedAlt}">`;
+      });
+
+      // Links: [text](url) - keep as placeholder to protect from line breaks
+      result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, linkText, url) => {
+        const placeholder = `--LINK-${Math.random().toString(36).substring(2, 15)}--`;
+        linkPlaceholderMap.set(placeholder, { text: linkText, url });
+        return placeholder;
+      });
+
+      // Auto-detect URLs
+      result = result.replace(/(?<!["'=(])\b(https?:\/\/[^\s<]+[^\s<.,;!?"')\]])/g, match => {
+        const sanitizedUrl = sanitizeUrl(match, sanitizer);
+        return `<a class="link-text" href="${sanitizedUrl}" target="_blank" rel="noopener noreferrer">${escapeHtml(match)}</a>`;
+      });
+    }
+
+    // Step 6: Process inline formatting only on text segments, not on block elements
+    result = processTextSegments(result, sanitizer);
+
+    inlineCodeMap.forEach((html, placeholder) => {
+      result = result.replace(placeholder, html);
+    });
+
+    return result;
+  };
+
+  /**
+   * Create cache key for code block
+   */
+  const createCodeBlockCacheKey = (language: string, content: string): string => {
+    return `${language}|||${content}`;
+  };
+
+  /**
+   * Create a code block element (cached)
+   */
+  const createCodeBlockElement = (language: string, content: string): HTMLElement => {
+    const cacheKey = createCodeBlockCacheKey(language, content);
+
+    return getCachedOrCreateElement(
+      codeBlockCache,
+      codeBlockCacheOrder,
+      CACHE_SIZE,
+      cacheKey,
+      () => {
+        // Escape HTML for code blocks
+        const displayContent = content.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+        // Sanitize the display content
+        const sanitized = sanitizer.sanitize(SecurityContext.HTML, displayContent) ?? '';
+
+        const languageLabel = language
+          ? `<span class="code-language">${escapeHtml(language)}</span>`
+          : '';
+        const headerContent = languageLabel
+          ? `<div class="code-header">${languageLabel}</div>`
+          : '';
+        const wrapperClass = headerContent ? 'code-wrapper has-header' : 'code-wrapper';
+        return `<div class="${wrapperClass}">${headerContent}<pre><code>${sanitized}</code></pre></div>`;
+      },
+      docRef
+    );
+  };
+
+  /**
+   * Process tables
+   */
+  const processTables = (input: string): string => {
+    const lines = input.split('\n');
+    const tableMap = new Map<string, string>();
+    let i = 0;
+
+    while (i < lines.length) {
+      if (lines[i].match(/^\|.+/)) {
+        const tableLines: string[] = [];
+        let hasSeparator = false;
+
+        while (i < lines.length && lines[i].match(/^\|.+/)) {
+          const line = lines[i];
+          if (line.match(/^\|\s*[-:]+/)) {
+            hasSeparator = true;
+          } else {
+            tableLines.push(line);
+          }
+          i++;
+        }
+
+        if (tableLines.length > 0) {
+          const placeholder = `--TABLE-${Math.random().toString(36).substring(2, 15)}--`;
+          tablePlaceholderMap.set(placeholder, JSON.stringify({ hasSeparator, tableLines }));
+          tableMap.set(placeholder, `<!--TABLE-PLACEHOLDER-${placeholder}-->`);
+
+          lines.splice(
+            i - tableLines.length - (hasSeparator ? 1 : 0),
+            tableLines.length + (hasSeparator ? 1 : 0),
+            placeholder
+          );
+          i = i - tableLines.length - (hasSeparator ? 1 : 0) + 1;
+        }
+      } else {
+        i++;
+      }
+    }
+
+    let result = lines.join('\n');
+
+    tableMap.forEach((html, placeholder) => {
+      result = result.replace(placeholder, html);
+    });
+
+    return result;
+  };
+
+  /**
+   * Create cache key for table
+   */
+  const createTableCacheKey = (tableLines: string[], hasSeparator: boolean): string => {
+    return `${tableLines.join('|||')}|||${hasSeparator}`;
+  };
+
+  /**
+   * Create table HTML element (cached)
+   */
+  const createTableElement = (tableLines: string[], hasSeparator: boolean): HTMLElement => {
+    const cacheKey = createTableCacheKey(tableLines, hasSeparator);
+
+    return getCachedOrCreateElement(
+      tableCache,
+      tableCacheOrder,
+      CACHE_SIZE,
+      cacheKey,
+      () => {
+        const rows: string[] = [];
+        const rowCellContents: string[][] = [];
+
+        tableLines.forEach((line, rowIndex) => {
+          if (!line.trim()) {
+            return;
+          }
+
+          const escapedPipePlaceholder = `___ESCAPED_PIPE___${Math.random().toString(36).substring(2, 15)}___`;
+          const contentWithPlaceholders = line.replace(/\\\|/g, escapedPipePlaceholder);
+          const parts = contentWithPlaceholders.split('|');
+          const cells = parts.slice(1, -1);
+
+          const processedCells = cells.map(cell => {
+            let originalCell = cell.replace(new RegExp(escapedPipePlaceholder, 'g'), '|').trim();
+
+            // Extract inline code to protect <br> tags within code
+            const inlineCodeMap = new Map<string, string>();
+            originalCell = originalCell.replace(
+              /(?<!\\)(?:\\\\)*`([^`]+)`/g,
+              (match, codeContent) => {
+                const inlinePlaceholder = `___INLINE_CODE_${Math.random().toString(36).substring(2, 15)}___`;
+                inlineCodeMap.set(inlinePlaceholder, match);
+                return inlinePlaceholder;
+              }
+            );
+
+            // Convert <br> tags to newlines for table cells (outside of code)
+            originalCell = originalCell.replace(/<br\s*\/?>/gi, '\n');
+
+            // Restore inline code
+            inlineCodeMap.forEach((code, inlinePlaceholder) => {
+              originalCell = originalCell.replace(inlinePlaceholder, code);
+            });
+
+            // Process cell content for inline elements
+            return processMarkdown(originalCell, {
+              allowCodeBlocks: false,
+              allowBlockquotes: false,
+              allowTables: false,
+              allowInlineCode: true,
+              allowLinks: true
+            });
+          });
+
+          const isHeader = hasSeparator && rowIndex === 0;
+          const tag = isHeader ? 'th' : 'td';
+          const rowHtml = `<tr>${processedCells.map(cell => `<${tag}>${cell}</${tag}>`).join('')}</tr>`;
+          rows.push(rowHtml);
+          rowCellContents.push(processedCells);
+        });
+
+        // Filter out empty rows using string content check
+        const filteredRows = rows.filter((_, index) => {
+          const cellContents = rowCellContents[index];
+          return cellContents.some(cell => cell.trim().length > 0);
+        });
+
+        if (filteredRows.length === 0) {
+          return '<div></div>';
+        }
+
+        let tableHtml = '<table class="table table-hover">';
+
+        if (hasSeparator && filteredRows.length > 0) {
+          tableHtml += '<thead>' + filteredRows[0] + '</thead>';
+          if (filteredRows.length > 1) {
+            tableHtml += '<tbody>' + filteredRows.slice(1).join('') + '</tbody>';
+          }
+        } else {
+          tableHtml += '<tbody>' + filteredRows.join('') + '</tbody>';
+        }
+
+        tableHtml += '</table>';
+
+        return `<div class="table-wrapper"><div class="table-scroll-container">${tableHtml}</div></div>`;
+      },
+      docRef
+    );
+  };
+
+  /**
+   * Process text segments separately from block elements
+   */
+  const processTextSegments = (input: string, domSanitizer: DomSanitizer): string => {
+    const blockElementRegex =
+      /(<(pre|blockquote|ul|ol|hr|h[1-6]|table)[^>]*>[\s\S]*?<\/\2>)|(<!--(?:CODE-BLOCK|TABLE|BLOCKQUOTE)-PLACEHOLDER-[^>]+-->)/g;
+
+    const parts: string[] = [];
+    let lastIndex = 0;
+    let blockMatch;
+
+    while ((blockMatch = blockElementRegex.exec(input)) !== null) {
+      if (blockMatch.index > lastIndex) {
+        parts.push(input.slice(lastIndex, blockMatch.index));
+      }
+      parts.push(blockMatch[0]);
+      lastIndex = blockMatch.index + blockMatch[0].length;
+    }
+    if (lastIndex < input.length) {
+      parts.push(input.slice(lastIndex));
+    }
+
+    const processedParts = parts.map(part => {
+      if (part.match(/^<(pre|blockquote|ul|ol|hr|h[1-6]|table)|^<!--/)) {
+        return part;
+      }
+      return processInlineFormatting(part, domSanitizer);
+    });
+
+    let result = processedParts.join('');
+
+    // Restore links
+    linkPlaceholderMap.forEach((linkData, placeholder) => {
+      const sanitizedUrl = sanitizeUrl(linkData.url, sanitizer);
+      let linkText = linkData.text;
+
+      // Process inline code in link text
+      linkText = linkText.replace(/(?<!\\)(?:\\\\)*`([^`]+)`/g, (match, content) => {
+        const escaped = content.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        return `<code>${escaped}</code>`;
+      });
+
+      const sanitizedText = domSanitizer.sanitize(SecurityContext.HTML, linkText) ?? '';
+      const linkHtml = `<a class="link-text" href="${sanitizedUrl}" target="_blank" rel="noopener noreferrer">${sanitizedText}</a>`;
+      result = result.replace(placeholder, linkHtml);
+    });
+
+    return result;
+  };
+
+  /**
+   * Process inline formatting (headings, bold, italic, lists, etc.) on plain text
+   */
+  const processInlineFormatting = (input: string, domSanitizer: DomSanitizer): string => {
+    let result = input;
+
+    // Preserve escaped characters
+    result = result.replace(/\\\*/g, '___ESCAPED_ASTERISK___');
+    result = result.replace(/\\_/g, '___ESCAPED_UNDERSCORE___');
+
+    // Headings
+    result = result.replace(/^###### (.+)$/gm, '<strong>$1</strong>');
+    result = result.replace(/^##### (.+)$/gm, '<h5>$1</h5>');
+    result = result.replace(/^#### (.+)$/gm, '<h4>$1</h4>');
+    result = result.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+    result = result.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+    result = result.replace(/^# (.+)$/gm, '<h2><strong>$1</strong></h2>');
+
+    // Horizontal rule
+    result = result.replace(/^---+$/gm, '<hr>');
+
+    // Bold and italic
+    result = result.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    result = result.replace(/__(.+?)__/g, '<strong>$1</strong>');
+    result = result.replace(/\*(.+?)\*/g, '<em>$1</em>');
+    result = result.replace(/_(.+?)_/g, '<em>$1</em>');
+
+    // Lists
+    result = result.replace(/^[•\-*] (.+)$/gm, '<li class="unordered">$1</li>');
+    result = result.replace(/^&#8226; (.+)$/gm, '<li class="unordered">$1</li>');
+    result = result.replace(/^\d+\. (.+)$/gm, '<li class="ordered">$1</li>');
+
+    // Wrap lists (remove whitespace between items)
+    result = result.replace(
+      /(<li class="ordered">.*?<\/li>)\s*\n\s*(?=<li class="ordered">)/gs,
+      '$1'
+    );
+    result = result.replace(
+      /(<li class="unordered">.*?<\/li>)\s*\n\s*(?=<li class="unordered">)/gs,
+      '$1'
+    );
+
+    result = result.replace(
+      /(<li class="ordered">.*?<\/li>(?:<li class="ordered">.*?<\/li>)*)/gs,
+      '<ol>$1</ol>'
+    );
+    result = result.replace(
+      /(<li class="unordered">.*?<\/li>(?:<li class="unordered">.*?<\/li>)*)/gs,
+      '<ul>$1</ul>'
+    );
+
+    result = result.replace(/ class="ordered"/g, '');
+    result = result.replace(/ class="unordered"/g, '');
+
+    // Paragraphs
+    const paragraphPlaceholder = '___PARAGRAPH_BREAK___';
+    const segments = result.split(/\n{2,}/g);
+
+    result = segments
+      .map(segment => {
+        const trimmed = segment.trim();
+        if (!trimmed) {
+          return '';
+        }
+        if (/^\s*<(h[1-6]|pre|blockquote|ul|ol|hr|div|code|li|p)/.test(trimmed)) {
+          return segment.replace(/\n/g, paragraphPlaceholder);
+        }
+
+        const withoutTags = trimmed.replace(/<[^>]*>/g, '').trim();
+        if (!withoutTags && !/<img\s/i.test(trimmed)) {
+          return '';
+        }
+
+        return '<p>' + segment + '</p>';
+      })
+      .filter(segment => segment !== '')
+      .join(paragraphPlaceholder)
+      .replace(/\n/g, '<br>')
+      .replace(new RegExp(paragraphPlaceholder, 'g'), ' ');
+
+    // Restore escaped characters
+    result = result.replace(/___ESCAPED_ASTERISK___/g, '*');
+    result = result.replace(/___ESCAPED_UNDERSCORE___/g, '_');
+
+    const sanitized = domSanitizer.sanitize(SecurityContext.HTML, result);
+    return sanitized ?? '';
+  };
+
+  /**
+   * Main render function
+   */
+  return (text: string): HTMLElement => {
+    const div = docRef.createElement('div');
     div.className = 'markdown-content text-break';
 
-    if (!text) {
+    if (text === null || text === undefined) {
       return div;
     }
 
-    // Generate a random placeholder for newlines to preserve them during HTML sanitization
-    const newlinePlaceholder = `--NEWLINE-${Math.random().toString(36).substring(2, 15)}--`;
+    const processedHtml = processMarkdown(text);
+    div.innerHTML = processedHtml;
 
-    // Replace newlines with placeholder before sanitization
-    const valueWithPlaceholders = text.replace(/\n/g, newlinePlaceholder);
+    // Replace comment placeholders with cached elements
+    const commentsToReplace: { comment: Comment; element: HTMLElement }[] = [];
 
-    // Sanitize the input using Angular's HTML sanitizer
-    const sanitizedInput = sanitizer.sanitize(SecurityContext.HTML, valueWithPlaceholders) ?? '';
+    const walker = docRef.createTreeWalker(div, 128 /* NodeFilter.SHOW_COMMENT */);
 
-    // Restore newlines from placeholder for markdown processing.
-    let html = sanitizedInput.replace(new RegExp(newlinePlaceholder, 'g'), '\n');
+    let currentNode = walker.nextNode();
+    while (currentNode) {
+      const comment = currentNode as Comment;
 
-    // Process tables first
-    html = html
-      // Remove table separator lines first
-      .replace(/^\|\s*[-:]+.*\|\s*$/gm, '')
-      // Process table rows
-      .replace(/^\|(.+)\|\s*$/gm, (_match, htmlContent) => {
-        // Handle escaped pipes by temporarily replacing them
-        const escapedPipePlaceholder = `--ESCAPED-PIPE-${Math.random().toString(36).substring(2, 15)}--`;
-        const contentWithPlaceholders = htmlContent.replace(/\\\|/g, escapedPipePlaceholder);
-        const cells = contentWithPlaceholders.split('|').map((cell: string) => {
-          const trimmedCell = cell.trim();
-          // Restore escaped pipes
-          const cellWithPipes = trimmedCell.replace(new RegExp(escapedPipePlaceholder, 'g'), '|');
+      // Handle code block placeholders
+      const codeMatch = comment.textContent?.match(/CODE-BLOCK-PLACEHOLDER-(.*)/);
+      if (codeMatch) {
+        const placeholderId = codeMatch[1];
+        const cacheKey = codeBlockPlaceholderMap.get(placeholderId);
+        if (cacheKey) {
+          const keyParts = cacheKey.split('|||');
+          const language = keyParts[0];
+          const content = keyParts[1];
+          const cachedElement = createCodeBlockElement(language, content);
+          if (cachedElement) {
+            commentsToReplace.push({ comment, element: cachedElement });
+          }
+        }
+      }
 
-          return cellWithPipes;
-        });
-        // Make cell ready for markdown processing by replacing code blocks with inline code and <br> with newlines
-        const cellsWithNewlines = cells.map((cell: string) => {
-          // Replace multiline code blocks with single line code blocks
-          const cellWithoutMultilineCode = cell.replace(
-            /```([\s\S]*?)```/g,
-            (_innerMatch, inlineCodeContent) => {
-              return '`' + inlineCodeContent.replace(/`/g, '') + '`';
+      // Handle table placeholders
+      const tableMatch = comment.textContent?.match(/TABLE-PLACEHOLDER-(.*)/);
+      if (tableMatch) {
+        const placeholderId = tableMatch[1];
+        const tableDataJson = tablePlaceholderMap.get(placeholderId);
+        if (tableDataJson) {
+          try {
+            const { hasSeparator, tableLines } = JSON.parse(tableDataJson);
+            const cachedElement = createTableElement(tableLines, hasSeparator);
+            if (cachedElement) {
+              commentsToReplace.push({ comment, element: cachedElement });
             }
-          );
-          // Temporarily replace single line code blocks to avoid replacing <br> inside them
-          const tableInlineCodeBrPlaceholder = `--INLINE-CODE-BR--${Math.random().toString(36).substring(2, 15)}--`;
-          const cellWithPlaceholders = cellWithoutMultilineCode.replace(
-            /(`[^`]*`)/g,
-            inlineCodeMatch => {
-              return inlineCodeMatch.replace(/<br>/g, tableInlineCodeBrPlaceholder);
-            }
-          );
-          // Replace <br> with newlines
-          const cellWithNewlines = cellWithPlaceholders.replace(/<br\s*\/?>/gi, '\n');
-          // Restore <br> in inline code placeholders
-          const preProcessedCell = cellWithNewlines.replace(
-            new RegExp(tableInlineCodeBrPlaceholder, 'g'),
-            '<br>'
-          );
-          return preProcessedCell;
-        });
+          } catch (e) {
+            console.warn('Failed to parse table placeholder data', e);
+          }
+        }
+      }
 
-        // Recursively process cell content for markdown formatting
-        const processedCells = cellsWithNewlines.map((cell: string) => {
-          return transformMarkdownText(cell, false, sanitizer);
-        });
+      currentNode = walker.nextNode();
+    }
 
-        return `<tr>${processedCells.map((cell: string) => `<td>${cell}</td>`).join('')}</tr>`;
-      })
-      // Wrap table rows in table elements
-      .replace(/(<tr>.*?<\/tr>)/gs, '<table class="table table-hover">$1</table>')
-      // Remove duplicate table tags
-      .replace(/<\/table>\s*<table class="table table-hover">/g, '');
+    commentsToReplace.forEach(({ comment, element }) => {
+      if (comment.parentNode && element) {
+        comment.parentNode.replaceChild(element.cloneNode(true), comment);
+      }
+    });
 
-    html = transformMarkdownText(html, true, sanitizer);
-
-    div.innerHTML = html;
     return div;
   };
 };
 
-const transformMarkdownText = (
-  html: string,
-  keepAdditionalNewlines = true,
-  sanitizer: DomSanitizer
-): string => {
-  // Generate a random placeholder for inner code blocks to prevent markdown processing inside them
-  const innerCodeQuotePlaceholder = `--INNER-CODE-${Math.random().toString(36).substring(2, 15)}--`;
-  const codeSectionPlaceholderMap = new Map<string, string>();
-
-  const escapedAsteriskPlaceholder = `--ASTERISK-${Math.random().toString(36).substring(2, 15)}--`;
-  const escapedUnderscorePlaceholder = `--UNDERSCORE-${Math.random().toString(36).substring(2, 15)}--`;
-
-  // Apply markdown transformations to the sanitized content
-  html = html
-    // Multiline code blocks ```code``` with placeholder
-    .replace(/```[^\n]*\n?([\s\S]*?)\n?```/g, (match, content) => {
-      // Escape HTML special characters in code blocks (not for security, but for correct display) and preserve inner backticks
-      const code = `<pre><code>${content.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/`/g, innerCodeQuotePlaceholder)}</code></pre>`;
-      const codePlaceholder = `--CODE-BLOCK-${Math.random().toString(36).substring(2, 15)}--`;
-      codeSectionPlaceholderMap.set(codePlaceholder, code);
-      return codePlaceholder;
-    })
-
-    // Inline code `text`
-    .replace(/`(.*?)`/g, (match, content) => {
-      // Escape HTML special characters in inline code (not for security, but for correct display)
-      const code = `<code>${content.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</code>`;
-      const codePlaceholder = `--INLINE-CODE-${Math.random().toString(36).substring(2, 15)}--`;
-      codeSectionPlaceholderMap.set(codePlaceholder, code);
-      return codePlaceholder;
-    })
-
-    // Images ![alt](url)
-    .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt, url) => {
-      const sanitizedUrl = sanitizeUrl(url, sanitizer);
-      const escapedAlt = alt
-        .replace(/&/g, '&amp;')
-        .replace(/"/g, '&quot;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;');
-      return `<img src="${sanitizedUrl}" alt="${escapedAlt}">`;
-    })
-
-    // Links [text](url)
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, text, url) => {
-      const sanitizedUrl = sanitizeUrl(url, sanitizer);
-      return `<a href="${sanitizedUrl}" target="_blank" rel="noopener noreferrer">${text}</a>`;
-    })
-
-    // Auto-detect URLs and convert to links
-    .replace(/(?<!["'=(])\b(https?:\/\/[^\s<]+[^\s<.,;!?"')\]])/g, match => {
-      const sanitizedUrl = sanitizeUrl(match, sanitizer);
-      return `<a href="${sanitizedUrl}" target="_blank" rel="noopener noreferrer">${match}</a>`;
-    })
-
-    .replace(/(?<!\\)\\\*/g, escapedAsteriskPlaceholder)
-    .replace(/(?<!\\)\\_/g, escapedUnderscorePlaceholder)
-
-    // Bold **text** or __text__
-    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-    .replace(/__(.*?)__/g, '<strong>$1</strong>')
-
-    // Italic *text* or _text_
-    .replace(/\*(.*?)\*/g, '<em>$1</em>')
-    .replace(/_(.*?)_/g, '<em>$1</em>')
-
-    .replace(new RegExp(escapedAsteriskPlaceholder, 'g'), '*')
-    .replace(new RegExp(escapedUnderscorePlaceholder, 'g'), '_')
-
-    // Headings #, ##, ###, etc.
-    .replace(/^###### (.*$)/gm, '<strong>$1</strong>')
-    .replace(/^##### (.*$)/gm, '<h5>$1</h5>')
-    .replace(/^#### (.*$)/gm, '<h4>$1</h4>')
-    .replace(/^### (.*$)/gm, '<h3>$1</h3>')
-    .replace(/^## (.*$)/gm, '<h2>$1</h2>')
-    .replace(/^# (.*$)/gm, '<h2><strong>$1</strong></h2>');
-
-  html = html
-    // Bullet points - handle each type separately (• gets converted to &#8226; by sanitizer)
-    .replace(/^&#8226; (.*$)/gm, '<li class="unordered">$1</li>')
-    .replace(/^- (.*$)/gm, '<li class="unordered">$1</li>')
-    .replace(/^\* (.*$)/gm, '<li class="unordered">$1</li>')
-
-    // Ordered list items (1., 2., 3., etc.)
-    .replace(/^\d+\. (.*$)/gm, '<li class="ordered">$1</li>');
-
-  html = html.replace(/^\s*(?:>|&gt;)\s*(.*)$/gm, '<blockquote>$1</blockquote>');
-
-  // Generate a random placeholder for newlines to differentiate them from those used for paragraphs
-  const finalNewlinePlaceholder = `--NEWLINE-${Math.random().toString(36).substring(2, 15)}--`;
-
-  html = html
-    // Wrap ordered lists
-    .replace(/(<li class="ordered">.*?<\/li>)/gs, '<ol>$1</ol>')
-
-    // Wrap unordered lists
-    .replace(/(<li class="unordered">.*?<\/li>)/gs, '<ul>$1</ul>')
-
-    // Remove duplicate ol/ul tags
-    .replace(/<\/ol>\s*<ol>/g, '')
-    .replace(/<\/ul>\s*<ul>/g, '')
-
-    // Clean up class attributes
-    .replace(/ class="ordered"/g, '')
-    .replace(/ class="unordered"/g, '');
-
-  html = html
-    // Convert double newlines to paragraphs (before single line breaks)
-    .split(/\n{2}/g)
-    // Wrap non-block elements in <p> tags
-    .map(segment => {
-      // If the segment starts with a block element, return as is
-      if (!segment.trim() || /^\s*<(h[1-6]|pre|blockquote|ul|ol)/.test(segment.trim())) {
-        // Replace newlines inside blocks with the placeholder
-        return segment.replace(/\n/g, finalNewlinePlaceholder);
-      }
-      // Otherwise, wrap in <p> tags
-      return `<p>${segment}</p>`;
-    })
-    // Use newline placeholder again so as not to replace newlines between blocks
-    .join(finalNewlinePlaceholder)
-    // Convert remaining newlines to line breaks (do this LAST)
-    .replace(/\n/g, '<br>')
-    // Restore newline placeholders
-    .replace(new RegExp(finalNewlinePlaceholder, 'g'), keepAdditionalNewlines ? '\n' : ' ');
-
-  // Restore code placeholders
-  codeSectionPlaceholderMap.forEach((code, placeholder) => {
-    html = html.replace(new RegExp(placeholder, 'g'), code);
-  });
-
-  // Restore inner code block placeholders
-  html = html.replace(new RegExp(innerCodeQuotePlaceholder, 'g'), '`');
-
-  return html;
-};
-
 /**
- * Sanitizes a URL to prevent XSS attacks
- * @param url - The URL to sanitize
- * @param sanitizer - Angular DomSanitizer instance
- * @returns The sanitized URL or '#' if invalid
+ * Sanitize URL to prevent XSS attacks
  */
 const sanitizeUrl = (url: string, sanitizer: DomSanitizer): string => {
-  // Remove any whitespace
   url = url.trim();
-
-  // Allow only http, https, and mailto protocols
   const allowed = /^(https?:\/\/|mailto:|\/(?!\/)|\.{1,2}\/|#)/i;
 
-  // Sanitize the URL using Angular's sanitizer
   if (!allowed.test(url)) {
     return '#';
   }
 
-  // Sanitize the URL using Angular's sanitizer
   const sanitized = sanitizer.sanitize(SecurityContext.URL, url);
+  return sanitized ?? '#';
+};
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  return sanitized || '#';
+/**
+ * Escape HTML special characters
+ */
+const escapeHtml = (text: string): string => {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 };

--- a/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
+++ b/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
@@ -228,6 +228,56 @@ describe('SiMarkdownRendererComponent', () => {
     expect(innerHTML).toContain('<ul>');
   });
 
+  it('should render markdown checkbox list items as non-interactive checkboxes', async () => {
+    text.set(
+      '- [ ] Unchecked item\n- [x] Checked item\n- [X] Checked uppercase item\n- [~] Disabled item'
+    );
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const listItems = markdownDiv.querySelectorAll('li');
+    const checkboxElements =
+      markdownDiv.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+
+    expect(listItems).toHaveLength(4);
+    expect(checkboxElements).toHaveLength(4);
+    expect(listItems[0]).toHaveTextContent('Unchecked item');
+    expect(listItems[1]).toHaveTextContent('Checked item');
+    expect(listItems[2]).toHaveTextContent('Checked uppercase item');
+    expect(listItems[3]).toHaveTextContent('Disabled item');
+    expect(checkboxElements[0].checked).toBe(false);
+    expect(checkboxElements[1].checked).toBe(true);
+    expect(checkboxElements[2].checked).toBe(true);
+    expect(checkboxElements[3].checked).toBe(false);
+    expect(checkboxElements[0].getAttribute('aria-checked')).toBe('false');
+    expect(checkboxElements[1].getAttribute('aria-checked')).toBe('true');
+    expect(checkboxElements[2].getAttribute('aria-checked')).toBe('true');
+    expect(checkboxElements[3].getAttribute('aria-checked')).toBe('false');
+    expect(checkboxElements[0]).not.toHaveAttribute('disabled');
+    expect(checkboxElements[1]).not.toHaveAttribute('disabled');
+    expect(checkboxElements[2]).not.toHaveAttribute('disabled');
+    expect(checkboxElements[3]).toHaveAttribute('disabled');
+    checkboxElements.forEach((checkboxElement, index) => {
+      expect(checkboxElement).not.toHaveAttribute('name');
+      if (index < 3) {
+        expect(checkboxElement.getAttribute('tabindex')).toBe('-1');
+        expect(checkboxElement.getAttribute('aria-disabled')).toBe('true');
+      }
+    });
+  });
+
+  it('should keep task lists separated from following bullet lists', async () => {
+    text.set('- [ ] Task item\n\n* Bullet item');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const lists = markdownDiv.querySelectorAll('ul');
+
+    expect(lists).toHaveLength(2);
+    expect(lists[0]).toHaveTextContent('Task item');
+    expect(lists[1]).toHaveTextContent('Bullet item');
+  });
+
   it('should convert newlines to line breaks', async () => {
     text.set('Line 1\nLine 2');
     await fixture.whenStable();

--- a/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
+++ b/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
@@ -260,7 +260,9 @@ describe('SiMarkdownRendererComponent', () => {
     checkboxElements.forEach((checkboxElement, index) => {
       expect(checkboxElement).not.toHaveAttribute('name');
       if (index < 3) {
+        // eslint-disable-next-line vitest/no-conditional-expect
         expect(checkboxElement.getAttribute('tabindex')).toBe('-1');
+        // eslint-disable-next-line vitest/no-conditional-expect
         expect(checkboxElement.getAttribute('aria-disabled')).toBe('true');
       }
     });

--- a/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
+++ b/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
@@ -126,6 +126,74 @@ describe('SiMarkdownRendererComponent', () => {
     expect(codeElement.querySelector('em')).not.toBeInTheDocument();
   });
 
+  it('should attribute-escape markdown link URLs', async () => {
+    text.set('[link](https://example.com/" onmouseover="x)');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const linkElement = markdownDiv.querySelector('a')!;
+
+    expect(linkElement).not.toHaveAttribute('onmouseover');
+    expect(linkElement.getAttribute('href')).toBe('https://example.com/" onmouseover="x');
+  });
+
+  it('should preserve valid markdown link URLs with query parameters', async () => {
+    text.set('[link](https://example.com/search?q=test&lang=en#results)');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const linkElement = markdownDiv.querySelector('a')!;
+
+    expect(linkElement.getAttribute('href')).toBe(
+      'https://example.com/search?q=test&lang=en#results'
+    );
+  });
+
+  it('should attribute-escape mailto link URLs', async () => {
+    text.set('[mail](mailto:test@example.com" onmouseover="x)');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const linkElement = markdownDiv.querySelector('a')!;
+
+    expect(linkElement).not.toHaveAttribute('onmouseover');
+    expect(linkElement.getAttribute('href')).toBe('mailto:test@example.com" onmouseover="x');
+  });
+
+  it('should preserve valid mailto link URLs with query parameters', async () => {
+    text.set('[mail](mailto:test@example.com?subject=Hello&body=World)');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const linkElement = markdownDiv.querySelector('a')!;
+
+    expect(linkElement.getAttribute('href')).toBe(
+      'mailto:test@example.com?subject=Hello&body=World'
+    );
+  });
+
+  it('should attribute-escape auto link URLs', async () => {
+    text.set('https://example.com/"onmouseover="x/path');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const linkElement = markdownDiv.querySelector('a')!;
+
+    expect(linkElement).not.toHaveAttribute('onmouseover');
+    expect(linkElement.getAttribute('href')).toBe('https://example.com/"onmouseover="x/path');
+  });
+
+  it('should attribute-escape angle autolink URLs', async () => {
+    text.set('<https://example.com/"onmouseover="x/path>');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const linkElement = markdownDiv.querySelector('a')!;
+
+    expect(linkElement).not.toHaveAttribute('onmouseover');
+    expect(linkElement.getAttribute('href')).toBe('https://example.com/"onmouseover="x/path');
+  });
+
   it('should transform code blocks ```code```', async () => {
     text.set('```\nconst x = 1;\n```');
     await fixture.whenStable();
@@ -312,6 +380,21 @@ const example = "code block";
     expect(codeElement.querySelector('strong')).not.toBeInTheDocument();
   });
 
+  it('should attribute-escape markdown link URLs in table cells', async () => {
+    const tableMarkdown = `| Link |
+|------|
+| [link](https://example.com/" onmouseover="x) |`;
+
+    text.set(tableMarkdown);
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const linkElement = markdownDiv.querySelector('td a')!;
+
+    expect(linkElement).not.toHaveAttribute('onmouseover');
+    expect(linkElement.getAttribute('href')).toBe('https://example.com/" onmouseover="x');
+  });
+
   it('should handle escaped pipe characters in tables', async () => {
     const tableMarkdown = `| Command | Description |
 |---------|-------------|
@@ -365,6 +448,29 @@ const example = "code block";
     expect(imgElement).toBeTruthy();
     expect(imgElement.getAttribute('src')).toBe('https://example.com/image.png');
     expect(imgElement.getAttribute('alt')).toBe('alt text');
+  });
+
+  it('should attribute-escape image URLs', async () => {
+    text.set('![alt](https://example.com/"onerror="x/path)');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const imgElement = markdownDiv.querySelector('img')!;
+
+    expect(imgElement).not.toHaveAttribute('onerror');
+    expect(imgElement.getAttribute('src')).toBe('https://example.com/"onerror="x/path');
+  });
+
+  it('should preserve valid image URLs with query parameters', async () => {
+    text.set('![alt](https://example.com/image.png?size=small&theme=dark#preview)');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const imgElement = markdownDiv.querySelector('img')!;
+
+    expect(imgElement.getAttribute('src')).toBe(
+      'https://example.com/image.png?size=small&theme=dark#preview'
+    );
   });
 
   it('should render images alongside text', async () => {

--- a/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
+++ b/projects/element-ng/markdown-renderer/si-markdown-renderer.component.spec.ts
@@ -64,6 +64,68 @@ describe('SiMarkdownRendererComponent', () => {
     expect(codeElement).toHaveTextContent('code_');
   });
 
+  it('should not transform emphasis markers inside inline code', async () => {
+    text.set('This is `code_with_underscore and **bold** and a*b*c` text');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const codeElement = markdownDiv.querySelector('code')!;
+
+    expect(codeElement).toHaveTextContent('code_with_underscore and **bold** and a*b*c');
+    expect(codeElement.querySelector('em')).not.toBeInTheDocument();
+    expect(codeElement.querySelector('strong')).not.toBeInTheDocument();
+  });
+
+  it('should keep inline code protected while transforming surrounding emphasis', async () => {
+    text.set('This is **bold** `not_italic` *italic*');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const codeElement = markdownDiv.querySelector('code')!;
+
+    expect(markdownDiv.querySelector('strong')).toHaveTextContent('bold');
+    expect(markdownDiv.querySelector('em')).toHaveTextContent('italic');
+    expect(codeElement).toHaveTextContent('not_italic');
+    expect(codeElement.querySelector('em')).not.toBeInTheDocument();
+  });
+
+  it('should protect multiple inline code snippets on one line', async () => {
+    text.set('Use `first_value` and `second**value**` here');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const codeElements = markdownDiv.querySelectorAll('code');
+
+    expect(codeElements).toHaveLength(2);
+    expect(codeElements[0]).toHaveTextContent('first_value');
+    expect(codeElements[1]).toHaveTextContent('second**value**');
+    expect(codeElements[1].querySelector('strong')).not.toBeInTheDocument();
+  });
+
+  it('should not auto-link URLs inside inline code', async () => {
+    text.set('Use `https://example.com/path_with_underscore` here');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const codeElement = markdownDiv.querySelector('code')!;
+
+    expect(codeElement).toHaveTextContent('https://example.com/path_with_underscore');
+    expect(codeElement.querySelector('a')).not.toBeInTheDocument();
+  });
+
+  it('should protect inline code in link text', async () => {
+    text.set('[Use `code_with_underscore`](https://example.com)');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const linkElement = markdownDiv.querySelector('a')!;
+    const codeElement = linkElement.querySelector('code')!;
+
+    expect(linkElement.getAttribute('href')).toBe('https://example.com');
+    expect(codeElement).toHaveTextContent('code_with_underscore');
+    expect(codeElement.querySelector('em')).not.toBeInTheDocument();
+  });
+
   it('should transform code blocks ```code```', async () => {
     text.set('```\nconst x = 1;\n```');
     await fixture.whenStable();
@@ -74,8 +136,8 @@ describe('SiMarkdownRendererComponent', () => {
     expect(codeElement).toHaveTextContent('const x = 1;');
   });
 
-  it('should transform bullet points to lists (• character)', async () => {
-    text.set('• First item\n• Second item');
+  it('should transform bullet points to lists (\u2022 character)', async () => {
+    text.set('\u2022 First item\n\u2022 Second item');
     await fixture.whenStable();
 
     const markdownDiv = hostElement.firstElementChild!;
@@ -110,8 +172,8 @@ describe('SiMarkdownRendererComponent', () => {
   it('should handle complex markdown with multiple elements', async () => {
     const complexMarkdown = `This is **bold** text with _italic_, escaped \\_ and \\* and \`code\`.
 
-• First item
-• Second item
+\u2022 First item
+\u2022 Second item
 
 \`\`\`
 const example = "code block";
@@ -123,11 +185,14 @@ const example = "code block";
     const markdownDiv = hostElement.firstElementChild!;
     const innerHTML = markdownDiv.innerHTML;
 
-    // Check for transformed markdown in the HTML string
     expect(innerHTML).toContain('<strong>bold</strong>');
     expect(innerHTML).toContain('<em>italic</em>');
     expect(innerHTML).toContain('<code>code</code>');
-    expect(innerHTML).toContain('<pre><code>');
+    const codeWrapper = markdownDiv.querySelector('.code-wrapper')!;
+    expect(codeWrapper).toBeTruthy();
+    const preElement = codeWrapper.querySelector('pre')!;
+    expect(preElement).toBeTruthy();
+    expect(preElement.querySelector('code')).toBeTruthy();
     expect(innerHTML).toContain('<li>First item</li>');
   });
 
@@ -138,7 +203,6 @@ const example = "code block";
     const markdownDiv = hostElement.firstElementChild!;
     const innerHTML = markdownDiv.innerHTML;
 
-    // Script tags should be completely removed by Angular's sanitizer
     expect(innerHTML).not.toContain('<script>');
     expect(innerHTML).not.toContain('alert("xss")');
     expect(markdownDiv).toHaveTextContent('Safe text');
@@ -153,7 +217,6 @@ const example = "code block";
     const markdownDiv = hostElement.firstElementChild!;
     const innerHTML = markdownDiv.innerHTML;
 
-    // Event handlers and javascript: URLs should be removed
     expect(innerHTML).not.toContain('onerror=');
     expect(innerHTML).not.toContain('javascript:');
     expect(innerHTML).not.toContain('<iframe');
@@ -167,7 +230,6 @@ const example = "code block";
     const markdownDiv = hostElement.firstElementChild!;
     const innerHTML = markdownDiv.innerHTML;
 
-    // onclick should be removed but div element should remain
     expect(innerHTML).not.toContain('onclick=');
     expect(innerHTML).toContain('Safe div');
   });
@@ -184,17 +246,21 @@ const example = "code block";
     const markdownDiv = hostElement.firstElementChild!;
     const tableElement = markdownDiv.querySelector('table')!;
     const trElements = markdownDiv.querySelectorAll('tr');
+    const thElements = markdownDiv.querySelectorAll('th');
     const tdElements = markdownDiv.querySelectorAll('td');
 
     expect(tableElement).toBeTruthy();
     expect(tableElement).toHaveClass('table');
     expect(tableElement).toHaveClass('table-hover');
-    expect(trElements).toHaveLength(3); // Header + 2 data rows
-    expect(tdElements).toHaveLength(6); // 2 columns × 3 rows
-    expect(tdElements[0]).toHaveTextContent('Name');
-    expect(tdElements[1]).toHaveTextContent('Role');
-    expect(tdElements[2]).toHaveTextContent('Alice');
-    expect(tdElements[3]).toHaveTextContent('Developer');
+    expect(trElements).toHaveLength(3);
+    expect(thElements).toHaveLength(2);
+    expect(tdElements).toHaveLength(4);
+    expect(thElements[0]).toHaveTextContent('Name');
+    expect(thElements[1]).toHaveTextContent('Role');
+    expect(tdElements[0]).toHaveTextContent('Alice');
+    expect(tdElements[1]).toHaveTextContent('Developer');
+    expect(tdElements[2]).toHaveTextContent('Bob');
+    expect(tdElements[3]).toHaveTextContent('Designer');
   });
 
   it('should escape HTML in table cells', async () => {
@@ -208,9 +274,9 @@ const example = "code block";
     const markdownDiv = hostElement.firstElementChild!;
     const tdElements = markdownDiv.querySelectorAll('td');
 
-    expect(tdElements[2].innerHTML).not.toContain('<script>');
-    expect(tdElements[2].textContent).toBe('');
-    expect(tdElements[3].innerHTML).toContain('<b>Bold</b>');
+    expect(tdElements[0].innerHTML).not.toContain('<script>');
+    expect(tdElements[0].textContent).toBe('');
+    expect(tdElements[1].innerHTML).toContain('<b>Bold</b>');
   });
 
   it('should handle tables with markdown formatting inside cells', async () => {
@@ -230,6 +296,22 @@ const example = "code block";
     expect(innerHTML).toContain('<code>Code</code>');
   });
 
+  it('should protect inline code in table cells', async () => {
+    const tableMarkdown = `| Feature | Code |
+|---------|------|
+| **Bold** | \`code_with_underscore and **bold**\` |`;
+
+    text.set(tableMarkdown);
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const codeElement = markdownDiv.querySelector('td code')!;
+
+    expect(codeElement).toHaveTextContent('code_with_underscore and **bold**');
+    expect(codeElement.querySelector('em')).not.toBeInTheDocument();
+    expect(codeElement.querySelector('strong')).not.toBeInTheDocument();
+  });
+
   it('should handle escaped pipe characters in tables', async () => {
     const tableMarkdown = `| Command | Description |
 |---------|-------------|
@@ -242,10 +324,10 @@ const example = "code block";
     const markdownDiv = hostElement.firstElementChild!;
     const tdElements = markdownDiv.querySelectorAll('td');
 
-    expect(tdElements[2]).toHaveTextContent('grep "text|pattern"');
-    expect(tdElements[3]).toHaveTextContent('Search for text OR pattern');
-    expect(tdElements[4]).toHaveTextContent("awk '{print $1|$2}'");
-    expect(tdElements[5]).toHaveTextContent('Print fields separated by pipe');
+    expect(tdElements[0]).toHaveTextContent('grep "text|pattern"');
+    expect(tdElements[1]).toHaveTextContent('Search for text OR pattern');
+    expect(tdElements[2]).toHaveTextContent("awk '{print $1|$2}'");
+    expect(tdElements[3]).toHaveTextContent('Print fields separated by pipe');
   });
 
   it('should handle lists and line breaks inside table cells', async () => {
@@ -261,19 +343,41 @@ const example = "code block";
     const innerHTML = markdownDiv.innerHTML;
     const tdElements = markdownDiv.querySelectorAll('td');
 
-    // Check that formatting is preserved
     expect(innerHTML).toContain('<strong>Lists</strong>');
     expect(innerHTML).toContain('<em>Line breaks</em>');
 
-    // Check that lists are properly formatted
-    expect(tdElements[3].innerHTML).toContain('<ul>');
-    expect(tdElements[3].innerHTML).toContain('<li>First item</li>');
-    expect(tdElements[3].innerHTML).toContain('<li>Second item</li>');
-    expect(tdElements[3].innerHTML).toContain('<li>Third item</li>');
+    expect(tdElements[1].innerHTML).toContain('<ul>');
+    expect(tdElements[1].innerHTML).toContain('<li>First item</li>');
+    expect(tdElements[1].innerHTML).toContain('<li>Second item</li>');
+    expect(tdElements[1].innerHTML).toContain('<li>Third item</li>');
 
-    // Check that line breaks work in cells - <br> tags remain as <br> in innerHTML, don't convert to \n in textContent
-    expect(tdElements[5].innerHTML).toContain('<br>');
-    expect(tdElements[5]).toHaveTextContent('Line 1Line 2Line 3');
+    expect(tdElements[3].innerHTML).toContain('<br>');
+    expect(tdElements[3]).toHaveTextContent('Line 1Line 2Line 3');
+  });
+
+  it('should render images from markdown', async () => {
+    text.set('![alt text](https://example.com/image.png)');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const imgElement = markdownDiv.querySelector('img')!;
+
+    expect(imgElement).toBeTruthy();
+    expect(imgElement.getAttribute('src')).toBe('https://example.com/image.png');
+    expect(imgElement.getAttribute('alt')).toBe('alt text');
+  });
+
+  it('should render images alongside text', async () => {
+    text.set('Some text ![logo](https://example.com/logo.png) more text');
+    await fixture.whenStable();
+
+    const markdownDiv = hostElement.firstElementChild!;
+    const imgElement = markdownDiv.querySelector('img')!;
+
+    expect(imgElement).toBeTruthy();
+    expect(imgElement.getAttribute('src')).toBe('https://example.com/logo.png');
+    expect(markdownDiv).toHaveTextContent('Some text');
+    expect(markdownDiv).toHaveTextContent('more text');
   });
 
   it('should update content when input changes', async () => {

--- a/projects/element-ng/markdown-renderer/si-markdown-renderer.component.ts
+++ b/projects/element-ng/markdown-renderer/si-markdown-renderer.component.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, effect, inject, input, ElementRef } from '@angular/core';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { Component, effect, inject, input, ElementRef, PLATFORM_ID } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
 import { getMarkdownRenderer } from './markdown-renderer';
@@ -18,13 +19,22 @@ import { getMarkdownRenderer } from './markdown-renderer';
 export class SiMarkdownRendererComponent {
   private sanitizer = inject(DomSanitizer);
   private hostElement = inject(ElementRef<HTMLElement>);
-  private markdownRenderer = getMarkdownRenderer(this.sanitizer);
+  private platformId = inject(PLATFORM_ID);
+  private isBrowser = isPlatformBrowser(this.platformId);
+  private doc = inject(DOCUMENT);
 
   /**
    * The markdown text to transform and display
    * @defaultValue ''
    */
   readonly text = input<string | undefined>();
+
+  private markdownRenderer = getMarkdownRenderer(
+    this.sanitizer,
+    undefined,
+    this.doc,
+    this.isBrowser
+  );
 
   constructor() {
     effect(() => {

--- a/projects/element-ng/markdown-renderer/si-markdown-renderer.component.ts
+++ b/projects/element-ng/markdown-renderer/si-markdown-renderer.component.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MIT
  */
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
-import { Component, effect, inject, input, ElementRef, PLATFORM_ID } from '@angular/core';
+import { Component, computed, effect, inject, input, ElementRef, PLATFORM_ID } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
-import { getMarkdownRenderer } from './markdown-renderer';
+import { getMarkdownRenderer, type MarkdownRendererOptions } from './markdown-renderer';
 
 /**
  * Component to display markdown text, uses the {@link getMarkdownRenderer} function internally, relies on `markdown-content` theme class.
@@ -29,20 +29,35 @@ export class SiMarkdownRendererComponent {
    */
   readonly text = input<string | undefined>();
 
-  private markdownRenderer = getMarkdownRenderer(
-    this.sanitizer,
-    undefined,
-    this.doc,
-    this.isBrowser
-  );
+  /**
+   * Optional syntax highlighter function for code blocks.
+   * Receives code content and optional language, returns an HTML content string to display inside of the code block or undefined to use default rendering.
+   * The returned code is sanitized before insertion.
+   * Make sure that the required styles/scripts for the syntax highlighter are included in your application.
+   * @defaultValue undefined
+   */
+  readonly syntaxHighlighter = input<
+    ((code: string, language?: string) => string | undefined) | undefined
+  >(undefined);
+
+  private readonly markdownRenderer = computed(() => {
+    const highlighterFn = this.syntaxHighlighter();
+
+    const options: MarkdownRendererOptions = {
+      syntaxHighlighter: highlighterFn
+    };
+
+    return getMarkdownRenderer(this.sanitizer, options, this.doc, this.isBrowser);
+  });
 
   constructor() {
     effect(() => {
       const contentValue = this.text();
       const containerEl = this.hostElement.nativeElement;
+      const renderer = this.markdownRenderer();
 
       if (containerEl) {
-        const formattedNode = this.markdownRenderer(contentValue ?? '');
+        const formattedNode = renderer(contentValue ?? '');
         containerEl.innerHTML = '';
         containerEl.appendChild(formattedNode);
       }

--- a/projects/element-theme/src/styles/components/_markdown-hljs-theme.scss
+++ b/projects/element-theme/src/styles/components/_markdown-hljs-theme.scss
@@ -1,0 +1,128 @@
+@use '../variables';
+
+// stylelint-disable selector-class-pattern
+
+// Custom highlight.js theme using Element Design System tokens
+// Automatically adapts to light and dark themes
+
+.markdown-content {
+  // 1. Default and text
+  .hljs {
+    color: variables.$element-text-primary;
+  }
+
+  // 2. Keywords
+  .hljs-keyword,
+  .hljs-literal {
+    color: variables.$element-data-purple-2;
+  }
+
+  // 3. Special keywords and operators
+  .hljs-operator {
+    color: variables.$element-data-plum-2;
+  }
+
+  // 4. Variables
+  .hljs-variable,
+  .hljs-variable.language_,
+  .hljs-variable.constant_,
+  .hljs-params,
+  .hljs-property {
+    color: variables.$element-data-6;
+  }
+
+  // 5. Functions and methods
+  .hljs-title,
+  .hljs-title.function_,
+  .hljs-title.function_.invoke__,
+  .hljs-built_in {
+    color: variables.$element-text-caution;
+  }
+
+  // 6. Strings
+  .hljs-string,
+  .hljs-regexp,
+  .hljs-char.escape_,
+  .hljs-subst,
+  .hljs-doctag {
+    color: variables.$element-text-warning;
+  }
+
+  // 7. Numbers
+  .hljs-number {
+    color: variables.$element-text-success;
+  }
+
+  // 8. Constants and enums
+  .hljs-symbol,
+  .hljs-bullet {
+    color: variables.$element-data-13;
+  }
+
+  // 9. Comments
+  .hljs-comment,
+  .hljs-quote {
+    color: variables.$element-data-green-3;
+  }
+
+  // 10. Brackets/punctuation
+  .hljs-punctuation {
+    color: variables.$element-data-17;
+  }
+
+  // 11. Tags (HTML/XML)
+  .hljs-tag,
+  .hljs-name,
+  .hljs-attr,
+  .hljs-attribute,
+  .hljs-selector-tag,
+  .hljs-selector-id,
+  .hljs-selector-class,
+  .hljs-selector-attr,
+  .hljs-selector-pseudo,
+  .hljs-meta,
+  .hljs-meta.keyword_,
+  .hljs-template-tag,
+  .hljs-template-variable {
+    color: variables.$element-data-5;
+  }
+
+  // 12. Types declaration and references
+  .hljs-type,
+  .hljs-title.class_,
+  .hljs-title.class_.inherited__,
+  .hljs-section {
+    color: variables.$element-data-4;
+  }
+
+  // 13. Invalid
+  .hljs-deletion {
+    color: variables.$element-data-10;
+  }
+
+  // Additions in diffs (use comment green)
+  .hljs-addition {
+    color: variables.$element-data-green-3;
+  }
+
+  // Emphasis
+  .hljs-emphasis {
+    font-style: italic;
+  }
+
+  // Strong emphasis
+  .hljs-strong {
+    font-weight: variables.$si-font-weight-semibold;
+  }
+
+  // Code blocks and formulas
+  .hljs-code,
+  .hljs-formula {
+    color: variables.$element-text-primary;
+  }
+
+  // Links
+  .hljs-link {
+    color: variables.$element-text-warning;
+  }
+}

--- a/projects/element-theme/src/styles/components/_markdown.scss
+++ b/projects/element-theme/src/styles/components/_markdown.scss
@@ -2,6 +2,8 @@
 
 @use '../variables';
 
+@use './markdown-hljs-theme';
+
 .markdown-content {
   max-inline-size: 100%;
   min-inline-size: 0;

--- a/projects/element-theme/src/styles/components/_markdown.scss
+++ b/projects/element-theme/src/styles/components/_markdown.scss
@@ -33,6 +33,17 @@
     overflow-wrap: break-word;
   }
 
+  .task-list-item {
+    list-style: none;
+
+    .form-check-input {
+      margin-inline-start: calc(-1rem - map.get(variables.$spacers, 2));
+      margin-inline-end: map.get(variables.$spacers, 2);
+      vertical-align: text-bottom;
+      pointer-events: none;
+    }
+  }
+
   .code-wrapper {
     display: flex;
     flex-direction: column;

--- a/projects/element-theme/src/styles/components/_markdown.scss
+++ b/projects/element-theme/src/styles/components/_markdown.scss
@@ -1,6 +1,6 @@
-@use '../variables';
-
 @use 'sass:map';
+
+@use '../variables';
 
 .markdown-content {
   max-inline-size: 100%;
@@ -33,11 +33,49 @@
     overflow-wrap: break-word;
   }
 
+  .code-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: map.get(variables.$spacers, 5);
+    inline-size: 100%;
+    margin-block: map.get(variables.$spacers, 4);
+    padding-block: map.get(variables.$spacers, 5);
+    padding-inline: map.get(variables.$spacers, 6);
+    color: variables.$element-text-primary;
+    background-color: transparent;
+    border: 1px solid variables.$element-ui-4;
+    border-radius: variables.$element-radius-2;
+  }
+
+  .code-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    // Match the minimum header height with the future copy-code button.
+    min-block-size: map.get(variables.$spacers, 9);
+  }
+
+  .code-language {
+    font-weight: variables.$si-font-weight-semibold;
+    text-transform: capitalize;
+  }
+
   pre {
+    margin: 0;
+    padding: 0;
+    overflow-x: auto;
+    background-color: transparent;
+    border: 0;
+    border-radius: 0;
+    font-size: variables.$si-font-size-caption;
+    line-height: 1.5;
+
     code {
+      color: inherit;
       background-color: transparent;
       padding-block: 0;
       padding-inline: 0;
+      border: 0;
       border-radius: 0;
     }
 
@@ -67,17 +105,38 @@
   > *:last-child {
     // stylelint-disable-next-line declaration-no-important
     margin-block-end: 0 !important;
+
+    &.code-wrapper > pre {
+      // stylelint-disable-next-line declaration-no-important
+      margin-block-end: 0 !important;
+    }
+  }
+
+  .table-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: map.get(variables.$spacers, 1);
+    inline-size: 100%;
+    margin-block-start: map.get(variables.$spacers, 6);
+    margin-block-end: map.get(variables.$spacers, 6);
+  }
+
+  .table-scroll-container {
+    inline-size: 100%;
+    overflow-x: auto;
   }
 
   table {
-    inline-size: max-content;
-    max-inline-size: 100%;
+    inline-size: 100%;
+    min-inline-size: 100%;
+    align-self: stretch;
     // stylelint-disable-next-line declaration-no-important
-    margin-block-start: map.get(variables.$spacers, 6) !important;
+    margin-block-start: 0 !important;
     // stylelint-disable-next-line declaration-no-important
     margin-block-end: 0 !important;
-    overflow: auto;
-    display: block;
+    display: table;
+    table-layout: auto;
     white-space: nowrap;
 
     ul,
@@ -85,11 +144,15 @@
       // stylelint-disable-next-line declaration-no-important
       padding-inline-start: map.get(variables.$spacers, 6) !important;
     }
+
+    td:last-child,
+    th:last-child {
+      inline-size: 100%;
+    }
   }
 
   table td,
   table th {
-    max-inline-size: 200px;
     overflow: hidden;
     text-overflow: ellipsis;
 

--- a/src/app/examples/datatable/datatable-bulk-actions.ts
+++ b/src/app/examples/datatable/datatable-bulk-actions.ts
@@ -50,9 +50,6 @@ export class SampleComponent implements OnInit {
   protected readonly collapsed = signal(false);
   protected readonly statusMenuOpen = signal(false);
 
-  private readonly bulkActionsTemplate = viewChild.required('bulkActionsTemplate', {
-    read: TemplateRef<unknown>
-  });
   private readonly checkboxCellTemplate = viewChild.required('checkboxCellTmpl', {
     read: TemplateRef<unknown>
   });

--- a/src/app/examples/si-chat-messages/si-ai-message.ts
+++ b/src/app/examples/si-chat-messages/si-ai-message.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject, PLATFORM_ID } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import {
   elementBookmark,
@@ -27,8 +28,15 @@ import { LOG_EVENT } from '@siemens/live-preview';
 export class SampleComponent {
   logEvent = inject(LOG_EVENT);
   private sanitizer = inject(DomSanitizer);
+  private doc = inject(DOCUMENT);
+  private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
-  protected markdownRenderer = getMarkdownRenderer(this.sanitizer);
+  protected markdownRenderer = getMarkdownRenderer(
+    this.sanitizer,
+    undefined,
+    this.doc,
+    this.isBrowser
+  );
 
   protected readonly icons = addIcons({
     elementThumbsUp,

--- a/src/app/examples/si-chat-messages/si-chat-container.ts
+++ b/src/app/examples/si-chat-messages/si-chat-container.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -9,7 +10,8 @@ import {
   inject,
   signal,
   TemplateRef,
-  viewChild
+  viewChild,
+  PLATFORM_ID
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import {
@@ -80,8 +82,15 @@ export class SampleComponent {
   private sanitizer = inject(DomSanitizer);
   private readonly toastService = inject(SiToastNotificationService);
   private readonly chatContainer = viewChild<SiChatContainerComponent>(SiChatContainerComponent);
+  private doc = inject(DOCUMENT);
+  private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
-  protected markdownRenderer = getMarkdownRenderer(this.sanitizer);
+  protected markdownRenderer = getMarkdownRenderer(
+    this.sanitizer,
+    undefined,
+    this.doc,
+    this.isBrowser
+  );
 
   protected readonly icons = addIcons({
     elementUser,

--- a/src/app/examples/si-chat-messages/si-user-message.ts
+++ b/src/app/examples/si-chat-messages/si-user-message.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject, PLATFORM_ID } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import {
   SiUserMessageComponent,
@@ -21,8 +22,15 @@ import { LOG_EVENT } from '@siemens/live-preview';
 export class SampleComponent {
   logEvent = inject(LOG_EVENT);
   private sanitizer = inject(DomSanitizer);
+  private doc = inject(DOCUMENT);
+  private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
-  protected markdownRenderer = getMarkdownRenderer(this.sanitizer);
+  protected markdownRenderer = getMarkdownRenderer(
+    this.sanitizer,
+    undefined,
+    this.doc,
+    this.isBrowser
+  );
 
   content = `Can you help me with this **code snippet**?
 

--- a/src/app/examples/si-markdown-renderer/si-markdown-renderer.html
+++ b/src/app/examples/si-markdown-renderer/si-markdown-renderer.html
@@ -1,3 +1,3 @@
 <div class="p-4">
-  <si-markdown-renderer [text]="markdownText()" />
+  <si-markdown-renderer [text]="markdownText()" [syntaxHighlighter]="syntaxHighlighter" />
 </div>

--- a/src/app/examples/si-markdown-renderer/si-markdown-renderer.ts
+++ b/src/app/examples/si-markdown-renderer/si-markdown-renderer.ts
@@ -12,6 +12,7 @@ import {
   signal
 } from '@angular/core';
 import { SiMarkdownRendererComponent } from '@siemens/element-ng/markdown-renderer';
+import hljs from 'highlight.js';
 
 @Component({
   selector: 'app-sample',
@@ -23,6 +24,17 @@ export class SampleComponent implements OnInit {
   private readonly http = inject(HttpClient);
   readonly markdownText = signal<string>('');
   private cdRef = inject(ChangeDetectorRef);
+
+  readonly syntaxHighlighter = (code: string, language?: string): string | undefined => {
+    if (language && hljs.getLanguage(language)) {
+      try {
+        return hljs.highlight(code, { language }).value;
+      } catch {
+        // fall back to no highlighting
+      }
+    }
+    return undefined;
+  };
 
   ngOnInit(): void {
     this.http.get('assets/sample-markdown.md', { responseType: 'text' }).subscribe(text => {

--- a/src/app/examples/si-markdown-renderer/si-markdown-renderer.ts
+++ b/src/app/examples/si-markdown-renderer/si-markdown-renderer.ts
@@ -12,7 +12,7 @@ import {
   signal
 } from '@angular/core';
 import { SiMarkdownRendererComponent } from '@siemens/element-ng/markdown-renderer';
-import hljs from 'highlight.js';
+import hljs from 'highlight.js/lib/common';
 
 @Component({
   selector: 'app-sample',

--- a/src/assets/sample-markdown.md
+++ b/src/assets/sample-markdown.md
@@ -1,4 +1,4 @@
-# AI Assistant Response
+# Sample Markdown Content
 
 Here's a **comprehensive example** of markdown content with various formatting options.
 
@@ -17,6 +17,8 @@ const result = calculateSum(5, 3);
 console.log(`Result: ${result}`);
 ```
 
+---
+
 ## Formatting Options
 
 Here's a paragraph explaining the formatting options available.
@@ -33,6 +35,8 @@ You can include links such as [Element](https://element.siemens.io) for more inf
 
 Links are also automatically detected: https://angular.io
 
+---
+
 ## Lists and Bullets
 
 Here are the key features:
@@ -44,6 +48,9 @@ Here are the key features:
 - Bullet point lists
 - Blockquote support
 
+* Or in the alternate format
+* Another bullet point
+
 This paragraph appears after the list to show proper spacing.
 
 ## Ordered Lists
@@ -53,6 +60,8 @@ Step-by-step instructions:
 1. First, analyze the requirements
 2. Then, implement the solution
 3. Finally, test the implementation
+
+---
 
 > This is a blockquote that demonstrates how quoted text appears in the markdown content component.
 
@@ -69,6 +78,16 @@ Another paragraph between the lists.
 2. Second ordered item
 
 Final paragraph to show proper spacing.
+
+---
+
+## Images
+
+Images can be included as follows:
+
+![Building Image](./assets/images/building-1.webp)
+
+---
 
 ## Tables
 

--- a/src/assets/sample-markdown.md
+++ b/src/assets/sample-markdown.md
@@ -48,6 +48,11 @@ Here are the key features:
 - Bullet point lists
 - Blockquote support
 
+- [ ] Open task-list item
+- [x] Completed task-list item
+- [x] Completed task-list item with uppercase marker
+- [~] Disabled task-list item
+
 * Or in the alternate format
 * Another bullet point
 

--- a/src/highlight-js-common.d.ts
+++ b/src/highlight-js-common.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+declare module 'highlight.js/lib/common' {
+  interface HighlightResult {
+    value: string;
+  }
+
+  interface HighlightJsCommon {
+    getLanguage(language: string): unknown;
+    highlight(code: string, options: { language: string }): HighlightResult;
+  }
+
+  const hljs: HighlightJsCommon;
+  export default hljs;
+}


### PR DESCRIPTION
Merge after #1811

Add optional syntax highlighting the markdown renderer for libraries like highlight.js and a custom hljs theme using Element design tokens
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1815/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1815/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1815/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1815/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1815/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1815/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1815/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1815/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1815/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1815/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->




