### PR TITLE
refactor: derive input disabled color from reboot.scss

### DIFF
--- a/projects/element-ng/datepicker/si-date-range.component.scss
+++ b/projects/element-ng/datepicker/si-date-range.component.scss
@@ -28,12 +28,6 @@ input {
     opacity: 1;
   }
 
-  &:disabled {
-    &::placeholder {
-      color: all-variables.$input-placeholder-disabled-color;
-    }
-  }
-
   &,
   &:focus {
     &:not([readonly]):focus::placeholder {

--- a/projects/element-ng/filtered-search/si-filtered-search-input.component.scss
+++ b/projects/element-ng/filtered-search/si-filtered-search-input.component.scss
@@ -9,11 +9,6 @@ input {
     opacity: 1;
   }
 
-  &:disabled,
-  &:disabled ::placeholder {
-    color: variables.$element-text-disabled;
-  }
-
   :host-context(si-filtered-search-value + :host) &::placeholder {
     color: transparent;
   }

--- a/projects/element-ng/filtered-search/si-filtered-search-value.component.scss
+++ b/projects/element-ng/filtered-search/si-filtered-search-value.component.scss
@@ -1,13 +1,6 @@
 @use '@siemens/element-theme/src/styles/variables';
 @use 'sass:map';
 
-:host-context(.disabled) {
-  input,
-  ::placeholder {
-    color: variables.$element-text-disabled;
-  }
-}
-
 .pill {
   background: var(--filter-pill-background-color);
 }

--- a/projects/element-ng/number-input/si-number-input.component.scss
+++ b/projects/element-ng/number-input/si-number-input.component.scss
@@ -14,12 +14,6 @@
   &:focus-within {
     @include all-variables.make-outline-focus();
   }
-
-  &.disabled {
-    ::placeholder {
-      color: all-variables.$input-placeholder-disabled-color;
-    }
-  }
 }
 
 input {

--- a/projects/element-theme/src/styles/bootstrap/_reboot.scss
+++ b/projects/element-theme/src/styles/bootstrap/_reboot.scss
@@ -409,6 +409,17 @@ textarea {
   line-height: inherit;
 }
 
+input,
+textarea {
+  &:disabled {
+    color: variables.$text-muted;
+
+    &::placeholder {
+      color: variables.$input-placeholder-disabled-color;
+    }
+  }
+}
+
 // Remove the inheritance of text transform in Firefox
 button,
 select {


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1823/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1823/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1823/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1823/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1823/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1823/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1823/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1823/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1823/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1823/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

