### PR TITLE
refactor(dashboards-ng): replace manual view removal with ViewContainerRef.clear()

### DIFF
--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
@@ -338,9 +338,7 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
   }
 
   private setupCatalog(): void {
-    if (this.editorHost().length > 0) {
-      this.editorHost().remove(0);
-    }
+    this.editorHost().clear();
     this.tearDownEditor();
     this.widgetConfig = undefined;
     this.view.set('list');


### PR DESCRIPTION
Use ViewContainerRef.clear() instead of manually checking length and removing the first entry. clear() removes all views and is a safe no-op when the container is already empty, making the guard unnecessary.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1825/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1825/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1825/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1825/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1825/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1825/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1825/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1825/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1825/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1825/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
