### PR TITLE
fix(forms): invalid controls should always have a red border

### DIFF
--- a/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--invalid-age-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--invalid-age-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ddd99a500e614cce1a8324810d756dee63bd30a6df107957e1e6f8aa520411b4
-size 49170
+oid sha256:14678360cce892f928cf22f3a6bb021d040eec5e3804c018ef2b4d90da94c91d
+size 49167

--- a/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--invalid-age-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--invalid-age-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a209590232e3a48597b9ec681ad2d81889eddf782bcc787ddef0331cc8b1005b
-size 49158
+oid sha256:2bf48dfc9875ad6a58df531734e4fe1b6d3ca0ed160dd42a57cef4109eedfdb0
+size 49188

--- a/projects/element-theme/src/styles/bootstrap/forms/_validation.scss
+++ b/projects/element-theme/src/styles/bootstrap/forms/_validation.scss
@@ -50,8 +50,7 @@
   }
 
   @if $color {
-    &:not(.no-validation):not(:hover),
-    &:not(.no-validation):focus {
+    &:not(.no-validation) {
       --border-color: #{$color};
     }
   }


### PR DESCRIPTION
Unless validation is disabled, hover/focus state should not affect the border.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2025/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2025/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2025/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2025/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2025/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2025/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2025/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2025/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2025/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2025/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

