### PR TITLE
chore(AGENTS.md): prefer `whenStable` in unit tests

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -37,6 +37,13 @@ conventions and best practices when reviewing code.
 - Do NOT use `mutate` on signals, use `update` or `set` instead
 - Do NOT use `effect()` for propagation of state changes — this leads to `ExpressionChangedAfterItHasBeenChecked` errors, infinite circular updates, or unnecessary change detection cycles. Use `computed()` instead to model state that depends on other state
 
+## Async Test Stabilization
+
+- Prefer `await fixture.whenStable()` over repeated `fixture.detectChanges()` calls after interactions or async state changes
+- `whenStable()` waits for pending microtasks, timers, and zone activity to settle, producing more reliable tests than manually pumping change detection
+- Use `fixture.detectChanges()` deliberately for the initial render or when the change detection boundary itself is under test
+- Do NOT chain multiple `detectChanges()` calls hoping to flush async work — use `whenStable()` instead
+
 ## Templates
 
 - Keep templates simple and avoid complex logic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,13 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Keep each test focused on a single behavior with clear arrange / act / assert phases
 - Cover happy paths, boundary conditions, and regression-prone branches. Avoid broad snapshot-style assertions that do not explain the intended behavior
 
+## Async Test Stabilization
+
+- Prefer `await fixture.whenStable()` over repeated `fixture.detectChanges()` calls after interactions or async state changes
+- `whenStable()` waits for pending microtasks, timers, and zone activity to settle, producing more reliable tests than manually pumping change detection
+- Use `fixture.detectChanges()` deliberately for the initial render or when the change detection boundary itself is under test
+- Do NOT chain multiple `detectChanges()` calls hoping to flush async work — use `whenStable()` instead
+
 ## State Management
 
 - Use signals for local component state


### PR DESCRIPTION
Angular recommends this approach.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1954/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1954/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1954/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1954/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1954/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1954/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1954/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1954/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1954/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1954/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
