### PR TITLE
refactor(select): prevent search icon from overlapping

### DIFF
--- a/projects/element-ng/select/select-list/si-select-list-has-filter.component.html
+++ b/projects/element-ng/select/select-list/si-select-list-has-filter.component.html
@@ -4,7 +4,7 @@
       #filter
       #siAutocomplete="siAutocomplete"
       siAutocomplete
-      class="form-control ps-9 border-0 rounded-2 bg-base-0"
+      class="form-control icon-start border-0 rounded-2 bg-base-0"
       [placeholder]="filterPlaceholder() | translate"
       [id]="baseId() + 'filter-input'"
       [attr.aria-labelledby]="baseId() + '-aria-label' + ' ' + labelledby()"

--- a/projects/element-ng/select/select-list/si-select-list-has-filter.component.scss
+++ b/projects/element-ng/select/select-list/si-select-list-has-filter.component.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @use '@siemens/element-theme/src/styles/variables';
 
 .si-select-filtered-items {
@@ -9,4 +10,8 @@
 
 si-loading-spinner {
   --loading-spinner-size: #{variables.$si-icon-font-size};
+}
+
+.icon-start {
+  padding-inline-start: calc(#{variables.$si-icon-font-size} + #{map.get(variables.$spacers, 5)});
 }


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->

Ensure the search icon in si-select with filter doesn't overlap the input in case the root font-size is increased 

See https://code.siemens.com/simpl/simpl-element/-/work_items/4
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2039/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2039/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2039/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2039/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2039/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2039/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2039/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2039/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2039/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2039/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
