### PR TITLE
refactor(tree): use DestroyRef instead of life-cycle method

### DIFF
--- a/api-goldens/element-ng/tree-view/index.api.md
+++ b/api-goldens/element-ng/tree-view/index.api.md
@@ -214,7 +214,7 @@ export class SiTreeViewComponent implements OnInit, OnChanges, OnDestroy, AfterV
 }
 
 // @public (undocumented)
-export class SiTreeViewItemComponent implements OnInit, OnDestroy, AfterViewInit, FocusableOption, DoCheck {
+export class SiTreeViewItemComponent implements OnInit, AfterViewInit, FocusableOption, DoCheck {
     constructor();
     focus(): void;
     getLabel(): string;

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
@@ -10,23 +10,24 @@ import {
   ChangeDetectorRef,
   Component,
   computed,
+  DestroyRef,
   DoCheck,
   effect,
   ElementRef,
   HostBinding,
   inject,
-  OnDestroy,
   OnInit,
   signal,
   TemplateRef,
   viewChild
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { correctKeyRTL, MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiLoadingSpinnerComponent } from '@siemens/element-ng/loading-spinner';
 import { MenuItem, SiMenuFactoryComponent } from '@siemens/element-ng/menu';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
-import { asyncScheduler, Subject, Subscription } from 'rxjs';
+import { asyncScheduler, Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 
 import { TREE_ITEM_CONTEXT } from '../si-tree-view-item-context';
@@ -70,12 +71,11 @@ import {
     '(keydown)': 'onKeydown($event)'
   }
 })
-export class SiTreeViewItemComponent
-  implements OnInit, OnDestroy, AfterViewInit, FocusableOption, DoCheck
-{
+export class SiTreeViewItemComponent implements OnInit, AfterViewInit, FocusableOption, DoCheck {
   private element = inject(ElementRef);
   private siTreeViewService = inject(SiTreeViewService);
   private cdRef = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
   protected treeItemContext = inject(TREE_ITEM_CONTEXT);
   protected treeViewComponent = this.treeItemContext.parent;
   /** @internal */
@@ -102,7 +102,6 @@ export class SiTreeViewItemComponent
   protected icons = this.treeViewComponent.computedIcons;
 
   private savedElement: ElementRef | undefined;
-  private subscriptions: Subscription[] = [];
   private indentLevel = this.treeItem.level ?? 0;
   private nextSiblingElement!: HTMLElement;
   protected readonly menuTrigger = viewChild(CdkMenuTrigger);
@@ -145,15 +144,17 @@ export class SiTreeViewItemComponent
   }
 
   ngOnInit(): void {
-    this.subscriptions.push(
-      this.scrollIntoView.subscribe(event => this.onScrollIntoViewByConsumer(event))
-    );
-    this.subscriptions.push(
-      this.childrenLoaded.subscribe(event => this.childrenLoadingDone(event))
-    );
-    this.subscriptions.push(
-      this.siTreeViewService.triggerMarkForCheck.subscribe(() => this.cdRef.markForCheck())
-    );
+    this.scrollIntoView
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(event => this.onScrollIntoViewByConsumer(event));
+
+    this.childrenLoaded
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(event => this.childrenLoadingDone(event));
+
+    this.siTreeViewService.triggerMarkForCheck
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.cdRef.markForCheck());
   }
 
   ngDoCheck(): void {
@@ -174,12 +175,6 @@ export class SiTreeViewItemComponent
       this.savedElement = undefined;
     }
     this.nextSiblingElement = this.element.nativeElement?.nextElementSibling;
-  }
-
-  ngOnDestroy(): void {
-    this.subscriptions
-      .filter(subscription => !!subscription)
-      .forEach(subscription => subscription.unsubscribe());
   }
 
   protected readonly enableSelection = this.treeViewComponent.enableSelection;

--- a/projects/element-ng/tree-view/si-tree-view.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.ts
@@ -17,6 +17,7 @@ import {
   computed,
   contentChild,
   contentChildren,
+  DestroyRef,
   ElementRef,
   inject,
   INJECTOR,
@@ -32,11 +33,12 @@ import {
   viewChild,
   viewChildren
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
 import { MenuItem } from '@siemens/element-ng/menu';
 import { ElementDimensions, ResizeObserverService } from '@siemens/element-ng/resize-observer';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
-import { asyncScheduler, defer, fromEvent, merge, Observable, Subject, Subscription } from 'rxjs';
+import { asyncScheduler, defer, fromEvent, merge, Observable, Subject } from 'rxjs';
 import { map, withLatestFrom } from 'rxjs/operators';
 
 import { SiTreeViewConverterService } from './si-tree-view-converter.service';
@@ -377,7 +379,6 @@ export class SiTreeViewComponent
   private manuallySelectedTreeItems = false;
   private latestFolderChanged?: TreeItem;
   private breadCrumbTreeItems: TreeItem[] = [];
-  private subscriptions: Subscription[] = [];
   private multiSelectionStart!: TreeItem;
   private _multiSelectionActive = false;
   private domChangeObserver?: MutationObserver;
@@ -391,6 +392,7 @@ export class SiTreeViewComponent
   private cdRef = inject(ChangeDetectorRef);
   private resizeObserver = inject(ResizeObserverService);
   private injector = inject(INJECTOR);
+  private destroyRef = inject(DestroyRef);
   /**
    * Create a virtual root node so there is just a single root node. This makes sure the tree
    * can be fully traversed starting from any node. This is needed e.g. for recursively
@@ -533,56 +535,62 @@ export class SiTreeViewComponent
     this.scroll$ = defer(() => fromEvent(this.treeViewInnerElement().nativeElement, 'scroll'));
     this.siTreeViewService.scroll$ = this.scroll$;
     if (this.isVirtualized()) {
-      this.subscriptions.push(this.scroll$.subscribe(event => this.onScroll(event)));
+      this.scroll$
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(event => this.onScroll(event));
     }
 
-    this.subscriptions.push(
-      this.siTreeViewService.clickEvent.subscribe(event => this.onItemClicked(event))
-    );
-    this.subscriptions.push(
-      this.siTreeViewService.folderClickEvent.subscribe(event => this.onItemFolderClicked(event))
-    );
-    this.subscriptions.push(
-      this.siTreeViewService.checkboxClickEvent.subscribe(event =>
-        this.onItemCheckboxClicked(event)
-      )
-    );
-    this.subscriptions.push(
-      this.siTreeViewService.loadChildrenEvent.subscribe(event => this.onLoadChildren(event))
-    );
-    this.subscriptions.push(
-      this.siTreeViewService.scrollIntoViewEvent.subscribe(event => this.onScrollIntoView(event))
-    );
-    this.subscriptions.push(
-      this.siTreeViewService.focusParentEvent.subscribe(event => {
+    this.siTreeViewService.clickEvent
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(event => this.onItemClicked(event));
+
+    this.siTreeViewService.folderClickEvent
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(event => this.onItemFolderClicked(event));
+
+    this.siTreeViewService.checkboxClickEvent
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(event => this.onItemCheckboxClicked(event));
+
+    this.siTreeViewService.loadChildrenEvent
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(event => this.onLoadChildren(event));
+
+    this.siTreeViewService.scrollIntoViewEvent
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(event => this.onScrollIntoView(event));
+
+    this.siTreeViewService.focusParentEvent
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(event => {
         if (!this.flatTree()) {
           this.focusParentItem(event);
           return;
         }
         this.onFlatTreeNavigateUp();
-      })
-    );
-    this.subscriptions.push(
-      this.siTreeViewService.focusFirstChildEvent.subscribe(event =>
-        this.focusFirstChildItem(event)
-      )
-    );
-    this.subscriptions.push(
-      this.siTreeViewVirtualizationService.itemsVirtualizedChanged.subscribe(
-        (event: ItemsVirtualizedArgs) => {
-          this.itemsVirtualizedChanged.emit(event);
-          this.evaluateForTreeItemsDiffer.next();
-          this.cdRef.markForCheck();
-        }
-      )
-    );
+      });
+
+    this.siTreeViewService.focusFirstChildEvent
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(event => this.focusFirstChildItem(event));
+
+    this.siTreeViewVirtualizationService.itemsVirtualizedChanged
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((event: ItemsVirtualizedArgs) => {
+        this.itemsVirtualizedChanged.emit(event);
+        this.evaluateForTreeItemsDiffer.next();
+        this.cdRef.markForCheck();
+      });
+
     this.initialized = true;
     this.handleTreeMode();
   }
 
   ngAfterViewInit(): void {
     this.addClassObserver();
-    this.subscriptions.push(this.monitorTreeSizeChanges().subscribe(d => this.updatePageSize(d)));
+    this.monitorTreeSizeChanges()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(d => this.updatePageSize(d));
     this.keyManager = new FocusKeyManager(this.getChildren(), this.injector)
       .withWrap()
       .withAllowedModifierKeys(['shiftKey'])
@@ -663,9 +671,9 @@ export class SiTreeViewComponent
   }
 
   ngOnDestroy(): void {
-    this.subscriptions
-      .filter(subscription => !!subscription)
-      .forEach(subscription => subscription.unsubscribe());
+    this.scrollChildIntoView.complete();
+    this.childrenLoaded.complete();
+    this.evaluateForTreeItemsDiffer.complete();
     this.domChangeObserver?.disconnect();
   }
 
@@ -1025,7 +1033,7 @@ export class SiTreeViewComponent
   }
 
   private emitSelectedItems(): void {
-    if (this.enableSelection()) {
+    if (!this.destroyRef.destroyed && this.enableSelection()) {
       if (this.siTreeViewService.groupedList) {
         const filtered: TreeItem[] = this.selectedTreeItems.filter(
           item => !this.siTreeViewService.isGroupedItem(item)


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->

- use DestroyRef instead of life-cycle method
- only use emit when the component isn't already destroyed

<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2030/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2030/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2030/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2030/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2030/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2030/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2030/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2030/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2030/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2030/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


