### PR TITLE
fix(dashbaords-ng): use square icon style for edit button

### DIFF
--- a/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.html
+++ b/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.html
@@ -8,7 +8,7 @@
           type="button"
           class="btn ms-auto"
           [class]="
-            showEditButtonLabelDesktop ? 'btn-secondary' : 'btn-circle btn-tertiary element-edit'
+            showEditButtonLabelDesktop ? 'btn-secondary' : 'btn-icon btn-tertiary element-edit'
           "
           [attr.aria-label]="labelEdit | translate"
           [attr.title]="!showEditButtonLabelDesktop ? (labelEdit | translate) : undefined"


### PR DESCRIPTION
edit button is part of dashboard toolbar which may also contain other action buttons.
As per UX this icon button should be square style and not the circle.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
