### PR TITLE
refactor(dashboards-ng): use computed for accentLine

### DIFF
--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.html
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.html
@@ -23,7 +23,7 @@
   <si-dashboard-card
     #card
     class="h-100 dragging-card"
-    [class]="accentLine"
+    [class]="accentLine()"
     [expandText]="labelExpand"
     [restoreText]="labelRestore"
     [heading]="widgetConfig().heading"

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
@@ -6,6 +6,7 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   Component,
   ComponentRef,
+  computed,
   DestroyRef,
   EnvironmentInjector,
   inject,
@@ -138,10 +139,10 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
   };
   protected widgetInstanceFooter?: TemplateRef<unknown>;
 
-  protected get accentLine(): string {
-    const widgetConfig = this.widgetConfig();
-    return widgetConfig.accentLine ? 'accent-' + widgetConfig.accentLine : '';
-  }
+  protected readonly accentLine = computed(() => {
+    const { accentLine } = this.widgetConfig();
+    return accentLine ? 'accent-' + accentLine : '';
+  });
 
   ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.widgetConfig) {


### PR DESCRIPTION
Replaces plain getter with computed

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1985/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1985/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1985/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1985/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1985/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1985/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1985/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1985/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1985/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1985/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

