### PR TITLE
refactor(dashboards-ng): simplify si-widget-host creation logic

### DIFF
--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.html
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.html
@@ -1,3 +1,15 @@
 <div class="grid-stack">
-  <ng-container #gridstackContainer />
+  @if (grid) {
+    @for (item of widgetConfigs(); track item.id) {
+      <si-widget-host
+        [grid]="grid"
+        [attr.item-id]="item.id"
+        [editable]="editable()"
+        [widgetConfig]="item"
+        [componentFactory]="widgetCatalogMap().get(item.widgetId)?.componentFactory"
+        (remove)="widgetInstanceRemove.emit(item.id)"
+        (edit)="widgetInstanceEdit.emit(item)"
+      />
+    }
+  }
 </div>

--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
@@ -67,13 +67,10 @@ describe('SiGridstackWrapperComponent', () => {
     });
 
     it('should mount the grid items', async () => {
-      const mountSpy = vi
-        .spyOn(SiGridstackWrapperComponent.prototype, 'mount')
-        .mockImplementation(() => {});
-
       await createComponent(TEST_WIDGET_CONFIGS, new Map([[TEST_WIDGET.id, TEST_WIDGET]]));
 
-      expect(mountSpy).toHaveBeenCalledWith(TEST_WIDGET_CONFIGS);
+      const widgetHosts = fixture.debugElement.queryAll(By.css('si-widget-host'));
+      expect(widgetHosts).toHaveLength(TEST_WIDGET_CONFIGS.length);
     });
 
     it('should render grid items', async () => {
@@ -95,29 +92,23 @@ describe('SiGridstackWrapperComponent', () => {
     });
 
     it('should mount newly added grid items', async () => {
-      const mountSpy = vi.spyOn(component, 'mount');
-
-      widgets.update(current => [...current, TEST_WIDGET_CONFIG_2]);
+      widgets.set([...widgets(), TEST_WIDGET_CONFIG_2]);
       await fixture.whenStable();
 
-      expect(mountSpy).toHaveBeenCalled();
-      expect(mountSpy).toHaveBeenCalledWith([TEST_WIDGET_CONFIG_2]);
+      const widgetHosts = fixture.debugElement.queryAll(By.css('si-widget-host'));
+      expect(widgetHosts).toHaveLength(3);
     });
 
     it('should unmount removed grid items', async () => {
-      const unmountSpy = vi.spyOn(component, 'unmount');
-
       widgets.set([TEST_WIDGET_CONFIG_1]);
       await fixture.whenStable();
 
-      expect(unmountSpy).toHaveBeenCalled();
-      expect(unmountSpy).toHaveBeenCalledWith([TEST_WIDGET_CONFIG_0]);
+      expect(fixture.debugElement.queryAll(By.css('si-widget-host'))).toHaveLength(1);
 
       widgets.set([]);
       await fixture.whenStable();
 
-      expect(unmountSpy).toHaveBeenCalled();
-      expect(unmountSpy).toHaveBeenCalledWith([TEST_WIDGET_CONFIG_1]);
+      expect(fixture.debugElement.queryAll(By.css('si-widget-host'))).toHaveLength(0);
     });
 
     it('should not trigger ngOnChanges on SiWidgetHostComponent when widget config reference is unchanged', async () => {
@@ -153,7 +144,7 @@ describe('SiGridstackWrapperComponent', () => {
   });
 
   describe('#getWidgetLayout()', () => {
-    it.skip('should return layout for a given widget id', async () => {
+    it('should return layout for a given widget id', async () => {
       await createComponent(TEST_WIDGET_CONFIGS, new Map([[TEST_WIDGET.id, TEST_WIDGET]]));
 
       TEST_WIDGET_CONFIGS.forEach(wg => {

--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.ts
@@ -2,27 +2,24 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
+import { isPlatformBrowser } from '@angular/common';
 import {
   ChangeDetectionStrategy,
+  afterNextRender,
   Component,
-  ComponentRef,
   computed,
+  DestroyRef,
   ElementRef,
   inject,
+  Injector,
   input,
-  inputBinding,
-  IterableDiffer,
-  IterableDiffers,
   NgZone,
   OnChanges,
   OnInit,
   output,
-  outputBinding,
-  signal,
+  PLATFORM_ID,
   SimpleChanges,
-  viewChild,
-  ViewContainerRef,
-  WritableSignal
+  viewChildren
 } from '@angular/core';
 import { GridItemHTMLElement, GridStack, GridStackNode, GridStackOptions } from 'gridstack';
 
@@ -43,6 +40,7 @@ export interface GridWrapperEvent {
 
 @Component({
   selector: 'si-gridstack-wrapper',
+  imports: [SiWidgetHostComponent],
   templateUrl: './si-gridstack-wrapper.component.html',
   styleUrl: './si-gridstack-wrapper.component.scss',
   changeDetection: ChangeDetectionStrategy.Default
@@ -90,52 +88,44 @@ export class SiGridstackWrapperComponent implements OnInit, OnChanges {
    */
   readonly widgetInstanceEdit = output<WidgetConfig>();
 
-  readonly gridstackContainer = viewChild('gridstackContainer', { read: ViewContainerRef });
-
-  private grid!: GridStack;
-  private markedForRender: WidgetConfig[] = [];
-  private readonly gridItems = signal<
-    {
-      id: string;
-      component: ComponentRef<SiWidgetHostComponent>;
-    }[]
-  >([]);
-  private readonly gridItemsMap = computed(
-    () => new Map(this.gridItems().map(item => [item.id, item]))
+  private readonly widgetHosts = viewChildren(SiWidgetHostComponent);
+  private readonly widgetHostsMap = computed(
+    () => new Map(this.widgetHosts().map(host => [host.widgetConfig().id, host]))
   );
-  private readonly itemIdAttr = 'item-id';
 
-  private ngZone = inject(NgZone);
-  private elementRef = inject(ElementRef);
-  private iterableDiffers = inject(IterableDiffers);
-  private widgetConfigsDiffer?: IterableDiffer<WidgetConfig>;
-  private readonly widgetConfigSignals = new Map<string, WritableSignal<WidgetConfig>>();
+  protected grid?: GridStack;
+
+  private readonly ngZone = inject(NgZone);
+  private readonly elementRef = inject(ElementRef);
+  private readonly injector = inject(Injector);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly isBrowser = isPlatformBrowser(this.platformId);
+  private readonly destroyRef = inject(DestroyRef);
 
   ngOnChanges(changes: SimpleChanges<this>): void {
-    if (changes.widgetConfigs) {
-      const { currentValue, firstChange } = changes.widgetConfigs;
+    if (changes.widgetConfigs && !changes.widgetConfigs.firstChange) {
+      const configs = changes.widgetConfigs.currentValue;
+      const newIds = new Set(configs.map(w => w.id));
+      const hostMap = this.widgetHostsMap();
 
-      this.grid?.batchUpdate(true);
-      if (firstChange) {
-        this.markedForRender = currentValue;
-        this.widgetConfigsDiffer = this.iterableDiffers
-          .find(currentValue)
-          .create((_, item: WidgetConfig) => item.id);
-      } else {
-        this.diffWidgetConfigs(currentValue);
+      const hasAdds = configs.some(w => !hostMap.has(w.id));
+
+      if (hasAdds) {
+        this.startBatch();
       }
 
-      this.updateLayout(currentValue);
-      this.grid?.batchUpdate(false);
+      if (this.isBrowser) {
+        for (const [id, host] of hostMap) {
+          if (!newIds.has(id)) {
+            this.grid?.removeWidget(host.elementRef);
+          }
+        }
+      }
     }
 
-    if (changes.editable) {
-      const { currentValue, firstChange } = changes.editable;
-
-      if (!firstChange) {
-        this.grid.enableMove(currentValue);
-        this.grid.enableResize(currentValue);
-      }
+    if (changes.editable && !changes.editable.firstChange) {
+      this.grid?.enableMove(changes.editable.currentValue);
+      this.grid?.enableResize(changes.editable.currentValue);
     }
   }
 
@@ -152,27 +142,15 @@ export class SiGridstackWrapperComponent implements OnInit, OnChanges {
     };
 
     this.grid = GridStack.init(options, this.elementRef.nativeElement.firstChild as HTMLElement);
+    this.startBatch();
     this.hookEvents(this.grid);
-
-    this.mount(this.markedForRender);
-    // Run initial diff to prime the differ with the current state
-    this.widgetConfigsDiffer?.diff(this.markedForRender);
+    this.destroyRef.onDestroy(() => this.grid?.destroy());
   }
 
-  mount(items: WidgetConfig[]): void {
-    if (items.length > 0) {
-      items.forEach(item => {
-        this.addToView(item);
-      });
-    }
-  }
-
-  unmount(items: WidgetConfig[]): void {
-    if (items.length > 0) {
-      items.forEach(item => {
-        this.removeFromView(item.id);
-      });
-    }
+  private startBatch(): void {
+    this.grid?.batchUpdate(true);
+    // this ensures that si-widget-host components are rendered before turning off batch mode.
+    afterNextRender(() => this.grid?.batchUpdate(false), { injector: this.injector });
   }
 
   /**
@@ -180,11 +158,11 @@ export class SiGridstackWrapperComponent implements OnInit, OnChanges {
    * Returns the position of a specific widget in the grid.
    */
   getWidgetLayout(widgetId: string): WidgetPositionConfig | undefined {
-    const gridItem = this.gridItemsMap().get(widgetId);
+    const gridItem = this.widgetHostsMap().get(widgetId);
     if (!gridItem) {
       return undefined;
     }
-    const element = gridItem.component.location.nativeElement as HTMLElement;
+    const element = gridItem.elementRef;
     return {
       id: widgetId,
       x: Number(element.getAttribute('gs-x')) || 0,
@@ -192,101 +170,6 @@ export class SiGridstackWrapperComponent implements OnInit, OnChanges {
       width: Number(element.getAttribute('gs-w')) || 0,
       height: Number(element.getAttribute('gs-h')) || 0
     };
-  }
-
-  private updateLayout(widgets: WidgetConfig[]): void {
-    const widgetConfigMap = new Map(widgets.map(w => [w.id, { ...w, w: w.width, h: w.height }]));
-
-    if (this.grid) {
-      const gridItems = this.grid.getGridItems();
-      gridItems.forEach(gridItem => {
-        const itemId = gridItem.getAttribute('item-id');
-        const config = widgetConfigMap.get(itemId!);
-        if (config) {
-          this.grid.update(gridItem, config);
-        }
-      });
-    }
-  }
-
-  private addToView(item: WidgetConfig): void {
-    const configSignal = signal(item);
-    this.widgetConfigSignals.set(item.id, configSignal);
-
-    const componentFactory = computed(
-      () => this.widgetCatalogMap().get(item.widgetId)?.componentFactory
-    );
-
-    const componentRef = this.gridstackContainer()!.createComponent(SiWidgetHostComponent, {
-      bindings: [
-        inputBinding('widgetConfig', configSignal),
-        inputBinding('editable', this.editable),
-        inputBinding('componentFactory', componentFactory),
-        outputBinding<string>('remove', widgetId => {
-          this.widgetInstanceRemove.emit(widgetId);
-        }),
-        outputBinding<WidgetConfig>('edit', widgetConfig => {
-          this.widgetInstanceEdit.emit(widgetConfig);
-        }),
-        outputBinding<Event>('gridEvent', event => {
-          this.gridEvent.emit({ event, grid: this.grid });
-        })
-      ]
-    });
-
-    const element = componentRef.location.nativeElement as HTMLElement;
-    element.setAttribute(this.itemIdAttr, item.id!);
-    this.gridItems.update(items => [...items, { id: item.id!, component: componentRef }]);
-    this.grid.makeWidget(element, {
-      w: item.width,
-      h: item.height,
-      x: item.x,
-      y: item.y,
-      minW: item.minWidth,
-      minH: item.minHeight
-    });
-  }
-
-  private removeFromView(widgetId: string): void {
-    const gridItemElements = this.grid.getGridItems();
-
-    const toRemove = gridItemElements.find(
-      (el: HTMLElement) => el.getAttribute(this.itemIdAttr) === widgetId
-    );
-
-    if (toRemove) {
-      this.grid.removeWidget(toRemove);
-      const gridItemToRemove = this.gridItemsMap().get(widgetId);
-      gridItemToRemove?.component.destroy();
-      this.widgetConfigSignals.delete(widgetId);
-      this.gridItemsMap().delete(widgetId);
-      this.gridItems.set(Array.from(this.gridItemsMap().values()));
-    }
-  }
-
-  /**
-   * Uses IterableDiffer to detect added, removed, and identity-changed items.
-   * Only widgets whose object reference changed get their signal updated.
-   */
-  private diffWidgetConfigs(configs: WidgetConfig[]): void {
-    const changes = this.widgetConfigsDiffer?.diff(configs);
-    if (changes) {
-      const toMount: WidgetConfig[] = [];
-      const toUnmount: WidgetConfig[] = [];
-
-      changes.forEachAddedItem(record => toMount.push(record.item));
-      changes.forEachRemovedItem(record => toUnmount.push(record.item));
-      changes.forEachIdentityChange(record =>
-        this.widgetConfigSignals.get(record.item.id)?.set(record.item)
-      );
-
-      if (toMount.length) {
-        this.mount(toMount);
-      }
-      if (toUnmount.length) {
-        this.unmount(toUnmount);
-      }
-    }
   }
 
   private hookEvents(grid: GridStack): void {

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
@@ -4,11 +4,10 @@
  */
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
-import { NO_ERRORS_SCHEMA, WritableSignal, inputBinding, signal } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { outputToObservable } from '@angular/core/rxjs-interop';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
-import { WidgetComponentFactory } from '@siemens/dashboards-ng';
 import {
   DeleteConfirmationDialogResult,
   SiActionDialogService
@@ -43,7 +42,6 @@ describe('SiWidgetHostComponent', () => {
       let component: SiWidgetHostComponent;
       let fixture: ComponentFixture<SiWidgetHostComponent>;
       let actionDialogService: SiActionDialogMockService;
-      let componentFactory: WritableSignal<WidgetComponentFactory | undefined>;
 
       beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -52,17 +50,17 @@ describe('SiWidgetHostComponent', () => {
           schemas: [NO_ERRORS_SCHEMA]
         }).compileComponents();
 
-        componentFactory = signal(widget.componentFactory);
-        fixture = TestBed.createComponent(SiWidgetHostComponent, {
-          bindings: [
-            inputBinding('componentFactory', componentFactory),
-            inputBinding('widgetConfig', () => TEST_WIDGET_CONFIG_0)
-          ]
-        });
+        fixture = TestBed.createComponent(SiWidgetHostComponent);
         component = fixture.componentInstance;
         actionDialogService = TestBed.inject(
           SiActionDialogService
         ) as unknown as SiActionDialogMockService;
+        fixture.componentRef.setInput('componentFactory', widget.componentFactory);
+        fixture.componentRef.setInput('widgetConfig', TEST_WIDGET_CONFIG_0);
+        fixture.componentRef.setInput('grid', {
+          update: vi.fn(),
+          makeWidget: vi.fn()
+        });
       });
 
       it('should create', () => {
@@ -79,7 +77,7 @@ describe('SiWidgetHostComponent', () => {
       });
 
       it('should not create widget instance without widget', async () => {
-        componentFactory.set(undefined);
+        fixture.componentRef.setInput('componentFactory', undefined);
         vi.useFakeTimers();
         vi.advanceTimersByTime(0);
         await fixture.whenStable();

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
@@ -39,7 +39,7 @@ import {
   SiTranslatePipe,
   t
 } from '@siemens/element-translate-ng/translate';
-import { GridItemHTMLElement, GridStackNode } from 'gridstack';
+import { GridStack, GridItemHTMLElement, GridStackNode } from 'gridstack';
 import { first } from 'rxjs';
 
 import {
@@ -67,12 +67,14 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
   private readonly destroyRef = inject(DestroyRef);
   private readonly translateService = injectSiTranslateService();
   private readonly liveAnnouncer = inject(LiveAnnouncer);
-  private readonly elementRef = inject<ElementRef<GridItemHTMLElement>>(ElementRef).nativeElement;
+  /** @internal */
+  readonly elementRef = inject<ElementRef<GridItemHTMLElement>>(ElementRef).nativeElement;
 
   /** @defaultValue false */
   readonly keyboardActive = signal(false);
 
   readonly widgetConfig = input.required<WidgetConfig>();
+  readonly grid = input<GridStack>();
 
   /**
    * The component factory for this widget's type.
@@ -192,6 +194,20 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.widgetConfig) {
+      const options = {
+        ...this.widgetConfig(),
+        w: this.widgetConfig().width,
+        h: this.widgetConfig().height,
+        x: this.widgetConfig().x,
+        y: this.widgetConfig().y,
+        minW: this.widgetConfig().minWidth,
+        minH: this.widgetConfig().minHeight
+      };
+      if (!changes.widgetConfig.firstChange) {
+        this.grid()?.update(this.elementRef, options);
+      } else {
+        this.grid()?.makeWidget(this.elementRef, options);
+      }
       if (this.widgetRef) {
         if (isSignal(this.widgetRef.instance.config)) {
           this.widgetRef.setInput('config', this.widgetConfig());


### PR DESCRIPTION
Replace imperative `ViewContainerRef` based widget host creation with declarative `@for` loop in the gridstack wrapper template. Each `si-widget-host` now registers itself with the grid via its own `ngOnInit/ngOnChanges` lifecycle, removing the need for `IterableDiffer`, manual signal wiring, and the mount/unmount methods.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1907/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1907/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1907/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1907/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1907/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1907/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1907/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1907/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1907/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1907/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->








