### PR TITLE
refactor(theme): use only a min-block-size for .dropdown-item

### DIFF
--- a/projects/element-ng/content-action-bar/si-content-action-bar.component.scss
+++ b/projects/element-ng/content-action-bar/si-content-action-bar.component.scss
@@ -1,5 +1,7 @@
+@use 'sass:map';
 @use '@siemens/element-theme/src/styles/variables/semantic-tokens';
 @use '@siemens/element-theme/src/styles/bootstrap/variables' as bootstrap-variables;
+@use '@siemens/element-theme/src/styles/variables/spacers';
 
 div > [si-content-action-bar-toggle] {
   // The siAutoCollapsableList directive reserves space for the overflow toggle by reading its
@@ -10,7 +12,7 @@ div > [si-content-action-bar-toggle] {
   // items and preventing resize-triggered expand/collapse from reaching a stable state.
   // The fixed inline-size guarantees a deterministic clientWidth at all times so the reserved
   // space matches the toggle's actual footprint the moment it becomes visible.
-  inline-size: calc(1.25rem + 2 * bootstrap-variables.$dropdown-item-padding-y);
+  inline-size: calc(1.25rem + 2 * map.get(spacers.$spacers, 4));
   justify-content: center;
   border-radius: semantic-tokens.$element-button-radius;
 }

--- a/projects/element-theme/src/styles/bootstrap/_badges.scss
+++ b/projects/element-theme/src/styles/bootstrap/_badges.scss
@@ -20,13 +20,13 @@
   padding-inline: variables.$badge-padding-x;
   margin-block: 0;
   margin-inline: map.get(spacers.$spacers, 4);
-  line-height: 1.25rem;
+  line-height: variables.$badge-line-height;
   flex-shrink: 0;
   font-size: typography.$si-font-size-body;
   font-weight: typography.$si-font-weight-body;
   max-inline-size: 24.5ch;
   // Make min-inline-size equal the badge height to create a circular badge when there's only one character.
-  min-inline-size: calc(1.25rem + 2 * #{variables.$badge-padding-y}); // 1.75rem = same as height
+  min-inline-size: variables.$badge-height;
   text-overflow: ellipsis;
   overflow: hidden;
   text-align: center;

--- a/projects/element-theme/src/styles/bootstrap/_dropdowns.scss
+++ b/projects/element-theme/src/styles/bootstrap/_dropdowns.scss
@@ -81,7 +81,7 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  block-size: calc(1lh + 2 * bootstrap-variables.$dropdown-item-padding-y);
+  min-block-size: calc(1lh + 2 * bootstrap-variables.$dropdown-item-padding-y);
   inline-size: 100%;
   padding-block: bootstrap-variables.$dropdown-item-padding-y;
   padding-inline: bootstrap-variables.$dropdown-item-padding-x;
@@ -160,6 +160,7 @@
   white-space: nowrap; // as with > li > a
   font-size: typography.$si-font-size-h5;
   font-weight: typography.$si-font-weight-h5;
+  line-height: bootstrap-variables.$dropdown-line-height;
 }
 
 .dropdown-divider {

--- a/projects/element-theme/src/styles/bootstrap/_dropdowns.scss
+++ b/projects/element-theme/src/styles/bootstrap/_dropdowns.scss
@@ -40,10 +40,16 @@
 
 .dropdown-menu-scroller {
   overflow: auto;
-  // 266px is based on figma and gives 6-8 items. Depending on the number of headings
+  // ~266px with rfs 16px, based on Figma and gives 6-8 items. Depending on the number of headings
   max-block-size: min(
     100vb,
-    calc((1lh + 2 * #{bootstrap-variables.$dropdown-item-padding-y}) * 8.3125) // = 266px with rfs 16px
+    calc(
+      (
+          bootstrap-variables.$dropdown-line-height + #{2 *
+            bootstrap-variables.$dropdown-item-padding-y}
+        ) *
+        8.3125
+    )
   );
 }
 
@@ -90,7 +96,7 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  block-size: calc(1lh + 2 * bootstrap-variables.$dropdown-item-padding-y);
+  min-block-size: calc(1lh + 2 * bootstrap-variables.$dropdown-item-padding-y);
   inline-size: 100%;
   padding-block: bootstrap-variables.$dropdown-item-padding-y;
   padding-inline: bootstrap-variables.$dropdown-item-padding-x;
@@ -169,6 +175,7 @@
   white-space: nowrap; // as with > li > a
   font-size: typography.$si-font-size-h5;
   font-weight: typography.$si-font-weight-h5;
+  line-height: bootstrap-variables.$dropdown-line-height;
 }
 
 .dropdown-divider {

--- a/projects/element-theme/src/styles/bootstrap/_variables.scss
+++ b/projects/element-theme/src/styles/bootstrap/_variables.scss
@@ -437,6 +437,16 @@ $nav-tabs-link-hover-border-color: transparent transparent $nav-tabs-border-colo
 $nav-tabs-link-active-color: semantic-tokens.$element-action-secondary-text-hover !default;
 $nav-tabs-link-active-bg: transparent !default;
 
+// Badges
+$badge-font-size: typography.$si-font-size-body;
+$badge-line-height: 1.25rem;
+$badge-font-weight: typography.$si-font-weight-body;
+$badge-color: semantic-tokens.$element-text-inverse !default;
+$badge-padding-y: map.get(spacers.$spacers, 1);
+$badge-padding-x: map.get(spacers.$spacers, 4);
+$badge-border-radius: 0.75rem;
+$badge-height: calc($badge-line-height + 2 * $badge-padding-y);
+
 // Dropdowns
 //
 // Dropdown menu container and contents.
@@ -445,7 +455,8 @@ $dropdown-padding-x: 0 !default;
 $dropdown-padding-y: map.get(spacers.$spacers, 4) !default;
 $dropdown-spacer: 0.125rem !default;
 $dropdown-font-size: $font-size-base !default;
-$dropdown-line-height: $line-height-base;
+// this is to have room for icon and badges
+$dropdown-line-height: $badge-height;
 $dropdown-color: $body-color !default;
 $dropdown-bg: semantic-tokens.$element-base-1 !default;
 $dropdown-border-radius: semantic-tokens.$element-radius-2 !default;
@@ -454,7 +465,7 @@ $dropdown-divider-margin-y: 4px !default;
 $dropdown-box-shadow: elevation.$element-elevation-2 !default;
 $dropdown-link-color: semantic-tokens.$element-text-primary !default;
 $dropdown-link-disabled-color: semantic-tokens.$element-text-disabled !default;
-$dropdown-item-padding-y: map.get(spacers.$spacers, 4);
+$dropdown-item-padding-y: map.get(spacers.$spacers, 2);
 $dropdown-item-padding-x: map.get(spacers.$spacers, 5);
 $dropdown-header-color: semantic-tokens.$element-text-primary !default;
 
@@ -519,14 +530,6 @@ $popover-arrow-height: 6px;
 $popover-arrow-color: $popover-bg !default;
 
 $popover-arrow-outer-color: $popover-border-color !default;
-
-// Badges
-$badge-font-size: typography.$si-font-size-body;
-$badge-font-weight: typography.$si-font-weight-body;
-$badge-color: semantic-tokens.$element-text-inverse !default;
-$badge-padding-y: map.get(spacers.$spacers, 1);
-$badge-padding-x: map.get(spacers.$spacers, 4);
-$badge-border-radius: 0.75rem;
 
 // Modals
 

--- a/projects/element-theme/src/styles/bootstrap/_variables.scss
+++ b/projects/element-theme/src/styles/bootstrap/_variables.scss
@@ -434,6 +434,17 @@ $nav-tabs-link-hover-border-color: transparent transparent $nav-tabs-border-colo
 $nav-tabs-link-active-color: semantic-tokens.$element-action-secondary-text-hover !default;
 $nav-tabs-link-active-bg: transparent !default;
 
+// Badges
+$badge-font-size: typography.$si-font-size-body;
+$badge-font-weight: typography.$si-font-weight-body;
+$badge-color: semantic-tokens.$element-text-inverse !default;
+$badge-padding-y: map.get(spacers.$spacers, 1);
+$badge-padding-x: map.get(spacers.$spacers, 4);
+$badge-border-radius: 0.75rem;
+$badge-dot-size: 0.625rem;
+$badge-line-height: 1.25rem;
+$badge-height: calc($badge-line-height + 2 * $badge-padding-y);
+
 // Dropdowns
 //
 // Dropdown menu container and contents.
@@ -442,7 +453,8 @@ $dropdown-padding-x: 0 !default;
 $dropdown-padding-y: map.get(spacers.$spacers, 4) !default;
 $dropdown-spacer: 0.125rem !default;
 $dropdown-font-size: $font-size-base !default;
-$dropdown-line-height: $line-height-base;
+// this is to have room for icon and badges
+$dropdown-line-height: $badge-height;
 $dropdown-color: $body-color !default;
 $dropdown-bg: semantic-tokens.$element-base-1 !default;
 $dropdown-border-radius: semantic-tokens.$element-radius-2 !default;
@@ -451,7 +463,7 @@ $dropdown-divider-margin-y: 4px !default;
 $dropdown-box-shadow: elevation.$element-elevation-2 !default;
 $dropdown-link-color: semantic-tokens.$element-text-primary !default;
 $dropdown-link-disabled-color: semantic-tokens.$element-text-disabled !default;
-$dropdown-item-padding-y: map.get(spacers.$spacers, 4);
+$dropdown-item-padding-y: map.get(spacers.$spacers, 2);
 $dropdown-item-padding-x: map.get(spacers.$spacers, 5);
 $dropdown-header-color: semantic-tokens.$element-text-primary !default;
 
@@ -516,15 +528,6 @@ $popover-arrow-height: 6px;
 $popover-arrow-color: $popover-bg !default;
 
 $popover-arrow-outer-color: $popover-border-color !default;
-
-// Badges
-$badge-font-size: typography.$si-font-size-body;
-$badge-font-weight: typography.$si-font-weight-body;
-$badge-color: semantic-tokens.$element-text-inverse !default;
-$badge-padding-y: map.get(spacers.$spacers, 1);
-$badge-padding-x: map.get(spacers.$spacers, 4);
-$badge-border-radius: 0.75rem;
-$badge-dot-size: 0.625rem;
 
 // Modals
 

--- a/src/app/examples/si-notification-item/si-notification-item-popover.html
+++ b/src/app/examples/si-notification-item/si-notification-item-popover.html
@@ -68,7 +68,7 @@
   <ng-template #notifications>
     <si-header-dropdown>
       <div class="d-flex flex-column notification-dropdown">
-        <div class="dropdown-header d-flex justify-content-between align-items-center px-6">
+        <div class="dropdown-header d-flex justify-content-between align-items-center px-6 py-4">
           <span class="si-title-2">Notifications</span>
           <button type="button" class="btn btn-tertiary" (click)="logEvent('Dismiss all')"
             >Dismiss all</button


### PR DESCRIPTION
The largest item in a menu item is the badge, so extend line-height to
that and adjust padding instead. There's no longer a requirement for
a fixed height, rather a min height so that items w/o text content get
the proper height
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1935/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1935/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1935/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1935/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1935/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1935/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1935/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1935/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1935/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1935/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->




