### PR TITLE
refactor(dashboards-ng): remove explicit editable$ subscribe in widget-host

### DIFF
--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
@@ -30,6 +30,7 @@ import { ContentActionBarMainItem, ViewType } from '@siemens/element-ng/content-
 import { SiDashboardCardComponent } from '@siemens/element-ng/dashboard';
 import { MenuItem } from '@siemens/element-ng/menu';
 import { t } from '@siemens/element-translate-ng/translate';
+import { tap } from 'rxjs';
 
 import { WidgetConfig, WidgetConfigEvent, WidgetInstance } from '../../model/widgets.model';
 import { SiGridService } from '../../services/si-grid.service';
@@ -86,7 +87,9 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
   secondaryActions: (MenuItemLegacy | MenuItem)[] = [];
   /** @defaultValue 'expanded' */
   actionBarViewType: ViewType = 'expanded';
-  editable$ = this.gridService.editable$;
+  protected editable$ = this.gridService.editable$.pipe(
+    tap(editable => this.setupEditable(editable))
+  );
 
   /** @defaultValue [] */
   editablePrimaryActions: (MenuItemLegacy | ContentActionBarMainItem)[] = [];
@@ -152,9 +155,6 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
 
   ngOnInit(): void {
     this.attachWidgetInstance();
-    this.editable$
-      .pipe<boolean>(takeUntilDestroyed(this.destroyRef))
-      .subscribe(editable => this.setupEditable(editable));
   }
 
   private attachWidgetInstance(): void {
@@ -176,7 +176,7 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
             this.widgetInstance.configChange
               .pipe(takeUntilDestroyed(this.destroyRef))
               .subscribe(event =>
-                setTimeout(() => this.setupEditable(this.editable$.value, event))
+                setTimeout(() => this.setupEditable(this.gridService.editable$.value, event))
               );
           }
           if (isSignal(this.widgetInstance.config)) {


### PR DESCRIPTION
There is already | async in template so explicit subscription is not needed here.
Move setupEditable side effect into editable$ pipe via tap, leveraging the template's async pipe subscription instead of a manual subscribe in ngOnInit. Update editable$ access modifier to protected as it is meant to be used internally.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1836/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1836/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1836/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1836/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1836/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1836/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1836/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1836/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1836/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1836/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
