### PR TITLE
feat(dashboards-ng): add translation support for widget name, description, and heading

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -288,10 +288,10 @@ export type WebComponent = CommonFactoryFields & {
 export interface Widget {
     componentFactory: WidgetComponentFactory;
     defaults?: Pick<WidgetConfig, 'width' | 'height' | 'minWidth' | 'minHeight' | 'heading' | 'expandable' | 'immutable' | 'image' | 'accentLine'>;
-    description?: string;
+    description?: TranslatableString;
     iconClass?: string;
     id: string;
-    name: string;
+    name: TranslatableString;
     payload?: any;
     version?: string;
 }
@@ -308,7 +308,7 @@ export interface WidgetConfig {
     // (undocumented)
     actionBarViewType?: ViewType;
     expandable?: boolean;
-    heading?: string;
+    heading?: TranslatableString;
     height?: number;
     id: string;
     image?: WidgetImage;

--- a/projects/dashboards-demo/src/app/components/widget-catalog/custom-widget-catalog.component.html
+++ b/projects/dashboards-demo/src/app/components/widget-catalog/custom-widget-catalog.component.html
@@ -18,8 +18,8 @@
     >
       <si-circle-status class="my-n4 me-5" [icon]="myDescriptor.iconClass" />
       <div class="d-flex flex-column align-items-start">
-        <span class="si-h5">{{ myDescriptor.name }}</span>
-        <span class="si-body">{{ myDescriptor.description }}</span>
+        <span class="si-h5">{{ myDescriptor.name | translate }}</span>
+        <span class="si-body">{{ myDescriptor.description | translate }}</span>
       </div>
     </button>
   </div>

--- a/projects/dashboards-demo/src/app/widgets/charts/widget-descriptors.ts
+++ b/projects/dashboards-demo/src/app/widgets/charts/widget-descriptors.ts
@@ -21,11 +21,9 @@ const loaderFunction = async (name: string): Promise<any> => {
 };
 
 export const LINE_CHART_DESC: Widget = {
-  name: 'Line Chart',
+  name: 'WIDGET.LINE_CHART',
   id: '@siemens/dashboards-demo/line-chart',
-  description: `A line chart is a type of chart used to show information that changes over time.\
-  Line charts are created by plotting a series of several points and connecting them with a straight line.\
-  Line charts are used to track changes over short and long periods.`,
+  description: 'WIDGET.LINE_CHART_DESC',
   iconClass: 'element-trend',
   componentFactory: {
     componentName: 'CartesianComponent',

--- a/projects/dashboards-demo/src/assets/i18n/de.json
+++ b/projects/dashboards-demo/src/assets/i18n/de.json
@@ -10,7 +10,8 @@
   "WIDGET": {
     "LINE_CHART": "Liniendiagramm",
     "BAR_CHART": "Balkendiagramm",
-    "CIRCLE_CHART": "Kuchendiagramm"
+    "CIRCLE_CHART": "Kuchendiagramm",
+    "LINE_CHART_DESC": "Ein Liniendiagramm ist eine Diagrammart, die verwendet wird, um Informationen darzustellen, die sich im Laufe der Zeit ändern. Liniendiagramme werden erstellt, indem mehrere Punkte eingezeichnet und mit einer geraden Linie verbunden werden. Liniendiagramme werden verwendet, um Veränderungen über kurze und lange Zeiträume zu verfolgen."
   },
   "TOOLBAR": {
     "SAVE_AS_DEFAULTS": "Als Standard speichern",

--- a/projects/dashboards-demo/src/assets/i18n/en.json
+++ b/projects/dashboards-demo/src/assets/i18n/en.json
@@ -10,7 +10,8 @@
   "WIDGET": {
     "LINE_CHART": "Line Chart",
     "BAR_CHART": "Bar Chart",
-    "CIRCLE_CHART": "Circle Chart"
+    "CIRCLE_CHART": "Circle Chart",
+    "LINE_CHART_DESC": "A line chart is a type of chart used to show information that changes over time.  Line charts are created by plotting a series of several points and connecting them with a straight line.  Line charts are used to track changes over short and long periods."
   },
   "TOOLBAR": {
     "SAVE_AS_DEFAULTS": "Save as defaults",

--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.html
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.html
@@ -31,8 +31,8 @@
               >
                 <si-circle-status class="my-n4 me-5" [icon]="widget.iconClass" />
                 <div class="d-flex flex-column align-items-start align-self-center">
-                  <span class="si-h5">{{ widget.name }}</span>
-                  <span class="si-body">{{ widget.description?.trim() }}</span>
+                  <span class="si-h5">{{ widget.name | translate }}</span>
+                  <span class="si-body">{{ widget.description?.trim() | translate }}</span>
                 </div>
               </li>
             }

--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.spec.ts
@@ -8,7 +8,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ModalRef } from '@siemens/element-ng/modal';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
-import { firstValueFrom } from 'rxjs';
+import {
+  provideMockTranslateServiceBuilder,
+  SiTranslateService
+} from '@siemens/element-translate-ng/translate';
+import { firstValueFrom, NEVER } from 'rxjs';
 
 import { TEST_WIDGET } from '../../../test/test-widget/test-widget';
 import { createTestingWidget, TestingModule } from '../../../test/testing.module';
@@ -282,5 +286,75 @@ describe('SiWidgetCatalogComponent', () => {
       fixture.debugElement.query(By.css('.si-layout-fixed-height')).children[0].nativeElement
         .tagName
     ).not.toBe('SI-TEST-WIDGET-EDITOR');
+  });
+
+  describe('Widget name and description translation', () => {
+    const translations: Record<string, string> = {
+      'WIDGET.NAME_KEY': 'Translated Widget Name',
+      'WIDGET.DESCRIPTION_KEY': 'Translated Widget Description'
+    };
+
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [TestingModule, SiWidgetCatalogComponent],
+        providers: [
+          { provide: ModalRef, useValue: new ModalRef() },
+          provideMockTranslateServiceBuilder(
+            () =>
+              ({
+                translate: (key: string) => translations[key] ?? key,
+                translateSync: (key: string) => translations[key] ?? key,
+                translationChange: NEVER
+              }) as unknown as SiTranslateService
+          )
+        ]
+      });
+
+      fixture = TestBed.createComponent(SiWidgetCatalogComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should display translated widget name and description', () => {
+      component.widgetCatalog = [
+        {
+          ...createTestingWidget('WIDGET.NAME_KEY', 'translatable-1'),
+          description: 'WIDGET.DESCRIPTION_KEY'
+        }
+      ];
+      fixture.detectChanges();
+
+      const listItems = fixture.debugElement.queryAll(By.css('.list-group-item'));
+      expect(listItems).toHaveLength(1);
+      expect(listItems[0].query(By.css('.si-h5')).nativeElement).toHaveTextContent(
+        'Translated Widget Name'
+      );
+      expect(listItems[0].query(By.css('.si-body')).nativeElement).toHaveTextContent(
+        'Translated Widget Description'
+      );
+    });
+
+    it('should filter widgets by translated name', () => {
+      component.widgetCatalog = [
+        {
+          ...createTestingWidget('WIDGET.NAME_KEY', 'translatable-1'),
+          description: 'WIDGET.DESCRIPTION_KEY'
+        },
+        createTestingWidget('Other Widget', 'other-1')
+      ];
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(2);
+
+      fixture.debugElement
+        .query(By.css('si-search-bar'))
+        .triggerEventHandler('searchChange', 'Translated');
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(1);
+      expect(
+        fixture.debugElement.query(By.css('.list-group-item .si-h5')).nativeElement
+      ).toHaveTextContent('Translated Widget Name');
+    });
   });
 });

