### PR TITLE
docs(tables): simplify naming of our tables section

### DIFF
--- a/docs/components/lists-tables-trees/overview.md
+++ b/docs/components/lists-tables-trees/overview.md
@@ -1,20 +1,17 @@
-# Tables & datatables
+# Tables
 
 They are used to organize and display structured information in rows and columns,
 enabling users to scan, compare, and analyze data efficiently.
-
-When tables handle large datasets and include features such as sorting, filtering
-or lazy loading, they are considered **datatables**.
 
 ## Usage ---
 
 Element covers three different implementations, each suited to different levels of complexity and scale:
 
 - [HTML table](../lists-tables-trees/HTML-table.md): simple, static, HTML-based tables.
-- [NGX-datatable](../lists-tables-trees/NGX-datatable.md): datatable for medium to large datasets,
+- [NGX-datatable](../lists-tables-trees/NGX-datatable.md): data table for medium to large datasets
   with built-in features like sorting and filtering.
-- [AG Grid](../lists-tables-trees/ag-grid.md): advanced datatable for complex, enterprise scenarios,
-  with extensive functionality (paid license required).
+- [AG Grid](../lists-tables-trees/ag-grid.md): advanced data grid for complex, enterprise scenarios
+  with extensive functionality **(paid license required)**.
 
 ### When to use
 


### PR DESCRIPTION
Since we have now three different table variants which we list and describe, I think we should simplify the title to the most generic term that fits all variants for easier readability.

Also, with "datatable" we were always refering to the "ngx-datatable" component. AG grid is usually referred to as "data grid". So I don't think it's necessary to define here a terminology to create a distinction between basic tables and more advanced tables. We already list and describe each variant which should be enough for the user to understand what is what.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1910/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1910/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1910/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1910/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1910/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1910/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1910/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1910/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1910/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1910/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

