### PR TITLE
build(renovate): use best practices config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,12 +1,13 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "config:recommended",
+    "config:best-practices",
     "group:allNonMajor",
     ":semanticCommits",
     ":semanticCommitTypeAll(chore)",
     ":prHourlyLimitNone",
-    ":prConcurrentLimitNone"
+    ":prConcurrentLimitNone",
+    ":maintainLockFilesMonthly"
   ],
   addLabels: ["dep-bump"],
   schedule: ["before 7am on Wednesday"],


### PR DESCRIPTION
Switch from `config:recommended` to [`config:best-practices`](https://docs.renovatebot.com/presets-config/#configbest-practices). 

Notable additions from best-practices:
- `helpers:pinGitHubActionDigests` — pins GitHub Action versions to their digests for improved supply chain security
- `security:minimumReleaseAgeNpm` — waits 3 days before raising npm updates, giving time for malware detection and preventing issues from unpublished packages
- already includes `config:recommended`

The best-practices preset includes `:maintainLockFilesWeekly` by default, which is overridden here with `:maintainLockFilesMonthly` to reduce noise, as weekly lock file maintenance is too frequent for our setup.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1818/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1818/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1818/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1818/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1818/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1818/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1818/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1818/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1818/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1818/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
