### PR TITLE
fix(toast-notification): fix missing toasts when called during bootstrap

### DIFF
--- a/api-goldens/element-ng/toast-notification/index.api.md
+++ b/api-goldens/element-ng/toast-notification/index.api.md
@@ -45,7 +45,7 @@ export interface SiToast {
 // @public (undocumented)
 export class SiToastNotificationService implements OnDestroy {
     constructor();
-    activeToasts: SiToast[];
+    get activeToasts(): SiToast[];
     hideToastNotification(toast?: SiToast): void;
     queueToastNotification(state: StatusType, title: string, message: string, disableAutoClose?: boolean, disableManualClose?: boolean, action?: Link): SiToast;
     showToastNotification(toast: SiToast): SiToast;

--- a/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.html
+++ b/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.html
@@ -1,10 +1,10 @@
-@for (toast of toasts() | async; track toast) {
+@for (toast of token.toasts(); track toast) {
   <si-toast-notification
     class="position-relative"
     animate.enter="toast-enter"
     animate.leave="toast-leave"
     [toast]="toast"
-    (paused)="paused.emit(toast)"
-    (resumed)="resumed.emit(toast)"
+    (paused)="token.pause(toast)"
+    (resumed)="token.resume(toast)"
   />
 }

--- a/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.spec.ts
@@ -2,52 +2,49 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Observable, Subject } from 'rxjs';
 
+import { SI_TOAST_TOKEN } from '../si-toast-token.model';
 import { SiToast } from '../si-toast.model';
 import { SiToastNotificationDrawerComponent } from './si-toast-notification-drawer.component';
 
-@Component({
-  imports: [SiToastNotificationDrawerComponent],
-  template: `<si-toast-notification-drawer [toasts]="toasts()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
-})
-class TestHostComponent {
-  readonly toasts = signal<Observable<SiToast[]>>(new Subject<SiToast[]>());
-}
 describe('SiToastNotificationDrawerComponent', () => {
-  let component: TestHostComponent;
-  let fixture: ComponentFixture<TestHostComponent>;
+  let toasts: WritableSignal<SiToast[]>;
+  let fixture: ComponentFixture<SiToastNotificationDrawerComponent>;
   let element: HTMLElement;
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(TestHostComponent);
-    component = fixture.componentInstance;
+    toasts = signal([]);
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: SI_TOAST_TOKEN,
+          useValue: {
+            toasts,
+            pause: () => {},
+            resume: () => {}
+          }
+        }
+      ]
+    });
+    fixture = TestBed.createComponent(SiToastNotificationDrawerComponent);
     element = fixture.nativeElement;
   });
 
-  it('should create', async () => {
-    await fixture.whenStable();
-    expect(component).toBeTruthy();
-  });
-
   it('renders toasts', async () => {
-    const toastSubject = new Subject<SiToast[]>();
-    component.toasts.set(toastSubject);
     fixture.detectChanges();
 
-    toastSubject.next([
-      { state: 'danger', title: 'danger toast', message: 'danger message', hidden: new Subject() },
-      { state: 'info', title: 'info toast', message: 'info message', hidden: new Subject() }
+    toasts.set([
+      { state: 'danger', title: 'danger toast', message: 'danger message' },
+      { state: 'info', title: 'info toast', message: 'info message' }
     ]);
 
     await fixture.whenStable();
 
-    const toasts = element.querySelectorAll('si-toast-notification');
-    expect(toasts.length).toBe(2);
-    expect(toasts[0]).toHaveTextContent('danger message');
-    expect(toasts[1]).toHaveTextContent('info message');
+    const domToasts = element.querySelectorAll('si-toast-notification');
+    expect(domToasts.length).toBe(2);
+    expect(domToasts[0]).toHaveTextContent('danger message');
+    expect(domToasts[1]).toHaveTextContent('info message');
   });
 });

--- a/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.ts
@@ -2,17 +2,15 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { areAnimationsDisabled } from '@siemens/element-ng/common';
-import { Observable } from 'rxjs';
 
 import { SiToastNotificationComponent } from '../si-toast-notification/si-toast-notification.component';
-import { SiToast } from '../si-toast.model';
+import { SI_TOAST_TOKEN } from '../si-toast-token.model';
 
 @Component({
   selector: 'si-toast-notification-drawer',
-  imports: [AsyncPipe, SiToastNotificationComponent],
+  imports: [SiToastNotificationComponent],
   templateUrl: './si-toast-notification-drawer.component.html',
   styleUrl: './si-toast-notification-drawer.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -22,9 +20,6 @@ import { SiToast } from '../si-toast.model';
   }
 })
 export class SiToastNotificationDrawerComponent {
-  readonly toasts = input<Observable<SiToast[]>>();
-  readonly paused = output<SiToast>();
-  readonly resumed = output<SiToast>();
-
+  protected readonly token = inject(SI_TOAST_TOKEN);
   protected animationsDisabled = areAnimationsDisabled();
 }

--- a/projects/element-ng/toast-notification/si-toast-notification.service.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification.service.ts
@@ -5,26 +5,39 @@
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { isPlatformBrowser } from '@angular/common';
-import { ComponentRef, inject, Injectable, Injector, OnDestroy, PLATFORM_ID } from '@angular/core';
+import {
+  ComponentRef,
+  inject,
+  Injectable,
+  Injector,
+  OnDestroy,
+  PLATFORM_ID,
+  Provider,
+  signal
+} from '@angular/core';
 import { isRTL, StatusType } from '@siemens/element-ng/common';
 import { Link } from '@siemens/element-ng/link';
 import { SiNoTranslateService, SiTranslateService } from '@siemens/element-translate-ng/translate';
-import { ReplaySubject, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 
 import { SiToastNotificationDrawerComponent } from './si-toast-notification-drawer/si-toast-notification-drawer.component';
+import { SI_TOAST_TOKEN, ToastToken } from './si-toast-token.model';
 import { SI_TOAST_AUTO_HIDE_DELAY, SiToast } from './si-toast.model';
 
 @Injectable({ providedIn: 'root' })
 export class SiToastNotificationService implements OnDestroy {
-  /**
-   * List of currently active toasts to see details or close them.
-   *
-   * @defaultValue []
-   */
-  activeToasts: SiToast[] = [];
+  private readonly activeToastsSignal = signal<SiToast[]>([]);
 
-  private activeToastsSubject = new ReplaySubject<SiToast[]>(1);
-  private queuedToastSubject = new Subject<SiToast>();
+  /** List of currently active toasts to see details or close them.  */
+  get activeToasts(): SiToast[] {
+    return this.activeToastsSignal();
+  }
+
+  private token: ToastToken = {
+    toasts: this.activeToastsSignal,
+    pause: toast => this.pauseToastNotification(toast),
+    resume: toast => this.resumeToastNotification(toast)
+  };
   private readonly maxToasts = 3;
 
   private componentRef?: ComponentRef<SiToastNotificationDrawerComponent>;
@@ -39,26 +52,7 @@ export class SiToastNotificationService implements OnDestroy {
   >();
 
   constructor() {
-    const isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
-    this.queuedToastSubject.subscribe((toast: SiToast) => {
-      this.activeToasts.push(toast);
-      if (this.activeToasts.length > this.maxToasts) {
-        this.hideToastNotification(this.activeToasts[0]);
-      }
-      this.activeToastsSubject.next(this.activeToasts);
-      if (!toast.disableAutoClose && toast.timeout) {
-        this.toastTimerDefaults.set(toast, {
-          pendingTimeout: toast.timeout,
-          initializeTime: Date.now()
-        });
-        this.toastTimeoutMap.set(
-          toast,
-          setTimeout(() => this.hideToastNotification(toast), toast.timeout)
-        );
-      }
-    });
-
-    if (isBrowser) {
+    if (isPlatformBrowser(inject(PLATFORM_ID))) {
       this.addToastDrawer();
     }
   }
@@ -102,7 +96,23 @@ export class SiToastNotificationService implements OnDestroy {
     toast.timeout ??= SI_TOAST_AUTO_HIDE_DELAY;
     toast.hidden ??= new Subject();
     toast.close = () => this.hideToastNotification(toast);
-    this.queuedToastSubject.next(toast);
+
+    const toasts = this.activeToastsSignal().concat(toast);
+    this.activeToastsSignal.set(toasts);
+    if (toasts.length > this.maxToasts) {
+      this.hideToastNotification(toasts[0]);
+    }
+    if (!toast.disableAutoClose && toast.timeout) {
+      this.toastTimerDefaults.set(toast, {
+        pendingTimeout: toast.timeout,
+        initializeTime: Date.now()
+      });
+      this.toastTimeoutMap.set(
+        toast,
+        setTimeout(() => this.hideToastNotification(toast), toast.timeout)
+      );
+    }
+
     return toast;
   }
 
@@ -113,7 +123,7 @@ export class SiToastNotificationService implements OnDestroy {
   hideToastNotification(toast?: SiToast): void {
     const hiddenToasts: SiToast[] = [];
     const activeToasts: SiToast[] = [];
-    this.activeToasts.forEach(item => {
+    this.activeToastsSignal().forEach(item => {
       if (!toast || item === toast) {
         hiddenToasts.push(item);
       } else {
@@ -121,8 +131,7 @@ export class SiToastNotificationService implements OnDestroy {
       }
     });
 
-    this.activeToasts = activeToasts;
-    this.activeToastsSubject.next(this.activeToasts);
+    this.activeToastsSignal.set(activeToasts);
 
     hiddenToasts.forEach(item => {
       item.hidden?.next();
@@ -148,7 +157,7 @@ export class SiToastNotificationService implements OnDestroy {
       this.toastTimeoutMap.set(
         toast,
         setTimeout(() => {
-          this.hideToastNotification(this.activeToasts.find(t => t === toast));
+          this.hideToastNotification(toast);
         }, this.toastTimerDefaults.get(toast)!.pendingTimeout)
       );
     }
@@ -164,25 +173,15 @@ export class SiToastNotificationService implements OnDestroy {
       this.buildInjector()
     );
     this.componentRef = this.overlayRef.attach(portal);
-    this.componentRef.setInput('toasts', this.activeToastsSubject);
-    this.componentRef.instance.paused.subscribe(toast => {
-      this.pauseToastNotification(toast);
-    });
-    this.componentRef.instance.resumed.subscribe(toast => {
-      this.resumeToastNotification(toast);
-    });
   }
 
-  // TODO remove once translation must be defined at application start
-  // Notification service is provided in 'root'. If no translation is defined, SiNoTranslateService is not provided
   private buildInjector(): Injector {
-    let injector = this.injector;
-    if (!injector.get(SiTranslateService, null)) {
-      injector = Injector.create({
-        providers: [{ provide: SiTranslateService, useClass: SiNoTranslateService, deps: [] }],
-        parent: this.injector
-      });
+    const providers: Provider[] = [{ provide: SI_TOAST_TOKEN, useValue: this.token }];
+    if (!this.injector.get(SiTranslateService, null)) {
+      // TODO remove once translation must be defined at application start
+      // Notification service is provided in 'root'. If no translation is defined, SiNoTranslateService is not provided
+      providers.push({ provide: SiTranslateService, useClass: SiNoTranslateService, deps: [] });
     }
-    return injector;
+    return Injector.create({ providers, parent: this.injector });
   }
 }

--- a/projects/element-ng/toast-notification/si-toast-token.model.ts
+++ b/projects/element-ng/toast-notification/si-toast-token.model.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { InjectionToken, Signal } from '@angular/core';
+
+import { SiToast } from './si-toast.model';
+
+export interface ToastToken {
+  toasts: Signal<SiToast[]>;
+  pause: (toast: SiToast) => void;
+  resume: (toast: SiToast) => void;
+}
+
+export const SI_TOAST_TOKEN = new InjectionToken<ToastToken>('SI_TOAST_TOKEN');


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1828/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1828/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1828/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1828/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1828/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1828/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1828/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1828/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1828/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1828/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


