### PR TITLE
refactor(theme): use relative units for pagination

### DIFF
--- a/projects/element-theme/src/styles/bootstrap/_pagination.scss
+++ b/projects/element-theme/src/styles/bootstrap/_pagination.scss
@@ -5,7 +5,7 @@
 
 @use 'sass:map';
 
-$page-button-size: 24px;
+$page-button-size: 1.5rem;
 
 .pagination {
   display: flex;


### PR DESCRIPTION
Uses block-size in rem w/o line-height/padding combination since the items are supposed to be round when possible.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1906/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1906/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1906/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1906/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1906/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1906/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1906/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1906/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1906/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1906/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

