### PR TITLE
feat(select): support constructions of custom select

### DIFF
--- a/api-goldens/element-ng/select/index.api.md
+++ b/api-goldens/element-ng/select/index.api.md
@@ -52,6 +52,22 @@ export interface SelectOptionSource<TValue> {
     valuesEqual?(optionA: TValue, optionB: TValue): boolean;
 }
 
+// @public
+export class SiCustomSelectDirective<T> implements ControlValueAccessor, SiFormItemControl {
+    constructor();
+    close(): void;
+    readonly disabled: _angular_core.Signal<boolean>;
+    readonly disabledInput: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    readonly errormessageId: _angular_core.InputSignal<string>;
+    readonly id: _angular_core.InputSignal<string>;
+    readonly isOpen: _angular_core.WritableSignal<boolean>;
+    open(event?: Event): void;
+    readonly openChange: _angular_core.OutputEmitterRef<boolean>;
+    readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    updateValue(value: T | undefined): void;
+    readonly value: _angular_core.ModelSignal<T | undefined>;
+}
+
 // @public (undocumented)
 export class SiSelectActionDirective {
     readonly selectActionAutoClose: _angular_core.InputSignalWithTransform<boolean, unknown>;
@@ -59,6 +75,18 @@ export class SiSelectActionDirective {
 
 // @public (undocumented)
 export class SiSelectActionsDirective {
+}
+
+// @public
+export class SiSelectComboboxComponent {
+}
+
+// @public
+export class SiSelectComboboxValueComponent {
+    readonly icon: _angular_core.InputSignal<string | undefined>;
+    readonly iconColor: _angular_core.InputSignal<string | undefined>;
+    readonly stackedIcon: _angular_core.InputSignal<string | undefined>;
+    readonly stackedIconColor: _angular_core.InputSignal<string | undefined>;
 }
 
 // @public (undocumented)
@@ -75,6 +103,15 @@ export class SiSelectComponent<T> implements SiFormItemControl {
     readonly openChange: _angular_core.OutputEmitterRef<boolean>;
     readonly placeholder: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
+}
+
+// @public
+export type SiSelectDropdownContentType = 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog';
+
+// @public
+export class SiSelectDropdownDirective {
+    constructor();
+    readonly contentType: _angular_core.InputSignal<SiSelectDropdownContentType>;
 }
 
 // @public

--- a/docs/components/forms-inputs/select.md
+++ b/docs/components/forms-inputs/select.md
@@ -343,8 +343,107 @@ The following demonstrates how to add a "Create" button within the dropdown acti
 
 <si-docs-component example="si-select/si-select" height="500"></si-docs-component>
 
+### Custom select (experimental)
+
+When the rigid `si-select` options API is not enough — for example to embed a
+tree, drive multi-stage selection with `Apply` / `Cancel` semantics, or render
+arbitrary UI inside the dropdown — applications can compose their own select
+from the following primitives:
+
+- `SiCustomSelectDirective` — host directive providing the combobox wiring:
+  `ControlValueAccessor` (`formControl`, `ngModel`, `[(value)]`), disabled /
+  readonly handling, `SiFormItemControl` integration, ARIA `combobox` role,
+  keyboard activation (Enter, Space, ArrowDown / ArrowUp), CDK overlay
+  lifecycle, and focus trapping inside the dropdown.
+- `SiSelectComboboxComponent` — the visual trigger that renders the projected
+  value and the dropdown caret. Pair it with `SiSelectComboboxValueComponent`
+  to mark individual selected entries.
+- `SiSelectDropdownDirective` — structural directive (`*si-select-dropdown` /
+  `<ng-template si-select-dropdown>`) that registers the dropdown content
+  template with the parent custom select. Requires a `contentType` input
+  whose value is forwarded to the `aria-haspopup` attribute of the combobox
+  host (`menu`, `listbox`, `tree`, `grid`, `dialog`, `true`, or `false`).
+
+The strategy is intentionally minimal: the host directive owns state, focus,
+keyboard handling and form integration, while applications retain full
+control over what is rendered in the trigger and in the dropdown. The same
+component can therefore be styled either as a `form-control` (inside an
+`si-form-item`, with validation) or as a button (`btn btn-primary-ghost`) by
+applying the corresponding class on the host element.
+
+A custom select component typically applies `SiCustomSelectDirective` as a
+host directive and exposes the inputs and outputs the application needs:
+
+```ts
+@Component({
+  selector: 'app-tree-select',
+  imports: [SiSelectComboboxComponent, SiSelectDropdownDirective, SiTreeViewComponent],
+  template: `
+    <si-select-combobox>
+      @if (select.value(); as val) {
+        {{ val }}
+      } @else {
+        <span class="text-secondary">Select a location...</span>
+      }
+    </si-select-combobox>
+
+    <ng-template si-select-dropdown contentType="tree">
+      <si-tree-view
+        ariaLabel="Locations"
+        [items]="items()"
+        [enableSelection]="true"
+        [singleSelectMode]="true"
+        (treeItemClicked)="selectItem($event)"
+      />
+    </ng-template>
+  `,
+  hostDirectives: [
+    {
+      directive: SiCustomSelectDirective,
+      inputs: ['disabled', 'readonly', 'value'],
+      outputs: ['valueChange']
+    }
+  ]
+})
+export class TreeSelectComponent {
+  protected readonly select = inject<SiCustomSelectDirective<string>>(SiCustomSelectDirective);
+
+  readonly items = input<TreeItem[]>([]);
+
+  selectItem(item: TreeItem): void {
+    if (item.label) {
+      this.select.updateValue(item.label as string);
+      this.select.close();
+    }
+  }
+}
+```
+
+Because `si-tree-view` (and similar components) mutate the model they render,
+inputs must be deep-cloned before they are passed in. A robust pattern is to
+keep a `pendingItems` signal that is repopulated from a fresh
+`JSON.parse(JSON.stringify(...))` clone whenever the dropdown opens, so each
+opening starts from a clean slate without leaking state back to the caller.
+
+<si-docs-component example="si-select/si-select-custom" height="450"></si-docs-component>
+
+The same primitives can drive a multi-select with `Apply` / `Cancel`. The
+host component buffers pending changes while the dropdown is open and only
+calls `select.updateValue(...)` once the user confirms — keeping the
+`ControlValueAccessor` value stable until the selection is applied.
+
+<si-docs-component example="si-select/si-select-multi-custom" height="450"></si-docs-component>
+
 <si-docs-api component="SiSelectComponent"></si-docs-api>
 
 <si-docs-api directive="SiSelectSimpleOptionsDirective" heading="Simple options (via SiSelectSimpleOptionsDirective)"></si-docs-api>
+
+<si-docs-api directive="SiCustomSelectDirective"></si-docs-api>
+
+<si-docs-api component="SiSelectComboboxComponent"></si-docs-api>
+
+<si-docs-api component="SiSelectComboboxValueComponent"></si-docs-api>
+
+<si-docs-api directive="SiSelectDropdownDirective"></si-docs-api>
 
 <si-docs-types></si-docs-types>

--- a/playwright/e2e/element-examples/si-select.spec.ts
+++ b/playwright/e2e/element-examples/si-select.spec.ts
@@ -7,6 +7,8 @@ import { expect, test } from '../../support/test-helpers';
 test.describe('si-select', () => {
   const example = 'si-select/si-select';
   const lazyLoadExample = 'si-select/si-select-lazy-load';
+  const customExample = 'si-select/si-select-custom';
+  const multiCustomExample = 'si-select/si-select-multi-custom';
 
   test(example, async ({ page, si }) => {
     await si.visitExample(example);
@@ -102,5 +104,52 @@ test.describe('si-select', () => {
     await si.runVisualAndA11yTests();
     await page.getByText('Switzerland').click();
     await si.runVisualAndA11yTests('checked');
+  });
+
+  test(customExample, async ({ page, si }) => {
+    await si.visitExample(customExample);
+
+    const comboboxes = page.getByRole('combobox');
+    const buttonCombobox = comboboxes.first();
+    const formControlCombobox = comboboxes.last();
+
+    // Button variant: open, snapshot, select a value.
+    await buttonCombobox.click();
+    await expect(buttonCombobox).toHaveAttribute('aria-expanded', 'true');
+    await si.runVisualAndA11yTests('custom-button-opened');
+
+    await page.getByRole('treeitem', { name: 'Company1' }).focus();
+    await page.keyboard.press('ArrowRight');
+    await page.getByRole('treeitem', { name: 'Milano' }).click();
+    await expect(buttonCombobox).not.toHaveAttribute('aria-expanded', 'true');
+    await expect(buttonCombobox).toContainText('Milano');
+
+    // Form-control variant: open, then close and snapshot the closed (invalid) state.
+    await formControlCombobox.click();
+    await expect(formControlCombobox).toHaveAttribute('aria-expanded', 'true');
+
+    await page.keyboard.press('Escape');
+    await expect(formControlCombobox).not.toHaveAttribute('aria-expanded', 'true');
+    await si.runVisualAndA11yTests('custom-form-control-closed');
+  });
+
+  test(multiCustomExample, async ({ page, si }) => {
+    await si.visitExample(multiCustomExample);
+
+    const formControlCombobox = page.getByRole('combobox').last();
+
+    // Open form-control variant.
+    await formControlCombobox.click();
+    await expect(formControlCombobox).toHaveAttribute('aria-expanded', 'true');
+
+    // Check the first node (selects all of its children).
+    await page.getByRole('tree').getByRole('checkbox').first().check();
+    await si.runVisualAndA11yTests('multi-custom-first-selected');
+
+    // Apply.
+    await page.getByRole('button', { name: 'Apply' }).click();
+    await expect(formControlCombobox).not.toHaveAttribute('aria-expanded', 'true');
+    await expect(formControlCombobox).toContainText('Company1');
+    await si.runVisualAndA11yTests('multi-custom-applied');
   });
 });

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-button-opened-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-button-opened-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7065445f9ded5fc9b85f16ce4f8d0d0ed85d143b64bebfe7b46e8e44f8c8340
+size 16049

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-button-opened-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-button-opened-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fc1e8e489ad9dd2fba28f1dd6ec6a5fbf56994d3ae491b0c5e8e7f92b4a9bbb
+size 16013

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-button-opened.yaml
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-button-opened.yaml
@@ -1,0 +1,14 @@
+- text: Button variant
+- combobox "Select a location..." [expanded]
+- text: Form-control variant Location (required)*
+- combobox "Select a location..."
+- text: "Control panel Current value (ngModel): none Current value (formControl): none Location valid: false"
+- checkbox "Readonly"
+- text: Readonly
+- checkbox "Disabled"
+- text: Disabled
+- tree "Locations":
+  - treeitem "Company1" [level=1]
+  - treeitem "Company2" [level=1]
+  - treeitem "Company3" [level=1]
+- button "Clear selection" [disabled]

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-closed-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-closed-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e0c6bd33a9dadd8fdb63eb6dc793eb5377aa415bd0acecd1a5f391d7d62f4fe
+size 13427

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-closed-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-closed-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ad5069dafdd4c062aaeb0777f0c312a0807b88df25d69b80c7b07fbc70f7571
+size 13171

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-closed.yaml
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-closed.yaml
@@ -1,0 +1,9 @@
+- text: Button variant
+- combobox "Milano"
+- text: Form-control variant Location (required)*
+- combobox "Select a location..."
+- text: "Required Control panel Current value (ngModel): Milano Current value (formControl): none Location valid: false"
+- checkbox "Readonly"
+- text: Readonly
+- checkbox "Disabled"
+- text: Disabled

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-opened-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-opened-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30bcf94a2014fcaead03f87615453ee759bdc92776cfbc82d4ab018eea692775
+size 20264

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-opened-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-opened-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95cf18fdec465f850aac9788db7ed3d619606f2cc312621e37f0002064a03f43
+size 20137

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-opened.yaml
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-custom--custom-form-control-opened.yaml
@@ -1,0 +1,14 @@
+- text: Button variant
+- combobox: Milano
+- text: Form-control variant Location (required)*
+- combobox [expanded]: Select a location...
+- text: "Control panel Current value (ngModel): Milano Current value (formControl): none Location valid: false"
+- checkbox "Readonly"
+- text: Readonly
+- checkbox "Disabled"
+- text: Disabled
+- tree "Locations":
+  - treeitem "Company1" [level=1]
+  - treeitem "Company2" [level=1]
+  - treeitem "Company3" [level=1]
+- button "Clear selection" [disabled]

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-applied-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-applied-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fda4a41f6064a8df0f4ef3ddaca4537e121da08fc77a047cf4913f52f056bd82
+size 13552

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-applied-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-applied-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d330ff45389df1fe678d76d0c66f6ad61e42193951bf5ed40d4013e7882bb9ef
+size 13211

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-applied.yaml
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-applied.yaml
@@ -1,0 +1,9 @@
+- text: Button variant
+- combobox "Select locations..."
+- text: Form-control variant Locations (required)*
+- combobox "Company1"
+- text: "Control panel Selected (ngModel): none Selected (formControl): Company1 Locations valid: true"
+- checkbox "Readonly"
+- text: Readonly
+- checkbox "Disabled"
+- text: Disabled

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-first-selected-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-first-selected-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad7ad1bdadb635feb217c85bcae21e686ca8d8f8ff9cd75d678ee87914496811
+size 22344

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-first-selected-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-first-selected-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:073f0dbb492578e434b251e92495f24bd078bbfd156068c5da493421ecfbac90
+size 22289

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-first-selected.yaml
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select-multi-custom--multi-custom-first-selected.yaml
@@ -1,0 +1,22 @@
+- text: Button variant
+- combobox "Select locations..."
+- text: Form-control variant Locations (required)*
+- combobox "Select locations..." [expanded]
+- text: "Control panel Selected (ngModel): none Selected (formControl): none Locations valid: false"
+- checkbox "Readonly"
+- text: Readonly
+- checkbox "Disabled"
+- text: Disabled
+- dialog "Select locations":
+  - tree "Locations":
+    - treeitem "Company1 Company1" [checked] [level=1]:
+      - checkbox "Company1" [checked]
+      - text: ""
+    - treeitem "Company2 Company2" [level=1]:
+      - checkbox "Company2"
+      - text: ""
+    - treeitem "Company3 Company3" [level=1]:
+      - checkbox "Company3"
+      - text: ""
+  - button "Cancel"
+  - button "Apply"

--- a/projects/element-ng/select/index.ts
+++ b/projects/element-ng/select/index.ts
@@ -15,3 +15,7 @@ export * from './select-list/si-select-list-has-filter.component';
 export * from './si-select-action.directive';
 export * from './si-select-actions.directive';
 export * from './si-select.types';
+export * from './si-custom-select.directive';
+export * from './si-select-combobox.component';
+export * from './si-select-combobox-value.component';
+export * from './si-select-dropdown.directive';

--- a/projects/element-ng/select/select-input/si-select-input.component.html
+++ b/projects/element-ng/select/select-input/si-select-input.component.html
@@ -20,7 +20,7 @@
   }
   @if (selectionStrategy.allowMultiple) {
     <div #overflowItem="siAutoCollapsableListOverflowItem" siAutoCollapsableListOverflowItem>
-      <div class="overflow-item"> {{ overflowItem.hiddenItemCount }}+</div>
+      <div class="pill py-0 ms-2"> {{ overflowItem.hiddenItemCount }}+</div>
     </div>
   }
 </div>

--- a/projects/element-ng/select/select-input/si-select-input.component.scss
+++ b/projects/element-ng/select/select-input/si-select-input.component.scss
@@ -39,10 +39,3 @@
 si-select-option + si-select-option::before {
   content: ',\00a0 ';
 }
-
-.overflow-item {
-  border-radius: all-variables.$element-radius-3;
-  background: all-variables.$element-base-0;
-  margin-inline-start: map.get(all-variables.$spacers, 2);
-  padding-inline: map.get(all-variables.$spacers, 4);
-}

--- a/projects/element-ng/select/select-list/si-select-list.component.html
+++ b/projects/element-ng/select/select-list/si-select-list.component.html
@@ -1,6 +1,6 @@
 <div
   cdkListbox
-  class="si-select-filtered-items focus-none"
+  class="dropdown-menu-scroller focus-none"
   [id]="baseId() + '-listbox'"
   [cdkListboxMultiple]="selectionStrategy.allowMultiple"
   [cdkListboxValue]="selectionStrategy.arrayValue()"

--- a/projects/element-ng/select/select-list/si-select-list.component.scss
+++ b/projects/element-ng/select/select-list/si-select-list.component.scss
@@ -1,5 +1,0 @@
-.si-select-filtered-items {
-  // 266px is based on figma and gives 6-8 items. Depending on the number of headings
-  max-block-size: min(100vh, 266px);
-  overflow-y: auto;
-}

--- a/projects/element-ng/select/select-list/si-select-list.component.ts
+++ b/projects/element-ng/select/select-list/si-select-list.component.ts
@@ -24,7 +24,6 @@ import { SiSelectListBase } from './si-select-list.base';
     SiSelectOptionRowComponent
   ],
   templateUrl: './si-select-list.component.html',
-  styleUrl: './si-select-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SiSelectListComponent<T> extends SiSelectListBase<T> implements OnInit {

--- a/projects/element-ng/select/si-custom-select.directive.spec.ts
+++ b/projects/element-ng/select/si-custom-select.directive.spec.ts
@@ -1,0 +1,342 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { OverlayContainer } from '@angular/cdk/overlay';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  inputBinding,
+  signal,
+  twoWayBinding
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { SI_FORM_ITEM_CONTROL } from '@siemens/element-ng/form';
+
+import { SiCustomSelectDirective } from './si-custom-select.directive';
+import { SiSelectComboboxComponent } from './si-select-combobox.component';
+import { SiSelectDropdownDirective } from './si-select-dropdown.directive';
+
+@Component({
+  selector: 'si-test-select',
+  imports: [SiSelectComboboxComponent, SiSelectDropdownDirective],
+  template: `
+    <si-select-combobox>
+      {{ select.value() ?? 'Pick...' }}
+    </si-select-combobox>
+
+    <ng-template si-select-dropdown contentType="listbox">
+      @for (opt of options(); track opt) {
+        <button type="button" class="dropdown-item" (click)="pick(opt)">{{ opt }}</button>
+      }
+    </ng-template>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [
+    {
+      directive: SiCustomSelectDirective,
+      inputs: ['disabled', 'readonly', 'value'],
+      outputs: ['valueChange']
+    }
+  ]
+})
+class SiTestSelectComponent {
+  readonly select = inject(SiCustomSelectDirective<string>);
+  readonly options = signal<string[]>(['Alpha', 'Beta', 'Gamma']);
+
+  pick(opt: string): void {
+    this.select.updateValue(opt);
+    this.select.close();
+  }
+}
+
+@Component({
+  imports: [SiTestSelectComponent, ReactiveFormsModule],
+  template: `<si-test-select [formControl]="control" />`
+})
+class FormHostComponent {
+  readonly control = new FormControl<string | undefined>(undefined);
+}
+
+describe('SiCustomSelectDirective', () => {
+  let fixture: ComponentFixture<SiTestSelectComponent>;
+  let overlayContainerElement: HTMLElement;
+
+  const getHost = (): HTMLElement => fixture.nativeElement;
+
+  const getOverlayDropdown = (): HTMLElement | null =>
+    overlayContainerElement.querySelector('.dropdown-menu');
+
+  const getDropdownItems = (): HTMLElement[] =>
+    Array.from(overlayContainerElement.querySelectorAll('.dropdown-item'));
+
+  describe('direct usage', () => {
+    let value: ReturnType<typeof signal<string | undefined>>;
+    let disabled: ReturnType<typeof signal<boolean>>;
+    let readonly: ReturnType<typeof signal<boolean>>;
+
+    beforeEach(async () => {
+      value = signal<string | undefined>(undefined);
+      disabled = signal(false);
+      readonly = signal(false);
+
+      fixture = TestBed.createComponent(SiTestSelectComponent, {
+        bindings: [
+          twoWayBinding('value', value),
+          inputBinding('disabled', disabled),
+          inputBinding('readonly', readonly)
+        ]
+      });
+      overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
+      await fixture.whenStable();
+    });
+
+    it('should render combobox role on host', () => {
+      expect(getHost()).toHaveAttribute('role', 'combobox');
+      expect(getHost()).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should aria-haspopup listbox', () => {
+      expect(getHost()).toHaveAttribute('aria-haspopup', 'listbox');
+    });
+
+    it('should reflect dropdown contentType on aria-haspopup', async () => {
+      @Component({
+        selector: 'si-test-tree-select',
+        imports: [SiSelectComboboxComponent, SiSelectDropdownDirective],
+        template: `
+          <si-select-combobox>{{ select.value() ?? 'Pick...' }}</si-select-combobox>
+          <ng-template si-select-dropdown contentType="tree" />
+        `,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        hostDirectives: [SiCustomSelectDirective]
+      })
+      class TreeSelectComponent {
+        readonly select = inject(SiCustomSelectDirective<string>);
+      }
+
+      const treeFixture = TestBed.createComponent(TreeSelectComponent);
+      await treeFixture.whenStable();
+
+      expect(treeFixture.nativeElement).toHaveAttribute('aria-haspopup', 'tree');
+    });
+
+    it('should have an id', () => {
+      expect(getHost()).toHaveAttribute('id');
+      expect(getHost().id).toMatch(/^__si-custom-select-\d+$/);
+    });
+
+    it('should have aria-labelledby pointing to its label id and combobox content id', () => {
+      expect(getHost()).toHaveAttribute(
+        'aria-labelledby',
+        `${getHost().id}-label ${getHost().id}-combobox`
+      );
+    });
+
+    it('should have aria-describedby pointing to its error message id', () => {
+      expect(getHost()).toHaveAttribute('aria-describedby', getHost().id + '-errormessage');
+    });
+
+    it('should display placeholder text when no value is set', () => {
+      expect(getHost()).toHaveTextContent('Pick...');
+    });
+
+    it('should open dropdown on click', async () => {
+      getHost().click();
+      await fixture.whenStable();
+
+      expect(getOverlayDropdown()).toBeInTheDocument();
+      expect(getHost()).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should render options in the dropdown', async () => {
+      getHost().click();
+      await fixture.whenStable();
+
+      const items = getDropdownItems();
+      expect(items).toHaveLength(3);
+      expect(items[0]).toHaveTextContent('Alpha');
+      expect(items[1]).toHaveTextContent('Beta');
+      expect(items[2]).toHaveTextContent('Gamma');
+    });
+
+    it('should select a value and close dropdown', async () => {
+      getHost().click();
+      await fixture.whenStable();
+
+      getDropdownItems()[1].click();
+      await fixture.whenStable();
+
+      expect(value()).toBe('Beta');
+      expect(getOverlayDropdown()).not.toBeInTheDocument();
+      expect(getHost()).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should display selected value text', async () => {
+      value.set('Gamma');
+      await fixture.whenStable();
+
+      expect(getHost()).toHaveTextContent('Gamma');
+    });
+
+    it('should close dropdown on backdrop click', async () => {
+      getHost().click();
+      await fixture.whenStable();
+
+      expect(getOverlayDropdown()).toBeInTheDocument();
+
+      const backdrop = overlayContainerElement
+        .closest('body')!
+        .querySelector<HTMLElement>('.cdk-overlay-backdrop');
+      backdrop!.click();
+      await fixture.whenStable();
+
+      expect(getOverlayDropdown()).not.toBeInTheDocument();
+    });
+
+    it('should close dropdown on Escape key', async () => {
+      getHost().click();
+      await fixture.whenStable();
+
+      expect(getOverlayDropdown()).toBeInTheDocument();
+
+      const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane')!;
+      overlayPane.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      await fixture.whenStable();
+
+      expect(getOverlayDropdown()).not.toBeInTheDocument();
+    });
+
+    it('should not open when disabled', async () => {
+      disabled.set(true);
+      await fixture.whenStable();
+
+      getHost().click();
+      await fixture.whenStable();
+
+      expect(getOverlayDropdown()).not.toBeInTheDocument();
+    });
+
+    it('should not open when readonly', async () => {
+      readonly.set(true);
+      await fixture.whenStable();
+
+      getHost().click();
+      await fixture.whenStable();
+
+      expect(getOverlayDropdown()).not.toBeInTheDocument();
+    });
+
+    it('should apply disabled host class', async () => {
+      disabled.set(true);
+      await fixture.whenStable();
+
+      expect(getHost()).toHaveClass('disabled');
+    });
+
+    it('should apply readonly host class', async () => {
+      readonly.set(true);
+      await fixture.whenStable();
+
+      expect(getHost()).toHaveClass('readonly');
+    });
+
+    it('should apply open host class when dropdown is open', async () => {
+      getHost().click();
+      await fixture.whenStable();
+
+      expect(getHost()).toHaveClass('open');
+    });
+
+    it('should apply dropdown host class', () => {
+      expect(getHost()).toHaveClass('dropdown');
+    });
+  });
+
+  describe('as form control', () => {
+    let formFixture: ComponentFixture<FormHostComponent>;
+    let formHost: FormHostComponent;
+
+    beforeEach(async () => {
+      formFixture = TestBed.createComponent(FormHostComponent);
+      fixture = undefined!;
+      overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
+      formHost = formFixture.componentInstance;
+      await formFixture.whenStable();
+    });
+
+    it('should write value from form control', async () => {
+      formHost.control.setValue('Alpha');
+      await formFixture.whenStable();
+
+      const host = formFixture.nativeElement.querySelector('si-test-select');
+      expect(host).toHaveTextContent('Alpha');
+    });
+
+    it('should update form control when value is selected', async () => {
+      const host: HTMLElement = formFixture.nativeElement.querySelector('si-test-select');
+      host.click();
+      await formFixture.whenStable();
+
+      getDropdownItems()[2].click();
+      await formFixture.whenStable();
+
+      expect(formHost.control.value).toBe('Gamma');
+    });
+
+    it('should mark control as touched when dropdown is closed', async () => {
+      const host: HTMLElement = formFixture.nativeElement.querySelector('si-test-select');
+      expect(formHost.control.touched).toBe(false);
+
+      host.click();
+      await formFixture.whenStable();
+
+      expect(formHost.control.touched).toBe(false);
+
+      getDropdownItems()[0].click();
+      await formFixture.whenStable();
+
+      expect(formHost.control.touched).toBe(true);
+    });
+
+    it('should mark control as touched when closing via backdrop', async () => {
+      const host: HTMLElement = formFixture.nativeElement.querySelector('si-test-select');
+      host.click();
+      await formFixture.whenStable();
+
+      const backdrop = overlayContainerElement
+        .closest('body')!
+        .querySelector<HTMLElement>('.cdk-overlay-backdrop');
+      backdrop!.click();
+      await formFixture.whenStable();
+
+      expect(formHost.control.touched).toBe(true);
+    });
+
+    it('should disable via form control', async () => {
+      formHost.control.disable();
+      await formFixture.whenStable();
+
+      const host: HTMLElement = formFixture.nativeElement.querySelector('si-test-select');
+      expect(host).toHaveClass('disabled');
+
+      host.click();
+      await formFixture.whenStable();
+
+      expect(getOverlayDropdown()).not.toBeInTheDocument();
+    });
+  });
+
+  describe('SiFormItemControl integration', () => {
+    it('should provide SI_FORM_ITEM_CONTROL token', async () => {
+      fixture = TestBed.createComponent(SiTestSelectComponent);
+      await fixture.whenStable();
+
+      const formItemControl = fixture.debugElement.injector.get(SI_FORM_ITEM_CONTROL);
+      expect(formItemControl).toBeTruthy();
+      expect(formItemControl.errormessageId).toBeDefined();
+    });
+  });
+});

--- a/projects/element-ng/select/si-custom-select.directive.ts
+++ b/projects/element-ng/select/si-custom-select.directive.ts
@@ -1,0 +1,321 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { ConfigurableFocusTrap, ConfigurableFocusTrapFactory } from '@angular/cdk/a11y';
+import { Overlay, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import { isPlatformBrowser } from '@angular/common';
+import {
+  booleanAttribute,
+  computed,
+  DestroyRef,
+  Directive,
+  ElementRef,
+  inject,
+  input,
+  model,
+  output,
+  PLATFORM_ID,
+  signal,
+  ViewContainerRef
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { SI_FORM_ITEM_CONTROL, SiFormItemControl } from '@siemens/element-ng/form';
+import { filter, merge, Subject, takeUntil } from 'rxjs';
+
+import type { SiSelectDropdownDirective } from './si-select-dropdown.directive';
+
+/**
+ * Host directive for building custom selects.
+ *
+ * Add this as a `hostDirective` on your component and expose the inputs/outputs you need.
+ * The directive handles:
+ * - {@link ControlValueAccessor} integration (`formControl`, `ngModel`, `[(value)]`)
+ * - Disabled / readonly state management
+ * - Overlay lifecycle for the dropdown (open/close)
+ * - Focus management and focus trapping in the dropdown
+ * - Opening the dropdown on click, Enter, Space, ArrowDown, ArrowUp
+ * - {@link SiFormItemControl} integration
+ *
+ * Use {@link SiSelectDropdownDirective} to mark the dropdown template in your component,
+ * and call {@link open}, {@link close}, {@link updateValue} from your component logic.
+ *
+ * @example
+ * ```ts
+ * @Component({
+ *   selector: 'app-my-select',
+ *   hostDirectives: [{
+ *     directive: SiCustomSelectDirective,
+ *     inputs: ['disabled', 'readonly', 'value'],
+ *     outputs: ['valueChange']
+ *   }],
+ *   template: `
+ *     <si-select-combobox>
+ *       {{ select.value() }}
+ *     </si-select-combobox>
+ *     <ng-template si-select-dropdown contentType="listbox">
+ *       <button (click)="select.updateValue('new'); select.close()">Pick</button>
+ *     </ng-template>
+ *   `
+ * })
+ * export class MySelectComponent {
+ *   readonly select = inject(SiCustomSelectDirective);
+ * }
+ * ```
+ *
+ * @experimental
+ */
+@Directive({
+  selector: '[siCustomSelect]',
+  providers: [
+    { provide: NG_VALUE_ACCESSOR, useExisting: SiCustomSelectDirective, multi: true },
+    { provide: SI_FORM_ITEM_CONTROL, useExisting: SiCustomSelectDirective }
+  ],
+  host: {
+    class: 'dropdown',
+    '[style.--si-action-icon-offset.rem]': '1.5',
+    role: 'combobox',
+    'aria-autocomplete': 'none',
+    '[attr.aria-haspopup]': 'haspopup()',
+    '[attr.aria-labelledby]': 'labelledby()',
+    '[attr.aria-describedby]': 'errormessageId()',
+    '[attr.aria-controls]': 'isOpen() ? dropdownId() : null',
+    '[attr.aria-expanded]': 'isOpen()',
+    '[attr.aria-disabled]': 'disabled()',
+    '[attr.id]': 'id()',
+    '[attr.tabindex]': 'disabled() ? "-1" : "0"',
+    '[class.disabled]': 'disabled()',
+    '[class.pe-none]': 'disabled()',
+    '[class.readonly]': 'readonly()',
+    '[class.open]': 'isOpen()',
+    '[class.show]': 'isOpen()',
+    '(click)': 'open()',
+    '(keydown.enter)': 'open()',
+    '(keydown.space)': 'open($event)',
+    '(keydown.arrowDown)': 'open($event)',
+    '(keydown.arrowUp)': 'open($event)'
+  }
+})
+export class SiCustomSelectDirective<T> implements ControlValueAccessor, SiFormItemControl {
+  private static idCounter = 0;
+
+  /**
+   * Unique identifier.
+   *
+   * @defaultValue
+   * ```
+   * `__si-custom-select-${SiCustomSelectDirective.idCounter++}`
+   * ```
+   */
+  readonly id = input(`__si-custom-select-${SiCustomSelectDirective.idCounter++}`);
+
+  /**
+   * Whether the select input is disabled.
+   *
+   * @defaultValue false
+   */
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  readonly disabledInput = input(false, { alias: 'disabled', transform: booleanAttribute });
+
+  /**
+   * Readonly state. Similar to disabled but with higher contrast.
+   *
+   * @defaultValue false
+   */
+  readonly readonly = input(false, { transform: booleanAttribute });
+
+  /** Emits when the dropdown open state changes. */
+  readonly openChange = output<boolean>();
+
+  /**
+   * The current value, supports two-way binding via `[(value)]`.
+   *
+   * @defaultValue undefined
+   */
+  readonly value = model<T | undefined>(undefined);
+
+  /**
+   * Whether the dropdown is currently open.
+   *
+   * @defaultValue false
+   */
+  readonly isOpen = signal(false);
+
+  /** @internal */
+  readonly labelledby = computed(() => `${this.id()}-label ${this.id()}-combobox`);
+
+  /** @internal */
+  readonly comboboxLabelId = computed(() => `${this.id()}-combobox`);
+
+  /** @internal */
+  readonly dropdownId = computed(() => this.id() + '-dropdown');
+
+  /**
+   * Value forwarded to the `aria-haspopup` attribute. Reflects the
+   * `contentType` input of the registered {@link SiSelectDropdownDirective},
+   * defaulting to `'listbox'` until a dropdown template is registered.
+   * @internal
+   */
+  readonly haspopup = computed(() => this.dropdownDirective()?.contentType() ?? 'listbox');
+
+  /**
+   * This ID will be bound to the `aria-describedby` attribute of the select.
+   *
+   * @defaultValue
+   * ```
+   * `${this.id()}-errormessage`
+   * ```
+   */
+  readonly errormessageId = input(`${this.id()}-errormessage`);
+
+  /** Combined disabled state from input and form control. */
+  readonly disabled = computed(() => this.disabledInput() || this.disabledByForm());
+
+  private onTouched: () => void = () => {};
+
+  private onChange: (_: T | undefined) => void = () => {};
+  private readonly disabledByForm = signal(false);
+
+  private readonly overlay = inject(Overlay);
+  private readonly focusTrapFactory = inject(ConfigurableFocusTrapFactory);
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly viewContainerRef = inject(ViewContainerRef);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
+  private overlayRef?: OverlayRef;
+  private focusTrap?: ConfigurableFocusTrap;
+  private readonly closeOverlay$ = new Subject<void>();
+
+  private readonly dropdownDirective = signal<SiSelectDropdownDirective | undefined>(undefined);
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.disposeOverlay();
+      this.closeOverlay$.complete();
+    });
+  }
+
+  /**
+   * Registers the dropdown directive. Called by
+   * {@link SiSelectDropdownDirective} when it is initialized.
+   * @internal
+   */
+  registerDropdown(directive: SiSelectDropdownDirective): void {
+    this.dropdownDirective.set(directive);
+  }
+
+  /**
+   * Updates the value programmatically.
+   * Call this from your dropdown template to set the new value.
+   */
+  updateValue(value: T | undefined): void {
+    this.value.set(value);
+    this.onChange(value);
+  }
+
+  /** Opens the dropdown overlay. */
+  open(event?: Event): void {
+    if (this.disabled() || this.readonly() || this.isOpen() || !this.isBrowser) {
+      return;
+    }
+
+    if (!this.dropdownDirective()) {
+      return;
+    }
+
+    // Prevent default scrolling behavior for Space / ArrowUp / ArrowDown.
+    event?.preventDefault();
+
+    const width = this.elementRef.nativeElement.getBoundingClientRect().width;
+    this.overlayRef = this.overlay.create({
+      positionStrategy: this.overlay
+        .position()
+        .flexibleConnectedTo(this.elementRef)
+        .withPositions([
+          // Preferred: below, aligned to the start edge of the trigger.
+          { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top' },
+          // Below, aligned to the end edge (trigger near the end of the viewport).
+          { originX: 'end', originY: 'bottom', overlayX: 'end', overlayY: 'top' },
+          // Above, aligned to the start edge (no space below).
+          { originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'bottom' },
+          // Above, aligned to the end edge (no space below, trigger near the end).
+          { originX: 'end', originY: 'top', overlayX: 'end', overlayY: 'bottom' },
+          // Below, centered (small screens, trigger in the middle).
+          { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top' },
+          // Above, centered.
+          { originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom' }
+        ])
+        .withFlexibleDimensions(true)
+        .withPush(true),
+      hasBackdrop: true,
+      backdropClass: 'cdk-overlay-transparent-backdrop',
+      panelClass: ['dropdown-menu', 'show'],
+      minWidth: width + 2
+    });
+
+    const portal = new TemplatePortal(this.dropdownDirective()!.templateRef, this.viewContainerRef);
+    this.overlayRef.attach(portal);
+    this.overlayRef.overlayElement.id = this.dropdownId();
+
+    this.focusTrap = this.focusTrapFactory.create(this.overlayRef.overlayElement);
+    this.focusTrap.focusFirstTabbableElementWhenReady();
+
+    this.isOpen.set(true);
+    this.openChange.emit(true);
+
+    merge(
+      this.overlayRef.backdropClick(),
+      this.overlayRef.keydownEvents().pipe(filter(e => e.key === 'Escape'))
+    )
+      .pipe(takeUntil(this.closeOverlay$), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.close());
+  }
+
+  /** Closes the dropdown overlay and restores focus. */
+  close(): void {
+    if (!this.isOpen()) {
+      return;
+    }
+    this.isOpen.set(false);
+    this.disposeOverlay();
+    this.openChange.emit(false);
+    this.onTouched();
+    if (this.isBrowser) {
+      this.elementRef.nativeElement.focus();
+    }
+  }
+
+  /** @internal */
+  writeValue(obj: T | null): void {
+    this.value.set(obj ?? undefined);
+  }
+
+  /** @internal */
+  registerOnChange(fn: (_: T | undefined) => void): void {
+    this.onChange = fn;
+  }
+
+  /** @internal */
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  /** @internal */
+  setDisabledState(isDisabled: boolean): void {
+    this.disabledByForm.set(isDisabled);
+  }
+
+  private disposeOverlay(): void {
+    if (this.overlayRef) {
+      this.closeOverlay$.next();
+      this.focusTrap?.destroy();
+      this.focusTrap = undefined;
+      this.overlayRef.detach();
+      this.overlayRef.dispose();
+      this.overlayRef = undefined;
+    }
+  }
+}

--- a/projects/element-ng/select/si-select-combobox-value.component.scss
+++ b/projects/element-ng/select/si-select-combobox-value.component.scss
@@ -1,0 +1,11 @@
+:host {
+  display: inline-block;
+  max-inline-size: 100%;
+}
+
+// Opt-in: when the consumer adds the `comma-separated` class to each value,
+// a comma is rendered between adjacent values. Not applied by default so
+// consumers remain free to use chips, custom separators or none at all.
+:host(.comma-separated:not(:first-of-type))::before {
+  content: ',\00a0';
+}

--- a/projects/element-ng/select/si-select-combobox-value.component.ts
+++ b/projects/element-ng/select/si-select-combobox-value.component.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { SiIconComponent } from '@siemens/element-ng/icon';
+
+/**
+ * Represents a single selected value inside an {@link SiSelectComboboxComponent}.
+ *
+ * Project one `<si-select-combobox-value>` per selected entry. Optional
+ * `icon`, `iconColor`, `stackedIcon` and `stackedIconColor` inputs mirror the
+ * icon API of {@link SelectOption} and render an icon (with optional stacked
+ * overlay) before the projected content.
+ *
+ * Add the `comma-separated` CSS class to render a comma between adjacent
+ * values. Omit it when using chips, custom separators, or a single value.
+ *
+ * @example
+ * ```html
+ * <si-select-combobox>
+ *   <si-select-combobox-value
+ *     icon="element-face-happy"
+ *     iconColor="status-success"
+ *   >
+ *     {{ select.value() }}
+ *   </si-select-combobox-value>
+ * </si-select-combobox>
+ * ```
+ *
+ * @experimental
+ */
+@Component({
+  selector: 'si-select-combobox-value',
+  imports: [SiIconComponent],
+  template: `
+    @if (icon(); as iconName) {
+      <div class="icon-stack icon me-2 my-n4">
+        <si-icon [icon]="iconName" [class]="iconColor() ?? ''" />
+        @if (stackedIcon(); as stackedIconName) {
+          <si-icon [icon]="stackedIconName" [class]="stackedIconColor() ?? ''" />
+        }
+      </div>
+    }
+    <ng-content />
+  `,
+  styleUrl: './si-select-combobox-value.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'text-nowrap'
+  }
+})
+export class SiSelectComboboxValueComponent {
+  /** An optional icon rendered before the projected content. */
+  readonly icon = input<string>();
+
+  /** Optional CSS color class applied to {@link icon}. */
+  readonly iconColor = input<string>();
+
+  /** Optional secondary icon stacked on top of {@link icon}. */
+  readonly stackedIcon = input<string>();
+
+  /** Optional CSS color class applied to {@link stackedIcon}. */
+  readonly stackedIconColor = input<string>();
+}

--- a/projects/element-ng/select/si-select-combobox.component.scss
+++ b/projects/element-ng/select/si-select-combobox.component.scss
@@ -1,0 +1,9 @@
+:host-context(.form-control.dropdown) .dropdown-caret {
+  margin-inline-end: calc(
+    (var(--si-feedback-icon-offset, 0px) + var(--si-action-icon-offset)) * -1
+  );
+}
+
+.dropdown-caret {
+  transform-origin: center;
+}

--- a/projects/element-ng/select/si-select-combobox.component.ts
+++ b/projects/element-ng/select/si-select-combobox.component.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { elementDown2 } from '@siemens/element-icons';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
+
+import { SiCustomSelectDirective } from './si-custom-select.directive';
+
+/**
+ * Visual trigger element for custom selects built with {@link SiCustomSelectDirective}.
+ * Renders the projected content and a dropdown caret icon.
+ *
+ * The ARIA role, focus handling, and state attributes live on the host component
+ * via {@link SiCustomSelectDirective} — this component is purely visual.
+ *
+ * @example
+ * ```html
+ * <si-select-combobox>
+ *   {{ select.value() }}
+ * </si-select-combobox>
+ * ```
+ *
+ * @experimental
+ */
+@Component({
+  selector: 'si-select-combobox',
+  imports: [SiIconComponent],
+  template: `
+    <ng-content />
+    <div class="form-control-actions ms-auto my-n4">
+      <si-icon class="dropdown-caret icon flip-rtl p-0 m-0" [icon]="icons.elementDown2" />
+    </div>
+  `,
+  styleUrl: './si-select-combobox.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'select focus-none dropdown-toggle d-flex align-items-center w-100',
+    '[attr.id]': 'customSelect.comboboxLabelId()',
+    '[class.show]': 'customSelect.isOpen()'
+  }
+})
+export class SiSelectComboboxComponent {
+  protected readonly icons = addIcons({ elementDown2 });
+  protected readonly customSelect = inject(SiCustomSelectDirective);
+}

--- a/projects/element-ng/select/si-select-dropdown.directive.ts
+++ b/projects/element-ng/select/si-select-dropdown.directive.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Directive, inject, input, TemplateRef } from '@angular/core';
+
+import { SiCustomSelectDirective } from './si-custom-select.directive';
+
+/**
+ * Possible values for the `aria-haspopup` attribute exposed by the
+ * combobox host of a custom select.
+ */
+export type SiSelectDropdownContentType =
+  | 'false'
+  | 'true'
+  | 'menu'
+  | 'listbox'
+  | 'tree'
+  | 'grid'
+  | 'dialog';
+
+/**
+ * Structural directive marking the dropdown template for custom selects
+ * built with {@link SiCustomSelectDirective}.
+ *
+ * When placed on an `<ng-template>`, it automatically registers the template
+ * with the parent {@link SiCustomSelectDirective}.
+ *
+ * @example
+ * ```html
+ * <ng-template si-select-dropdown contentType="listbox">
+ *   <!-- custom dropdown content -->
+ * </ng-template>
+ * ```
+ *
+ * @experimental
+ */
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: '[si-select-dropdown]'
+})
+export class SiSelectDropdownDirective {
+  /**
+   * Describes the kind of content rendered by the dropdown. The value is
+   * forwarded to the `aria-haspopup` attribute of the combobox host of
+   * the parent {@link SiCustomSelectDirective}.
+   */
+  readonly contentType = input.required<SiSelectDropdownContentType>();
+
+  /** @internal */
+  readonly templateRef = inject<TemplateRef<void>>(TemplateRef);
+
+  constructor() {
+    const customSelect = inject(SiCustomSelectDirective, { optional: true });
+    customSelect?.registerDropdown(this);
+  }
+}

--- a/projects/element-ng/select/testing/si-select.harness.ts
+++ b/projects/element-ng/select/testing/si-select.harness.ts
@@ -99,7 +99,7 @@ export class SiSelectHarness extends ComponentHarness {
 
   async getOverflowCount(): Promise<number> {
     await new Promise<void>(resolve => setTimeout(() => resolve()));
-    return this.locatorForOptional('.overflow-item')()
+    return this.locatorForOptional('.pill')()
       .then(overflow => overflow?.text())
       .then(overflow => overflow?.replace('+', ''))
       .then(overflow => (overflow ? +overflow : 0));

--- a/projects/element-theme/src/styles/bootstrap/_dropdowns.scss
+++ b/projects/element-theme/src/styles/bootstrap/_dropdowns.scss
@@ -38,6 +38,15 @@
   }
 }
 
+.dropdown-menu-scroller {
+  overflow: auto;
+  // 266px is based on figma and gives 6-8 items. Depending on the number of headings
+  max-block-size: min(
+    100vh,
+    calc((1lh + 2 * #{bootstrap-variables.$dropdown-item-padding-y}) * 8.3125) // = 266px with rfs 16px
+  );
+}
+
 :is(.dropdown-menu, .dropdown-item) {
   .icon + .item-title {
     padding-inline-start: map.get(spacers.$spacers, 4);

--- a/src/app/examples/si-select/si-select-custom.html
+++ b/src/app/examples/si-select/si-select-custom.html
@@ -1,0 +1,50 @@
+<si-card class="card-outline" heading="Button variant">
+  <div class="card-body" body>
+    <app-tree-select
+      class="btn btn-primary-ghost fw-normal"
+      [items]="treeItems"
+      [disabled]="disabled"
+      [readonly]="readonly"
+      [(ngModel)]="selectedLocation"
+    />
+  </div>
+</si-card>
+
+<si-card class="mt-6" heading="Form-control variant">
+  <div class="card-body" body>
+    <si-form-item label="Location (required)">
+      <app-tree-select
+        class="form-control"
+        [items]="treeItems"
+        [readonly]="readonly"
+        [formControl]="locationControl"
+      />
+    </si-form-item>
+  </div>
+</si-card>
+
+<div class="card mt-6 e2e-ignore">
+  <div class="card-header">Control panel</div>
+  <div class="card-body">
+    <div class="mb-6">Current value (ngModel): {{ selectedLocation?.label ?? 'none' }}</div>
+    <div class="mb-6"
+      >Current value (formControl): {{ locationControl.value?.label ?? 'none' }}</div
+    >
+    <div class="mb-6">Location valid: {{ locationControl.valid }}</div>
+    <div class="mb-5">
+      <si-form-item class="form-switch" label="Readonly">
+        <input type="checkbox" class="form-check-input" [(ngModel)]="readonly" />
+      </si-form-item>
+    </div>
+    <div class="mb-5">
+      <si-form-item class="form-switch" label="Disabled">
+        <input
+          type="checkbox"
+          class="form-check-input"
+          [(ngModel)]="disabled"
+          (ngModelChange)="toggleDisabled($event)"
+        />
+      </si-form-item>
+    </div>
+  </div>
+</div>

--- a/src/app/examples/si-select/si-select-custom.ts
+++ b/src/app/examples/si-select/si-select-custom.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component, inject, input, signal } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { SiCardComponent } from '@siemens/element-ng/card';
+import { SiFormItemComponent } from '@siemens/element-ng/form';
+import {
+  SiCustomSelectDirective,
+  SiSelectComboboxComponent,
+  SiSelectComboboxValueComponent,
+  SiSelectDropdownDirective
+} from '@siemens/element-ng/select';
+import { SiTreeViewComponent, TreeItem } from '@siemens/element-ng/tree-view';
+
+import { treeItems } from '../si-tree-view/tree-items';
+
+/**
+ * Reusable tree-select built with SiCustomSelectDirective as a host directive.
+ * Embeds an si-tree-view inside the dropdown and lets the user pick a location.
+ */
+@Component({
+  selector: 'app-tree-select',
+  imports: [
+    SiSelectComboboxComponent,
+    SiSelectComboboxValueComponent,
+    SiSelectDropdownDirective,
+    SiTreeViewComponent
+  ],
+  template: `
+    <si-select-combobox>
+      @if (select.value(); as val) {
+        <si-select-combobox-value [icon]="val.icon">
+          {{ val.label }}
+        </si-select-combobox-value>
+      } @else {
+        <span class="text-secondary">Select a location...</span>
+      }
+    </si-select-combobox>
+
+    <ng-template si-select-dropdown contentType="tree">
+      <si-tree-view
+        class="d-block mt-n4 dropdown-menu-scroller"
+        ariaLabel="Locations"
+        [items]="pendingItems()"
+        [enableSelection]="true"
+        [singleSelectMode]="true"
+        [isVirtualized]="false"
+        (treeItemClicked)="selectItem($event)"
+      />
+      <div class="dropdown-divider"></div>
+      <div class="d-flex flex-column align-items-start">
+        <button
+          type="button"
+          class="btn btn-link mx-5 my-4"
+          [disabled]="!select.value()"
+          (click)="clearSelection()"
+          >Clear selection</button
+        >
+      </div>
+    </ng-template>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [
+    {
+      directive: SiCustomSelectDirective,
+      inputs: ['disabled', 'readonly', 'value'],
+      outputs: ['valueChange']
+    }
+  ]
+})
+export class TreeSelectComponent {
+  protected readonly select = inject<SiCustomSelectDirective<TreeItem>>(SiCustomSelectDirective);
+
+  /** The tree items to display. */
+  readonly items = input<TreeItem[]>([]);
+
+  /**
+   * Pending tree items rendered inside the dropdown. The tree view mutates the
+   * model (e.g. selection state), so we deep-clone the input before each open
+   * to avoid leaking state back into the caller's data.
+   */
+  protected readonly pendingItems = signal<TreeItem[]>([]);
+
+  constructor() {
+    this.select.openChange.subscribe(open => {
+      if (open) {
+        const clone = JSON.parse(JSON.stringify(this.items())) as TreeItem[];
+        applySelectionState(clone, this.select.value()?.label as string | undefined);
+        this.pendingItems.set(clone);
+      } else {
+        this.pendingItems.set([]);
+      }
+    });
+  }
+
+  selectItem(item: TreeItem): void {
+    if (item.label) {
+      this.select.updateValue(item);
+      this.select.close();
+    }
+  }
+
+  clearSelection(): void {
+    this.select.updateValue(undefined);
+    this.select.close();
+  }
+}
+
+/** Marks the item matching `selected` as selected. */
+const applySelectionState = (items: TreeItem[], selected: string | undefined): void => {
+  for (const item of items) {
+    if (item.children?.length) {
+      applySelectionState(item.children, selected);
+    } else {
+      item.selected = item.label === selected;
+    }
+  }
+};
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    TreeSelectComponent,
+    FormsModule,
+    ReactiveFormsModule,
+    SiCardComponent,
+    SiFormItemComponent
+  ],
+  templateUrl: './si-select-custom.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'p-5' }
+})
+export class SampleComponent {
+  selectedLocation: TreeItem | undefined;
+  disabled = false;
+  readonly = false;
+  readonly treeItems = treeItems;
+  readonly locationControl = new FormControl<TreeItem | undefined>(undefined, Validators.required);
+
+  toggleDisabled(disabled: boolean): void {
+    if (disabled) {
+      this.locationControl.disable();
+    } else {
+      this.locationControl.enable();
+    }
+  }
+}

