### PR TITLE
fix(status-toggle): hide draggable highlight when selected item is disabled

### DIFF
--- a/projects/element-ng/status-toggle/si-status-toggle.component.html
+++ b/projects/element-ng/status-toggle/si-status-toggle.component.html
@@ -15,7 +15,9 @@
     [style.inset-inline-start]="draggablePosition()"
     [style.width.%]="100 / itemsValue.length"
   >
-    <div class="visible-toggle-draggable"></div>
+    @if (selectedIndex() !== undefined) {
+      <div class="visible-toggle-draggable"></div>
+    }
   </div>
 
   @let selIndexValue = selectedIndex();


### PR DESCRIPTION
When the selected item is disabled one, the highlight moves to next available item. I find it confusing because the next item appears be in inconsistent state, highlighted but not selected, while the original selection was different one.

In general the highlight is applied when the selection happens

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1987/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1987/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1987/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1987/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1987/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1987/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1987/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1987/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1987/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1987/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
