### PR TITLE
feat(navbar-vertical-next): add alwaysOpenGroupsInFlyout mode

### DIFF
--- a/api-goldens/element-ng/navbar-vertical-next/index.api.md
+++ b/api-goldens/element-ng/navbar-vertical-next/index.api.md
@@ -5,7 +5,9 @@
 ```ts
 
 import * as _angular_core from '@angular/core';
+import { Injector } from '@angular/core';
 import { OnChanges } from '@angular/core';
+import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import * as _siemens_element_ng_navbar_vertical_next from '@siemens/element-ng/navbar-vertical-next';
 import * as _siemens_element_translate_ng_translate from '@siemens/element-translate-ng/translate';
@@ -15,6 +17,7 @@ import { TemplateRef } from '@angular/core';
 // @public (undocumented)
 export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
     constructor();
+    readonly alwaysOpenGroupsInFlyout: _angular_core.InputSignalWithTransform<boolean, unknown>;
     collapse(): void;
     readonly collapsed: _angular_core.ModelSignal<boolean>;
     expand(): void;
@@ -43,7 +46,7 @@ export class SiNavbarVerticalNextGroupComponent {
 }
 
 // @public (undocumented)
-export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit {
+export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit, OnDestroy {
     constructor();
     // (undocumented)
     readonly expanded: _angular_core.WritableSignal<boolean>;

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7efb84ab9b585f05ad74437670c65093d9dfc173b698be2577d5aaf76cd6ae4
-size 25725
+oid sha256:af3234763e719139fbf419e6855dfd6a6e13efef600f5ab0627add7461fb29bd
+size 23994

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b80b4b3b7fb4dece0ddc34679b29197a6d3222bfd77442a974bec106862abb18
-size 24685
+oid sha256:b04dbf1104ef78cf170a0f3126673f85117dc933c7a0db4cbfca9588e1c59672
+size 23214

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded.yaml
@@ -16,14 +16,8 @@
   - group "User management"
   - link "Test coverage":
     - /url: "#/viewer/viewer/coverage"
-  - button "Documentation" [expanded]
-  - group "Documentation":
-    - link "Sub item 4":
-      - /url: "#/viewer/viewer/subItem4"
-    - link "Sub item 5":
-      - /url: "#/viewer/viewer/subItem5"
-    - link "Sub item 6":
-      - /url: "#/viewer/viewer/subItem6"
+  - button "Documentation"
+  - group "Documentation"
   - button "Action"
   - link "Settings":
     - /url: "#/viewer/viewer/settings"

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-footer-items.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-footer-items.component.scss
@@ -12,6 +12,10 @@
   display: none;
 }
 
+:host-context(.nav-drill-down) {
+  display: none;
+}
+
 @include all-variables.media-breakpoint-up(sm) {
   :host-context(:not(.nav-text-only).nav-collapsed) {
     display: block;

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group-trigger.directive.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group-trigger.directive.ts
@@ -15,6 +15,7 @@ import {
   Injector,
   input,
   linkedSignal,
+  OnDestroy,
   OnInit,
   signal,
   TemplateRef,
@@ -23,7 +24,7 @@ import {
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 
-import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
+import { SI_NAVBAR_ITEM_LABEL, SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
 
 /**
  * Using this component, to anchor the flyout inside the navbar within the a11y tree.
@@ -53,7 +54,7 @@ class SiNavbarFlyoutAnchorComponent {
     '(click)': 'triggered()'
   }
 })
-export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit {
+export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit, OnDestroy {
   private static idCounter = 0;
 
   /** @internal */
@@ -85,7 +86,9 @@ export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit {
   readonly active = signal(false);
 
   protected readonly navbar = inject(SI_NAVBAR_VERTICAL_NEXT);
+  private readonly itemLabel = inject(SI_NAVBAR_ITEM_LABEL, { optional: true });
 
+  private drillDownActive = false;
   private flyoutOutsideClickSubscription?: Subscription;
   private readonly viewContainer = inject(ViewContainerRef);
   private readonly overlay = inject(Overlay);
@@ -121,6 +124,14 @@ export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit {
     this.attachInline();
   }
 
+  ngOnDestroy(): void {
+    this.flyoutOutsideClickSubscription?.unsubscribe();
+    this.overlayRef.dispose();
+    if (this.drillDownActive) {
+      this.navbar.endDrillDownSilently();
+    }
+  }
+
   /** @internal */
   hideFlyout(): void {
     if (this.flyout()) {
@@ -134,12 +145,32 @@ export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit {
   }
 
   protected triggered(): void {
-    if (this.navbar.collapsed()) {
+    if (this.navbar.mobileScreen() && !this.navbar.collapsed()) {
+      if (this.drillDownActive) {
+        this.navbar.endDrillDown();
+      } else {
+        this.showDrillDown();
+      }
+    } else if (this.navbar.collapsed() || this.navbar.alwaysOpenGroupsInFlyout()) {
       this.toggleFlyout();
     } else {
       this.expanded.set(!this.expanded());
       this.navbar.groupStateChanged(this.stateId(), this.expanded());
     }
+  }
+
+  private showDrillDown(): void {
+    this.drillDownActive = true;
+    const label = this.itemLabel?.() ?? '';
+
+    const idx = this.viewContainer.indexOf(this.groupView);
+    if (idx !== -1) {
+      this.viewContainer.detach(idx);
+    }
+    this.navbar.startDrillDown(this.groupTemplate(), this.injector, label, this.groupId, () => {
+      this.drillDownActive = false;
+      this.attachInline();
+    });
   }
 
   private toggleFlyout(): void {

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group.component.ts
@@ -20,7 +20,7 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
       [class.inline-group]="!flyout"
       [class.dropdown-menu]="flyout"
       [cdkTrapFocus]="flyout"
-      [cdkTrapFocusAutoCapture]="flyout"
+      [cdkTrapFocusAutoCapture]="autoCaptureFocus"
     >
       <div [class.overflow-hidden]="!flyout">
         <ng-content />
@@ -44,8 +44,12 @@ export class SiNavbarVerticalNextGroupComponent {
   // Store initial value, as the mode for an instance never changes.
   protected flyout = this.groupTrigger.flyout();
 
+  protected readonly autoCaptureFocus = this.flyout;
+
   protected readonly visible = computed(() => {
-    return this.flyout || (!this.navbar.collapsed() && this.groupTrigger.expanded());
+    const drillInfo = this.navbar.drilledGroupInfo();
+    const isDrilled = !!drillInfo && drillInfo.groupId === this.groupTrigger.groupId;
+    return isDrilled || this.flyout || (!this.navbar.collapsed() && this.groupTrigger.expanded());
   });
 
   constructor() {

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.html
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.html
@@ -18,5 +18,8 @@
   >
 }
 @if (group) {
-  <si-icon aria-hidden="true" class="dropdown-caret me-0 text-body" [icon]="icons.elementDown2" />
+  <si-icon
+    class="dropdown-caret me-0 text-body"
+    [icon]="groupsOpenExternally() ? icons.elementRight2 : icons.elementDown2"
+  />
 }

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.scss
@@ -86,6 +86,14 @@
   }
 }
 
+:host-context(.nav-drill-down si-navbar-vertical-next-group) :host(.navbar-vertical-item) {
+  padding-inline-start: 0;
+}
+
+:host-context(.dropdown-menu) :host(.navbar-vertical-item) {
+  padding-inline-start: 0;
+}
+
 :host(.dropdown-item) {
   .item-title {
     font-weight: normal;

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.spec.ts
@@ -5,6 +5,8 @@
 import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { SiNavbarVerticalNextGroupTriggerDirective } from './si-navbar-vertical-next-group-trigger.directive';
+import { SiNavbarVerticalNextGroupComponent } from './si-navbar-vertical-next-group.component';
 import { SiNavbarVerticalNextItemComponent } from './si-navbar-vertical-next-item.component';
 import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
 
@@ -51,12 +53,16 @@ describe('SiNavbarVerticalNextItemComponent', () => {
   const mockNavbar = {
     collapsed: signal(false),
     textOnly: signal(false),
+    alwaysOpenGroupsInFlyout: signal(false),
+    drilledGroupInfo: signal<unknown>(null),
+    mobileScreen: signal(false),
     itemTriggered: vi.fn()
   };
 
   beforeEach(async () => {
     mockNavbar.collapsed.set(false);
     mockNavbar.textOnly.set(false);
+    mockNavbar.alwaysOpenGroupsInFlyout.set(false);
 
     await TestBed.configureTestingModule({
       providers: [{ provide: SI_NAVBAR_VERTICAL_NEXT, useValue: mockNavbar }]
@@ -283,6 +289,55 @@ describe('SiNavbarVerticalNextItemComponent', () => {
       badgeTestFixture.detectChanges();
       linkElement = badgeTestFixture.nativeElement.querySelector('a.navbar-vertical-item');
       expect(linkElement).not.toHaveClass('hide-badge-collapsed');
+    });
+  });
+
+  describe('dropdown-caret icon based on openGroupsInFlyout', () => {
+    @Component({
+      imports: [
+        SiNavbarVerticalNextItemComponent,
+        SiNavbarVerticalNextGroupTriggerDirective,
+        SiNavbarVerticalNextGroupComponent
+      ],
+      template: `
+        <button
+          type="button"
+          si-navbar-vertical-next-item
+          [siNavbarVerticalNextGroupTriggerFor]="groupTemplate"
+        >
+          Group Item
+        </button>
+        <ng-template #groupTemplate>
+          <si-navbar-vertical-next-group />
+        </ng-template>
+      `
+    })
+    class TestGroupItemHostComponent {}
+
+    let groupFixture: ComponentFixture<TestGroupItemHostComponent>;
+
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        providers: [{ provide: SI_NAVBAR_VERTICAL_NEXT, useValue: mockNavbar }]
+      }).compileComponents();
+
+      mockNavbar.alwaysOpenGroupsInFlyout.set(false);
+      groupFixture = TestBed.createComponent(TestGroupItemHostComponent);
+      groupFixture.detectChanges();
+    });
+
+    it('should show down caret when alwaysOpenGroupsInFlyout is false', () => {
+      const caretIcon = groupFixture.nativeElement.querySelector('si-icon.dropdown-caret');
+      expect(caretIcon.getAttribute('data-icon')).toBe('elementDown2');
+    });
+
+    it('should show right caret when alwaysOpenGroupsInFlyout is true', async () => {
+      mockNavbar.alwaysOpenGroupsInFlyout.set(true);
+      await groupFixture.whenStable();
+
+      const caretIcon = groupFixture.nativeElement.querySelector('si-icon.dropdown-caret');
+      expect(caretIcon.getAttribute('data-icon')).toBe('elementRight2');
     });
   });
 });

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
@@ -7,17 +7,18 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  ElementRef,
   inject,
   input,
   OnInit
 } from '@angular/core';
 import { RouterLinkActive } from '@angular/router';
-import { elementDown2 } from '@siemens/element-icons';
+import { elementDown2, elementRight2 } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiLinkDirective } from '@siemens/element-ng/link';
 
 import { SiNavbarVerticalNextGroupTriggerDirective } from './si-navbar-vertical-next-group-trigger.directive';
-import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
+import { SI_NAVBAR_ITEM_LABEL, SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
 
 /** @experimental */
 @Component({
@@ -26,18 +27,27 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
   imports: [SiIconComponent],
   templateUrl: './si-navbar-vertical-next-item.component.html',
   styleUrl: './si-navbar-vertical-next-item.component.scss',
+  providers: [
+    {
+      provide: SI_NAVBAR_ITEM_LABEL,
+      useFactory: () => {
+        const el = inject(ElementRef<HTMLElement>);
+        return () => el.nativeElement.querySelector('.item-title')?.textContent?.trim() ?? '';
+      }
+    }
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'class': 'focus-inside',
-    '[class.dropdown-item]': 'this.parent?.group?.flyout()',
-    '[class.navbar-vertical-item]': '!this.parent?.group?.flyout()',
+    '[class.dropdown-item]': '!groupsOpenExternally() && this.parent?.group?.flyout()',
+    '[class.navbar-vertical-item]': '!this.parent?.group?.flyout() || groupsOpenExternally()',
     '[class.active]': 'active',
     '[class.hide-badge-collapsed]': 'hideBadgeWhenCollapsed()',
     '(click)': 'triggered()'
   }
 })
 export class SiNavbarVerticalNextItemComponent implements OnInit {
-  protected readonly icons = addIcons({ elementDown2 });
+  protected readonly icons = addIcons({ elementDown2, elementRight2 });
 
   /** Optional icon to render before the label. */
   readonly icon = input<string>();
@@ -91,6 +101,10 @@ export class SiNavbarVerticalNextItemComponent implements OnInit {
     }
     return badge.toString();
   });
+
+  protected readonly groupsOpenExternally = computed(
+    () => this.navbar.mobileScreen() || this.navbar.alwaysOpenGroupsInFlyout()
+  );
 
   ngOnInit(): void {
     if (this.group && this.active) {

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-items.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-items.component.scss
@@ -14,6 +14,10 @@
   display: none;
 }
 
+:host-context(.nav-drill-down) {
+  display: none;
+}
+
 @include all-variables.media-breakpoint-up(sm) {
   :host-context(:not(.nav-text-only).nav-collapsed) {
     display: block;

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.scss
@@ -17,6 +17,10 @@
   }
 }
 
+:host-context(.nav-drill-down) {
+  display: none;
+}
+
 si-search-bar {
   inline-size: 100%;
 }

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.html
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.html
@@ -26,6 +26,15 @@
       </div>
     </div>
     <ng-content select="si-navbar-vertical-next-search" />
+    @if (mobileScreen() && drilledGroupInfo()) {
+      <div class="navbar-vertical-no-collapse drill-back-header">
+        <button type="button" class="btn focus-inside drill-back-btn" (click)="endDrillDown()">
+          <si-icon class="icon-lg flip-rtl" [icon]="icons.elementLeft2" />
+          <span class="si-h5 text-truncate">{{ drilledGroupInfo()!.label }}</span>
+        </button>
+      </div>
+    }
+    <ng-container #drillDownOutlet />
     <ng-content select="si-navbar-vertical-next-items" />
     <ng-content select="si-navbar-vertical-next-footer-items" />
   </nav>

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.scss
@@ -116,3 +116,34 @@ nav {
     padding-inline-start: $vertical-nav-width;
   }
 }
+
+.drill-back-header {
+  margin-block-start: map.get(all-variables.$spacers, 4);
+}
+
+.drill-back-btn {
+  display: flex;
+  justify-content: flex-start;
+  inline-size: 100%;
+  padding-block: map.get(all-variables.$spacers, 4);
+  padding-inline: 0 map.get(all-variables.$spacers, 5);
+  min-block-size: 40px;
+  border-radius: 0;
+  background: none;
+  border: 0;
+  color: all-variables.$element-text-secondary;
+
+  si-icon {
+    margin-inline-start: map.get(all-variables.$spacers, 5);
+    flex-shrink: 0;
+  }
+
+  span {
+    margin-inline-start: map.get(all-variables.$spacers, 4);
+    min-inline-size: 0;
+  }
+
+  &:hover {
+    background: all-variables.$element-base-1-hover;
+  }
+}

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
@@ -7,16 +7,21 @@ import {
   booleanAttribute,
   ChangeDetectionStrategy,
   Component,
+  EmbeddedViewRef,
   inject,
+  Injector,
   input,
   model,
   OnChanges,
   OnInit,
   signal,
-  SimpleChanges
+  SimpleChanges,
+  TemplateRef,
+  ViewChild,
+  ViewContainerRef
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { elementDoubleLeft, elementDoubleRight } from '@siemens/element-icons';
+import { elementDoubleLeft, elementDoubleRight, elementLeft2 } from '@siemens/element-icons';
 import { SI_UI_STATE_SERVICE } from '@siemens/element-ng/common';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { BOOTSTRAP_BREAKPOINTS } from '@siemens/element-ng/resize-observer';
@@ -43,11 +48,12 @@ interface UIState {
     class: 'si-layout-inner ready',
     '[class.nav-collapsed]': 'collapsed()',
     '[class.nav-text-only]': 'textOnly()',
-    '[class.visible]': 'visible()'
+    '[class.visible]': 'visible()',
+    '[class.nav-drill-down]': 'mobileScreen() && drilledGroupInfo()'
   }
 })
 export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
-  protected readonly icons = addIcons({ elementDoubleLeft, elementDoubleRight });
+  protected readonly icons = addIcons({ elementDoubleLeft, elementDoubleRight, elementLeft2 });
   /**
    * Whether the navbar-vertical is collapsed.
    *
@@ -61,6 +67,15 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
    * @defaultValue false
    */
   readonly textOnly = input(false, { transform: booleanAttribute });
+
+  /**
+   * When `true`, item-groups always open as a transient flyout panel adjacent to the
+   * trigger, regardless of whether the navbar is collapsed or expanded.
+   * Flyouts open and close on click.
+   *
+   * @defaultValue false
+   */
+  readonly alwaysOpenGroupsInFlyout = input(false, { transform: booleanAttribute });
 
   /**
    * List of vertical navigation items
@@ -115,7 +130,22 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
   private uiStateService = inject(SI_UI_STATE_SERVICE, { optional: true });
   private breakpointObserver = inject(BreakpointObserver);
 
+  /** @defaultValue false */
   protected readonly smallScreen = signal(false);
+
+  /** @internal — true when viewport ≤ smMinimum (576 px); drives drill-down behaviour */
+  readonly mobileScreen = signal(false);
+
+  /** @internal */
+  readonly drilledGroupInfo = signal<{
+    label: string;
+    groupId: string;
+    onBack: () => void;
+  } | null>(null);
+
+  @ViewChild('drillDownOutlet', { read: ViewContainerRef })
+  private drillDownVCR?: ViewContainerRef;
+  private drillDownViewRef?: EmbeddedViewRef<unknown>;
 
   /**
    * @defaultValue
@@ -135,6 +165,16 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
       .subscribe(({ matches }) => {
         this.collapsed.set(matches || this.preferCollapse);
         this.smallScreen.set(matches);
+      });
+
+    this.breakpointObserver
+      .observe(`(max-width: ${BOOTSTRAP_BREAKPOINTS.smMinimum}px)`)
+      .pipe(takeUntilDestroyed())
+      .subscribe(({ matches }) => {
+        this.mobileScreen.set(matches);
+        if (!matches) {
+          this.endDrillDown();
+        }
       });
   }
 
@@ -210,5 +250,38 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
     if (this.smallScreen()) {
       this.collapsed.set(true);
     }
+    this.endDrillDown();
+  }
+
+  /** @internal */
+  startDrillDown(
+    template: TemplateRef<unknown>,
+    injector: Injector,
+    label: string,
+    groupId: string,
+    onBack: () => void
+  ): void {
+    this.drilledGroupInfo.set({ label, groupId, onBack });
+    this.drillDownVCR?.clear();
+    this.drillDownViewRef = this.drillDownVCR?.createEmbeddedView(template, undefined, {
+      injector
+    });
+  }
+
+  /** @internal */
+  endDrillDown(): void {
+    const onBack = this.drilledGroupInfo()?.onBack;
+    this.endDrillDownSilently();
+    onBack?.();
+  }
+
+  /** @internal */
+  endDrillDownSilently(): void {
+    if (!this.drilledGroupInfo()) {
+      return;
+    }
+    this.drilledGroupInfo.set(null);
+    this.drillDownViewRef?.destroy();
+    this.drillDownViewRef = undefined;
   }
 }

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.provider.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.provider.ts
@@ -10,3 +10,7 @@ import type { SiNavbarVerticalNextComponent } from './si-navbar-vertical-next.co
 export const SI_NAVBAR_VERTICAL_NEXT = new InjectionToken<SiNavbarVerticalNextComponent>(
   'SI_NAVBAR_VERTICAL_NEXT'
 );
+
+/** @experimental */
+/** @internal Provides the label text of the navbar item hosting the group trigger. */
+export const SI_NAVBAR_ITEM_LABEL = new InjectionToken<() => string>('SI_NAVBAR_ITEM_LABEL');

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
@@ -14,6 +14,7 @@ import {
   SiUIStateService,
   UIStateStorage
 } from '@siemens/element-ng/common';
+import { BOOTSTRAP_BREAKPOINTS } from '@siemens/element-ng/resize-observer';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -41,10 +42,17 @@ class SynchronousMockStore implements UIStateStorage {
 
 @Injectable({ providedIn: 'root' })
 class BreakpointObserverMock implements Partial<BreakpointObserver> {
+  /** Controls the lg breakpoint — drives collapsed/smallScreen state. */
   readonly isSmall = new BehaviorSubject<boolean>(false);
+  /** Controls the sm breakpoint — drives mobileScreen/drill-down state. */
+  readonly isMobile = new BehaviorSubject<boolean>(false);
 
-  observe(): Observable<BreakpointState> {
-    return this.isSmall.pipe(map(matches => ({ matches, breakpoints: {} })));
+  observe(value: string | readonly string[]): Observable<BreakpointState> {
+    const query = Array.isArray(value) ? value[0] : (value as string);
+    const source$ = query.includes(`${BOOTSTRAP_BREAKPOINTS.smMinimum}px`)
+      ? this.isMobile
+      : this.isSmall;
+    return source$.pipe(map(matches => ({ matches, breakpoints: { [query]: matches } })));
   }
 }
 
@@ -66,6 +74,7 @@ class EmptyComponent {}
       [textOnly]="textOnly()"
       [stateId]="stateId"
       [collapsed]="collapsed()"
+      [alwaysOpenGroupsInFlyout]="alwaysOpenGroupsInFlyout()"
     >
       <si-navbar-vertical-next-search [debounceTime]="0" (searchChange)="searchEvent($event)" />
       @if (showDeclarativeFlyoutGroup()) {
@@ -112,6 +121,19 @@ class EmptyComponent {}
           </button>
         </si-navbar-vertical-next-items>
       }
+
+      @if (showDrillDownGroup()) {
+        <si-navbar-vertical-next-items>
+          <a si-navbar-vertical-next-item routerLink="home" routerLinkActive>Home</a>
+          <button
+            type="button"
+            si-navbar-vertical-next-item
+            [siNavbarVerticalNextGroupTriggerFor]="drillDownGroup"
+          >
+            item-drill
+          </button>
+        </si-navbar-vertical-next-items>
+      }
     </si-navbar-vertical-next>
 
     <ng-template #flyoutGroup>
@@ -152,15 +174,28 @@ class EmptyComponent {}
           sub-item2
         </a>
       </si-navbar-vertical-next-group>
+    </ng-template>
+
+    <ng-template #drillDownGroup>
+      <si-navbar-vertical-next-group>
+        <a si-navbar-vertical-next-item routerLink="item-1/sub-item-1" routerLinkActive>
+          drill-sub-item1
+        </a>
+        <a si-navbar-vertical-next-item routerLink="item-1/sub-item-2" routerLinkActive>
+          drill-sub-item2
+        </a>
+      </si-navbar-vertical-next-group>
     </ng-template>`
 })
 class TestHostComponent {
   readonly textOnly = signal(true);
   stateId?: string;
   readonly collapsed = signal(false);
+  readonly alwaysOpenGroupsInFlyout = signal(false);
   readonly showDeclarativeFlyoutGroup = signal(false);
   readonly showDeclarativeNavigationGroup = signal(false);
   readonly showDeclarativeStateGroups = signal(false);
+  readonly showDrillDownGroup = signal(false);
 
   searchEvent(event: string): void {}
 }
