### PR TITLE
fix(datepicker): set correct range preview on dateRange input changes

### DIFF
--- a/projects/element-ng/datepicker/si-datepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-datepicker.component.spec.ts
@@ -6,9 +6,9 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { userEvent } from 'vitest/browser';
 
 import { SiDatepickerComponent, SiDatepickerModule } from '.';
-import { runOnPushChangeDetection } from '../test-helpers';
 import { today } from './date-time-helper';
 import { DatepickerConfig, DateRange } from './si-datepicker.model';
 import { SiCalendarCellHarness } from './testing/si-calendar-cell.harness';
@@ -47,7 +47,6 @@ describe('SiDatepickerComponent', () => {
   /** Update datepicker configuration */
   const updateConfig = async (c: DatepickerConfig): Promise<void> => {
     component.config.set(c);
-    fixture.detectChanges();
     await fixture.whenStable();
   };
 
@@ -350,7 +349,6 @@ describe('SiDatepickerComponent', () => {
       const spy = vi.spyOn(component, 'rangeChanged');
       // Select 18. of month
       await picker.selectCell({ text: '18' });
-      fixture.detectChanges();
 
       expect(spy).toHaveBeenCalledTimes(1);
       const dateRange = vi.mocked(spy).mock.lastCall![0]!;
@@ -366,13 +364,33 @@ describe('SiDatepickerComponent', () => {
         start: new Date(NaN),
         end: new Date(NaN)
       });
-      await runOnPushChangeDetection(fixture);
+      await fixture.whenStable();
 
       expect(
         await picker
           .getCells({ isDisabled: false, isPreview: false })
           .then(cells => cells[6].getText())
       ).toEqual('7');
+    });
+
+    it('should show range hover preview when dateRange input has start but no end', async () => {
+      component.dateRange.set({ start: new Date('2023-12-15'), end: undefined });
+      await fixture.whenStable();
+
+      await userEvent.hover(helper.getEnabledCellWithText('20')!);
+      await fixture.whenStable();
+
+      expect(helper.queryAsArray('.range-hover').length).toBeGreaterThan(0);
+    });
+
+    it('should not show range hover preview when dateRange input has start and end', async () => {
+      component.dateRange.set({ start: new Date('2023-12-15'), end: new Date('2023-12-20') });
+      await fixture.whenStable();
+
+      await userEvent.hover(helper.getEnabledCellWithText('25')!);
+      await fixture.whenStable();
+
+      expect(helper.queryAsArray('.range-hover')).toHaveLength(0);
     });
   });
 });

--- a/projects/element-ng/datepicker/si-datepicker.component.ts
+++ b/projects/element-ng/datepicker/si-datepicker.component.ts
@@ -365,6 +365,7 @@ export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
         if (!isValid(dateRange?.end)) {
           dateRange!.end = undefined;
         }
+        this.rangeType.set(dateRange.start && !dateRange.end ? 'END' : 'START');
       }
 
       // Only one calendar is used when no dateRangeRole is available.


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->

When consumer apps update the `dateRange` input  e.g. assign a valid start & end date the day view in the datepicker shouldn't show the range preview. <!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1847/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1847/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1847/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1847/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1847/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1847/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1847/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1847/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1847/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1847/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


