### PR TITLE
fix(date-range-filter): show a label instead of ? when range is not defined

### DIFF
--- a/api-goldens/element-ng/date-range-filter/index.api.md
+++ b/api-goldens/element-ng/date-range-filter/index.api.md
@@ -105,6 +105,7 @@ export class SiDateRangeFilterComponent implements OnChanges {
     readonly refLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly reverseInputFields: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly searchLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
+    readonly selectRangeLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly showApplyButton: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly todayLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly toLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.html
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.html
@@ -91,7 +91,9 @@
           {{ calculated.start | date: pipeFormat() }} -
           {{ calculated.end | date: pipeFormat() }}
         } @else {
-          ?
+          <span class="text-secondary">
+            {{ selectRangeLabel() | translate }}
+          </span>
         }
       } @else {
         @let range = dateRange();
@@ -99,7 +101,9 @@
         @if (range.end) {
           {{ range.end | date: pipeFormat() }}
         } @else {
-          {{ rangeEndDateMissingLabel() | translate }}
+          <span class="text-secondary">
+            {{ rangeEndDateMissingLabel() | translate }}
+          </span>
         }
       }
     </span>

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
@@ -305,6 +305,17 @@ export class SiDateRangeFilterComponent implements OnChanges {
   readonly rangeEndDateMissingLabel = input(
     t(() => $localize`:@@SI_DATE_RANGE_FILTER.SELECT_RANGE_END:Select end date`)
   );
+  /**
+   * label when range is not defined in the preview
+   *
+   * @defaultValue
+   * ```
+   * t(() => $localize`:@@SI_DATE_RANGE_FILTER.SELECT_RANGE_LABEL:Select date range`)
+   * ```
+   */
+  readonly selectRangeLabel = input(
+    t(() => $localize`:@@SI_DATE_RANGE_FILTER.SELECT_RANGE_LABEL:Select date range`)
+  );
 
   /** Event fired when the apply button has been clicked */
   readonly applyClicked = output<void>();

--- a/projects/element-ng/translate/si-translatable-keys.interface.ts
+++ b/projects/element-ng/translate/si-translatable-keys.interface.ts
@@ -74,6 +74,7 @@ export interface SiTranslatableKeys {
   'SI_DATE_RANGE_FILTER.REF_POINT'?: string;
   'SI_DATE_RANGE_FILTER.SEARCH'?: string;
   'SI_DATE_RANGE_FILTER.SELECT_RANGE_END'?: string;
+  'SI_DATE_RANGE_FILTER.SELECT_RANGE_LABEL'?: string;
   'SI_DATE_RANGE_FILTER.TO'?: string;
   'SI_DATE_RANGE_FILTER.TODAY'?: string;
   'SI_DATE_RANGE_FILTER.UNIT'?: string;

--- a/src/app/examples/si-date-range-filter/si-date-range-filter-popup.html
+++ b/src/app/examples/si-date-range-filter/si-date-range-filter-popup.html
@@ -10,7 +10,7 @@
     {{ resolved?.start | date: 'shortDate' }} -
     {{ resolved?.end | date: 'shortDate' }}
   } @else {
-    ?
+    <span class="text-secondary">Select date range</span>
   }
 </button>
 


### PR DESCRIPTION

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1989/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1989/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1989/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1989/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1989/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1989/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1989/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1989/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1989/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1989/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->




