### PR TITLE
fix(loading-spinner): update blocking state when toggled at runtime

### DIFF
--- a/api-goldens/element-ng/loading-spinner/index.api.md
+++ b/api-goldens/element-ng/loading-spinner/index.api.md
@@ -12,6 +12,7 @@ import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import * as rxjs from 'rxjs';
 import * as _siemens_element_translate_ng_translate from '@siemens/element-translate-ng/translate';
+import { SimpleChanges } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public (undocumented)

--- a/projects/element-ng/loading-spinner/si-loading-spinner.directive.spec.ts
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.directive.spec.ts
@@ -77,4 +77,19 @@ describe('SiLoadingSpinnerDirective', () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(isLoading()).toBe(false);
   });
+
+  it('should propagate blocking change to si-loading-spinner component', async () => {
+    await vi.advanceTimersByTimeAsync(initialDelay);
+    await vi.advanceTimersByTimeAsync(initialDelay);
+    expect(isLoading()).toBe(true);
+    expect(fixture.nativeElement.querySelector('.blocking-spinner')).not.toBeInTheDocument();
+
+    component.blocking.set(true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fixture.nativeElement.querySelector('.blocking-spinner')).toBeInTheDocument();
+
+    component.blocking.set(false);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fixture.nativeElement.querySelector('.blocking-spinner')).not.toBeInTheDocument();
+  });
 });

--- a/projects/element-ng/loading-spinner/si-loading-spinner.directive.ts
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.directive.ts
@@ -6,6 +6,7 @@ import { ComponentPortal, DomPortalOutlet } from '@angular/cdk/portal';
 import {
   booleanAttribute,
   ChangeDetectorRef,
+  ComponentRef,
   computed,
   Directive,
   ElementRef,
@@ -15,6 +16,7 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
+  SimpleChanges,
   ViewContainerRef
 } from '@angular/core';
 import { BehaviorSubject, combineLatest, merge, Subscription, timer } from 'rxjs';
@@ -62,19 +64,8 @@ export class SiLoadingSpinnerDirective implements OnInit, OnChanges, OnDestroy {
   private readonly initialWaitTime = computed(() => (this.initialDelay() ? 500 : 0));
   private minSpinTime = 500;
   private portalOutlet?: DomPortalOutlet;
-  private readonly compPortal = new ComponentPortal(
-    SiLoadingSpinnerComponent,
-    this.viewRef,
-    Injector.create({
-      providers: [
-        { provide: LOADING_SPINNER_BLOCKING, useFactory: () => this.blocking() },
-        {
-          provide: LOADING_SPINNER_OVERLAY,
-          useValue: true
-        }
-      ]
-    })
-  );
+  private readonly compPortal = new ComponentPortal(SiLoadingSpinnerComponent, this.viewRef);
+  private compPortalRef: ComponentRef<SiLoadingSpinnerComponent> | null = null;
 
   // this makes sure the spinner only displays with a delay of 500ms and stays for 500ms so
   // that it doesn't flicker
@@ -93,8 +84,9 @@ export class SiLoadingSpinnerDirective implements OnInit, OnChanges, OnDestroy {
   );
 
   private createPortal(): void {
+    this.compPortal.injector = this.createPortalInjector();
     this.portalOutlet ??= new DomPortalOutlet(this.el.nativeElement);
-    this.compPortal.attach(this.portalOutlet);
+    this.compPortalRef = this.compPortal.attach(this.portalOutlet);
   }
 
   ngOnInit(): void {
@@ -110,10 +102,13 @@ export class SiLoadingSpinnerDirective implements OnInit, OnChanges, OnDestroy {
     });
   }
 
-  ngOnChanges(): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     const newState = !!this.siLoading();
     if (newState !== this.progressSubject.value) {
       this.progressSubject.next(newState);
+    }
+    if (changes.blocking && this.compPortalRef) {
+      this.compPortalRef.setInput('isBlockingSpinner', this.blocking());
     }
   }
 
@@ -123,5 +118,17 @@ export class SiLoadingSpinnerDirective implements OnInit, OnChanges, OnDestroy {
       this.compPortal.detach();
     }
     this.portalOutlet?.dispose();
+  }
+
+  private createPortalInjector(): Injector {
+    return Injector.create({
+      providers: [
+        { provide: LOADING_SPINNER_BLOCKING, useFactory: () => this.blocking() },
+        {
+          provide: LOADING_SPINNER_OVERLAY,
+          useValue: true
+        }
+      ]
+    });
   }
 }


### PR DESCRIPTION
Recreate the portal injector on each attach and use setInput in ngOnChanges so toggling blocking on siLoading updates the blocking-spinner class on the rendered si-loading-spinner component.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1946/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1946/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1946/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1946/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1946/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1946/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1946/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1946/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1946/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1946/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