@@ -261,6 +296,99 @@ describe('SiNavbarVerticalNext', () => {
       document.body.click();
 
       expect(await item.isFlyout()).toBe(false);
+    });
+
+    it('should open flyout on click when alwaysOpenGroupsInFlyout is set', async () => {
+      component.alwaysOpenGroupsInFlyout.set(true);
+      component.showDeclarativeFlyoutGroup.set(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const item = await harness.findItemByLabel('item-1');
+      await item.click();
+      expect(await item.isFlyout()).toBe(true);
+    });
+
+    it('should drill down into group on click when on small screen', async () => {
+      const breakpointObserver = TestBed.inject(BreakpointObserverMock);
+      // Only activate mobile (sm) breakpoint — lg stays false so navbar remains expanded.
+      breakpointObserver.isMobile.next(true);
+      component.showDrillDownGroup.set(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const nativeEl = fixture.nativeElement as HTMLElement;
+      const groupTrigger = nativeEl.querySelector<HTMLButtonElement>(
+        'button[si-navbar-vertical-next-item]'
+      )!;
+      groupTrigger.click();
+      await fixture.whenStable();
+
+      // Back button appears with the group's label
+      const backBtn = nativeEl.querySelector<HTMLElement>('.drill-back-btn');
+      expect(backBtn).not.toBeNull();
+      expect(backBtn!.textContent).toContain('item-drill');
+
+      // Sub-items for the drilled group are rendered
+      const subItems = nativeEl.querySelectorAll<HTMLElement>('a[si-navbar-vertical-next-item]');
+      expect(subItems.length).toBeGreaterThan(0);
+
+      // Top-level items panel is hidden while drilled
+      const itemsPanel = nativeEl.querySelector('si-navbar-vertical-next-items');
+      expect(itemsPanel).toHaveStyle('display: none');
+    });
+
+    it('should return to top-level when back button is clicked after drill-down', async () => {
+      const breakpointObserver = TestBed.inject(BreakpointObserverMock);
+      breakpointObserver.isMobile.next(true);
+      component.showDrillDownGroup.set(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const nativeEl = fixture.nativeElement as HTMLElement;
+      const groupTrigger = nativeEl.querySelector<HTMLButtonElement>(
+        'button[si-navbar-vertical-next-item]'
+      )!;
+      groupTrigger.click();
+      await fixture.whenStable();
+
+      const backBtn = nativeEl.querySelector<HTMLButtonElement>('.drill-back-btn')!;
+      expect(backBtn).not.toBeNull();
+
+      backBtn.click();
+      await fixture.whenStable();
+
+      // Back button is gone
+      expect(nativeEl.querySelector('.drill-back-btn')).toBeNull();
+
+      // The top-level items panel button is visible again
+      const groupTriggerAfter = nativeEl.querySelector<HTMLButtonElement>(
+        'button[si-navbar-vertical-next-item]'
+      );
+      expect(groupTriggerAfter).not.toBeNull();
+
+      // Top-level items panel is visible again
+      const itemsPanel = nativeEl.querySelector('si-navbar-vertical-next-items');
+      expect(itemsPanel).not.toHaveStyle('display: none');
+    });
+
+    it('should end drill-down when viewport grows beyond mobile breakpoint', async () => {
+      const breakpointObserver = TestBed.inject(BreakpointObserverMock);
+      breakpointObserver.isMobile.next(true);
+      component.showDrillDownGroup.set(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const nativeEl = fixture.nativeElement as HTMLElement;
+      nativeEl.querySelector<HTMLButtonElement>('button[si-navbar-vertical-next-item]')!.click();
+      await fixture.whenStable();
+      expect(nativeEl.querySelector('.drill-back-btn')).not.toBeNull();
+
+      // Simulate resizing to a wider viewport (no longer mobile)
+      breakpointObserver.isMobile.next(false);
+      await fixture.whenStable();
+
+      expect(nativeEl.querySelector('.drill-back-btn')).toBeNull();
     });
 
     it('should emit search event', async () => {

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-always-flyout.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-always-flyout.html
@@ -1,0 +1,96 @@
+<div class="has-navbar-fixed-top">
+  <si-application-header>
+    <si-header-brand>
+      <a routerLink="/" siHeaderLogo></a>
+      <h1 class="application-name">Navbar Vertical Next — Always Open Groups In Flyout</h1>
+    </si-header-brand>
+  </si-application-header>
+
+  <si-navbar-vertical-next
+    alwaysOpenGroupsInFlyout
+    stateId="navbar-vertical-next-always-flyout"
+    navbarCollapseButtonText="collapse"
+    navbarExpandButtonText="expand"
+  >
+    <si-navbar-vertical-next-search placeholder="Search..." />
+    <si-navbar-vertical-next-items>
+      <a si-navbar-vertical-next-item routerLink="home" routerLinkActive icon="element-home">
+        Home
+      </a>
+      <si-navbar-vertical-next-header>Modules</si-navbar-vertical-next-header>
+      <a si-navbar-vertical-next-item routerLink="energy" routerLinkActive icon="element-trend">
+        Energy &amp; sustainability
+      </a>
+      <button
+        type="button"
+        si-navbar-vertical-next-item
+        icon="element-user-group"
+        [siNavbarVerticalNextGroupTriggerFor]="userManagement"
+      >
+        User management
+      </button>
+      <a
+        si-navbar-vertical-next-item
+        routerLink="coverage"
+        routerLinkActive
+        icon="element-diagnostic"
+      >
+        Test coverage
+      </a>
+      <si-navbar-vertical-next-divider />
+      <button
+        type="button"
+        si-navbar-vertical-next-item
+        icon="element-document"
+        [siNavbarVerticalNextGroupTriggerFor]="documentation"
+      >
+        Documentation
+      </button>
+    </si-navbar-vertical-next-items>
+    <si-navbar-vertical-next-footer-items>
+      <a
+        si-navbar-vertical-next-item
+        routerLink="settings"
+        routerLinkActive
+        icon="element-settings"
+      >
+        Settings
+      </a>
+    </si-navbar-vertical-next-footer-items>
+
+    <div class="si-layout-main-padding">
+      <div class="si-layout-header">
+        <h2 class="si-layout-title si-layout-top-element">Here is a title</h2>
+      </div>
+      <router-outlet />
+    </div>
+  </si-navbar-vertical-next>
+</div>
+
+<ng-template #userManagement>
+  <si-navbar-vertical-next-group routerLinkActive>
+    <a si-navbar-vertical-next-item routerLink="subItem" routerLinkActive icon="element-rocket">
+      Sub item
+    </a>
+    <a si-navbar-vertical-next-item routerLink="subItem2" routerLinkActive icon="element-rocket">
+      Sub item 2
+    </a>
+    <a si-navbar-vertical-next-item routerLink="subItem3" routerLinkActive icon="element-rocket">
+      Sub item 3
+    </a>
+  </si-navbar-vertical-next-group>
+</ng-template>
+
+<ng-template #documentation>
+  <si-navbar-vertical-next-group routerLinkActive>
+    <a si-navbar-vertical-next-item routerLink="subItem4" routerLinkActive icon="element-rocket">
+      Sub item 4
+    </a>
+    <a si-navbar-vertical-next-item routerLink="subItem5" routerLinkActive icon="element-rocket">
+      Sub item 5
+    </a>
+    <a si-navbar-vertical-next-item routerLink="subItem6" routerLinkActive icon="element-rocket">
+      Sub item 6
+    </a>
+  </si-navbar-vertical-next-group>
+</ng-template>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-always-flyout.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-always-flyout.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import {
+  ActivatedRoute,
+  Router,
+  RouterLink,
+  RouterLinkActive,
+  RouterOutlet
+} from '@angular/router';
+import {
+  SiApplicationHeaderComponent,
+  SiHeaderBrandDirective,
+  SiHeaderLogoDirective
+} from '@siemens/element-ng/application-header';
+import {
+  SiNavbarVerticalNextSearchComponent,
+  SiNavbarVerticalNextItemsComponent,
+  SiNavbarVerticalNextComponent,
+  SiNavbarVerticalNextDividerComponent,
+  SiNavbarVerticalNextFooterItemsComponent,
+  SiNavbarVerticalNextGroupComponent,
+  SiNavbarVerticalNextGroupTriggerDirective,
+  SiNavbarVerticalNextHeaderComponent,
+  SiNavbarVerticalNextItemComponent
+} from '@siemens/element-ng/navbar-vertical-next';
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    SiNavbarVerticalNextComponent,
+    SiNavbarVerticalNextSearchComponent,
+    SiNavbarVerticalNextItemsComponent,
+    SiNavbarVerticalNextFooterItemsComponent,
+    SiNavbarVerticalNextItemComponent,
+    SiNavbarVerticalNextGroupComponent,
+    SiNavbarVerticalNextGroupTriggerDirective,
+    SiNavbarVerticalNextHeaderComponent,
+    SiNavbarVerticalNextDividerComponent,
+    SiApplicationHeaderComponent,
+    SiHeaderBrandDirective,
+    RouterLink,
+    RouterLinkActive,
+    RouterOutlet,
+    SiHeaderLogoDirective
+  ],
+  templateUrl: './si-navbar-vertical-next-always-flyout.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SampleComponent implements OnInit {
+  private activeRoute = inject(ActivatedRoute);
+  private router = inject(Router);
+
+  ngOnInit(): void {
+    this.router.navigate(['home'], { relativeTo: this.activeRoute });
+  }
+}


### PR DESCRIPTION
- Add `alwaysOpenGroupsInFlyout` input to open groups as flyout panels on click, regardless of collapsed state
- Switch caret icon from down to right when flyout mode is active
- Implement drill-down functionality for mobile view

Closes #1944

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1971/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1971/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1971/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1971/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1971/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1971/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1971/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1971/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1971/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1971/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->











