### PR TITLE
feat(utilities): add `border-*-ai` utilities

### DIFF
--- a/docs/fundamentals/styles/borders.md
+++ b/docs/fundamentals/styles/borders.md
@@ -50,8 +50,27 @@ Customize the radius using the following utils:
 
 > **Note:** Since `rounded-2` is the default shape for _Element_, it is possible to use the shorthand `rounded` CSS class.
 
+## AI gradient borders
+
+Add a 1px gradient border to any element using the AI border utility classes.
+The gradient border is rendered via a masked pseudo-element and works with both opaque and transparent backgrounds.
+
+| Class                   | Description                                |
+| ----------------------- | ------------------------------------------ |
+| `.border-horizontal-ai` | Horizontal (left-to-right) gradient border |
+| `.border-vertical-ai`   | Vertical (top-to-bottom) gradient border   |
+
+The element must have a `border-radius` set for the gradient to follow the rounded shape.
+
+```html
+<span class="badge border-horizontal-ai">AI generated</span>
+<div class="card border-vertical-ai">...</div>
+```
+
 ## Examples
 
 <si-docs-component example="borders/borders" height="300"></si-docs-component>
 
 <si-docs-component example="shapes/shapes" height="300"></si-docs-component>
+
+<si-docs-component example="ai-border/ai-border" height="300"></si-docs-component>

--- a/playwright/e2e/element-examples/static.spec.ts
+++ b/playwright/e2e/element-examples/static.spec.ts
@@ -4,6 +4,7 @@
  */
 import { test } from '../../support/test-helpers';
 
+test('ai-border/ai-border', ({ si }) => si.static());
 test('badges/badges', ({ si }) => si.static());
 test('buttons/buttons', ({ si }) => si.static());
 test('buttons/button-groups', ({ si }) => si.static());

--- a/playwright/snapshots/static.spec.ts-snapshots/ai-border--ai-border-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/ai-border--ai-border-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:521191c19207888ef6773f394403f0bb2d1bb4d5cfeb91afbd38c8397098018b
+size 10570

--- a/playwright/snapshots/static.spec.ts-snapshots/ai-border--ai-border-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/ai-border--ai-border-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a173aab16b86fd7b6266a70b2c1421c2f61a0cef349e656e0a3c8e420f865b9e
+size 9901

--- a/playwright/snapshots/static.spec.ts-snapshots/ai-border--ai-border.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/ai-border--ai-border.yaml
@@ -1,0 +1,2 @@
+- text: AI generated AI insights
+- paragraph: AI-generated content with a vertical gradient border

--- a/projects/element-theme/src/styles/bootstrap/_utilities.scss
+++ b/projects/element-theme/src/styles/bootstrap/_utilities.scss
@@ -105,3 +105,46 @@ $status-colors: (
     color: #{$value} !important; // stylelint-disable-line declaration-no-important
   }
 }
+
+// AI gradient border utilities.
+// Two filled mask layers with `exclude` compositing subtract the inner area,
+// leaving only a 1px border ring visible. Works with transparent backgrounds.
+@mixin border-ai($angle) {
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(
+      $angle,
+      #{semantic-tokens.$element-base-1-selected} -6.48%,
+      #{semantic-tokens.$element-base-1-hover} -0.82%,
+      #{semantic-tokens.$element-ui-0} 49.58%,
+      #{semantic-tokens.$element-base-1-hover} 101.07%,
+      #{semantic-tokens.$element-base-1-selected} 106.73%
+    );
+    mask-image:
+      linear-gradient(
+        #{semantic-tokens.$element-text-primary},
+        #{semantic-tokens.$element-text-primary}
+      ),
+      linear-gradient(
+        #{semantic-tokens.$element-text-primary},
+        #{semantic-tokens.$element-text-primary}
+      );
+    mask-clip: border-box, content-box;
+    mask-composite: exclude;
+    padding: 1px;
+    pointer-events: none;
+  }
+}
+
+.border-horizontal-ai {
+  @include border-ai(90deg);
+}
+
+.border-vertical-ai {
+  @include border-ai(180deg);
+}

--- a/src/app/examples/ai-border/ai-border.html
+++ b/src/app/examples/ai-border/ai-border.html
@@ -1,0 +1,8 @@
+<div class="mb-5">
+  <span class="badge border-horizontal-ai">AI generated</span>
+</div>
+<div>
+  <si-card class="border-vertical-ai" heading="AI insights">
+    <p class="card-body card-text" body>AI-generated content with a vertical gradient border</p>
+  </si-card>
+</div>

--- a/src/app/examples/ai-border/ai-border.ts
+++ b/src/app/examples/ai-border/ai-border.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { SiCardComponent } from '@siemens/element-ng/card';
+
+@Component({
+  selector: 'app-sample',
+  imports: [SiCardComponent],
+  templateUrl: './ai-border.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'p-5 bg-base-1'
+  }
+})
+export class SampleComponent {}


### PR DESCRIPTION
In order to highlight AI related content, we need a gradient border. Since CSS borders do not support gradients we need this workaround.

This border is supposed to be only used on cards and badges, but with those utilities they could be used on every container.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1853/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1853/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1853/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1853/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1853/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1853/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1853/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1853/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1853/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1853/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

