### PR TITLE
ci(vrt-update): actually only regenerate the relevant images

### DIFF
--- a/.github/workflows/vrt-update.yaml
+++ b/.github/workflows/vrt-update.yaml
@@ -151,18 +151,18 @@ jobs:
 
       - name: Update VRTs
         run: |
-          if [ "${{ github.event.inputs.regenerate_all }}" = "true" ]; then
+          if [ "${{ inputs.regenerate_all }}" = "true" ]; then
             echo "Regenerate all flag is set - removing existing snapshots..."
             if [ -d "playwright/snapshots" ]; then
               rm -rf playwright/snapshots
             fi
             mkdir -p playwright/snapshots
             echo "Starting fresh snapshot generation..."
+            npx playwright test --update-snapshots=all
           else
             echo "Updating only changed snapshots..."
+            npx playwright test --update-snapshots=changed
           fi
-
-          npx playwright test --update-snapshots=all
 
           # Verify that snapshots were generated
           if [ ! -d "playwright/snapshots" ] || [ -z "$(ls -A playwright/snapshots 2>/dev/null)" ]; then


### PR DESCRIPTION
Currently always all are generated incorrectly, making the update job useless.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1842/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1842/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1842/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1842/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1842/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1842/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1842/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1842/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1842/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1842/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
