### PR TITLE
fix(status-bar): a11y fix for collapse button

### DIFF
--- a/projects/element-ng/status-bar/si-status-bar.component.html
+++ b/projects/element-ng/status-bar/si-status-bar.component.html
@@ -88,19 +88,17 @@
   </div>
   @if (responsiveMode) {
     <div class="d-flex align-items-center justify-content-center">
-      <a
+      <button
+        type="button"
         class="collapse-expand text-center p-0 focus-force"
-        tabindex="0"
-        role="button"
         [attr.aria-label]="(expanded() ? collapseButtonText() : expandButtonText()) | translate"
         [attr.aria-expanded]="!!expanded()"
         [attr.aria-controls]="statusId"
         [class.expanded]="expanded() === 2"
-        (keydown.enter)="toggleExpand()"
         (click)="toggleExpand()"
       >
         <si-icon class="icon" [icon]="icons.elementDown2" />
-      </a>
+      </button>
     </div>
   }
 </div>

--- a/projects/element-ng/status-bar/si-status-bar.component.scss
+++ b/projects/element-ng/status-bar/si-status-bar.component.scss
@@ -70,8 +70,10 @@ $blink-transition-duration: variables.$element-default-transition-duration;
 
 .collapse-expand {
   background-color: variables.$element-base-1;
+  border: 0;
   border-radius: 0 0 20px 20px;
   inline-size: 40px;
+  color: variables.$element-ui-0;
   cursor: pointer;
 
   &.expanded {


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2000/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2000/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2000/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2000/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2000/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2000/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2000/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2000/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2000/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2000/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

