### PR TITLE
fix(filtered-search): emit event when search text is cleared

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search.component.html
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.html
@@ -43,7 +43,7 @@
     (createCriterionByName)="onCreateCriterionByName($event)"
     (backspaceOverflow)="freeTextBackspace()"
     (createFreeTextPill)="createFreeTextPill($event)"
-    (searchValueChange)="onSearchValueChange($event)"
+    (searchValueChange)="onSearchValueChange()"
     (inputFocus)="freeTextFocus()"
     (enterSubmit)="submit()"
   />

--- a/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
@@ -1415,6 +1415,13 @@ describe('SiFilteredSearchComponent', () => {
         criteria: [],
         value: 'bla'
       });
+
+      await freeTextSearch.clearText();
+      await tick();
+      expect(component.doSearch).toHaveBeenCalledWith({
+        criteria: [],
+        value: ''
+      });
     });
 
     it('should emit values while typing in the typeahead part (criterion name and value)', async () => {

--- a/projects/element-ng/filtered-search/si-filtered-search.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.ts
@@ -702,9 +702,9 @@ export class SiFilteredSearchComponent implements OnInit, OnChanges {
     this.addCriterion(criterion, event.value);
   }
 
-  protected onSearchValueChange(value: string): void {
+  protected onSearchValueChange(): void {
     // Only emit a change event if free text pills are not enabled and the free text search is enabled.
-    if (value && !this.disableFreeTextSearch() && !this.freeTextCriterion()) {
+    if (!this.disableFreeTextSearch() && !this.freeTextCriterion()) {
       this.emitChangeEvent();
     }
   }


### PR DESCRIPTION
Previously, the FS did not emit a change when the free-text input was cleared.
There was an explicit check to prevent an emission in case the free-text was empty.
This commit removes this checks.

Closes #1980<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1981/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1981/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1981/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1981/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1981/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1981/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1981/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1981/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1981/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1981/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
