### PR TITLE
refactor(dashboards-ng): remove unused widgetInstanceEditorRef field

### DIFF
--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
@@ -5,7 +5,6 @@
 import { CdkListbox, CdkOption } from '@angular/cdk/listbox';
 import {
   Component,
-  ComponentRef,
   computed,
   EnvironmentInjector,
   inject,
@@ -172,8 +171,6 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
   private readonly editorWizardState = signal<WidgetInstanceEditorWizardState | undefined>(
     undefined
   );
-  private widgetInstanceEditorRef?: ComponentRef<WidgetInstanceEditor>;
-
   private subscriptions: Subscription[] | OutputRefSubscription[] = [];
   private dialogService = inject(SiActionDialogService);
   private injector = inject(Injector);
@@ -280,10 +277,9 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
       this.envInjector
     ).subscribe({
       next: componentRef => {
-        this.widgetInstanceEditorRef = componentRef;
         this.widgetInstanceEditor = componentRef.instance;
         if (isSignal(this.widgetInstanceEditor.config)) {
-          this.widgetInstanceEditorRef.setInput('config', this.widgetConfig);
+          componentRef.setInput('config', this.widgetConfig);
         } else {
           this.widgetInstanceEditor.config = this.widgetConfig!;
         }


### PR DESCRIPTION
The widgetInstanceEditorRef class field was only used to store the componentRef and call setInput on it. Since componentRef is already available in the subscription callback scope, the field is unnecessary. This change removes the field and uses the local componentRef parameter directly, reducing the component's surface area.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1927/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1927/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1927/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1927/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1927/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1927/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1927/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1927/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1927/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1927/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

