### PR TITLE
fix(forms): maintain hover/focus state with sibling form-control-actions

### DIFF
--- a/playwright/e2e/element-examples/si-datepicker.spec.ts
+++ b/playwright/e2e/element-examples/si-datepicker.spec.ts
@@ -30,4 +30,14 @@ test.describe('si-datepicker', () => {
       await si.runVisualAndA11yTests('year');
     });
   });
+
+  test('calendar-button states', async ({ page, si }) => {
+    await si.visitExample('si-datepicker/si-datepicker-input');
+    const calendarButton = page.getByLabel('Open calendar').first();
+    await calendarButton.focus();
+    await si.runVisualAndA11yTests('calendar-button-focus', { skipAriaSnapshot: true });
+    await calendarButton.blur();
+    await calendarButton.hover();
+    await si.runVisualAndA11yTests('calendar-button-hover', { skipAriaSnapshot: true });
+  });
 });

--- a/playwright/snapshots/password-strength.spec.ts-snapshots/input-fields--password--visibility-toggle-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/password-strength.spec.ts-snapshots/input-fields--password--visibility-toggle-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97d4c19c5ebb1135d5089177b60c26c19dd92b348262cd22edf7319dc378f5fd
-size 17911
+oid sha256:cbe4919d5939e7b72b824924caaaf2d679b91c768e413c19f37c94dd5e43d463
+size 17952

--- a/playwright/snapshots/password-strength.spec.ts-snapshots/input-fields--password--visibility-toggle-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/password-strength.spec.ts-snapshots/input-fields--password--visibility-toggle-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf3ea9ef3056eb4e3119cebeac979e9e3f376d23ad98ed089308980f172b9a98
-size 17799
+oid sha256:0a75538afd914f8822b2a8b9abc67e184c174138e66afe5fe97d144012861ab4
+size 17819

--- a/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-focus-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-focus-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10cc7109558f8eea42847334fb0d541bf07a183cd52606ffb61dc9f7115c7c47
+size 31749

--- a/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-focus-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-focus-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b164612d6a3ad84fcbc512df3a66c58da3460b1d2d1a4b457f30fb4461861b37
+size 31082

--- a/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-hover-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-hover-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d6c862a550e4d07e860f3f6c6693c1fddccf2a00c105a5b8a82f5cad3eba95c
+size 31451

--- a/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-hover-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-hover-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a30c57734b431ab19bfc7ca9e065a5da3086db9ce5a4224659df0dac697a3cf1
+size 30870

--- a/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
+++ b/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
@@ -68,7 +68,7 @@
     background: semantic-tokens.$element-base-information;
   }
 
-  &:is(:focus, :hover) {
+  &:is(:focus, :hover, :has(+ .form-control-actions:is(:hover, :focus-within))) {
     --border-color: #{semantic-tokens.$element-ui-1};
     --si-textarea-mask: #{semantic-tokens.$element-base-input-experimental};
     background-color: semantic-tokens.$element-base-input-experimental;
@@ -76,7 +76,7 @@
 
   &:is(.readonly, [readonly]) {
     &,
-    &:is(:hover, :focus) {
+    &:is(:hover, :focus, :has(+ .form-control-actions:is(:hover, :focus-within))) {
       --border-color: #{semantic-tokens.$element-ui-4};
       --si-textarea-mask: transparent;
       background-color: transparent;
@@ -86,7 +86,7 @@
 
   &:is(.disabled, :disabled) {
     &,
-    &:is(:hover, :focus) {
+    &:is(:hover, :focus, :has(+ .form-control-actions:is(:hover, :focus-within))) {
       --border-color: #{semantic-tokens.$element-ui-4};
       --si-textarea-mask: transparent;
       background-color: transparent;


### PR DESCRIPTION
Previously, when hovering/focusing form-control-actions that where a sibling, the hover/focus state was removed from the input.
With this change, it sticks except for the focus ring.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2024/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2024/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2024/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2024/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2024/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2024/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2024/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2024/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2024/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2024/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->





