### PR TITLE
fix(pagination): handle page size zero

### DIFF
--- a/projects/element-ng/pagination/si-pagination.component.spec.ts
+++ b/projects/element-ng/pagination/si-pagination.component.spec.ts
@@ -102,4 +102,27 @@ describe('SiPaginationComponent', () => {
     expect(buttons.item(1)).toBeDisabled();
     expect(getCurrentItem()).toHaveTextContent('3');
   });
+
+  it('should calculate total pages from pageSize and totalRowCount', () => {
+    fixture.componentRef.setInput('pageSize', 10);
+    fixture.componentRef.setInput('totalRowCount', 45);
+    fixture.componentRef.setInput('currentPage', 1);
+
+    fixture.detectChanges();
+
+    expect(getItems()).toHaveLength(5);
+    expect(getSeparators()).toHaveLength(0);
+  });
+
+  it('should treat a page size of zero as one item per page', () => {
+    fixture.componentRef.setInput('pageSize', 0);
+    fixture.componentRef.setInput('totalRowCount', 3);
+    fixture.componentRef.setInput('currentPage', 1);
+
+    fixture.detectChanges();
+
+    expect(getItems()).toHaveLength(3);
+    expect(getSeparators()).toHaveLength(0);
+    expect(getCurrentItem()).toHaveTextContent('1');
+  });
 });

--- a/projects/element-ng/pagination/si-pagination.component.ts
+++ b/projects/element-ng/pagination/si-pagination.component.ts
@@ -68,9 +68,10 @@ export class SiPaginationComponent {
    */
   readonly navAriaLabel = input(t(() => $localize`:@@SI_PAGINATION.NAV_LABEL:Pagination`));
 
-  private readonly calculatedTotalPages = computed(
-    () => this.totalPages() ?? Math.ceil((this.totalRowCount() ?? 0) / (this.pageSize() ?? 1))
-  );
+  private readonly calculatedTotalPages = computed(() => {
+    const safePageSize = Math.max(this.pageSize() ?? 0, 1);
+    return this.totalPages() ?? Math.ceil((this.totalRowCount() ?? 0) / safePageSize);
+  });
 
   protected readonly prevDisabled = computed(() => this.currentPage() === 1);
 


### PR DESCRIPTION
Inconsistent state when pagesize is zero<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1877/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1877/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1877/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1877/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1877/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1877/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1877/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1877/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1877/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1877/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



