### PR TITLE
refactor(dashboards-ng): simplify statusChanges/configChange subscription logic

### DIFF
--- a/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.ts
@@ -155,23 +155,17 @@ export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy 
         this.widgetInstanceEditor.statusChangesHandler = this.handleStatusChanges.bind(this);
       }
 
-      let hasStatusChangesEmitter = false;
       if (this.widgetInstanceEditor.statusChanges) {
-        hasStatusChangesEmitter = true;
         this.subscriptions.push(
-          this.widgetInstanceEditor.statusChanges.subscribe(statusChanges => {
-            this.handleStatusChanges(statusChanges);
-          }) as Subscription
+          this.widgetInstanceEditor.statusChanges.subscribe(statusChanges =>
+            this.handleStatusChanges(statusChanges)
+          ) as Subscription
         );
-      }
-
-      if (this.widgetInstanceEditor.configChange) {
+      } else if (this.widgetInstanceEditor.configChange) {
         this.subscriptions.push(
-          this.widgetInstanceEditor.configChange.subscribe(config => {
-            if (!hasStatusChangesEmitter) {
-              this.widgetConfigModified.set(true);
-            }
-          }) as Subscription
+          this.widgetInstanceEditor.configChange.subscribe(() =>
+            this.widgetConfigModified.set(true)
+          ) as Subscription
         );
       }
       if (this.isEditorWizard(this.widgetInstanceEditor)) {


### PR DESCRIPTION
Replace redundant hasStatusChangesEmitter flag with else-if branch, removing unnecessary configChange subscription when statusChanges exists.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1824/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1824/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1824/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1824/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1824/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1824/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1824/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1824/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1824/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1824/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
