### PR TITLE
fix(charts): retain grid config on theme change

### DIFF
--- a/projects/charts-ng/common/si-chart-base.component.ts
+++ b/projects/charts-ng/common/si-chart-base.component.ts
@@ -940,13 +940,15 @@ export class SiChartBaseComponent implements AfterViewInit, OnChanges, OnInit, O
 
   private modifyTopAlignment(key: string): void {
     const options = this.actualOptions;
-    if (options.grid) {
+    if (options.grid && !this.options()?.grid) {
       const gridOptions = this.getThemeCustomValue([key, 'grid'], {});
       echarts.util.merge(options.grid, gridOptions, true);
     }
 
-    const legendOptions = this.getThemeCustomValue([key, 'legend'], {});
-    options.legend?.forEach(legend => echarts.util.merge(legend, legendOptions, true));
+    if (!this.options()?.legend) {
+      const legendOptions = this.getThemeCustomValue([key, 'legend'], {});
+      options.legend?.forEach(legend => echarts.util.merge(legend, legendOptions, true));
+    }
   }
 
   protected afterChartInit(skipZoom?: boolean): void {

--- a/src/app/examples/si-charts/generic/si-chart-generic.ts
+++ b/src/app/examples/si-charts/generic/si-chart-generic.ts
@@ -17,6 +17,12 @@ import { SiResizeObserverDirective } from '@siemens/element-ng/resize-observer';
 export class SampleComponent {
   public genericChartOptions: EChartOption = {
     color: ['#66CAEC', '#006486', '#FA848C'],
+    grid: {
+      top: 100,
+      bottom: 40,
+      left: 70,
+      right: 70
+    },
     tooltip: {
       trigger: 'axis',
       axisPointer: {


### PR DESCRIPTION
When the grid config is provided by the user, and theme switch is performed, the grid config from theme is taken and overrides the one from user

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1898/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



