### PR TITLE
refactor(dashboards-ng): simplify widget editor subscription logic in catalog

### DIFF
--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
@@ -288,23 +288,17 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
           this.widgetInstanceEditor.statusChangesHandler = this.handleStatusChanges.bind(this);
         }
 
-        let hasStatusChangesEmitter = false;
         if (this.widgetInstanceEditor.statusChanges) {
-          hasStatusChangesEmitter = true;
           this.subscriptions.push(
             this.widgetInstanceEditor.statusChanges.subscribe(statusChanges =>
               this.handleStatusChanges(statusChanges)
             )
           );
-        }
-
-        if (this.widgetInstanceEditor.configChange) {
+        } else if (this.widgetInstanceEditor.configChange) {
           this.subscriptions.push(
-            this.widgetInstanceEditor.configChange.subscribe(config => {
-              if (!hasStatusChangesEmitter) {
-                this.widgetConfigModified = true;
-              }
-            })
+            this.widgetInstanceEditor.configChange.subscribe(
+              () => (this.widgetConfigModified = true)
+            )
           );
         }
 


### PR DESCRIPTION
Replaced the statusChanges / configChange subscription block with a cleaner else if structure. The configChange subscription only served as a fallback when statusChanges wasn't available, so the mutable hasStatusChangesEmitter flag and nested condition were unnecessary.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1926/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1926/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1926/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1926/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1926/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1926/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1926/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1926/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1926/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1926/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


