### PR TITLE
feat(live-preview): allow overriding root font size

### DIFF
--- a/api-goldens/live-preview/index.api.md
+++ b/api-goldens/live-preview/index.api.md
@@ -195,6 +195,12 @@ export class SiLivePreviewComponent implements OnInit, AfterViewInit, OnChanges 
     // (undocumented)
     renderingError: any;
     // (undocumented)
+    rfsSelectionChanges(value: string): void;
+    // (undocumented)
+    rootFontSize: number | 'initial';
+    // (undocumented)
+    rootFontSizes: number[];
+    // (undocumented)
     rtlSwitcher: boolean | undefined;
     // (undocumented)
     selectedFramework: string;
@@ -259,6 +265,8 @@ export interface SiLivePreviewConfig {
     // (undocumented)
     modules: any[];
     // (undocumented)
+    rootFontSizes?: number[];
+    // (undocumented)
     rtlSwitcher?: boolean;
     // (undocumented)
     themeSwitcher?: boolean;
@@ -308,6 +316,8 @@ export class SiLivePreviewIframeComponent implements OnInit, OnChanges {
     readonly previewIframe: i0.Signal<ElementRef<any> | undefined>;
     // (undocumented)
     reactVueTemplate?: string;
+    // (undocumented)
+    rootFontSize: number | 'initial';
     // (undocumented)
     template: string;
     // (undocumented)

--- a/projects/live-preview/components/si-example-viewer/si-example-viewer.component.ts
+++ b/projects/live-preview/components/si-example-viewer/si-example-viewer.component.ts
@@ -5,7 +5,7 @@
 import { Component, HostBinding, inject, viewChild } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 
-import { setDeviceMode, setDirectionRtl } from '../../helpers/utils';
+import { setDeviceMode, setDirectionRtl, setRootFontSize } from '../../helpers/utils';
 import {
   SI_LIVE_PREVIEW_CONFIG,
   SI_LIVE_PREVIEW_INTERNALS
@@ -111,6 +111,9 @@ export class SiExampleViewerComponent {
     if (params.locale) {
       this.setLocale(params.locale);
       handled = true;
+    }
+    if (params.rfs) {
+      setRootFontSize(parseInt(params.rfs, 10));
     }
     if (params.isRTL) {
       this.setRTL(params.isRTL);

--- a/projects/live-preview/components/si-live-preview-iframe/si-live-preview-iframe.component.ts
+++ b/projects/live-preview/components/si-live-preview-iframe/si-live-preview-iframe.component.ts
@@ -47,6 +47,7 @@ export class SiLivePreviewIframeComponent implements OnInit, OnChanges {
   @Input() iFrameWidth?: string;
   @Input() theme = 'light';
   @Input() locale?: string;
+  @Input() rootFontSize: number | 'initial' = 0;
   @Input() isRTL?: boolean;
   @Input() loadReact?: boolean;
   @Input() loadVue?: boolean;
@@ -214,6 +215,9 @@ export class SiLivePreviewIframeComponent implements OnInit, OnChanges {
     if (this.locale) {
       url += '&locale=' + this.locale;
     }
+    if (this.rootFontSize) {
+      url += '&rfs=' + this.rootFontSize;
+    }
     if (this.templateModified && !skipTemplate) {
       url += '&t=' + this.encode(this.template);
     }
@@ -240,6 +244,7 @@ export class SiLivePreviewIframeComponent implements OnInit, OnChanges {
         reactVueTemplate: this.reactVueTemplate,
         theme: this.theme,
         locale: this.locale,
+        rootFontSize: this.rootFontSize,
         isRTL: this.isRTL,
         mode: this.mode,
         safeAreaTop: this.landscape

--- a/projects/live-preview/components/si-live-preview-wrapper/si-live-preview-wrapper.component.ts
+++ b/projects/live-preview/components/si-live-preview-wrapper/si-live-preview-wrapper.component.ts
@@ -14,7 +14,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { fromEvent } from 'rxjs';
 
-import { setDeviceMode, setDirectionRtl } from '../../helpers/utils';
+import { setDeviceMode, setDirectionRtl, setRootFontSize } from '../../helpers/utils';
 import {
   SI_LIVE_PREVIEW_CONFIG,
   SI_LIVE_PREVIEW_INTERNALS
@@ -50,6 +50,7 @@ export class SiLivePreviewWrapperComponent {
   private isRTL = false;
   private mode!: string;
   private locale?: string;
+  private rootFontSize?: number | 'initial';
   private initialUrl: string;
 
   private config = inject(SI_LIVE_PREVIEW_CONFIG);
@@ -115,6 +116,10 @@ export class SiLivePreviewWrapperComponent {
 
     if (this.locale !== event.data.locale) {
       this.setLocale(event.data.locale);
+    }
+    if (this.rootFontSize !== event.data.rootFontSize) {
+      this.rootFontSize = event.data.rootFontSize;
+      setRootFontSize(event.data.rootFontSize);
     }
 
     if (this.isRTL !== event.data.isRTL) {

--- a/projects/live-preview/components/si-live-preview/si-live-preview.component.html
+++ b/projects/live-preview/components/si-live-preview/si-live-preview.component.html
@@ -9,6 +9,7 @@
       [isFullscreen]="isFullscreen"
       [theme]="theme"
       [locale]="locale"
+      [rootFontSize]="rootFontSize"
       [isRTL]="isRTL"
       [loadReact]="loadReact"
       [loadVue]="loadVue"
@@ -104,7 +105,7 @@
     <div class="buttons">
       @if (webcomponents && showEditor && frameworks.size > 1) {
         <select
-          aria-label="select framework"
+          aria-label="Select framework"
           class="btn-command locale-selection"
           [(ngModel)]="selectedFramework"
           (ngModelChange)="changeFramework($event)"
@@ -116,9 +117,27 @@
           }
         </select>
       }
+      @if (rootFontSizes.length) {
+        <select
+          name="selectRfs"
+          aria-label="Root font size"
+          title="Root font size"
+          class="btn-command rfs-selection"
+          [ngModel]="rootFontSize"
+          (ngModelChange)="rfsSelectionChanges($event)"
+        >
+          <option value="0">none</option>
+          <option value="initial">initial</option>
+          @for (rfs of rootFontSizes; track rfs) {
+            <option [value]="rfs">{{ rfs }}px</option>
+          }
+        </select>
+      }
       @if (!!localeApi && showEditor) {
         <select
-          aria-label="select locale"
+          name="selectLocale"
+          aria-label="Select locale"
+          title="Locale"
           class="btn-command locale-selection"
           (change)="localeSelectionChanged($event.target)"
         >

--- a/projects/live-preview/components/si-live-preview/si-live-preview.component.scss
+++ b/projects/live-preview/components/si-live-preview/si-live-preview.component.scss
@@ -280,6 +280,7 @@ fieldset {
 }
 
 .rtl-selection,
+.rfs-selection,
 .locale-selection {
   font-size: 14px;
 }

--- a/projects/live-preview/components/si-live-preview/si-live-preview.component.ts
+++ b/projects/live-preview/components/si-live-preview/si-live-preview.component.ts
@@ -80,6 +80,8 @@ export class SiLivePreviewComponent implements OnInit, AfterViewInit, OnChanges 
   loadJs = false;
   switcherEnabled = this.config.themeSwitcher;
   rtlSwitcher = this.config.rtlSwitcher;
+  rootFontSizes = this.config.rootFontSizes ?? [];
+  rootFontSize: number | 'initial' = 0;
   webcomponents = this.config.webcomponents;
   frameworks = new Map([['Angular', 'angular']]);
   selectedFramework = localStorage.getItem('si-live-preview-framework') ?? 'angular';
@@ -157,6 +159,8 @@ export class SiLivePreviewComponent implements OnInit, AfterViewInit, OnChanges 
   ngOnInit(): void {
     this.availableLocales = this.localeApi?.availableLocales() ?? [];
     this.theme = localStorage.getItem('si-live-preview-theme') ?? 'light';
+    const rfs = localStorage.getItem('si-live-preview-rfs') ?? '';
+    this.rootFontSize = rfs === 'initial' ? rfs : rfs ? parseInt(rfs, 10) : 0;
   }
 
   ngAfterViewInit(): void {
@@ -567,6 +571,11 @@ export class SiLivePreviewComponent implements OnInit, AfterViewInit, OnChanges 
     this.changeLocale(locale);
   }
 
+  rfsSelectionChanges(value: string): void {
+    this.rootFontSize = value === 'initial' ? value : parseInt(value, 10);
+    localStorage.setItem('si-live-preview-rfs', this.rootFontSize.toString());
+  }
+
   changeLocale(locale: string): void {
     this.locale = locale;
   }
@@ -612,6 +621,9 @@ export class SiLivePreviewComponent implements OnInit, AfterViewInit, OnChanges 
     }
     if (this.locale) {
       url += '&locale=' + this.locale;
+    }
+    if (this.rootFontSize) {
+      url += '&rfs=' + this.rootFontSize;
     }
     if (this.activeTab === 'react') {
       url += '&t=' + encodeURIComponent(this.templateReact) + '&framework=react';

--- a/projects/live-preview/helpers/utils.ts
+++ b/projects/live-preview/helpers/utils.ts
@@ -18,6 +18,15 @@ export const setDirectionRtl = (rtl: boolean): void => {
   document.documentElement.setAttribute('dir', rtl ? 'rtl' : 'ltr');
 };
 
+export const setRootFontSize = (rfs: number | 'initial'): void => {
+  const htmlTag = document.documentElement;
+  if (!rfs) {
+    htmlTag.style.removeProperty('font-size');
+  } else {
+    htmlTag.style.setProperty('font-size', rfs === 'initial' ? rfs : rfs + 'px');
+  }
+};
+
 export const provideExampleRoutes = (routes: Route[]): Provider => {
   return {
     provide: SI_LIVE_PREVIEW_EXAMPLE_ROUTES,

--- a/projects/live-preview/interfaces/live-preview-config.ts
+++ b/projects/live-preview/interfaces/live-preview-config.ts
@@ -19,6 +19,7 @@ export interface SiLivePreviewConfig {
   rtlSwitcher?: boolean;
   landscapeToggle?: boolean;
   webcomponents?: boolean;
+  rootFontSizes?: number[];
 }
 
 export interface SiLivePreviewInternals {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -133,7 +133,8 @@ export const APP_CONFIG: ApplicationConfig = {
           ticketBaseUrl: 'https://github.com/siemens/element/issues/new',
           themeSwitcher: true,
           rtlSwitcher: true,
-          webcomponents: true
+          webcomponents: true,
+          rootFontSizes: [] // enable: [16, 24, 32]
         },
         false
       )


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1865/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1865/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1865/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1865/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1865/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1865/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1865/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1865/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1865/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1865/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



