### PR TITLE
refactor(navbar-vertical-next): extract search functionality into a new component

### DIFF
--- a/api-goldens/element-ng/navbar-vertical-next/index.api.md
+++ b/api-goldens/element-ng/navbar-vertical-next/index.api.md
@@ -24,10 +24,6 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
     expand(): void;
     readonly navbarCollapseButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly navbarExpandButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
-    readonly searchable: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly searchDebounceTime: _angular_core.InputSignal<number>;
-    readonly searchEvent: _angular_core.OutputEmitterRef<string>;
-    readonly searchPlaceholder: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly skipLinkMainContentLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly skipLinkNavigationLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly stateId: _angular_core.InputSignal<string | undefined>;
@@ -79,6 +75,13 @@ export class SiNavbarVerticalNextItemComponent implements OnInit {
 
 // @public (undocumented)
 export class SiNavbarVerticalNextModule {
+}
+
+// @public (undocumented)
+export class SiNavbarVerticalNextSearchComponent {
+    readonly debounceTime: _angular_core.InputSignal<number>;
+    readonly placeholder: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
+    readonly searchChange: _angular_core.OutputEmitterRef<string>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/projects/element-ng/navbar-vertical-next/index.ts
+++ b/projects/element-ng/navbar-vertical-next/index.ts
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 export * from './si-navbar-vertical-items-next.component';
-export * from './si-navbar-vertical-next.component';
 export * from './si-navbar-vertical-next-divider.component';
-export * from './si-navbar-vertical-next-group.component';
 export * from './si-navbar-vertical-next-group-trigger.directive';
+export * from './si-navbar-vertical-next-group.component';
 export * from './si-navbar-vertical-next-header.component';
 export * from './si-navbar-vertical-next-item.component';
+export * from './si-navbar-vertical-next-search.component';
+export * from './si-navbar-vertical-next.component';
 export * from './si-navbar-vertical-next.module';

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.html
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.html
@@ -1,0 +1,17 @@
+<si-search-bar
+  class="mx-4"
+  colorVariant="base-0"
+  prohibitedCharacters="*?"
+  [placeholder]="placeholder() | translate"
+  [debounceTime]="debounceTime()"
+  [showIcon]="true"
+  (searchChange)="searchChange.emit($event)"
+/>
+<button
+  type="button"
+  class="btn-search bg-base-0 p-3 mx-4 mobile navbar-vertical-no-collapse text-secondary"
+  [attr.aria-label]="placeholder() | translate"
+  (click)="expandForSearch()"
+>
+  <si-icon class="icon" [icon]="icons.elementSearch" />
+</button>

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.scss
@@ -1,0 +1,44 @@
+@use 'sass:map';
+@use '@siemens/element-theme/src/styles/all-variables';
+
+:host {
+  display: flex;
+  align-items: center;
+  block-size: 40px;
+  margin-block-start: map.get(all-variables.$spacers, 4);
+  overflow-x: hidden;
+}
+
+:host-context(.nav-collapsed) {
+  display: none;
+
+  si-search-bar {
+    display: none;
+  }
+}
+
+si-search-bar {
+  inline-size: 100%;
+}
+
+.btn-search {
+  display: none;
+  border: 0;
+  border-radius: all-variables.$element-radius-2;
+}
+
+@include all-variables.media-breakpoint-up(sm) {
+  :host-context(:not(.nav-text-only).nav-collapsed) {
+    display: flex;
+  }
+
+  .btn-search {
+    display: none;
+  }
+
+  :host-context(.nav-collapsed) {
+    .btn-search {
+      display: block;
+    }
+  }
+}

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+  output,
+  viewChild
+} from '@angular/core';
+import { elementSearch } from '@siemens/element-icons';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
+import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
+import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
+
+import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
+
+/** @experimental */
+@Component({
+  selector: 'si-navbar-vertical-next-search',
+  imports: [SiIconComponent, SiSearchBarComponent, SiTranslatePipe],
+  templateUrl: './si-navbar-vertical-next-search.component.html',
+  styleUrl: './si-navbar-vertical-next-search.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SiNavbarVerticalNextSearchComponent {
+  protected readonly icons = addIcons({ elementSearch });
+
+  /**
+   * Placeholder text for the search bar
+   *
+   * @defaultValue
+   * ```
+   * t(() => $localize`:@@SI_NAVBAR_VERTICAL.SEARCH_PLACEHOLDER:Search ...`)
+   * ```
+   */
+  readonly placeholder = input(
+    t(() => $localize`:@@SI_NAVBAR_VERTICAL.SEARCH_PLACEHOLDER:Search ...`)
+  );
+
+  /**
+   * Debounce time for the search input
+   * @defaultValue 400
+   */
+  readonly debounceTime = input(400);
+
+  /**
+   * Output for search bar input
+   */
+  readonly searchChange = output<string>();
+
+  private readonly navbar = inject(SI_NAVBAR_VERTICAL_NEXT);
+  private readonly searchBar = viewChild.required(SiSearchBarComponent);
+
+  protected expandForSearch(): void {
+    this.navbar.expand();
+    setTimeout(() => this.searchBar().focus());
+  }
+}

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.html
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.html
@@ -27,27 +27,7 @@
         </button>
       </div>
     </div>
-    @if (searchable()) {
-      <div class="nav-search">
-        <si-search-bar
-          class="mx-4"
-          colorVariant="base-0"
-          prohibitedCharacters="*?"
-          [placeholder]="searchPlaceholder() | translate"
-          [debounceTime]="searchDebounceTime()"
-          [showIcon]="true"
-          (searchChange)="doSearch($event)"
-        />
-        <button
-          type="button"
-          class="btn-search bg-base-0 p-3 mx-4 mobile navbar-vertical-no-collapse text-secondary"
-          [attr.aria-label]="searchPlaceholder() | translate"
-          (click)="expandForSearch()"
-        >
-          <si-icon class="icon" [icon]="icons.elementSearch" />
-        </button>
-      </div>
-    }
+    <ng-content select="si-navbar-vertical-next-search" />
     <ng-content select="si-navbar-vertical-items-next" />
   </nav>
 }

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.scss
@@ -1,4 +1,3 @@
-@use 'sass:map';
 @use '@siemens/element-theme/src/styles/all-variables';
 
 $vertical-nav-width: 240px;
@@ -61,28 +60,6 @@ nav {
   }
 }
 
