### PR TITLE
fix(status-bar): fix responsive mode items not updating

### DIFF
--- a/api-goldens/element-ng/status-bar/index.api.md
+++ b/api-goldens/element-ng/status-bar/index.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import * as _angular_core from '@angular/core';
-import { DoCheck } from '@angular/core';
 import { ExtendedStatusType } from '@siemens/element-ng/common';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
@@ -16,7 +15,7 @@ import { SimpleChanges } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public
-export class SiStatusBarComponent implements DoCheck, OnDestroy, OnChanges {
+export class SiStatusBarComponent implements OnDestroy, OnChanges {
     constructor();
     readonly allOkText: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly blink: _angular_core.InputSignalWithTransform<boolean, unknown>;
@@ -31,7 +30,7 @@ export class SiStatusBarComponent implements DoCheck, OnDestroy, OnChanges {
 }
 
 // @public (undocumented)
-export class SiStatusBarItemComponent {
+export class SiStatusBarItemComponent implements OnChanges {
     // (undocumented)
     readonly blink: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
@@ -40,6 +39,8 @@ export class SiStatusBarItemComponent {
     readonly color: _angular_core.InputSignal<string | undefined>;
     // (undocumented)
     readonly heading: _angular_core.InputSignal<TranslatableString>;
+    // (undocumented)
+    readonly significanceChange: _angular_core.OutputEmitterRef<void>;
     // (undocumented)
     readonly status: _angular_core.InputSignal<ExtendedStatusType | undefined>;
     // (undocumented)

--- a/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.ts
+++ b/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.ts
@@ -9,6 +9,9 @@ import {
   ElementRef,
   inject,
   input,
+  OnChanges,
+  output,
+  SimpleChanges,
   viewChild
 } from '@angular/core';
 import { ExtendedStatusType } from '@siemens/element-ng/common';
@@ -24,7 +27,7 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
     '[class.clickable]': 'clickable()'
   }
 })
-export class SiStatusBarItemComponent {
+export class SiStatusBarItemComponent implements OnChanges {
   private readonly statusIcons = inject(STATUS_ICON_CONFIG);
   readonly status = input<ExtendedStatusType>();
   readonly value = input.required<TranslatableString | number>();
@@ -36,6 +39,8 @@ export class SiStatusBarItemComponent {
   readonly valueOnly = input<boolean | undefined, unknown>(false, { transform: booleanAttribute });
   /** @defaultValue false */
   readonly clickable = input(false, { transform: booleanAttribute });
+
+  readonly significanceChange = output<void>();
 
   private readonly bg = viewChild.required<ElementRef>('bg');
 
@@ -49,6 +54,17 @@ export class SiStatusBarItemComponent {
   protected readonly background = computed(() =>
     this.blink() && this.status() !== 'success' ? (this.statusIcon()?.background ?? '') : ''
   );
+
+  ngOnChanges(changes: SimpleChanges<this>): void {
+    if (changes.value) {
+      if (
+        (changes.value.previousValue && !changes.value.currentValue) ||
+        (!changes.value.previousValue && changes.value.currentValue)
+      ) {
+        this.significanceChange.emit();
+      }
+    }
+  }
 
   private calculateContrastFix(): boolean {
     // see https://www.w3.org/TR/AERT/#color-contrast

--- a/projects/element-ng/status-bar/si-status-bar.component.html
+++ b/projects/element-ng/status-bar/si-status-bar.component.html
@@ -70,6 +70,7 @@
             [blink]="item.blink !== false && blink()"
             [clickable]="!!item.action"
             [style.flex-basis.%]="responsiveMode ? 100 / responsiveMode : null"
+            (significanceChange)="significanceChanged()"
             (click)="onItemClicked(item)"
             (keydown.enter)="onItemClicked(item)"
           />

--- a/projects/element-ng/status-bar/si-status-bar.component.ts
+++ b/projects/element-ng/status-bar/si-status-bar.component.ts
@@ -8,7 +8,6 @@ import {
   booleanAttribute,
   ChangeDetectionStrategy,
   Component,
-  DoCheck,
   ElementRef,
   inject,
   input,
@@ -68,7 +67,7 @@ let idCounter = 1;
   styleUrl: './si-status-bar.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SiStatusBarComponent implements DoCheck, OnDestroy, OnChanges {
+export class SiStatusBarComponent implements OnDestroy, OnChanges {
   private static readonly itemMinWidth = 100;
   private static readonly itemMaxWidth = 152;
   private static readonly itemSpacing = 4;
@@ -156,6 +155,7 @@ export class SiStatusBarComponent implements DoCheck, OnDestroy, OnChanges {
   protected statusId = `__si-status-bar-${idCounter++}`;
 
   private timer: any;
+  private significanceUpdateTimer: any = 0;
 
   private blinkSubs?: Subscription;
 
@@ -188,14 +188,18 @@ export class SiStatusBarComponent implements DoCheck, OnDestroy, OnChanges {
     this.resizeHandler();
   }
 
-  ngDoCheck(): void {
-    if (this.responsiveMode) {
-      this.calcResponsiveItems();
-    }
-  }
-
   ngOnDestroy(): void {
     this.blinkSubs?.unsubscribe();
+    clearTimeout(this.significanceUpdateTimer);
+  }
+
+  protected significanceChanged(): void {
+    if (this.responsiveMode && !this.significanceUpdateTimer) {
+      this.significanceUpdateTimer = setTimeout(() => {
+        this.significanceUpdateTimer = 0;
+        this.calcResponsiveItems();
+      });
+    }
   }
 
   protected onItemClicked(item: StatusBarItem): void {
@@ -257,6 +261,7 @@ export class SiStatusBarComponent implements DoCheck, OnDestroy, OnChanges {
 
     if (this.responsiveMode) {
       this.contentHeight.set(this.expanded() ? this.content().nativeElement.scrollHeight : 0);
+      this.significanceChanged();
     } else {
       this.expanded.set(0);
       this.placeholderHeight.set(0);


### PR DESCRIPTION
Since zoneless, ngDoCheck() isn't enough to update responsive mode. When the array reference of the input items doesn't change, nothing gets updated.

This PR changes the items to signal a significant change i.e. value from != 0 to 0 and vice versa and then recalculate when needed.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1948/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1948/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1948/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1948/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1948/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1948/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1948/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1948/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1948/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1948/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


