### PR TITLE
test(content-action-bar): verify content-action-bar responsive behavi…

### DIFF
--- a/playwright/e2e/element-examples/si-content-action-bar-states.spec.ts
+++ b/playwright/e2e/element-examples/si-content-action-bar-states.spec.ts
@@ -6,11 +6,38 @@ import { expect, test } from '../../support/test-helpers';
 
 test.describe('si-content-action-bar-states', () => {
   const example = 'si-content-action-bar/si-content-action-bar-states';
+  const exampleDashboard = 'si-dashboard/si-dashboard-card';
 
   test('long list', async ({ page, si }) => {
     await si.visitExample(example);
     await page.getByText('Long-List').first().click();
     await expect(page.locator('.dropdown-menu').first()).toBeVisible();
     await si.runVisualAndA11yTests();
+  });
+
+  test('responsive behaviour', async ({ page, si }) => {
+    await page.setViewportSize({ width: 1400, height: 900 });
+    await si.visitExample(exampleDashboard);
+
+    await expect(page.getByRole('button', { name: 'Toggle' })).not.toBeVisible();
+    // Full menu should be visible at wide viewport
+    const menuItems = ['Settings', 'Copy', 'Delete'];
+    await expect(page.getByRole('menubar')).toBeVisible();
+    for (const item of menuItems) {
+      await expect(page.getByRole('menuitem', { name: item })).toBeVisible();
+    }
+
+    // Shrink viewport so only the toggle button is visible
+    await page.setViewportSize({ width: 350, height: 900 });
+    await expect(page.getByRole('button', { name: 'Toggle' })).toBeVisible();
+    await expect(page.getByRole('menubar')).not.toBeVisible();
+
+    // Expand viewport so the full menu becomes visible again
+    await page.setViewportSize({ width: 1400, height: 900 });
+    await expect(page.getByRole('button', { name: 'Toggle' })).not.toBeVisible();
+    await expect(page.getByRole('menubar')).toBeVisible();
+    for (const item of menuItems) {
+      await expect(page.getByRole('menuitem', { name: item })).toBeVisible();
+    }
   });
 });

--- a/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5fbe1e01716123bab38173bf584dc8dae8374edaa7866c36164feb9e9ce8be6f
-size 12153
+oid sha256:ec2e5c0a7fefe31553772f3bcafe03fe7c151c33d7b18ee294c57daa1482b6b6
+size 14365

--- a/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a66ab9eb2b00d2e28a3c10cb4f224469fbc875d380a72b2f8b1add7897207e21
-size 11507
+oid sha256:2ffa950872852d1e1d4fa28ccf0c2807f4b8089f8270250eb6e222873cc080c0
+size 13531

--- a/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-dashboard-card.yaml
@@ -1,5 +1,9 @@
 - text: Natural Gas Usage Shows the usage of natural gas
-- button "Toggle"
+- menubar:
+  - menuitem "Settings"
+  - menuitem "Copy"
+  - menuitem "Delete"
+  - menuitem "Toggle"
 - paragraph: Some quick example text to build on the card title and make up the bulk of the card's content.
 - button "Expand"
 - button "Restore"

--- a/src/app/examples/si-dashboard/si-dashboard-card.html
+++ b/src/app/examples/si-dashboard/si-dashboard-card.html
@@ -5,6 +5,7 @@
         #card
         heading="Natural Gas Usage"
         subHeading="Shows the usage of natural gas"
+        actionBarViewType="expanded"
         [enableExpandInteraction]="enableExpandInteraction()"
         [primaryActions]="primaryActions()"
         [secondaryActions]="secondaryActions()"


### PR DESCRIPTION
…our in e2e test

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->

Add E2E test to verify the responsive behaviour of the content action bar<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1977/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1977/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1977/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1977/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1977/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1977/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1977/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1977/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1977/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1977/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