--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
@@ -18,7 +18,11 @@ import { SiActionDialogService } from '@siemens/element-ng/action-modal';
 import { SiCircleStatusComponent } from '@siemens/element-ng/circle-status';
 import { SiEmptyStateComponent } from '@siemens/element-ng/empty-state';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
-import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
+import {
+  injectSiTranslateService,
+  SiTranslatePipe,
+  t
+} from '@siemens/element-translate-ng/translate';
 
 import { createWidgetConfig, Widget, WidgetConfig } from '../../model/widgets.model';
 import { SiWidgetEditorBase } from '../si-widget-editor-base';
@@ -92,6 +96,8 @@ export class SiWidgetCatalogComponent extends SiWidgetEditorBase implements OnIn
     () => !!this.selected()?.componentFactory.editorComponentName
   );
 
+  private readonly translateService = injectSiTranslateService();
+
   protected labelCancel = t(() => $localize`:@@DASHBOARD.WIDGET_LIBRARY.CANCEL:Cancel`);
   protected labelPrevious = t(() => $localize`:@@DASHBOARD.WIDGET_LIBRARY.PREVIOUS:Previous`);
   protected labelNext = t(() => $localize`:@@DASHBOARD.WIDGET_LIBRARY.NEXT:Next`);
@@ -158,9 +164,11 @@ export class SiWidgetCatalogComponent extends SiWidgetEditorBase implements OnIn
       this.filteredWidgetCatalog = this.widgetCatalog;
     } else {
       this.searchTerm = searchTerm;
-      this.filteredWidgetCatalog = this.widgetCatalog.filter(wd =>
-        wd.name.toLowerCase().includes(searchTerm.trim().toLowerCase())
-      );
+      const term = searchTerm.trim().toLowerCase();
+      this.filteredWidgetCatalog = this.widgetCatalog.filter(wd => {
+        const name = this.translateService.translateSync(wd.name);
+        return name.toLowerCase().includes(term);
+      });
     }
     if (this.filteredWidgetCatalog.length > 0) {
       this.selectWidget(this.filteredWidgetCatalog[0]);

--- a/projects/dashboards-ng/src/model/widgets.model.ts
+++ b/projects/dashboards-ng/src/model/widgets.model.ts
@@ -6,6 +6,7 @@ import { EventEmitter, InputSignal, OutputEmitterRef, TemplateRef, Type } from '
 import { AccentLineType, MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
 import { ContentActionBarMainItem, ViewType } from '@siemens/element-ng/content-action-bar';
 import { MenuItem } from '@siemens/element-ng/menu';
+import { TranslatableString } from '@siemens/element-translate-ng/translate';
 import { Subject } from 'rxjs';
 
 /**
@@ -19,9 +20,9 @@ export interface Widget {
   /** An optional version string. */
   version?: string;
   /** The name of the widget that is presented in the widget catalog. */
-  name: string;
+  name: TranslatableString;
   /** An optional description that is visible in the widget catalog. */
-  description?: string;
+  description?: TranslatableString;
   /** A CSS icon class that specifies the widget icon, displayed in the catalog. */
   iconClass?: string;
   /** The factory to instantiate a widget instance component that is added to the dashboard. */
@@ -183,7 +184,7 @@ export interface WidgetConfig {
   /**
    * grid item header text.
    */
-  heading?: string;
+  heading?: TranslatableString;
   /** Defines whether the widget instance component can be expanded and enlarged over the dashboard. */
   expandable?: boolean;
   /** A widget specific payload object. Placeholder to pass in additional configuration. */

--- a/projects/dashboards-ng/tsconfig.spec.json
+++ b/projects/dashboards-ng/tsconfig.spec.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["vitest/globals", "@siemens/element-translate-ng/localize-types", "node"],
+    "types": [
+      "vitest/globals",
+      "vitest/browser",
+      "@siemens/element-translate-ng/localize-types",
+      "node"
+    ],
     "lib": ["es2022", "dom", "esnext.disposable"],
     "paths": {
       "@siemens/element-translate-ng": [


### PR DESCRIPTION
Widget names and descriptions in the catalog now support translation keys, allowing localized widget catalog.

The `heading` field in `WidgetConfig` is now typed as `TranslatableString` for consistency with downstream `si-card` components that already apply translation.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1893/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1893/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1893/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1893/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1893/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1893/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1893/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1893/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1893/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1893/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->











