### PR TITLE
refactor(theme): use relative units for switch sizing

### DIFF
--- a/projects/element-theme/src/styles/components/_switch.scss
+++ b/projects/element-theme/src/styles/components/_switch.scss
@@ -2,13 +2,13 @@
 
 @use 'sass:map';
 
-$si-switch-size: 20px !default;
+$si-switch-size: 1.25rem !default;
 $si-switch-inline-size: calc(2 * #{$si-switch-size});
 $si-switch-inline-spacing: calc($si-switch-inline-size + map.get(variables.$spacers, 4));
 $si-switch-background-off-color: variables.$element-ui-4 !default;
 $si-switch-background-on-color: variables.$element-ui-0 !default;
 $si-switch-background-disabled-color: variables.$element-ui-3 !default;
-$si-switch-slider-margin: 4px !default;
+$si-switch-slider-margin: 0.25rem !default;
 $si-switch-slider-off-color: variables.$element-ui-2 !default;
 $si-switch-slider-on-color: variables.$element-ui-5 !default;
 $si-switch-transition-length: variables.element-transition-duration(0.4s) !default;
@@ -22,7 +22,7 @@ $si-switch-knob-size: calc(#{$si-switch-size} - 2 * #{$si-switch-slider-margin})
   .form-check-input {
     cursor: pointer;
     inset: 0;
-    margin-block: - map.get(variables.$spacers, 1);
+    margin-block: -0.125rem;
     margin-inline-start: calc(-1 * $si-switch-inline-spacing);
     inline-size: $si-switch-inline-size !important; // stylelint-disable-line declaration-no-important
     block-size: #{$si-switch-size} !important; // stylelint-disable-line declaration-no-important


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->

See https://code.siemens.com/simpl/simpl-element/-/work_items/4

<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1844/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1844/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1844/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1844/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1844/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1844/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1844/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1844/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1844/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1844/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

