### PR TITLE
fix(dashboard-card): display subHeading

### DIFF
--- a/playwright/e2e/dashboards-demo/dashboard.spec.ts
+++ b/playwright/e2e/dashboards-demo/dashboard.spec.ts
@@ -147,7 +147,7 @@ test.describe('dashboard', () => {
     await expect(page.getByLabel('Edit')).toBeVisible();
     const editBtn = page.getByLabel('Edit');
     await editBtn.click();
-    const pieChart = page.getByText('Pie Chart', { exact: true }).locator('..');
+    const pieChart = page.locator('si-dashboard-card').filter({ hasText: 'Pie Chart' });
     await pieChart.getByLabel('Remove').click();
     await page.waitForTimeout(100);
     await expect(page.locator('si-delete-confirmation-dialog')).toBeVisible();

--- a/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5593e79383d437b0e636fbc5f6fac988642ec56f0d23040eaa78a85ed59cc72
-size 9743
+oid sha256:7e55f1bd21abcacd61a99908bcfe1401b2665a6ce832231c2d3630b3e30e8f60
+size 12152

--- a/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ee5c230ffc0fb39bc8c8b1c7b2b080d8223728dfbd556cc96691beee44196ae
-size 9105
+oid sha256:d5a2a5bd843fdc24c722104777eca1e6141f11a5eafba7d298f3cf836ad19a04
+size 11506

--- a/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card.yaml
@@ -1,4 +1,4 @@
-- text: Natural Gas Usage
+- text: Natural Gas Usage Shows the usage of natural gas
 - button "Toggle"
 - paragraph: Some quick example text to build on the card title and make up the bulk of the card's content.
 - button "Expand"

--- a/projects/element-ng/dashboard/si-dashboard-card.component.html
+++ b/projects/element-ng/dashboard/si-dashboard-card.component.html
@@ -12,9 +12,16 @@
   @if (heading() || displayContentActionBar()) {
     <div class="card-header d-flex justify-content-between">
       <ng-content #cardHeaderIcon select="[headerIcon]" />
-      @if (heading()) {
-        <div class="text-truncate">{{ heading() | translate }}</div>
-      }
+      <div class="heading">
+        @if (heading()) {
+          <div class="text-truncate si-h5">{{ heading() | translate }}</div>
+        }
+        @if (subHeading()) {
+          <div class="text-truncate si-body text-secondary pt-2">{{
+            subHeading() | translate
+          }}</div>
+        }
+      </div>
 
       <div class="cab d-flex ms-6 my-n4 me-n5">
         @if (displayContentActionBar()) {

--- a/projects/element-ng/dashboard/si-dashboard-card.component.scss
+++ b/projects/element-ng/dashboard/si-dashboard-card.component.scss
@@ -16,12 +16,12 @@
   }
 }
 
-.card-header {
-  block-size: map.get(variables.$spacers, 9) + map.get(variables.$spacers, 4); // need to reduce height due to content action button
-}
-
 .text-truncate {
   flex: 0 1 auto;
+}
+
+.heading {
+  overflow: hidden;
 }
 
 .cab {

--- a/projects/element-ng/dashboard/si-dashboard-card.component.spec.ts
+++ b/projects/element-ng/dashboard/si-dashboard-card.component.spec.ts
@@ -12,6 +12,7 @@ describe('SiDashboardCardComponent', () => {
   let fixture: ComponentFixture<SiDashboardCardComponent>;
   let element: HTMLElement;
   let heading: WritableSignal<string>;
+  let subHeading: WritableSignal<string>;
   let primaryActions: WritableSignal<any>;
   let secondaryActions: WritableSignal<any>;
   let enableExpandInteraction: WritableSignal<boolean>;
@@ -24,12 +25,14 @@ describe('SiDashboardCardComponent', () => {
 
   beforeEach(() => {
     heading = signal('');
+    subHeading = signal('');
     primaryActions = signal([]);
     secondaryActions = signal([]);
     enableExpandInteraction = signal(false);
     fixture = TestBed.createComponent(SiDashboardCardComponent, {
       bindings: [
         inputBinding('heading', heading),
+        inputBinding('subHeading', subHeading),
         inputBinding('primaryActions', primaryActions),
         inputBinding('secondaryActions', secondaryActions),
         inputBinding('enableExpandInteraction', enableExpandInteraction)
@@ -42,6 +45,20 @@ describe('SiDashboardCardComponent', () => {
     heading.set('TITLE_KEY');
     await fixture.whenStable();
     expect(element.querySelector('.card-header')!).toHaveTextContent('TITLE_KEY');
+  });
+
+  it('should have a subHeading', async () => {
+    heading.set('TITLE_KEY');
+    subHeading.set('SUB_TITLE_KEY');
+    await fixture.whenStable();
+    expect(element.querySelector('.card-header .heading')!).toHaveTextContent('SUB_TITLE_KEY');
+  });
+
+  it('should not render subHeading when not set', async () => {
+    heading.set('TITLE_KEY');
+    await fixture.whenStable();
+    const subHeadingEl = element.querySelector('.card-header .si-body.text-secondary');
+    expect(subHeadingEl).toBeNull();
   });
 
   describe('content action bar', () => {

--- a/src/app/examples/si-dashboard/si-dashboard-card.html
+++ b/src/app/examples/si-dashboard/si-dashboard-card.html
@@ -4,6 +4,7 @@
       <si-dashboard-card
         #card
         heading="Natural Gas Usage"
+        subHeading="Shows the usage of natural gas"
         [enableExpandInteraction]="enableExpandInteraction()"
         [primaryActions]="primaryActions()"
         [secondaryActions]="secondaryActions()"


### PR DESCRIPTION
Aligned the heading section with si-card. The subHeading input was inherited from `SiCardBaseDirective` but not rendered in the dashboard card template.

Resolves #1874

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1875/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1875/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1875/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1875/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1875/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1875/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1875/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1875/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1875/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1875/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->





