### PR TITLE
fix(form): correct misleading validation messages for date/time bounds

### DIFF
--- a/projects/element-ng/form/si-form-validation-error.service.ts
+++ b/projects/element-ng/form/si-form-validation-error.service.ts
@@ -47,24 +47,22 @@ export const buildDefaults = (): SiFormValidationErrorMapper => ({
     () => $localize`:@@SI_FORM_CONTAINER.ERROR.DATE_FORMAT_START:Invalid start date`
   ),
   maxDate: t(
-    () => $localize`:@@SI_FORM_CONTAINER.ERROR.MAX_DATE:Date prior to {{maxString}} required`
+    () =>
+      $localize`:@@SI_FORM_CONTAINER.ERROR.MAX_DATE:Date up to and including {{maxString}} required`
   ),
-  minDate: t(
-    () => $localize`:@@SI_FORM_CONTAINER.ERROR.MIN_DATE:Date after {{minString}} required`
-  ),
+  minDate: t(() => $localize`:@@SI_FORM_CONTAINER.ERROR.MIN_DATE:Date from {{minString}} required`),
   maxTime: t(
-    () => $localize`:@@SI_FORM_CONTAINER.ERROR.MAX_TIME:Time prior to {{maxString}} required`
+    () =>
+      $localize`:@@SI_FORM_CONTAINER.ERROR.MAX_TIME:Time up to and including {{maxString}} required`
   ),
-  minTime: t(
-    () => $localize`:@@SI_FORM_CONTAINER.ERROR.MIN_TIME:Time after {{minString}} required`
-  ),
+  minTime: t(() => $localize`:@@SI_FORM_CONTAINER.ERROR.MIN_TIME:Time from {{minString}} required`),
   rangeAfterMaxDate: t(
     () =>
-      $localize`:@@SI_FORM_CONTAINER.ERROR.RANGE_AFTER_MAX_DATE:Period prior to {{maxString}} required`
+      $localize`:@@SI_FORM_CONTAINER.ERROR.RANGE_AFTER_MAX_DATE:Period up to and including {{maxString}} required`
   ),
   rangeBeforeMinDate: t(
     () =>
-      $localize`:@@SI_FORM_CONTAINER.ERROR.RANGE_BEFORE_MIN_DATE:Period after {{minString}} required`
+      $localize`:@@SI_FORM_CONTAINER.ERROR.RANGE_BEFORE_MIN_DATE:Period from {{minString}} required`
   ),
   // Time units
   hours: t(


### PR DESCRIPTION
The min/max validation messages implied exclusive bounds (e.g. "Date after 12/03/2025") when the validation is actually inclusive. This caused confusion as the boundary value itself is valid but the message suggested otherwise.

Changed wording from "after"/"prior to" to "on or after"/"on or before" for minDate, maxDate, minTime, maxTime, rangeBeforeMinDate, and rangeAfterMaxDate error messages.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1894/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1894/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1894/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1894/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1894/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1894/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1894/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1894/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1894/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1894/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



