### PR TITLE
refactor(card): move card header to its own component

### DIFF
--- a/projects/element-ng/card/index.ts
+++ b/projects/element-ng/card/index.ts
@@ -3,5 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 export * from './si-card.component';
+export * from './si-card-header.component';
 export * from './si-action-card.component';
 export * from './si-card.module';

--- a/projects/element-ng/card/si-action-card.component.html
+++ b/projects/element-ng/card/si-action-card.component.html
@@ -10,19 +10,14 @@
 
 <div class="content-container" [class.card-content-split]="imgSrc()">
   @if (heading()) {
-    <div class="card-header d-flex justify-content-between">
-      <ng-content #cardHeaderIcon select="[headerIcon]" />
-      <div class="heading">
-        @if (heading()) {
-          <div class="text-truncate si-h5" [id]="headingId">{{ heading() | translate }}</div>
-        }
-        @if (subHeading()) {
-          <div class="text-truncate si-body text-secondary pt-2" [id]="subHeadingId">{{
-            subHeading() | translate
-          }}</div>
-        }
-      </div>
-    </div>
+    <si-card-header
+      [heading]="heading()"
+      [subHeading]="subHeading()"
+      [headingId]="headingId"
+      [subHeadingId]="subHeadingId"
+    >
+      <ng-content select="[headerIcon]" ngProjectAs="[headerIcon]" />
+    </si-card-header>
   }
   <div class="d-contents" [id]="contentId">
     <ng-content #cardBody select="[body]" />

--- a/projects/element-ng/card/si-action-card.component.ts
+++ b/projects/element-ng/card/si-action-card.component.ts
@@ -6,6 +6,7 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, input, model } fr
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiCardBaseDirective } from './si-card-base.directive';
+import { SiCardHeaderComponent } from './si-card-header.component';
 
 /**
  * An action card component that extends the base card component with option to
@@ -21,7 +22,7 @@ import { SiCardBaseDirective } from './si-card-base.directive';
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'button[si-action-card]',
-  imports: [SiTranslatePipe],
+  imports: [SiCardHeaderComponent, SiTranslatePipe],
   templateUrl: './si-action-card.component.html',
   styleUrl: './si-card.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/element-ng/card/si-card-header.component.html
+++ b/projects/element-ng/card/si-card-header.component.html
@@ -1,0 +1,24 @@
+<ng-content select="[headerIcon]" />
+<div class="heading">
+  @if (heading()) {
+    <div class="text-truncate si-h5" [id]="headingId()">{{ heading() | translate }}</div>
+  }
+  @if (subHeading()) {
+    <div class="text-truncate si-body text-secondary pt-2" [id]="subHeadingId()">
+      {{ subHeading() | translate }}
+    </div>
+  }
+</div>
+
+<div class="cab d-flex ms-6 my-n4 me-n5">
+  @if (displayContentActionBar()) {
+    <si-content-action-bar
+      class="ms-auto"
+      [primaryActions]="primaryActions()"
+      [secondaryActions]="secondaryActions()"
+      [actionParam]="actionParam()"
+      [viewType]="actionBarViewType()"
+      [attr.title]="actionBarTitle() | translate"
+    />
+  }
+</div>

--- a/projects/element-ng/card/si-card-header.component.scss
+++ b/projects/element-ng/card/si-card-header.component.scss
@@ -1,0 +1,23 @@
+@use 'sass:map';
+
+@use '@siemens/element-theme/src/styles/bootstrap/variables';
+@use '@siemens/element-theme/src/styles/variables/spacers';
+
+.text-truncate {
+  flex: 0 1 auto;
+}
+
+.heading {
+  min-inline-size: 0;
+  overflow: hidden;
+}
+
+.cab {
+  flex: 1 0 0;
+  min-inline-size: calc(1lh + 2 * variables.$card-cap-padding-y);
+}
+
+::ng-deep .icon[headerIcon] {
+  // The icon would be 8px too high without this.
+  margin-block: - map.get(spacers.$spacers, 2);
+}

--- a/projects/element-ng/card/si-card-header.component.ts
+++ b/projects/element-ng/card/si-card-header.component.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
+import {
+  ContentActionBarMainItem,
+  SiContentActionBarComponent,
+  ViewType
+} from '@siemens/element-ng/content-action-bar';
+import { MenuItem } from '@siemens/element-ng/menu';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
+
+/**
+ * Shared card header used internally by `SiCardComponent`, `SiActionCardComponent`,
+ * and `SiDashboardCardComponent`. Not intended for direct use by consuming applications.
+ *
+ * @internal
+ */
+@Component({
+  selector: 'si-card-header',
+  imports: [SiContentActionBarComponent, SiTranslatePipe],
+  templateUrl: './si-card-header.component.html',
+  styleUrl: './si-card-header.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'card-header d-flex justify-content-between'
+  }
+})
+export class SiCardHeaderComponent {
+  readonly heading = input<TranslatableString>();
+  readonly subHeading = input<TranslatableString>();
+  readonly headingId = input<string>();
+  readonly subHeadingId = input<string>();
+  /** @defaultValue [] */
+  readonly primaryActions = input<(MenuItemLegacy | ContentActionBarMainItem)[]>([]);
+  /** @defaultValue [] */
+  readonly secondaryActions = input<(MenuItemLegacy | MenuItem)[]>([]);
+  readonly actionParam = input<unknown>();
+  /** @defaultValue 'collapsible' */
+  readonly actionBarViewType = input<ViewType>('collapsible');
+  /** @defaultValue '' */
+  readonly actionBarTitle = input<TranslatableString>('');
+
+  readonly displayContentActionBar = computed(
+    () => this.primaryActions()?.length > 0 || this.secondaryActions()?.length > 0
+  );
+}

