### PR TITLE
chore(gemini): limit OnPush review comment to newly added components

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -23,7 +23,7 @@ conventions and best practices when reviewing code.
 - Use `input()` and `output()` functions instead of decorators
 - Use `computed()` for derived state
 - Use signal queries (`viewChild()`, `viewChildren()`, `contentChild()`, `contentChildren()`) instead of decorator queries (`@ViewChild`, `@ViewChildren`, `@ContentChild`, `@ContentChildren`)
-- Set `changeDetection: ChangeDetectionStrategy.OnPush` in `@Component` decorator
+- Set `changeDetection: ChangeDetectionStrategy.OnPush` in `@Component` decorator. Only flag this for **newly added** components in the PR. Do NOT flag existing components that are missing it — adding OnPush to existing components is out of scope for a PR review.
 - Prefer inline templates for small components
 - Prefer Reactive forms instead of Template-driven ones
 - Do NOT use `ngClass`, use `class` bindings instead


### PR DESCRIPTION
We haven't enabled onpush on certain components by purpose. Gemini shouldn't flag onpush review comment on those.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1923/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1923/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1923/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1923/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1923/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1923/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1923/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1923/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1923/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1923/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
