### PR TITLE
fix(status-bar): use static toggle button text instead of dynamic expand/collapse text

### DIFF
--- a/projects/element-ng/status-bar/si-status-bar.component.html
+++ b/projects/element-ng/status-bar/si-status-bar.component.html
@@ -91,7 +91,7 @@
       <button
         type="button"
         class="collapse-expand text-center p-0 focus-force"
-        [attr.aria-label]="(expanded() ? collapseButtonText() : expandButtonText()) | translate"
+        [attr.aria-label]="toggleButtonText() | translate"
         [attr.aria-expanded]="!!expanded()"
         [attr.aria-controls]="statusId"
         [class.expanded]="expanded() === 2"

--- a/projects/element-ng/status-bar/si-status-bar.component.ts
+++ b/projects/element-ng/status-bar/si-status-bar.component.ts
@@ -118,8 +118,18 @@ export class SiStatusBarComponent implements OnDestroy, OnChanges {
    */
   readonly blinkPulse = input<Observable<boolean>>();
   /**
+   * Text for the navbar expand/collapse toggle button. Required for a11y.
+   *
+   * @defaultValue
+   * ```
+   * t(() => $localize`:@@SI_STATUS_BAR.TOGGLE:Toggle`)
+   * ```
+   */
+  readonly toggleButtonText = input(t(() => $localize`:@@SI_STATUS_BAR.TOGGLE:Toggle`));
+  /**
    * Text for the navbar expand button. Required for a11y
    *
+   * @deprecated Use {@link toggleButtonText} instead.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_STATUS_BAR.EXPAND:Expand`)
@@ -129,6 +139,7 @@ export class SiStatusBarComponent implements OnDestroy, OnChanges {
   /**
    * Text for the navbar collapse button. Required for a11y
    *
+   * @deprecated Use {@link toggleButtonText} instead.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_STATUS_BAR.COLLAPSE:Collapse`)

--- a/projects/element-ng/translate/si-translatable-keys.interface.ts
+++ b/projects/element-ng/translate/si-translatable-keys.interface.ts
@@ -218,6 +218,7 @@ export interface SiTranslatableKeys {
   'SI_STATUS_BAR.COLLAPSE'?: string;
   'SI_STATUS_BAR.EXPAND'?: string;
   'SI_STATUS_BAR.MUTE'?: string;
+  'SI_STATUS_BAR.TOGGLE'?: string;
   'SI_THRESHOLD.ADD'?: string;
   'SI_THRESHOLD.DELETE'?: string;
   'SI_THRESHOLD.INPUT_LABEL'?: string;


### PR DESCRIPTION
…and/collapse text

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2012/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2012/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2012/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2012/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2012/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2012/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2012/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2012/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2012/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2012/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
