### PR TITLE
refactor(theme): generate better CSS, dont't use deprecated variable

### DIFF
--- a/projects/element-theme/src/styles/bootstrap/_variables.scss
+++ b/projects/element-theme/src/styles/bootstrap/_variables.scss
@@ -355,10 +355,11 @@ $input-height-border: $input-border-width * 2 !default;
 
 $input-height: functions.add(
   $input-line-height * 1em,
-  functions.add($input-padding-y * 2, $input-height-border, false)
+  ($input-padding-y + $input-border-width) * 2
 ) !default;
 
-$input-height-inner: functions.subtract($input-height, $input-height-border) !default;
+// don't derive from $input-height as it generates a nested calc() expression
+$input-height-inner: functions.add($input-line-height * 1em, $input-padding-y * 2) !default;
 // Wrap in parenthesis: `*` binds tighter than `-`, so without them only the border term gets multiplied.
 // DEPRECATED: Calculate it yourself using $input-height-inner
 $input-height-inner-half: calc((#{$input-height-inner}) * 0.5) !default;

--- a/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
+++ b/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
@@ -37,7 +37,7 @@
   background-repeat: no-repeat;
   background-size: variables.$form-feedback-icon-size;
   background-position-y: top
-    calc((#{variables.$input-height-inner-half} - (#{variables.$form-feedback-icon-size} * 0.5)));
+    calc((#{variables.$input-height-inner} - #{variables.$form-feedback-icon-size}) * 0.5);
   background-position-x: right
     calc(
       #{map.get(spacers.$spacers, 2) - variables.$input-border-width} +


### PR DESCRIPTION
Currently we have

```css
background-position-y: top calc(calc((calc(calc(1.1428571429em + 16px) - 2px)) * 0.5) - 1.25rem * 0.5);
```

This PR changes this to

```css
background-position-y: top calc((calc(1.1428571429em + 14px) - 1.25rem) * 0.5);
```

still not ideal, but much better

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2037/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2037/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2037/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2037/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2037/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2037/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2037/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2037/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2037/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2037/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