-.nav-search {
-  display: flex;
-  align-items: center;
-  block-size: 40px;
-  margin-block-start: map.get(all-variables.$spacers, 4);
-  overflow-x: hidden;
-
-  :host(.nav-collapsed) & {
-    display: none;
-  }
-}
-
-si-search-bar {
-  inline-size: 100%;
-}
-
-.btn-search {
-  display: none;
-  border: 0;
-  border-radius: all-variables.$element-radius-2;
-}
-
 :host.nav-collapsed {
   .mobile-drawer {
     border: 0;
@@ -90,10 +67,6 @@ si-search-bar {
     background: all-variables.$element-base-1;
     text-align: end;
     box-shadow: all-variables.$element-elevation-1;
-  }
-
-  si-search-bar {
-    display: none;
   }
 }
 
@@ -123,24 +96,6 @@ si-search-bar {
     .mobile-drawer {
       background: transparent;
       box-shadow: none;
-    }
-
-    &.nav-collapsed {
-      .nav-search {
-        display: flex;
-      }
-    }
-  }
-
-  .btn-search {
-    display: none;
-  }
-
-  :host {
-    &.nav-collapsed {
-      .btn-search {
-        display: block;
-      }
     }
   }
 

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
@@ -12,17 +12,14 @@ import {
   model,
   OnChanges,
   OnInit,
-  output,
   signal,
-  SimpleChanges,
-  viewChild
+  SimpleChanges
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { elementDoubleLeft, elementDoubleRight, elementSearch } from '@siemens/element-icons';
+import { elementDoubleLeft, elementDoubleRight } from '@siemens/element-icons';
 import { SI_UI_STATE_SERVICE } from '@siemens/element-ng/common';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { BOOTSTRAP_BREAKPOINTS } from '@siemens/element-ng/resize-observer';
-import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
 import { SiSkipLinkTargetDirective } from '@siemens/element-ng/skip-links';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
@@ -37,7 +34,7 @@ interface UIState {
 /** @experimental */
 @Component({
   selector: 'si-navbar-vertical-next',
-  imports: [SiIconComponent, SiSearchBarComponent, SiSkipLinkTargetDirective, SiTranslatePipe],
+  imports: [SiIconComponent, SiSkipLinkTargetDirective, SiTranslatePipe],
   templateUrl: './si-navbar-vertical-next.component.html',
   styleUrl: './si-navbar-vertical-next.component.scss',
   providers: [{ provide: SI_NAVBAR_VERTICAL_NEXT, useExisting: SiNavbarVerticalNextComponent }],
@@ -50,32 +47,13 @@ interface UIState {
   }
 })
 export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
-  protected readonly icons = addIcons({ elementDoubleLeft, elementDoubleRight, elementSearch });
+  protected readonly icons = addIcons({ elementDoubleLeft, elementDoubleRight });
   /**
    * Whether the navbar-vertical is collapsed.
    *
    * @defaultValue false
    */
   readonly collapsed = model(false);
-
-  /**
-   * Toggles search bar
-   *
-   * @defaultValue false
-   */
-  readonly searchable = input(false, { transform: booleanAttribute });
-
-  /**
-   * Placeholder text for search
-   *
-   * @defaultValue
-   * ```
-   * t(() => $localize`:@@SI_NAVBAR_VERTICAL.SEARCH_PLACEHOLDER:Search ...`)
-   * ```
-   */
-  readonly searchPlaceholder = input(
-    t(() => $localize`:@@SI_NAVBAR_VERTICAL.SEARCH_PLACEHOLDER:Search ...`)
-  );
 
   /**
    * Set to `true` if there are no icons
@@ -145,18 +123,6 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
   readonly skipLinkMainContentLabel = input(
     t(() => $localize`:@@SI_NAVBAR_VERTICAL.SKIP_LINK.MAIN_LABEL:Main content`)
   );
-  /**
-   * Debounce time for the search input
-   * @defaultValue 400
-   */
-  readonly searchDebounceTime = input(400);
-  /**
-   * Output for search bar input
-   */
-  readonly searchEvent = output<string>();
-
-  private readonly searchBar = viewChild.required(SiSearchBarComponent);
-
   private uiStateService = inject(SI_UI_STATE_SERVICE, { optional: true });
   private breakpointObserver = inject(BreakpointObserver);
 
@@ -228,15 +194,6 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
       this.preferCollapse = this.collapsed();
     }
     this.saveUIState();
-  }
-
-  protected expandForSearch(): void {
-    this.expand();
-    setTimeout(() => this.searchBar().focus());
-  }
-
-  protected doSearch(event: string): void {
-    this.searchEvent.emit(event);
   }
 
   /** @internal */

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.module.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.module.ts
@@ -10,6 +10,7 @@ import { SiNavbarVerticalNextGroupTriggerDirective } from './si-navbar-vertical-
 import { SiNavbarVerticalNextGroupComponent } from './si-navbar-vertical-next-group.component';
 import { SiNavbarVerticalNextHeaderComponent } from './si-navbar-vertical-next-header.component';
 import { SiNavbarVerticalNextItemComponent } from './si-navbar-vertical-next-item.component';
+import { SiNavbarVerticalNextSearchComponent } from './si-navbar-vertical-next-search.component';
 import { SiNavbarVerticalNextComponent } from './si-navbar-vertical-next.component';
 
 /** @experimental */
@@ -21,7 +22,8 @@ import { SiNavbarVerticalNextComponent } from './si-navbar-vertical-next.compone
     SiNavbarVerticalNextGroupComponent,
     SiNavbarVerticalNextGroupTriggerDirective,
     SiNavbarVerticalNextHeaderComponent,
-    SiNavbarVerticalNextItemComponent
+    SiNavbarVerticalNextItemComponent,
+    SiNavbarVerticalNextSearchComponent
   ],
   exports: [
     SiNavbarVerticalItemsNextComponent,
@@ -30,7 +32,8 @@ import { SiNavbarVerticalNextComponent } from './si-navbar-vertical-next.compone
     SiNavbarVerticalNextGroupComponent,
     SiNavbarVerticalNextGroupTriggerDirective,
     SiNavbarVerticalNextHeaderComponent,
-    SiNavbarVerticalNextItemComponent
+    SiNavbarVerticalNextItemComponent,
+    SiNavbarVerticalNextSearchComponent
   ]
 })
 export class SiNavbarVerticalNextModule {}

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
@@ -22,7 +22,8 @@ import {
   SiNavbarVerticalNextComponent,
   SiNavbarVerticalNextGroupComponent,
   SiNavbarVerticalNextGroupTriggerDirective,
-  SiNavbarVerticalNextItemComponent
+  SiNavbarVerticalNextItemComponent,
+  SiNavbarVerticalNextSearchComponent
 } from './index';
 import { SiNavbarVerticalNextHarness } from './testing/si-navbar-vertical-next.harness';
 
