### PR TITLE
refactor(dashboards-ng): use computed for hasEditor value

### DIFF
--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
@@ -105,7 +105,9 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
   protected filteredWidgetCatalog: Widget[] = [];
   protected readonly selected = signal<Widget | undefined>(undefined);
   private widgetConfig?: Omit<WidgetConfig, 'id'>;
-  private readonly hasEditor = signal<boolean>(false);
+  private readonly hasEditor = computed(
+    () => !!this.selected()?.componentFactory.editorComponentName
+  );
 
   protected labelCancel = t(() => $localize`:@@DASHBOARD.WIDGET_LIBRARY.CANCEL:Cancel`);
   protected labelPrevious = t(() => $localize`:@@DASHBOARD.WIDGET_LIBRARY.PREVIOUS:Previous`);
@@ -367,11 +369,6 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
 
   protected selectWidget(widget?: Widget): void {
     this.selected.set(widget);
-    if (widget?.componentFactory?.editorComponentName) {
-      this.hasEditor.set(true);
-    } else {
-      this.hasEditor.set(false);
-    }
     if (widget) {
       // need to keep this in setTimeout to avoid ExpressionChangedAfterItHasBeenCheckedError
       setTimeout(() => {


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1826/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1826/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1826/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1826/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1826/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1826/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1826/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1826/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1826/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1826/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