--- a/projects/element-ng/card/si-card.component.html
+++ b/projects/element-ng/card/si-card.component.html
@@ -10,32 +10,17 @@
 
 <div class="content-container" [class.card-content-split]="imgSrc()">
   @if (heading() || displayContentActionBar()) {
-    <div class="card-header d-flex justify-content-between">
-      <ng-content #cardHeaderIcon select="[headerIcon]" />
-      <div class="heading">
-        @if (heading()) {
-          <div class="text-truncate si-h5">{{ heading() | translate }}</div>
-        }
-        @if (subHeading()) {
-          <div class="text-truncate si-body text-secondary pt-2">{{
-            subHeading() | translate
-          }}</div>
-        }
-      </div>
-
-      <div class="cab d-flex ms-6 my-n4 me-n5">
-        @if (displayContentActionBar()) {
-          <si-content-action-bar
-            class="ms-auto"
-            [primaryActions]="primaryActions()"
-            [secondaryActions]="secondaryActions()"
-            [actionParam]="actionParam()"
-            [viewType]="actionBarViewType()"
-            [attr.title]="actionBarTitle() | translate"
-          />
-        }
-      </div>
-    </div>
+    <si-card-header
+      [heading]="heading()"
+      [subHeading]="subHeading()"
+      [primaryActions]="primaryActions()"
+      [secondaryActions]="secondaryActions()"
+      [actionParam]="actionParam()"
+      [actionBarViewType]="actionBarViewType()"
+      [actionBarTitle]="actionBarTitle()"
+    >
+      <ng-content select="[headerIcon]" ngProjectAs="[headerIcon]" />
+    </si-card-header>
   }
   <ng-content #cardBody select="[body]" />
   <ng-content #cardFooter select="[footer]" />

