### PR TITLE
refactor(dashboards-ng): deduplicate widget editor logic into base class

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -26,11 +26,13 @@ import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { OutputEmitterRef } from '@angular/core';
+import { OutputRefSubscription } from '@angular/core';
 import { Provider } from '@angular/core';
 import { SiDashboardComponent } from '@siemens/element-ng/dashboard';
 import * as _siemens_element_translate_ng_translate from '@siemens/element-translate-ng/translate';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { TemplateRef } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 import { Type } from '@angular/core';
@@ -237,7 +239,7 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
 }
 
 // @public
-export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
+export class SiWidgetCatalogComponent extends SiWidgetEditorBase implements OnInit {
     readonly closed: _angular_core.OutputEmitterRef<Omit<WidgetConfig, "id"> | undefined>;
     readonly searchPlaceholder: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     widgetCatalog: Widget[];
@@ -254,7 +256,7 @@ export abstract class SiWidgetIdProvider {
 }
 
 // @public
-export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy {
+export class SiWidgetInstanceEditorDialogComponent extends SiWidgetEditorBase implements OnInit {
     readonly closed: _angular_core.OutputEmitterRef<WidgetConfig | undefined>;
     readonly editorSetupCompleted: _angular_core.OutputEmitterRef<void>;
     readonly widget: _angular_core.InputSignal<Widget>;

--- a/projects/dashboards-ng/src/components/si-widget-editor-base.ts
+++ b/projects/dashboards-ng/src/components/si-widget-editor-base.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import {
+  ComponentRef,
+  Directive,
+  EnvironmentInjector,
+  inject,
+  Injector,
+  isSignal,
+  OnDestroy,
+  OutputRefSubscription,
+  signal,
+  viewChild,
+  ViewContainerRef
+} from '@angular/core';
+import { Observable, Subscription } from 'rxjs';
+
+import {
+  WidgetComponentFactory,
+  WidgetConfig,
+  WidgetConfigStatus,
+  WidgetInstanceEditor,
+  WidgetInstanceEditorWizard,
+  WidgetInstanceEditorWizardState
+} from '../model/widgets.model';
+import { setupWidgetEditor } from '../widget-loader';
+
+/**
+ * Base class encapsulating common widget editor lifecycle management.
+ * Both `SiWidgetCatalogComponent` and `SiWidgetInstanceEditorDialogComponent`
+ * extend this class to share editor setup, teardown, and status handling logic.
+ */
+@Directive()
+export abstract class SiWidgetEditorBase implements OnDestroy {
+  /** Indicates if the current config is valid or not. */
+  protected readonly invalidConfig = signal(false);
+
+  /** Marks the widget configuration as modified. */
+  protected readonly widgetConfigModified = signal(false);
+
+  protected readonly editorWizardState = signal<WidgetInstanceEditorWizardState | undefined>(
+    undefined
+  );
+
+  protected widgetInstanceEditor?: WidgetInstanceEditor;
+  protected subscriptions: (Subscription | OutputRefSubscription)[] = [];
+
+  protected readonly editorHost = viewChild.required('editorHost', { read: ViewContainerRef });
+  protected injector = inject(Injector);
+  protected envInjector = inject(EnvironmentInjector);
+
+  ngOnDestroy(): void {
+    this.tearDownEditor();
+  }
+
+  protected loadWidgetEditor(
+    widgetComponentFactory: WidgetComponentFactory,
+    host: ViewContainerRef
+  ): Observable<ComponentRef<WidgetInstanceEditor>> {
+    return setupWidgetEditor(widgetComponentFactory, host, this.injector, this.envInjector);
+  }
+
+  protected initializeEditor(
+    componentRef: ComponentRef<WidgetInstanceEditor>,
+    config: WidgetConfig | Omit<WidgetConfig, 'id'>
+  ): void {
+    this.widgetInstanceEditor = componentRef.instance;
+    if (isSignal(this.widgetInstanceEditor.config)) {
+      componentRef.setInput('config', config);
+    } else {
+      this.widgetInstanceEditor.config = config;
+    }
+    // To be used by webcomponent wrapper
+    if ('statusChangesHandler' in this.widgetInstanceEditor) {
+      this.widgetInstanceEditor.statusChangesHandler = this.handleStatusChanges.bind(this);
+    }
+
+    if (this.widgetInstanceEditor.statusChanges) {
+      this.subscriptions.push(
+        this.widgetInstanceEditor.statusChanges.subscribe(statusChanges =>
+          this.handleStatusChanges(statusChanges)
+        )
+      );
+    } else if (this.widgetInstanceEditor.configChange) {
+      this.subscriptions.push(
+        this.widgetInstanceEditor.configChange.subscribe(() => this.widgetConfigModified.set(true))
+      );
+    }
+
+    if (this.isEditorWizard(this.widgetInstanceEditor)) {
+      this.editorWizardState.set(this.widgetInstanceEditor.state);
+
+      if (this.widgetInstanceEditor.stateChange) {
+        this.subscriptions.push(
+          this.widgetInstanceEditor.stateChange.subscribe(state =>
+            this.editorWizardState.set(state)
+          )
+        );
+      }
+    }
+  }
+
+  protected tearDownEditor(): void {
+    this.invalidConfig.set(false);
+    this.widgetConfigModified.set(false);
+    this.editorWizardState.set(undefined);
+    this.widgetInstanceEditor = undefined;
+    this.subscriptions.forEach(s => s.unsubscribe());
+    this.subscriptions = [];
+  }
+
+  protected isEditorWizard(
+    editor?: WidgetInstanceEditor | WidgetInstanceEditorWizard
+  ): editor is WidgetInstanceEditorWizard {
+    return !!editor && 'state' in editor;
+  }
+
+  protected handleStatusChanges(statusChanges: Partial<WidgetConfigStatus>): void {
+    if (statusChanges.invalid !== undefined) {
+      this.invalidConfig.set(statusChanges.invalid);
+    }
+    if (statusChanges.modified !== undefined) {
+      this.widgetConfigModified.set(statusChanges.modified);
+    }
+  }
+}

--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
@@ -6,36 +6,22 @@ import { CdkListbox, CdkOption } from '@angular/cdk/listbox';
 import {
   Component,
   computed,
-  EnvironmentInjector,
   inject,
-  Injector,
   input,
   isSignal,
-  OnDestroy,
   OnInit,
   output,
-  OutputRefSubscription,
   signal,
-  viewChild,
-  ViewContainerRef
+  viewChild
 } from '@angular/core';
 import { SiActionDialogService } from '@siemens/element-ng/action-modal';
 import { SiCircleStatusComponent } from '@siemens/element-ng/circle-status';
 import { SiEmptyStateComponent } from '@siemens/element-ng/empty-state';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
-import { Subscription } from 'rxjs';
 
-import {
-  createWidgetConfig,
-  Widget,
-  WidgetConfig,
-  WidgetConfigStatus,
-  WidgetInstanceEditor,
-  WidgetInstanceEditorWizard,
-  WidgetInstanceEditorWizardState
-} from '../../model/widgets.model';
-import { setupWidgetEditor } from '../../widget-loader';
+import { createWidgetConfig, Widget, WidgetConfig } from '../../model/widgets.model';
+import { SiWidgetEditorBase } from '../si-widget-editor-base';
 
 /**
  * Default widget catalog implementation to show all available widgets that can be added
@@ -56,7 +42,7 @@ import { setupWidgetEditor } from '../../widget-loader';
   templateUrl: './si-widget-catalog.component.html',
   styleUrl: './si-widget-catalog.component.scss'
 })
-export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
+export class SiWidgetCatalogComponent extends SiWidgetEditorBase implements OnInit {
   /**
    * Placeholder text for the search input field in the widget catalog.
    *
@@ -82,8 +68,6 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
    * @defaultValue 'list'
    */
   readonly view = signal<'list' | 'editor' | 'editor-only'>('list');
-
-  protected readonly editorHost = viewChild.required('editorHost', { read: ViewContainerRef });
 
   /**
    * Property to provide the available widgets to the catalog. The flexible
@@ -158,23 +142,7 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
     }
   });
 
-  /** Indicates if the current config is valid or not. If invalid, the add button is disabled. */
-  private readonly invalidConfig = signal(false);
-
-  /**
-   * Marks the widget configuration as modified. Is set when widget editor instance
-   * emits configChange events. Triggers edit discard confirmation dialog when widget config
-   * is modified but not added to the dashboard.
-   * */
-  private widgetConfigModified = false;
-  private widgetInstanceEditor?: WidgetInstanceEditor;
-  private readonly editorWizardState = signal<WidgetInstanceEditorWizardState | undefined>(
-    undefined
-  );
-  private subscriptions: (Subscription | OutputRefSubscription)[] = [];
   private dialogService = inject(SiActionDialogService);
-  private injector = inject(Injector);
-  private envInjector = inject(EnvironmentInjector);
   private readonly widgetCdkListbox = viewChild(CdkListbox<Widget>);
 
   ngOnInit(): void {
@@ -182,10 +150,6 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
     if (this.widgetCatalog.length > 0) {
       this.selectWidget(this.widgetCatalog[0]);
     }
-  }
-
-  ngOnDestroy(): void {
-    this.tearDownEditor();
   }
 
   protected onSearch(searchTerm?: string): void {
@@ -206,7 +170,7 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
   }
 
   protected onCancel(): void {
-    if (!this.widgetConfigModified) {
+    if (!this.widgetConfigModified()) {
       this.closed.emit(undefined);
     } else {
       this.dialogService
@@ -241,7 +205,7 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
     if (this.isEditorWizard(this.widgetInstanceEditor) && this.editorWizardState()?.hasPrevious) {
       this.widgetInstanceEditor.previous();
       this.editorWizardState.set(this.widgetInstanceEditor.state);
-    } else if (!this.widgetConfigModified) {
+    } else if (!this.widgetConfigModified()) {
       this.setupCatalog();
     } else {
       this.dialogService
@@ -270,63 +234,14 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
     this.view.set('editor');
     this.widgetConfig = createWidgetConfig(selected);
 
-    setupWidgetEditor(
-      selected.componentFactory,
-      this.editorHost(),
-      this.injector,
-      this.envInjector
-    ).subscribe({
+    this.loadWidgetEditor(selected.componentFactory, this.editorHost()).subscribe({
       next: componentRef => {
-        this.widgetInstanceEditor = componentRef.instance;
-        if (isSignal(this.widgetInstanceEditor.config)) {
-          componentRef.setInput('config', this.widgetConfig);
-        } else {
-          this.widgetInstanceEditor.config = this.widgetConfig!;
-        }
-        // To be used by webcomponent wrapper
-        if ('statusChangesHandler' in this.widgetInstanceEditor) {
-          this.widgetInstanceEditor.statusChangesHandler = this.handleStatusChanges.bind(this);
-        }
-
-        if (this.widgetInstanceEditor.statusChanges) {
-          this.subscriptions.push(
-            this.widgetInstanceEditor.statusChanges.subscribe(statusChanges =>
-              this.handleStatusChanges(statusChanges)
-            )
-          );
-        } else if (this.widgetInstanceEditor.configChange) {
-          this.subscriptions.push(
-            this.widgetInstanceEditor.configChange.subscribe(
-              () => (this.widgetConfigModified = true)
-            )
-          );
-        }
-
-        if (this.isEditorWizard(this.widgetInstanceEditor)) {
-          this.editorWizardState.set(this.widgetInstanceEditor.state);
-
-          if (this.widgetInstanceEditor.stateChange) {
-            this.subscriptions.push(
-              this.widgetInstanceEditor.stateChange.subscribe(state =>
-                this.editorWizardState.set(state)
-              )
-            );
-          }
-        }
+        this.initializeEditor(componentRef, this.widgetConfig!);
       },
       error: error => {
         console.error(error);
       }
     });
-  }
-
-  private tearDownEditor(): void {
-    this.invalidConfig.set(false);
-    this.widgetConfigModified = false;
-    this.editorWizardState.set(undefined);
-    this.widgetInstanceEditor = undefined;
-    this.subscriptions.forEach(s => s.unsubscribe());
-    this.subscriptions = [];
   }
 
   private setupCatalog(): void {
@@ -362,21 +277,6 @@ export class SiWidgetCatalogComponent implements OnInit, OnDestroy {
       setTimeout(() => {
         this.widgetCdkListbox()?.selectValue(widget);
       });
-    }
-  }
-
-  private isEditorWizard(
-    editor?: WidgetInstanceEditor | WidgetInstanceEditorWizard
-  ): editor is WidgetInstanceEditorWizard {
-    return !!editor && 'state' in editor;
-  }
-
-  private handleStatusChanges(statusChanges: Partial<WidgetConfigStatus>): void {
-    if (statusChanges.invalid !== undefined) {
-      this.invalidConfig.set(statusChanges.invalid);
-    }
-    if (statusChanges.modified !== undefined) {
-      this.widgetConfigModified = statusChanges.modified;
     }
   }
 }

--- a/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component.ts
@@ -2,36 +2,12 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  Component,
-  computed,
-  EnvironmentInjector,
-  inject,
-  Injector,
-  input,
-  isSignal,
-  model,
-  OnDestroy,
-  OnInit,
-  output,
-  OutputRefSubscription,
-  signal,
-  viewChild,
-  ViewContainerRef
-} from '@angular/core';
+import { Component, computed, inject, input, isSignal, model, OnInit, output } from '@angular/core';
 import { SiActionDialogService } from '@siemens/element-ng/action-modal';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
-import { Subscription } from 'rxjs';
 
-import {
-  Widget,
-  WidgetConfig,
-  WidgetConfigStatus,
-  WidgetInstanceEditor,
-  WidgetInstanceEditorWizard,
-  WidgetInstanceEditorWizardState
-} from '../../model/widgets.model';
-import { setupWidgetEditor } from '../../widget-loader';
+import { Widget, WidgetConfig } from '../../model/widgets.model';
+import { SiWidgetEditorBase } from '../si-widget-editor-base';
 
 /**
  * The Dialog component is utilized when editing a widget instance within a dashboard.
@@ -45,7 +21,7 @@ import { setupWidgetEditor } from '../../widget-loader';
   templateUrl: './si-widget-instance-editor-dialog.component.html',
   styleUrl: './si-widget-instance-editor-dialog.component.scss'
 })
-export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy {
+export class SiWidgetInstanceEditorDialogComponent extends SiWidgetEditorBase implements OnInit {
   /**
    * Input for the widget instance configuration. It is used to populate the
    * widget editor.
@@ -68,11 +44,6 @@ export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy 
    * Emits when the editor instantiation is completed.
    */
   readonly editorSetupCompleted = output<void>();
-
-  protected readonly editorHost = viewChild.required('editorHost', { read: ViewContainerRef });
-
-  /** Indicates if the current config is valid or not. If invalid, the save button will be disabled. */
-  protected readonly invalidConfig = signal(false);
 
   protected readonly showNextButton = computed(() =>
     this.editorWizardState() !== undefined ? true : false
@@ -121,70 +92,15 @@ export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy 
     () => $localize`:@@DASHBOARD.WIDGET_EDITOR_DIALOG.DISCARD_CONFIG_CHANGE_DIALOG.CANCEL:Cancel`
   );
 
-  /**
-   * Marks the widget configuration as modified. Is set when widget editor instance
-   * emits configChange events. Triggers edit discard confirmation dialog when widget config
-   * is modified but not dialog is canceled.
-   * */
-  private readonly widgetConfigModified = signal(false);
-  private widgetInstanceEditor?: WidgetInstanceEditor;
-  private readonly editorWizardState = signal<WidgetInstanceEditorWizardState | undefined>(
-    undefined
-  );
-
-  private subscriptions: (Subscription | OutputRefSubscription)[] = [];
-  private injector = inject(Injector);
-  private envInjector = inject(EnvironmentInjector);
   private dialogService = inject(SiActionDialogService);
 
   ngOnInit(): void {
-    setupWidgetEditor(
-      this.widget().componentFactory,
-      this.editorHost(),
-      this.injector,
-      this.envInjector
-    ).subscribe(componentRef => {
-      this.widgetInstanceEditor = componentRef.instance;
-      if (isSignal(this.widgetInstanceEditor.config)) {
-        componentRef.setInput('config', this.widgetConfig()!);
-      } else {
-        this.widgetInstanceEditor.config = this.widgetConfig()!;
+    this.loadWidgetEditor(this.widget().componentFactory, this.editorHost()).subscribe(
+      componentRef => {
+        this.initializeEditor(componentRef, this.widgetConfig()!);
+        this.editorSetupCompleted.emit();
       }
-      // To be used by webcomponent wrapper
-      if ('statusChangesHandler' in this.widgetInstanceEditor) {
-        this.widgetInstanceEditor.statusChangesHandler = this.handleStatusChanges.bind(this);
-      }
-
-      if (this.widgetInstanceEditor.statusChanges) {
-        this.subscriptions.push(
-          this.widgetInstanceEditor.statusChanges.subscribe(statusChanges =>
-            this.handleStatusChanges(statusChanges)
-          )
-        );
-      } else if (this.widgetInstanceEditor.configChange) {
-        this.subscriptions.push(
-          this.widgetInstanceEditor.configChange.subscribe(() =>
-            this.widgetConfigModified.set(true)
-          )
-        );
-      }
-      if (this.isEditorWizard(this.widgetInstanceEditor)) {
-        this.editorWizardState.set(this.widgetInstanceEditor.state);
-
-        if (this.widgetInstanceEditor.stateChange) {
-          this.subscriptions.push(
-            this.widgetInstanceEditor.stateChange.subscribe(state =>
-              this.editorWizardState.set(state)
-            )
-          );
-        }
-      }
-      this.editorSetupCompleted.emit();
-    });
-  }
-
-  ngOnDestroy(): void {
-    this.tearDownEditor();
+    );
   }
 
   protected onCancel(): void {
@@ -240,27 +156,5 @@ export class SiWidgetInstanceEditorDialogComponent implements OnInit, OnDestroy 
     }
 
     this.closed.emit(this.widgetConfig());
-  }
-
-  private tearDownEditor(): void {
-    this.editorWizardState.set(undefined);
-    this.widgetInstanceEditor = undefined;
-    this.subscriptions.forEach(s => s.unsubscribe());
-    this.subscriptions = [];
-  }
-
-  private isEditorWizard(
-    editor?: WidgetInstanceEditor | WidgetInstanceEditorWizard
-  ): editor is WidgetInstanceEditorWizard {
-    return !!editor && 'state' in editor;
-  }
-
-  private handleStatusChanges(statusChanges: Partial<WidgetConfigStatus>): void {
-    if (statusChanges.invalid !== undefined) {
-      this.invalidConfig.set(statusChanges.invalid);
-    }
-    if (statusChanges.modified !== undefined) {
-      this.widgetConfigModified.set(statusChanges.modified);
-    }
   }
 }


### PR DESCRIPTION
Extract common widget editor lifecycle management into a shared `SiWidgetEditorBase` abstract directive class. Both `SiWidgetCatalogComponent` and `SiWidgetInstanceEditorDialogComponent` now extend this base class instead of duplicating the same setup, teardown, and status handling logic.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1978/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1978/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1978/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1978/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1978/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1978/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1978/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1978/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1978/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1978/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


