### PR TITLE
fix(live-preview): rendering error text not readable

### DIFF
--- a/projects/live-preview/components/si-live-preview/si-live-preview.component.html
+++ b/projects/live-preview/components/si-live-preview/si-live-preview.component.html
@@ -431,7 +431,9 @@
       </div>
       <div #consoleContainer class="scroller">
         @if (renderingError) {
-          <pre class="alert-danger"><code>{{ renderingError.toString() }}</code></pre>
+          <pre
+            class="alert-danger"
+          ><code class="bg-none">{{ renderingError.toString() }}</code></pre>
         }
         @if (!renderingError && logMessages.length) {
           <ul>

--- a/projects/live-preview/components/si-live-preview/si-live-preview.component.scss
+++ b/projects/live-preview/components/si-live-preview/si-live-preview.component.scss
@@ -161,6 +161,10 @@ $font-size-small: 11px;
       }
     }
 
+    code.bg-none {
+      background: none;
+    }
+
     ul {
       list-style: none;
       margin: 0;


### PR DESCRIPTION
remove default background on `code` so that error text is visible inside alert-danger container

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1912/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1912/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1912/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1912/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1912/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1912/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1912/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1912/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1912/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1912/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

