### PR TITLE
fix(list-widget): use translated labels for list widget filtering and sorting

### DIFF
--- a/api-goldens/element-ng/dashboard/index.api.md
+++ b/api-goldens/element-ng/dashboard/index.api.md
@@ -78,7 +78,7 @@ export class SiListWidgetBodyComponent extends SiWidgetBaseDirective<SiListWidge
     readonly link: _angular_core.InputSignal<Link | undefined>;
     readonly numberOfLinks: _angular_core.InputSignal<number>;
     readonly search: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly searchPlaceholderLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
+    readonly searchPlaceholderLabel: _angular_core.InputSignal<TranslatableString>;
     readonly sort: _angular_core.InputSignal<SortOrder | undefined>;
 }
 

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.spec.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.spec.ts
@@ -4,7 +4,13 @@
  */
 import { inputBinding, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  provideMockTranslateServiceBuilder,
+  SiTranslateService
+} from '@siemens/element-translate-ng/translate';
+import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
+import { userEvent } from 'vitest/browser';
 
 import { SiListWidgetBodyComponent, SortOrder } from './si-list-widget-body.component';
 import { SiListWidgetItem } from './si-list-widget-item.component';
@@ -190,5 +196,125 @@ describe('SiListWidgetBodyComponent', () => {
       items = element.querySelectorAll('si-list-widget-item');
       expect(items.length).toBe(6);
     });
+  });
+});
+
+describe('SiListWidgetBodyComponent with translations', () => {
+  const translations: Record<string, string> = {
+    KEY_APPLE: 'Apple',
+    KEY_BANANA: 'Banana',
+    KEY_CHERRY: 'Cherry'
+  };
+
+  let fixture: ComponentFixture<SiListWidgetBodyComponent>;
+  let element: HTMLElement;
+  let value: WritableSignal<SiListWidgetItem[] | undefined>;
+  let sort: WritableSignal<SortOrder | undefined>;
+  let search: WritableSignal<boolean>;
+  const searchInput = (): HTMLInputElement => element.querySelector('input')!;
+
+  beforeEach(() => {
+    value = signal(undefined);
+    sort = signal(undefined);
+    search = signal(false);
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockTranslateServiceBuilder(
+          () =>
+            ({
+              translate: (keys: string | string[]) => {
+                if (typeof keys === 'string') {
+                  return translations[keys] ?? keys;
+                }
+                return Object.fromEntries(keys.map(k => [k, translations[k] ?? k]));
+              },
+              translateAsync: (keys: string | string[]) => {
+                if (typeof keys === 'string') {
+                  return of(translations[keys] ?? keys);
+                }
+                return of(Object.fromEntries(keys.map(k => [k, translations[k] ?? k])));
+              }
+            }) as unknown as SiTranslateService
+        )
+      ]
+    });
+
+    fixture = TestBed.createComponent(SiListWidgetBodyComponent, {
+      bindings: [
+        inputBinding('value', value),
+        inputBinding('sort', sort),
+        inputBinding('search', search)
+      ]
+    });
+    element = fixture.nativeElement;
+  });
+
+  it('should filter by translated label, not translation key', async () => {
+    value.set([
+      { label: 'KEY_APPLE' as any },
+      { label: 'KEY_BANANA' as any },
+      { label: 'KEY_CHERRY' as any }
+    ]);
+    search.set(true);
+    await fixture.whenStable();
+
+    vi.useFakeTimers();
+    // Searching by translated value should find the item
+    await userEvent.fill(searchInput(), 'Banana');
+    vi.advanceTimersByTime(400);
+    await fixture.whenStable();
+
+    let items = element.querySelectorAll('si-list-widget-item');
+    expect(items).toHaveLength(1);
+    expect(items.item(0).textContent).toContain('Banana');
+
+    // Searching by translation key should NOT find the item
+    await userEvent.fill(searchInput(), 'KEY_BANANA');
+    vi.advanceTimersByTime(400);
+    await fixture.whenStable();
+
+    items = element.querySelectorAll('si-list-widget-item');
+    expect(items).toHaveLength(0);
+    vi.useRealTimers();
+  });
+
+  it('should sort by translated label, not translation key', async () => {
+    // Keys in reverse alphabetical order, but translated values are: Apple, Banana, Cherry
+    value.set([
+      { label: 'KEY_CHERRY' as any },
+      { label: 'KEY_APPLE' as any },
+      { label: 'KEY_BANANA' as any }
+    ]);
+    sort.set('ASC');
+    await fixture.whenStable();
+
+    const items = element.querySelectorAll('si-list-widget-item');
+    expect(items).toHaveLength(3);
+    expect(Array.from(items).map(el => el.textContent)).toEqual([
+      expect.stringContaining('Apple'),
+      expect.stringContaining('Banana'),
+      expect.stringContaining('Cherry')
+    ]);
+  });
+
+  it('should filter by translated link title, not translation key', async () => {
+    value.set([
+      { label: { title: 'KEY_APPLE' as any } },
+      { label: { title: 'KEY_BANANA' as any } },
+      { label: { title: 'KEY_CHERRY' as any } }
+    ]);
+    search.set(true);
+    await fixture.whenStable();
+
+    vi.useFakeTimers();
+    await userEvent.fill(searchInput(), 'Cherry');
+    vi.advanceTimersByTime(400);
+    await fixture.whenStable();
+
+    const items = element.querySelectorAll('si-list-widget-item');
+    expect(items).toHaveLength(1);
+    expect(items.item(0).textContent).toContain('Cherry');
+    vi.useRealTimers();
   });
 });

