### PR TITLE
refactor(form-control): use correct variables to calculate the height

### DIFF
--- a/projects/element-theme/src/styles/bootstrap/_variables.scss
+++ b/projects/element-theme/src/styles/bootstrap/_variables.scss
@@ -353,17 +353,17 @@ $input-plaintext-color: $body-color !default;
 
 $input-height-border: $input-border-width * 2 !default;
 
-$input-height-inner: functions.add($input-line-height * 1em, $input-padding-y * 2) !default;
-$input-height-inner-half: functions.add($input-line-height * 0.5em, $input-padding-y) !default;
-$input-height-inner-quarter: functions.add(
-  $input-line-height * 0.25em,
-  $input-padding-y * 0.5
-) !default;
-
 $input-height: functions.add(
   $input-line-height * 1em,
   functions.add($input-padding-y * 2, $input-height-border, false)
 ) !default;
+
+$input-height-inner: functions.subtract($input-height, $input-height-border, false) !default;
+// Wrap in parenthesis: `*` binds tighter than `-`, so without them only the border term gets multiplied.
+// DEPRECATED: Calculate it yourself using $input-height-inner
+$input-height-inner-half: calc((#{$input-height-inner}) * 0.5) !default;
+// DEPRECATED: Calculate it yourself using $input-height-inner
+$input-height-inner-quarter: calc((#{$input-height-inner}) * 0.25) !default;
 
 $input-transition:
   border-color 0.15s ease-in-out,

--- a/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
+++ b/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
@@ -1,7 +1,6 @@
 @use '../../variables/focus';
 @use '../../variables/semantic-tokens';
 @use '../../variables/spacers';
-@use '../../variables/typography';
 @use '../../variables/utilities';
 @use '../variables';
 
@@ -95,7 +94,7 @@
 
 .form-control:not(textarea):not(select[multiple]) {
   // force height to fix line-height issue in firefox
-  block-size: calc(#{typography.$si-line-height-body}em + #{2 * map.get(spacers.$spacers, 4)});
+  block-size: variables.$input-height;
 }
 
 .addon-second-icon {


### PR DESCRIPTION
Same outcome, but now uses the pre-calculated input heights to calculate to overall height.
This expresses the way how the overall height is determined more clearly.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1959/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1959/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1959/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1959/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1959/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1959/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1959/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1959/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1959/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1959/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

