### PR TITLE
chore(eslint): move no-restricted-syntax rule to root level config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -104,6 +104,10 @@ export const tsConfig = defineConfig({
     'no-restricted-syntax': [
       'error',
       {
+        selector: 'TSEnumDeclaration',
+        message: "Don't declare enums"
+      },
+      {
         selector: 'TSTypeReference:not([typeArguments]) > Identifier[name="SimpleChanges"]',
         message: 'Use SimpleChanges<this> instead of plain SimpleChanges'
       }

--- a/projects/element-ng/eslint.config.js
+++ b/projects/element-ng/eslint.config.js
@@ -40,13 +40,6 @@ export default defineConfig(
           style: 'camelCase'
         }
       ],
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'TSEnumDeclaration',
-          message: "Don't declare enums"
-        }
-      ],
       '@typescript-eslint/no-deprecated': ['off']
     }
   },


### PR DESCRIPTION
The no-restricted-syntax rule declared in eslint.config.js was shadowing the root-level no-restricted-syntax configuration. 
In ESLint flat config, a child-level rule declaration completely replaces the parent — it does not merge with it. 
This meant the root-level restriction on `TSTypeReference:not([typeArguments]) > Identifier[name="SimpleChanges"] ` (which enforces typed SimpleChanges usage) was silently ineffective for the element-ng project. Removing the project-level override allows the root config's no-restricted-syntax rules to apply as intended.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1965/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1965/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1965/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1965/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1965/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1965/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1965/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1965/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1965/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1965/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