--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.ts
@@ -3,10 +3,17 @@
  * SPDX-License-Identifier: MIT
  */
 import { booleanAttribute, Component, computed, input, model, OnChanges } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { Link } from '@siemens/element-ng/link';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
-import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
+import {
+  injectSiTranslateService,
+  SiTranslatePipe,
+  t,
+  TranslatableString
+} from '@siemens/element-translate-ng/translate';
+import { map, of, switchMap } from 'rxjs';
 
 import { SiWidgetBaseDirective } from '../si-widget-base.directive';
 import { SiListWidgetItem, SiListWidgetItemComponent } from './si-list-widget-item.component';
@@ -29,6 +36,8 @@ export class SiListWidgetBodyComponent
   extends SiWidgetBaseDirective<SiListWidgetItem[]>
   implements OnChanges
 {
+  private readonly translateService = injectSiTranslateService();
+
   /** Optional footer link for the list widget */
   readonly link = input<Link>();
 
@@ -126,9 +135,38 @@ export class SiListWidgetBodyComponent
   /** Used to display the defined number of ghost items */
   protected readonly ghosts = computed(() => new Array(this.numberOfLinks() ?? 6));
 
+  /** Replica of value with pre-translated labels, recomputed when value or language changes. */
+  private readonly translatedItems = toSignal(
+    toObservable(this.value).pipe(
+      switchMap(items => {
+        if (!items) {
+          return of(undefined);
+        }
+        const keys = items.map(item =>
+          typeof item.label === 'object' ? (item.label.title ?? '') : item.label
+        );
+        return this.translateService.translateAsync(keys).pipe(
+          map(translations =>
+            items.map(item => {
+              const key = typeof item.label === 'object' ? (item.label.title ?? '') : item.label;
+              const translatedLabel = (translations[key] ?? key) as TranslatableString;
+              return {
+                ...item,
+                label:
+                  typeof item.label === 'object'
+                    ? { ...item.label, title: translatedLabel }
+                    : translatedLabel
+              };
+            })
+          )
+        );
+      })
+    )
+  );
+
   /** Holds the list items that are displayed. May be filtered and sorted. */
   protected readonly filteredListWidgetItems = computed(() => {
-    const value = this.value();
+    const value = this.translatedItems();
     const sort = this.sort();
     const searchText = this.searchText();
     let filteredListWidgetItems: SiListWidgetItem[] | undefined;


### PR DESCRIPTION
Previously, `filterFn` and `compareFn` operated on raw translation keys instead of the actual translated text. Resolve labels asynchronously via `translateAsync` and cache them as a pre-translated items signal so filtering and sorting match the rendered output.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1940/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1940/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1940/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1940/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1940/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1940/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1940/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1940/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1940/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1940/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->





