### PR TITLE
fix(tooltip): remove aria-describedby when tooltip is disabled

### DIFF
--- a/projects/element-ng/tooltip/si-tooltip.directive.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.ts
@@ -22,7 +22,7 @@ import { SiTooltipService, TooltipRef } from './si-tooltip.service';
   selector: '[siTooltip]',
   providers: [SiTooltipService],
   host: {
-    '[attr.aria-describedby]': 'describedBy',
+    '[attr.aria-describedby]': 'isDisabled() ? null : describedBy',
     '(focus)': 'focusIn($event)',
     '(mouseenter)': 'show()',
     '(touchstart)': 'hide()',


### PR DESCRIPTION
When the tooltip is disabled, the referenced tooltip element does not exist in the DOM. Keeping aria-describedby pointing to a non-existent ID causes assistive technologies to look for a description that is not present.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1834/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1834/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1834/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1834/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1834/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1834/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1834/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1834/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1834/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1834/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
