### PR TITLE
refactor(tree): tree state indicator grow with root font size

### DIFF
--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.scss
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.scss
@@ -172,8 +172,8 @@
 .si-tree-view-state-indicator {
   margin-block: 0;
   margin-inline: calc(var(--si-tree-view-padding-base-horizontal) * 0.75);
-  min-inline-size: map.get(variables.$spacers, 3);
-  block-size: map.get(variables.$spacers, 3);
+  min-inline-size: 0.375rem;
+  block-size: 0.375rem;
   border-radius: 50%;
 
   &.si-tree-view-state-indicator-endmost {


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->

Ensure the tree state indicator grow with the root font-size

See https://code.siemens.com/simpl/simpl-element/-/work_items/4<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2040/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2040/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2040/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2040/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2040/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2040/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2040/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2040/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2040/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2040/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
