### PR TITLE
fix(dashboards-ng): use siTooltip over html native tooltip

### DIFF
--- a/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.html
+++ b/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.html
@@ -11,7 +11,8 @@
             showEditButtonLabelDesktop ? 'btn-secondary' : 'btn-icon btn-tertiary element-edit'
           "
           [attr.aria-label]="labelEdit | translate"
-          [attr.title]="!showEditButtonLabelDesktop ? (labelEdit | translate) : undefined"
+          [siTooltip]="labelEdit"
+          [isDisabled]="showEditButtonLabelDesktop"
           [disabled]="disabled()"
           (click)="onEdit()"
         >

--- a/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.ts
+++ b/projects/dashboards-ng/src/components/dashboard-toolbar/si-dashboard-toolbar.component.ts
@@ -9,6 +9,7 @@ import { SiContentActionBarComponent } from '@siemens/element-ng/content-action-
 import { SiLinkDirective } from '@siemens/element-ng/link';
 import { SiLoadingButtonComponent } from '@siemens/element-ng/loading-spinner';
 import { SiResponsiveContainerDirective } from '@siemens/element-ng/resize-observer';
+import { SiTooltipDirective } from '@siemens/element-ng/tooltip';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
 import { DashboardToolbarItem } from '../../model/si-dashboard-toolbar.model';
@@ -29,7 +30,8 @@ import { SiGridComponent } from '../grid/si-grid.component';
     SiLoadingButtonComponent,
     RouterLink,
     SiResponsiveContainerDirective,
-    SiTranslatePipe
+    SiTranslatePipe,
+    SiTooltipDirective
   ],
   templateUrl: './si-dashboard-toolbar.component.html',
   host: {


### PR DESCRIPTION
replace native html tooltip with `siTooltip` for better consistency.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1835/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1835/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1835/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1835/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1835/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1835/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1835/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1835/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1835/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1835/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