--- a/src/app/examples/si-select/si-select-multi-custom.html
+++ b/src/app/examples/si-select/si-select-multi-custom.html
@@ -1,0 +1,56 @@
+<si-card class="card-outline" heading="Button variant">
+  <div class="card-body" body>
+    <app-tree-multi-select
+      class="btn btn-primary-ghost fw-normal w-100"
+      [items]="treeItems"
+      [disabled]="disabled"
+      [readonly]="readonly"
+      [(ngModel)]="selectedLocations"
+    />
+  </div>
+</si-card>
+
+<si-card class="mt-6" heading="Form-control variant">
+  <div class="card-body" body>
+    <si-form-item label="Locations (required)">
+      <app-tree-multi-select
+        class="form-control"
+        [items]="treeItems"
+        [readonly]="readonly"
+        [formControl]="locationsControl"
+      />
+    </si-form-item>
+  </div>
+</si-card>
+
+<div class="card mt-6 e2e-ignore">
+  <div class="card-header">Control panel</div>
+  <div class="card-body">
+    <div class="mb-6"
+      >Selected (ngModel):
+      {{ selectedLocations.length ? labelsOf(selectedLocations).join(', ') : 'none' }}</div
+    >
+    <div class="mb-6"
+      >Selected (formControl):
+      {{
+        locationsControl.value.length ? labelsOf(locationsControl.value).join(', ') : 'none'
+      }}</div
+    >
+    <div class="mb-6">Locations valid: {{ locationsControl.valid }}</div>
+    <div class="mb-5">
+      <si-form-item class="form-switch" label="Readonly">
+        <input type="checkbox" class="form-check-input" [(ngModel)]="readonly" />
+      </si-form-item>
+    </div>
+    <div class="mb-5">
+      <si-form-item class="form-switch" label="Disabled">
+        <input
+          type="checkbox"
+          class="form-check-input"
+          [(ngModel)]="disabled"
+          (ngModelChange)="toggleDisabled($event)"
+        />
+      </si-form-item>
+    </div>
+  </div>
+</div>

