### PR TITLE
refactor(select): use model signal for `value`

### DIFF
--- a/projects/element-ng/date-range-filter/si-relative-date.component.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.ts
@@ -130,7 +130,10 @@ export class SiRelativeDateComponent implements OnChanges {
     this.value.set(nextValue);
   }
 
-  protected changeUnit(newUnit: string): void {
+  protected changeUnit(newUnit: string | undefined): void {
+    if (newUnit === undefined) {
+      return;
+    }
     this.unit.set(newUnit);
     const item = this.offsetList().find(x => x.value === this.unit())!;
     const roundedOffset = Math.max(1, Math.round(this.value() / item.offset));

--- a/projects/element-ng/phone-number/si-phone-number-input.component.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.ts
@@ -321,7 +321,7 @@ export class SiPhoneNumberInputComponent
     });
   }
 
-  protected countryInput(num: CountryInfo): void {
+  protected countryInput(num: CountryInfo | undefined): void {
     this.selectedCountry = num;
     this.updatePlaceholder();
     this.refreshValueAfterCountryChange();

--- a/projects/element-ng/select/selection/si-select-multi-value.directive.spec.ts
+++ b/projects/element-ng/select/selection/si-select-multi-value.directive.spec.ts
@@ -38,7 +38,7 @@ class TestComponent {
 
   changedValue?: string[];
 
-  valueChange(valueChange: string[]): void {
+  valueChange(valueChange: string[] | undefined): void {
     this.changedValue = valueChange;
   }
 }

--- a/projects/element-ng/select/selection/si-select-selection-strategy.ts
+++ b/projects/element-ng/select/selection/si-select-selection-strategy.ts
@@ -6,10 +6,10 @@ import {
   booleanAttribute,
   computed,
   Directive,
+  effect,
   inject,
   input,
-  Input,
-  output,
+  model,
   signal,
   Signal
 } from '@angular/core';
@@ -40,12 +40,7 @@ export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements Cont
   /**
    * The selected value(s).
    */
-  @Input() set value(value: IV | undefined) {
-    this.updateFromInput(this.toArrayValue(value));
-  }
-
-  /** Emitted when the selection is changed */
-  readonly valueChange = output<IV>();
+  readonly value = model<IV | undefined>();
 
   /**
    * Whether the select control allows to select multiple values.
@@ -57,9 +52,7 @@ export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements Cont
    * Provides the internal value always as an array
    * @internal
    */
-  readonly arrayValue: Signal<readonly T[]> = computed(() =>
-    this.selectOptions.selectedRows().map(option => option.value)
-  );
+  readonly arrayValue: Signal<readonly T[]> = computed(() => this.toArrayValue(this.value()));
 
   /**
    * Registered form callback which shall be called on blur.
@@ -71,6 +64,10 @@ export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements Cont
   protected onChange: (_: any) => void = () => {};
   private readonly disabledNgControl = signal(false);
   private readonly selectOptions = inject<SiSelectOptionsStrategy<T>>(SI_SELECT_OPTIONS_STRATEGY);
+
+  constructor() {
+    effect(() => this.selectOptions.onValueChange(this.arrayValue()));
+  }
 
   registerOnTouched(fn: any): void {
     this.onTouched = fn;
@@ -87,8 +84,7 @@ export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements Cont
   updateFromUser(values: T[]): void {
     const parsedValue = this.fromArrayValue(values);
     this.onChange(parsedValue);
-    this.valueChange.emit(parsedValue);
-    this.selectOptions.onValueChange(values);
+    this.value.set(parsedValue);
   }
 
   setDisabledState(isDisabled: boolean): void {
@@ -96,14 +92,10 @@ export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements Cont
   }
 
   writeValue(obj: any): void {
-    this.updateFromInput(this.toArrayValue(obj));
+    this.value.set(obj);
   }
 
   protected abstract toArrayValue(value: IV | undefined): readonly T[];
 
   protected abstract fromArrayValue(value: readonly T[]): IV;
-
-  private updateFromInput(values: readonly T[]): void {
-    this.selectOptions.onValueChange(values);
-  }
 }

--- a/projects/element-ng/select/si-select.component.spec.ts
+++ b/projects/element-ng/select/si-select.component.spec.ts
@@ -120,7 +120,7 @@ class TestHostMultiComponent {
   readonly readonly = signal(false);
   readonly hasFilter = signal(false);
 
-  selectionChanged: ($event: any[]) => void = () => {};
+  selectionChanged: ($event: any[] | undefined) => void = () => {};
   optionEqualCheckFn = (a: string, b: string): boolean => a.toLowerCase() === b.toLowerCase();
 }
 

--- a/src/app/examples/si-select/si-select-lazy-load.ts
+++ b/src/app/examples/si-select/si-select-lazy-load.ts
@@ -69,7 +69,7 @@ export class SampleComponent {
   disabled = false;
   value: string[] = ['DE'];
 
-  selectionChanged(value: string[]): void {
+  selectionChanged(value: string[] | undefined): void {
     this.logEvent('Selection:', this.value);
   }
 }

--- a/src/app/examples/si-select/si-select.ts
+++ b/src/app/examples/si-select/si-select.ts
@@ -158,7 +158,7 @@ export class SampleComponent {
     );
   }
 
-  selectionChanged(value: string): void {
+  selectionChanged(value: string | undefined): void {
     const option = this.optionsList.find(o => o.type === 'option' && o.value === value);
     this.logEvent(`Selection: ${this.value}, '${option?.label}'`);
   }


### PR DESCRIPTION
The `si-select` selection strategy was still using an `@Input`. This replaces it with a `model`.
As a side effect `valueChange` can now emit undefined. This is actually more correct than the previous approach.

BREAKING CHANGE:
`si-select` is now using a `model` for the `value(Change)` input / output. With that, the type now indicates that undefined can be emitted as well. This may require adjustments when using the `valueChange` event.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
