### PR TITLE
fix(navbar-primary): align translation defaults with launchpad

### DIFF
--- a/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.ts
+++ b/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.ts
@@ -120,10 +120,10 @@ export class SiNavbarPrimaryComponent implements OnChanges, HeaderWithDropdowns 
    *
    * @defaultValue
    * ```
-   * t(() => $localize`:@@SI_LAUNCHPAD.TITLE:Launchpad`)
+   * t(() => $localize`:@@SI_LAUNCHPAD.TITLE:Switch applications`)
    * ```
    */
-  readonly appSwitcherTitle = input(t(() => $localize`:@@SI_LAUNCHPAD.TITLE:Launchpad`));
+  readonly appSwitcherTitle = input(t(() => $localize`:@@SI_LAUNCHPAD.TITLE:Switch applications`));
 
   /**
    * sub-title for the launchpad
@@ -142,12 +142,10 @@ export class SiNavbarPrimaryComponent implements OnChanges, HeaderWithDropdowns 
    *
    * @defaultValue
    * ```
-   * t(() => $localize`:@@SI_LAUNCHPAD.FAVORITE_APPS:Favorite apps`)
+   * t(() => $localize`:@@SI_LAUNCHPAD.FAVORITE_APPS:Favorites`)
    * ```
    */
-  readonly favoriteAppsTitle = input(
-    t(() => $localize`:@@SI_LAUNCHPAD.FAVORITE_APPS:Favorite apps`)
-  );
+  readonly favoriteAppsTitle = input(t(() => $localize`:@@SI_LAUNCHPAD.FAVORITE_APPS:Favorites`));
 
   /**
    * Title or translate key for the default apps section.


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1990/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1990/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1990/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1990/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1990/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1990/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1990/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1990/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1990/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1990/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
