### PR TITLE
feat(search-bar): add maxlength input to limit search input length

### DIFF
--- a/api-goldens/element-ng/search-bar/index.api.md
+++ b/api-goldens/element-ng/search-bar/index.api.md
@@ -20,6 +20,7 @@ export class SiSearchBarComponent implements OnInit, OnDestroy, ControlValueAcce
     readonly debounceTime: _angular_core.InputSignalWithTransform<number, unknown>;
     // (undocumented)
     readonly disabledInput: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    readonly maxlength: _angular_core.InputSignalWithTransform<number | undefined, unknown>;
     readonly placeholder: _angular_core.InputSignal<string>;
     readonly prohibitedCharacters: _angular_core.InputSignal<string | undefined>;
     // (undocumented)

--- a/projects/element-ng/search-bar/si-search-bar.component.html
+++ b/projects/element-ng/search-bar/si-search-bar.component.html
@@ -13,6 +13,7 @@
     [class.is-invalid]="isInvalid"
     [class.icon-end]="searchValue()"
     [attr.tabindex]="tabbable() ? '' : '-1'"
+    [attr.maxlength]="maxlength()"
     [readonly]="readonly()"
     (focus)="inFocus = true"
     (blur)="onBlur()"

--- a/projects/element-ng/search-bar/si-search-bar.component.ts
+++ b/projects/element-ng/search-bar/si-search-bar.component.ts
@@ -97,6 +97,13 @@ export class SiSearchBarComponent implements OnInit, OnDestroy, ControlValueAcce
   readonly disabledInput = input(false, { alias: 'disabled', transform: booleanAttribute });
 
   /**
+   * Defines the maximum length of the search input.
+   *
+   * @defaultValue undefined
+   */
+  readonly maxlength = input(undefined, { transform: numberAttribute });
+
+  /**
    * Aria label for the clear button.
    *
    * @defaultValue


### PR DESCRIPTION
Adds a maxlength input to the SiSearchBarComponent that allows consumers to define the maximum length of the search input field.

See https://code.siemens.com/simpl/simpl-element/-/work_items/2647<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2017/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2017/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2017/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2017/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2017/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2017/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2017/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2017/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2017/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2017/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


