### PR TITLE
refactor(dashboards-ng): avoid unnecessary lookups

### DIFF
--- a/projects/dashboards-ng/src/components/grid/si-grid.component.ts
+++ b/projects/dashboards-ng/src/components/grid/si-grid.component.ts
@@ -416,9 +416,9 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private updateWidgetPositions(widgetConfigs: WidgetConfig[]): WidgetConfig[] {
-    const layout = this.gridStackWrapper().getLayout();
+    const wrapper = this.gridStackWrapper();
     const widgets = widgetConfigs.map(widget => {
-      const position = layout.find(p => p.id === widget.id);
+      const position = wrapper.getWidgetLayout(widget.id);
       if (
         position &&
         (widget.x !== position.x ||

--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
@@ -173,8 +173,8 @@ describe('SiGridstackWrapperComponent', () => {
     });
   });
 
-  describe('#getLayout()', () => {
-    it('should return layout of grid items', async () => {
+  describe('#getWidgetLayout()', () => {
+    it('should return layout for a given widget id', async () => {
       fixture = TestBed.createComponent(HostComponent);
       host = fixture.componentInstance;
       gridService.widgetCatalog.set([TEST_WIDGET]);
@@ -182,26 +182,25 @@ describe('SiGridstackWrapperComponent', () => {
       fixture.detectChanges();
       // to avoid injector destroyed error
       await new Promise(resolve => setTimeout(resolve, 0));
-      const layout = host.gridStackWrapper()!.getLayout();
-      expect(layout).toBeDefined();
-      expect(layout.length).toBe(TEST_WIDGET_CONFIGS.length);
-      layout.forEach(position => {
-        const wg = TEST_WIDGET_CONFIGS.find(wc => wc.id === position.id)!;
-        expect(position.x).toBe(wg.x);
-        expect(position.y).toBe(wg.y);
-        expect(position.width).toBe(wg.width);
-        expect(position.height).toBe(wg.height);
+      TEST_WIDGET_CONFIGS.forEach(wg => {
+        const position = host.gridStackWrapper()!.getWidgetLayout(wg.id);
+        expect(position).toBeDefined();
+        expect(position!.id).toBe(wg.id);
+        expect(position!.x).toBe(wg.x);
+        expect(position!.y).toBe(wg.y);
+        expect(position!.width).toBe(wg.width);
+        expect(position!.height).toBe(wg.height);
       });
     });
 
-    it('should return empty array without widgets', () => {
+    it('should return undefined for unknown widget id', () => {
       fixture = TestBed.createComponent(HostComponent);
       host = fixture.componentInstance;
       gridService.widgetCatalog.set([TEST_WIDGET]);
       host.widgets = [];
       fixture.detectChanges();
-      const layout = host.gridStackWrapper()!.getLayout();
-      expect(layout).toEqual([]);
+      const position = host.gridStackWrapper()!.getWidgetLayout('non-existent-id');
+      expect(position).toBeUndefined();
     });
   });
 

--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.ts
@@ -160,21 +160,23 @@ export class SiGridstackWrapperComponent implements OnInit, OnChanges {
     }
   }
 
-  getLayout(): WidgetPositionConfig[] {
-    const gridItems = this.grid?.getGridItems();
-    if (gridItems.length > 0) {
-      const positions = gridItems.map(gridItemHTMLElement => {
-        const id = gridItemHTMLElement.getAttribute('item-id')!;
-        const x = Number(gridItemHTMLElement.getAttribute('gs-x')) || 0;
-        const y = Number(gridItemHTMLElement.getAttribute('gs-y')) || 0;
-        const width = Number(gridItemHTMLElement.getAttribute('gs-w')) || 0;
-        const height = Number(gridItemHTMLElement.getAttribute('gs-h')) || 0;
-        return { id, x, y, width, height };
-      });
-      return positions;
-    } else {
-      return [];
+  /**
+   *
+   * Returns the position of a specific widget in the grid.
+   */
+  getWidgetLayout(widgetId: string): WidgetPositionConfig | undefined {
+    const gridItem = this.gridItemsMap().get(widgetId);
+    if (!gridItem) {
+      return undefined;
     }
+    const element = gridItem.component.location.nativeElement as HTMLElement;
+    return {
+      id: widgetId,
+      x: Number(element.getAttribute('gs-x')) || 0,
+      y: Number(element.getAttribute('gs-y')) || 0,
+      width: Number(element.getAttribute('gs-w')) || 0,
+      height: Number(element.getAttribute('gs-h')) || 0
+    };
   }
 
   private updateLayout(widgets: WidgetConfig[]): void {


### PR DESCRIPTION
- Add getWidgetLayout(widgetId) to SiGridstackWrapperComponent using O(1) Map lookup via stored ComponentRef
- Update SiGridComponent.updateWidgetPositions to use getWidgetLayout instead of getLayout with linear search

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1881/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1881/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1881/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1881/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1881/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1881/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1881/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1881/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1881/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1881/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