@@ -55,19 +56,18 @@ class EmptyComponent {}
     RouterLink,
     RouterLinkActive,
     SiNavbarVerticalItemsNextComponent,
+    SiNavbarVerticalNextSearchComponent,
     SiNavbarVerticalNextComponent,
     SiNavbarVerticalNextGroupComponent,
     SiNavbarVerticalNextGroupTriggerDirective,
     SiNavbarVerticalNextItemComponent
   ],
   template: `<si-navbar-vertical-next
-      [searchable]="true"
       [textOnly]="textOnly()"
       [stateId]="stateId"
       [collapsed]="collapsed()"
-      [searchDebounceTime]="0"
-      (searchEvent)="searchEvent($event)"
     >
+      <si-navbar-vertical-next-search [debounceTime]="0" (searchChange)="searchEvent($event)" />
       @if (showDeclarativeFlyoutGroup()) {
         <si-navbar-vertical-items-next>
           <button

--- a/projects/element-ng/navbar-vertical-next/testing/si-navbar-vertical-next.harness.ts
+++ b/projects/element-ng/navbar-vertical-next/testing/si-navbar-vertical-next.harness.ts
@@ -13,8 +13,8 @@ export class SiNavbarVerticalNextHarness extends ComponentHarness {
   static hostSelector = 'si-navbar-vertical-next';
 
   private readonly collapseToggle = this.locatorFor('.collapse-toggle button');
-  private readonly searchButton = this.locatorFor('.btn-search');
-  private readonly searchInput = this.locatorFor('si-search-bar input');
+  private readonly searchButton = this.locatorFor('si-navbar-vertical-next-search .btn-search');
+  private readonly searchInput = this.locatorFor('si-navbar-vertical-next-search input');
 
   async toggleCollapse(): Promise<void> {
     return this.collapseToggle().then(toggle => toggle.click());

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
@@ -10,9 +10,8 @@
     stateId="navbar-vertical-next-badges"
     navbarCollapseButtonText="collapse"
     navbarExpandButtonText="expand"
-    searchPlaceholder="Search..."
-    [searchable]="true"
   >
+    <si-navbar-vertical-next-search placeholder="Search..." />
     <si-navbar-vertical-items-next>
       <a
         si-navbar-vertical-next-item

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.ts
@@ -16,6 +16,7 @@ import {
   SiHeaderLogoDirective
 } from '@siemens/element-ng/application-header';
 import {
+  SiNavbarVerticalNextSearchComponent,
   SiNavbarVerticalItemsNextComponent,
   SiNavbarVerticalNextComponent,
   SiNavbarVerticalNextDividerComponent,
@@ -30,6 +31,7 @@ import { LOG_EVENT } from '@siemens/live-preview';
   selector: 'app-sample',
   imports: [
     SiNavbarVerticalNextComponent,
+    SiNavbarVerticalNextSearchComponent,
     SiNavbarVerticalItemsNextComponent,
     SiNavbarVerticalNextItemComponent,
     SiNavbarVerticalNextGroupComponent,

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-routing.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-routing.html
@@ -10,9 +10,8 @@
     stateId="navbar-vertical-next-routing"
     navbarCollapseButtonText="collapse"
     navbarExpandButtonText="expand"
-    searchPlaceholder="Search..."
-    [searchable]="true"
   >
+    <si-navbar-vertical-next-search placeholder="Search..." />
     <si-navbar-vertical-items-next>
       <a si-navbar-vertical-next-item routerLink="home" routerLinkActive icon="element-home">
         Home

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-routing.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-routing.ts
@@ -19,6 +19,7 @@ import {
 import { SiBreadcrumbRouterComponent } from '@siemens/element-ng/breadcrumb-router';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
 import {
+  SiNavbarVerticalNextSearchComponent,
   SiNavbarVerticalItemsNextComponent,
   SiNavbarVerticalNextComponent,
   SiNavbarVerticalNextHeaderComponent,
@@ -102,6 +103,7 @@ export const ROUTES: Route[] = [
   selector: 'app-sample',
   imports: [
     SiNavbarVerticalNextComponent,
+    SiNavbarVerticalNextSearchComponent,
     SiNavbarVerticalItemsNextComponent,
     SiNavbarVerticalNextItemComponent,
     SiNavbarVerticalNextHeaderComponent,

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
@@ -10,9 +10,8 @@
     stateId="navbar-vertical-next-with-icons"
     navbarCollapseButtonText="collapse"
     navbarExpandButtonText="expand"
-    searchPlaceholder="Search..."
-    [searchable]="true"
   >
+    <si-navbar-vertical-next-search placeholder="Search..." />
     <si-navbar-vertical-items-next>
       <a si-navbar-vertical-next-item routerLink="home" routerLinkActive icon="element-home">
         Home

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.ts
@@ -16,6 +16,7 @@ import {
   SiHeaderLogoDirective
 } from '@siemens/element-ng/application-header';
 import {
+  SiNavbarVerticalNextSearchComponent,
   SiNavbarVerticalItemsNextComponent,
   SiNavbarVerticalNextComponent,
   SiNavbarVerticalNextDividerComponent,
@@ -30,6 +31,7 @@ import { LOG_EVENT } from '@siemens/live-preview';
   selector: 'app-sample',
   imports: [
     SiNavbarVerticalNextComponent,
+    SiNavbarVerticalNextSearchComponent,
     SiNavbarVerticalItemsNextComponent,
     SiNavbarVerticalNextItemComponent,
     SiNavbarVerticalNextGroupComponent,


### PR DESCRIPTION
Extract search functionality from `SiNavbarVerticalNextComponent` into a new `SiNavbarVerticalNextSearchComponent`. Search is now used via content projection (<si-navbar-vertical-next-search>) instead of input/output bindings (searchable, searchPlaceholder, searchDebounceTime, searchEvent).

See #1792

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1913/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1913/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1913/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1913/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1913/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1913/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1913/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1913/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1913/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1913/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