--- a/projects/element-ng/card/si-card.component.scss
+++ b/projects/element-ng/card/si-card.component.scss
@@ -1,26 +1,7 @@
-@use 'sass:map';
-
-@use '@siemens/element-theme/src/styles/variables/spacers';
-
 :host {
   &.card-horizontal {
     flex-direction: row;
   }
-}
-
-.text-truncate {
-  flex: 0 1 auto;
-}
-
-.heading {
-  flex: 1 1 auto;
-  min-inline-size: 0;
-  overflow: hidden;
-}
-
-.cab {
-  flex: 1 0 0;
-  min-inline-size: 40px;
 }
 
 .card-img-top {
@@ -35,11 +16,6 @@
   inline-size: 50%;
   object-fit: var(--si-card-img-object-fit, scale-down);
   object-position: var(--si-card-img-object-position, left center);
-}
-
-.card-header ::ng-deep .icon[headerIcon] {
-  // The icon would be 8px too high without this.
-  margin-block: - map.get(spacers.$spacers, 2);
 }
 
 .card-content-split {

--- a/projects/element-ng/card/si-card.component.ts
+++ b/projects/element-ng/card/si-card.component.ts
@@ -4,19 +4,16 @@
  */
 import { Component, computed, input } from '@angular/core';
 import { MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
-import {
-  ContentActionBarMainItem,
-  SiContentActionBarComponent,
-  ViewType
-} from '@siemens/element-ng/content-action-bar';
+import { ContentActionBarMainItem, ViewType } from '@siemens/element-ng/content-action-bar';
 import { MenuItem } from '@siemens/element-ng/menu';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiCardBaseDirective } from './si-card-base.directive';
+import { SiCardHeaderComponent } from './si-card-header.component';
 
 @Component({
   selector: 'si-card',
-  imports: [SiContentActionBarComponent, SiTranslatePipe],
+  imports: [SiCardHeaderComponent, SiTranslatePipe],
   templateUrl: './si-card.component.html',
   styleUrl: './si-card.component.scss'
 })

--- a/projects/element-ng/dashboard/si-dashboard-card.component.html
+++ b/projects/element-ng/dashboard/si-dashboard-card.component.html
@@ -10,32 +10,17 @@
 
 <div class="content-container" [class.card-content-split]="imgSrc()">
   @if (heading() || displayContentActionBar()) {
-    <div class="card-header d-flex justify-content-between">
-      <ng-content #cardHeaderIcon select="[headerIcon]" />
-      <div class="heading">
-        @if (heading()) {
-          <div class="text-truncate si-h5">{{ heading() | translate }}</div>
-        }
-        @if (subHeading()) {
-          <div class="text-truncate si-body text-secondary pt-2">{{
-            subHeading() | translate
-          }}</div>
-        }
-      </div>
-
-      <div class="cab d-flex ms-6 my-n4 me-n5">
-        @if (displayContentActionBar()) {
-          <si-content-action-bar
-            class="ms-auto"
-            [primaryActions]="primaryActionsComputed()"
-            [secondaryActions]="secondaryActions()"
-            [actionParam]="actionParam()"
-            [viewType]="actionBarViewTypeComputed()"
-            [attr.title]="actionBarTitleComputed() | translate"
-          />
-        }
-      </div>
-    </div>
+    <si-card-header
+      [heading]="heading()"
+      [subHeading]="subHeading()"
+      [primaryActions]="primaryActionsComputed()"
+      [secondaryActions]="secondaryActions()"
+      [actionParam]="actionParam()"
+      [actionBarViewType]="actionBarViewTypeComputed()"
+      [actionBarTitle]="actionBarTitleComputed()"
+    >
+      <ng-content select="[headerIcon]" ngProjectAs="[headerIcon]" />
+    </si-card-header>
   }
   <ng-content #cardBody select="[body]" />
   <ng-content #cardFooter select="[footer]" />

--- a/projects/element-ng/dashboard/si-dashboard-card.component.scss
+++ b/projects/element-ng/dashboard/si-dashboard-card.component.scss
@@ -1,7 +1,3 @@
-@use 'sass:map';
-
-@use '@siemens/element-theme/src/styles/variables';
-
 :host {
   &.card-horizontal {
     flex-direction: row;
@@ -14,19 +10,6 @@
     position: absolute;
     inset: 0;
   }
-}
-
-.text-truncate {
-  flex: 0 1 auto;
-}
-
-.heading {
-  overflow: hidden;
-}
-
-.cab {
-  flex: 1 0 0;
-  min-inline-size: 40px;
 }
 
 .card-img-top {

--- a/projects/element-ng/dashboard/si-dashboard-card.component.ts
+++ b/projects/element-ng/dashboard/si-dashboard-card.component.ts
@@ -14,12 +14,9 @@ import {
   signal
 } from '@angular/core';
 import { elementPinch, elementZoom } from '@siemens/element-icons';
-import { SiCardComponent } from '@siemens/element-ng/card';
+import { SiCardComponent, SiCardHeaderComponent } from '@siemens/element-ng/card';
 import { MenuItem } from '@siemens/element-ng/common';
-import {
-  ContentActionBarMainItem,
-  SiContentActionBarComponent
-} from '@siemens/element-ng/content-action-bar';
+import { ContentActionBarMainItem } from '@siemens/element-ng/content-action-bar';
 import { addIcons } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
@@ -27,7 +24,7 @@ import { SiDashboardService } from './si-dashboard.service';
 
 @Component({
   selector: 'si-dashboard-card',
-  imports: [SiContentActionBarComponent, SiTranslatePipe],
+  imports: [SiCardHeaderComponent, SiTranslatePipe],
   templateUrl: './si-dashboard-card.component.html',
   styleUrl: './si-dashboard-card.component.scss',
   host: {


### PR DESCRIPTION
Extracts the duplicated card header markup and styles into a new shared `SiCardHeaderComponent`, eliminating copy-paste across `SiCardComponent`, `SiActionCardComponent`, and `SiDashboardCardComponent`


<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1966/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1966/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1966/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1966/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1966/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1966/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1966/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1966/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1966/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1966/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

