### PR TITLE
fix(datepicker): correctly classify noon as PM in si-timepicker merid…

### DIFF
--- a/projects/element-ng/datepicker/si-timepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.spec.ts
@@ -189,6 +189,19 @@ describe('SiTimepickerComponent', () => {
       expect(component.picker().isPM()).toBe(false);
     });
 
+    it('should show PM meridian for noon (12:xx in 24h)', () => {
+      component.time.setValue('2022-01-12 11:59:59.000');
+      fixture.detectChanges();
+      expect(component.picker().isPM()).toBe(false);
+
+      component.time.setValue('2022-01-12 12:30:00.000');
+      fixture.detectChanges();
+
+      expect(component.picker().isPM()).toBe(true);
+      const select = element.querySelector<HTMLSelectElement>('select');
+      expect(select?.value).toBe('pm');
+    });
+
     it('should falsify isPM when meridian is hidden', () => {
       fixture.detectChanges();
       component.time.setValue('2022-01-12 16:23:59.435');

--- a/projects/element-ng/datepicker/si-timepicker.component.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.ts
@@ -489,9 +489,12 @@ export class SiTimepickerComponent implements ControlValueAccessor, Validator, S
 
       let hours = time.getHours();
       if (this.use12HourClock()) {
-        // 12:00 am is midnight while 12:00 pm is noon when users enter a value greater than 12 we can assume it's pm
-        this.meridian.set(hours > 12 ? 'pm' : 'am');
-        this.meridianChange.emit(this.meridian());
+        // 12:00 am is midnight while 12:00 pm is noon; hours >= 12 means PM
+        const meridian = hours >= 12 ? 'pm' : 'am';
+        if (this.meridian() !== meridian) {
+          this.meridian.set(meridian);
+          this.meridianChange.emit(this.meridian());
+        }
         hours = hours % 12;
         if (hours === 0) {
           hours = 12;


### PR DESCRIPTION
…ian detection

fixes #1886

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1887/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1887/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1887/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1887/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1887/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1887/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1887/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1887/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1887/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1887/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


