### PR TITLE
fix(live-preview): code editor cursor position misaligned

### DIFF
--- a/projects/live-preview/components/si-live-preview/si-live-preview-codeflask.scss
+++ b/projects/live-preview/components/si-live-preview/si-live-preview-codeflask.scss
@@ -61,9 +61,14 @@ $lines-background: element-vars.$element-base-4;
       hyphens: none;
     }
 
+    code {
+      padding: 0;
+    }
+
     .codeflask__flatten,
     .codeflask__code {
       font-family: variables.$font-family-monospace;
+      line-height: 20px;
     }
 
     // this fixes rendering problem during scrolling


### PR DESCRIPTION
template editor on live previewer is not usable due to a regression introduced from https://github.com/siemens/element/pull/1775

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1849/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1849/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1849/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1849/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1849/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1849/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1849/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1849/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1849/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1849/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
