### PR TITLE
refactor(timeline-widget): remove ::ng-deep

### DIFF
--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-body.component.scss
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-body.component.scss
@@ -5,10 +5,6 @@
   background-color: variables.$element-base-1;
   flex: auto;
   overflow: hidden;
-
-  si-timeline-widget-item:last-child ::ng-deep .si-timeline-widget-item-lower-line {
-    display: none;
-  }
 }
 
 div {

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.scss
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.scss
@@ -1,0 +1,3 @@
+:host(:last-child) .si-timeline-widget-item-lower-line {
+  display: none;
+}

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-item.component.ts
@@ -113,6 +113,7 @@ export interface SiTimelineWidgetItem {
   selector: 'si-timeline-widget-item',
   imports: [SiIconComponent, SiTranslatePipe, A11yModule, RouterLink, SiMenuModule, CdkMenuTrigger],
   templateUrl: './si-timeline-widget-item.component.html',
+  styleUrl: './si-timeline-widget-item.component.scss',
   host: {
     role: 'listitem'
   }


### PR DESCRIPTION
Remove use of ::ng-deep on parent by moving style to the component itself

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1922/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1922/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1922/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1922/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1922/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1922/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1922/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1922/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1922/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1922/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

