### PR TITLE
fix(datepicker): remove focus ring on date-range input when calendar button is focused

### DIFF
--- a/playwright/e2e/element-examples/si-daterange.spec.ts
+++ b/playwright/e2e/element-examples/si-daterange.spec.ts
@@ -24,6 +24,18 @@ test.describe('si-datepicker', () => {
     await page.locator('tbody > tr .si-h4').nth(5).click();
     await si.runVisualAndA11yTests('selection');
   });
+
+  test(example + ' input focus shows focus ring', async ({ page, si }) => {
+    await si.visitExample(example);
+    await page.locator('si-date-range input').first().focus();
+    await si.runVisualAndA11yTests('input-focus');
+  });
+
+  test(example + ' calendar button focus hides focus ring', async ({ page, si }) => {
+    await si.visitExample(example);
+    await page.getByLabel('Open calendar').first().focus();
+    await si.runVisualAndA11yTests('button-focus');
+  });
 });
 
 test.describe('si-datepicker', () => {

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--button-focus-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--button-focus-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5c484265a957d4c68ad18dca5898d72b98cfddd07b4263633eee3246bbd4b8f
+size 12355

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--button-focus-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--button-focus-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58721776bcde5e1c7acf8d0e20236e721a6a9de3fa894ac4b79e8c51f635ecb0
+size 12323

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--button-focus.yaml
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--button-focus.yaml
@@ -1,0 +1,9 @@
+- text: Date range
+- group "Date range":
+  - textbox "Start date"
+  - text: ""
+  - textbox "End date"
+  - button "Open calendar"
+- heading "Date range value" [level=4]
+- heading "Validation:" [level=4]
+- text: Date range is VALID

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--input-focus-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--input-focus-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8a6eae4f5132d3cb200adcd501bf4ef990cada3cb2a6c81bae43468cf04ea02
+size 11664

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--input-focus-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--input-focus-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0eb9d77adab49b018e3cc11e6df0c0455632ec5948737d4bbc474cd3f811fe68
+size 11638

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--input-focus.yaml
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--input-focus.yaml
@@ -1,0 +1,9 @@
+- text: Date range
+- group "Date range":
+  - textbox "Start date"
+  - text: ""
+  - textbox "End date"
+  - button "Open calendar"
+- heading "Date range value" [level=4]
+- heading "Validation:" [level=4]
+- text: Date range is VALID

--- a/projects/element-ng/datepicker/si-date-range.component.scss
+++ b/projects/element-ng/datepicker/si-date-range.component.scss
@@ -8,7 +8,7 @@
   padding-inline-end: map.get(all-variables.$spacers, 2) - all-variables.$input-border-width;
 }
 
-:host(:focus-within) {
+:host(:focus-within:has(input:focus)) {
   @include all-variables.make-outline-focus();
 }
 


### PR DESCRIPTION
## Summary

- Fix focus ring remaining visible on the date-range input wrapper when the calendar toggle button is focused
- Changed `:host(:focus-within)` to `:host(:focus-within:has(input:focus))` so the focus ring only appears when an actual input element has focus, matching the behavior of the normal datepicker<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-1997/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-1997/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-1997/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-1997/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1997/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1997/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1997/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1997/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1997/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-1997/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