--- a/src/app/examples/si-select/si-select-multi-custom.ts
+++ b/src/app/examples/si-select/si-select-multi-custom.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component, inject, input, signal } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  SiAutoCollapsableListDirective,
+  SiAutoCollapsableListItemDirective,
+  SiAutoCollapsableListOverflowItemDirective
+} from '@siemens/element-ng/auto-collapsable-list';
+import { SiCardComponent } from '@siemens/element-ng/card';
+import { SiFormItemComponent } from '@siemens/element-ng/form';
+import {
+  SiCustomSelectDirective,
+  SiSelectComboboxComponent,
+  SiSelectComboboxValueComponent,
+  SiSelectDropdownDirective
+} from '@siemens/element-ng/select';
+import { SiTreeViewComponent, TreeItem } from '@siemens/element-ng/tree-view';
+
+import { treeItems } from '../si-tree-view/tree-items';
+import {
+  cloneTreeWithCheckedState,
+  collectCheckedLeaves,
+  compactSelected,
+  expandCompactItems
+} from './tree-select-utils';
+
+/**
+ * Reusable multi-select tree component with an Apply button.
+ * Uses SiCustomSelectDirective as a host directive and checkboxes in the tree view.
+ *
+ * When all children of a parent are selected only the parent label is shown
+ * in the value display instead of every individual leaf.
+ */
+@Component({
+  selector: 'app-tree-multi-select',
+  imports: [
+    SiAutoCollapsableListDirective,
+    SiAutoCollapsableListItemDirective,
+    SiAutoCollapsableListOverflowItemDirective,
+    SiSelectComboboxComponent,
+    SiSelectComboboxValueComponent,
+    SiSelectDropdownDirective,
+    SiTreeViewComponent
+  ],
+  template: `
+    <si-select-combobox class="text-nowrap">
+      <div class="d-flex flex-fill overflow-hidden" siAutoCollapsableList>
+        @if (select.value(); as value) {
+          @for (item of value; track item.label) {
+            <si-select-combobox-value
+              class="comma-separated"
+              siAutoCollapsableListItem
+              [icon]="item.icon"
+            >
+              {{ item.label }}
+            </si-select-combobox-value>
+          } @empty {
+            <span class="text-secondary">Select locations...</span>
+          }
+        } @else {
+          <span class="text-secondary">Select locations...</span>
+        }
+        <span
+          #overflow="siAutoCollapsableListOverflowItem"
+          siAutoCollapsableListOverflowItem
+          class="pill py-0 ms-2"
+          >{{ overflow.hiddenItemCount }}+</span
+        >
+      </div>
+    </si-select-combobox>
+
+    <ng-template si-select-dropdown contentType="dialog">
+      <div role="dialog" aria-label="Select locations">
+        <si-tree-view
+          class="d-block mt-n4 dropdown-menu-scroller"
+          ariaLabel="Locations"
+          [items]="pendingItems()"
+          [enableCheckbox]="true"
+          [inheritChecked]="true"
+          [isVirtualized]="false"
+        />
+        <div class="d-flex gap-5 justify-content-end p-5 pb-2 border-top">
+          <button type="button" class="btn btn-secondary" (click)="cancel()">Cancel</button>
+          <button type="button" class="btn btn-primary" (click)="apply()">Apply</button>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [
+    {
+      directive: SiCustomSelectDirective,
+      inputs: ['disabled', 'readonly', 'value'],
+      outputs: ['valueChange']
+    }
+  ]
+})
+export class TreeMultiSelectComponent {
+  protected readonly select = inject<SiCustomSelectDirective<TreeItem[]>>(SiCustomSelectDirective);
+
+  /** The tree items to display. */
+  readonly items = input.required<TreeItem[]>();
+
+  /** Pending tree items with checkbox state (not yet applied). */
+  protected readonly pendingItems = signal<TreeItem[]>([]);
+
+  constructor() {
+    this.select.openChange.subscribe(open => {
+      if (open) {
+        // Expand any compacted parent-items back to leaf labels so the
+        // tree checkbox state is restored correctly.
+        const compacted = this.select.value() ?? [];
+        const expanded = expandCompactItems(compacted);
+        this.pendingItems.set(cloneTreeWithCheckedState(this.items(), expanded));
+      } else {
+        this.pendingItems.set([]);
+      }
+    });
+  }
+
+  apply(): void {
+    const checkedLeaves = collectCheckedLeaves(this.pendingItems());
+    // Compact items so fully-selected subtrees are replaced by the parent
+    // item (e.g. 'Milano' instead of every individual location).
+    const compacted = compactSelected(this.items(), checkedLeaves);
+    this.select.updateValue(compacted);
+    this.select.close();
+  }
+
+  cancel(): void {
+    this.select.close();
+  }
+}
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    TreeMultiSelectComponent,
+    FormsModule,
+    ReactiveFormsModule,
+    SiCardComponent,
+    SiFormItemComponent
+  ],
+  templateUrl: './si-select-multi-custom.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'p-5' }
+})
+export class SampleComponent {
+  selectedLocations: TreeItem[] = [];
+  disabled = false;
+  readonly = false;
+  readonly treeItems = treeItems;
+  readonly locationsControl = new FormControl<TreeItem[]>([], {
+    nonNullable: true,
+    validators: Validators.required
+  });
+
+  toggleDisabled(disabled: boolean): void {
+    if (disabled) {
+      this.locationsControl.disable();
+    } else {
+      this.locationsControl.enable();
+    }
+  }
+
+  labelsOf(items: TreeItem[]): string[] {
+    return items.map(item => item.label as string);
+  }
+}

--- a/src/app/examples/si-select/tree-select-utils.ts
+++ b/src/app/examples/si-select/tree-select-utils.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import type { TreeItem } from '@siemens/element-ng/tree-view';
+
+/** Recursively sets the `checked` state on every node. */
+const applyCheckedState = (nodes: TreeItem[], selected: string[]): void => {
+  for (const node of nodes) {
+    if (node.children?.length) {
+      applyCheckedState(node.children, selected);
+      const allChecked = node.children.every(c => c.checked === 'checked');
+      const someChecked = node.children.some(
+        c => c.checked === 'checked' || c.checked === 'indeterminate'
+      );
+      node.checked = allChecked ? 'checked' : someChecked ? 'indeterminate' : 'unchecked';
+    } else {
+      node.checked = selected.includes(node.label as string) ? 'checked' : 'unchecked';
+    }
+  }
+};
+
+/**
+ * Deep-clones tree items via JSON serialization and sets the `checked` state
+ * based on the provided selected labels. The deep clone is required because
+ * the tree view mutates the model (checked / state / etc.).
+ */
+export const cloneTreeWithCheckedState = (items: TreeItem[], selected: string[]): TreeItem[] => {
+  const clone = JSON.parse(JSON.stringify(items)) as TreeItem[];
+  applyCheckedState(clone, selected);
+  return clone;
+};
+
+/**
+ * Collects all checked leaf labels from a tree.
+ */
+export const collectCheckedLeaves = (items: TreeItem[]): string[] => {
+  const result: string[] = [];
+  for (const item of items) {
+    if (item.children?.length) {
+      result.push(...collectCheckedLeaves(item.children));
+    } else if (item.checked === 'checked' && item.label) {
+      result.push(item.label as string);
+    }
+  }
+  return result;
+};
+
+/** Collects all leaf labels beneath every node in `nodes`. */
+const collectAllLeafLabels = (nodes: TreeItem[]): string[] => {
+  const result: string[] = [];
+  for (const node of nodes) {
+    if (node.children?.length) {
+      result.push(...collectAllLeafLabels(node.children));
+    } else if (node.label) {
+      result.push(node.label as string);
+    }
+  }
+  return result;
+};
+
+const compactNode = (nodes: TreeItem[], selectedSet: Set<string>, result: TreeItem[]): void => {
+  for (const node of nodes) {
+    if (node.children?.length) {
+      const allLeafLabels = collectAllLeafLabels(node.children);
+      const allSelected = allLeafLabels.every(label => selectedSet.has(label));
+
+      if (allSelected && allLeafLabels.length > 0) {
+        result.push(node);
+      } else {
+        compactNode(node.children, selectedSet, result);
+      }
+    } else if (node.label && selectedSet.has(node.label as string)) {
+      result.push(node);
+    }
+  }
+};
+
+/**
+ * Given a flat list of checked leaf labels and the full tree, returns a
+ * compacted list of {@link TreeItem} references where fully-selected subtrees
+ * are replaced by their parent node.
+ */
+export const compactSelected = (items: TreeItem[], selected: string[]): TreeItem[] => {
+  const selectedSet = new Set(selected);
+  const result: TreeItem[] = [];
+  compactNode(items, selectedSet, result);
+  return result;
+};
+
+/**
+ * Expands a list of compacted {@link TreeItem} references back to the
+ * leaf labels they represent, so the tree can restore checkbox state.
+ */
+export const expandCompactItems = (items: TreeItem[]): string[] => {
+  const result: string[] = [];
+  for (const item of items) {
+    if (item.children?.length) {
+      result.push(...collectAllLeafLabels(item.children));
+    } else if (item.label) {
+      result.push(item.label as string);
+    }
+  }
+  return result;
+};

--- a/src/app/examples/si-tree-view/tree-items.ts
+++ b/src/app/examples/si-tree-view/tree-items.ts
@@ -99,7 +99,8 @@ export const treeItems: TreeItem[] = [
     icon: 'element-project',
     children: [
       {
-        label: 'Child Company3'
+        label: 'Child Company3',
+        state: 'leaf'
       }
     ]
   }


### PR DESCRIPTION
Adding a set of utilities that allows customers
to create selects with custom backed value selection, for instance using `si-tree-view`.

A very simple version of it can look like this:

```ts
@Component({
  selector: 'app-tree-select',
  imports: [SiSelectComboboxComponent, SiSelectDropdownDirective, SiTreeViewComponent],
  template: `
    <si-select-combobox>
      @if (select.value(); as val) {
        {{ val }}
      } @else {
        <span class="text-secondary">Select a location...</span>
      }
    </si-select-combobox>

    <ng-template si-select-dropdown>
      <si-tree-view
        class="d-block"
        ariaLabel="Locations"
        [items]="items()"
        [enableSelection]="true"
        [singleSelectMode]="true"
        [isVirtualized]="false"
        (treeItemClicked)="selectItem($event)"
      />
    </ng-template>
  `,
  changeDetection: ChangeDetectionStrategy.OnPush,
  hostDirectives: [
    {
      directive: SiCustomSelectDirective,
      inputs: ['disabled', 'readonly', 'value'],
      outputs: ['valueChange']
    }
  ]
})
export class TreeSelectComponent {
  protected readonly select = inject(SiCustomSelectDirective);

  /** The tree items to display. */
  readonly items = input<TreeItem[]>([]);

  selectItem(item: TreeItem): void {
    if (item.label) {
      this.select.updateValue(item.label as string);
      this.select.close();
    }
  }
}
```

The goal is to empower applications
to build selects with whatever content they need
while we take care of accesibility and proper appereance.

Closes #1840

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1852/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1852/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1852/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1852/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1852/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1852/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1852/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1852/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1852/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1852/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

















