### PR TITLE
fix(header-dropdown): decrement backdrop counter for every nested lev…

### DIFF
--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--account-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--account-expanded-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3144819927477642342cad3e5014665e0325fb24f23025804ef4e4b67da11f25
-size 26146
+oid sha256:d5e4167c4cb38dbdc4fe9960bde29943a1a42870eace3cc915b72bcf5a635e6a
+size 26418

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--account-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--account-expanded-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d130413fd1b61684a15304cdf10c44213356b87b05e7e879b0bb7130fbbc913
-size 25649
+oid sha256:7fde52cbe3f5ab0c07c7645fc097d23f9313788cddabea9b4d0268239535866c
+size 25849

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-account-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-account-expanded-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a0c991e8c2655e71ee25e96ff283ed07e86829d204edbe4ab67543429e0d2d98
-size 18483
+oid sha256:9af71dee8c412b7ae028ea8fed32151f0906be5f3acd7f2c1c60b3c64095ac8d
+size 18673

--- a/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-account-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-application-header.spec.ts-snapshots/si-application-header--si-application-header--mobile-account-expanded-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8747febd1516b52c018c1dd45602bbb85d216010bf68e9a1286d9842ce66907a
-size 17079
+oid sha256:005d8e7e575e00a787c79d8194454e62dbf27aea3bc48b94307908f9fde6bd32
+size 17273

--- a/projects/element-ng/application-header/si-application-header.component.spec.ts
+++ b/projects/element-ng/application-header/si-application-header.component.spec.ts
@@ -124,6 +124,21 @@ describe('SiApplicationHeaderComponent', () => {
       expect(await headerHarness.hasBackdrop()).toBe(false);
     });
 
+    it('should remove backdrop when leaf item of nested dropdown is clicked', async () => {
+      const actionItemHarness = await headerHarness.getActionItem('AItem 1');
+      await actionItemHarness.toggle();
+      expect(await headerHarness.hasBackdrop()).toBe(true);
+      const dropdown1 = await actionItemHarness.getDropdown();
+      const nestedTrigger = await dropdown1.getTrigger('DItem 1');
+      await nestedTrigger.toggle();
+      expect(await headerHarness.hasBackdrop()).toBe(true);
+      await nestedTrigger
+        .getDropdown()
+        .then(dropdown => dropdown.getItem('DItem 2'))
+        .then(item => item.click());
+      expect(await headerHarness.hasBackdrop()).toBe(false);
+    });
+
     it('should have backdrop for collapsible action-item opened', async () => {
       await headerHarness.openCollapsibleActions();
       expect(await headerHarness.hasBackdrop()).toBe(true);

--- a/projects/element-ng/header-dropdown/si-header-dropdown-trigger.directive.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown-trigger.directive.ts
@@ -179,12 +179,13 @@ export class SiHeaderDropdownTriggerDirective implements OnChanges, OnInit, OnDe
       this.parent.openSubmenu = undefined;
     }
 
+    if (this.navbar?.dropdownClosed) {
+      this.navbar?.dropdownClosed(this);
+    }
+
     if (options?.all && this.parent) {
       this.parent.close(options);
     } else {
-      if (this.navbar?.dropdownClosed) {
-        this.navbar?.dropdownClosed(this);
-      }
       this.openChange.emit(false);
     }
   }

--- a/src/app/examples/si-application-header/si-application-header.html
+++ b/src/app/examples/si-application-header/si-application-header.html
@@ -119,7 +119,16 @@
   <si-header-dropdown>
     <div class="dropdown-header">Selection has no effect!</div>
     <button si-header-dropdown-item type="button">German</button>
-    <button si-header-dropdown-item type="button">English</button>
+    <button si-header-dropdown-item type="button" [siHeaderDropdownTriggerFor]="englishVariants">
+      English
+    </button>
+  </si-header-dropdown>
+</ng-template>
+
+<ng-template #englishVariants>
+  <si-header-dropdown>
+    <button si-header-dropdown-item type="button">English (US)</button>
+    <button si-header-dropdown-item type="button">English (UK)</button>
   </si-header-dropdown>
 </ng-template>
 


### PR DESCRIPTION
…el on close

The methode `close({ all: true })` only notified the navbar on the root trigger, so `openDropdownCount` in `SiApplicationHeaderComponent` was decremented once instead of once per open level.
With a nested mobile dropdown this left the backdrop stuck on screen after closing a leaf item.

See https://teams.microsoft.com/l/message/19:e8fc7360327a46d49ec85dcdefce72ca@thread.skype/1776954456854?tenantId=38ae3bcd-9579-4fd4-adda-b42e1495d55a&groupId=0c7848fd-9242-4b46-8ca8-7707d43ce038&parentMessageId=1776954456854&teamName=SiMPL&channelName=General&createdTime=1776954456854

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1951/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1951/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1951/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1951/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1951/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1951/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1951/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1951/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1951/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1951/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

