### PR TITLE
feat(ag-grid): update sorting icons

### DIFF
--- a/projects/element-ng/ag-grid/parts/icon-overrides.part.ts
+++ b/projects/element-ng/ag-grid/parts/icon-overrides.part.ts
@@ -8,7 +8,6 @@ import {
   elementCopy,
   elementCut,
   elementDown2,
-  elementDown4,
   elementDownload,
   elementEdit,
   elementFilter,
@@ -34,10 +33,10 @@ import {
   elementRight2,
   elementRight4,
   elementShow,
+  elementSortDown,
   elementSortUp,
   elementSum,
   elementUp2,
-  elementUp4,
   elementZoom
 } from '@siemens/element-icons';
 import { iconOverrides } from 'ag-grid-community';
@@ -67,7 +66,7 @@ export const elementIconOverrides = iconOverrides({
   icons: createIconMap({
     aggregation: elementSum,
     arrows: elementMove,
-    asc: elementUp4,
+    asc: elementSortUp,
     cancel: elementCancel,
     chart: elementReport,
     'chevron-down': elementDown2,
@@ -80,7 +79,7 @@ export const elementIconOverrides = iconOverrides({
     copy: elementCopy,
     cross: elementCancel,
     cut: elementCut,
-    desc: elementDown4,
+    desc: elementSortDown,
     edit: elementEdit,
     expanded: elementLeft2,
     'eye-slash': elementHide,


### PR DESCRIPTION
Replace elementUp4/elementDown4 with elementSortUp/elementSortDown for asc/desc icon overrides.

Fixes #2009

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2014/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2014/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2014/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2014/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2014/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2014/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2014/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2014/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2014/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2014/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
