### PR TITLE
fix(status-bar): focus outline hidden behind background color

### DIFF
--- a/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.scss
+++ b/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.scss
@@ -45,6 +45,7 @@ $colorbar-width: map.get(variables.$spacers, 2);
 
 .status-item {
   position: relative;
+  isolation: isolate;
   padding-block: $item-padding;
   padding-inline: $item-padding-small $item-padding;
   min-inline-size: $item-min-width;
@@ -59,6 +60,7 @@ $colorbar-width: map.get(variables.$spacers, 2);
 .bg {
   position: absolute;
   inset: 0;
+  z-index: -1;
   border-radius: variables.$element-radius-2;
   pointer-events: none;
 }


### PR DESCRIPTION
When a `si-status-bar-item` has a background color applied (via the #bg div), the focus outline on the parent `status-item` is not visible. This happens because the `bg` div is absolutely positioned with `inset: 0` covering the entire area including the inward focus outline (focus-inside). Since the outline is drawn inward (negative offset), the `bg` div paints on top of it.

Add `isolation: isolate` on `.status-item` and `z-index: -1` on `.bg` so the background overlay paints below the inward focus outline.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1821/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1821/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1821/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1821/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1821/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1821/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1821/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1821/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1821/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1821/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

