### PR TITLE
fix(side-panel): fix tabbed navigation

### DIFF
--- a/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item-side-panel--popover.yaml
+++ b/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item-side-panel--popover.yaml
@@ -1,3 +1,11 @@
+- banner:
+  - link "Siemens logo":
+    - /url: "#/"
+  - text: Application name
+  - button "Tenant 1"
+  - button "4 Notifications"
+  - button "Support"
+  - button "John Doe"
 - paragraph: Notifications
 - menubar:
   - menuitem "Mark all as read"
@@ -78,11 +86,3 @@
 - button "Read"
 - button "Archive"
 - button "Delete"
-- banner:
-  - link "Siemens logo":
-    - /url: "#/"
-  - text: Application name
-  - button "Tenant 1"
-  - button "4 Notifications"
-  - button "Support"
-  - button "John Doe"

--- a/playwright/snapshots/si-page-header.spec.ts-snapshots/si-page-header--si-page-header--large.yaml
+++ b/playwright/snapshots/si-page-header.spec.ts-snapshots/si-page-header--si-page-header--large.yaml
@@ -1,6 +1,5 @@
 - link "Jump to Main content"
 - link "Jump to Navigation"
-- button "Toggle"
 - banner:
   - link "Siemens logo":
     - /url: "#/"
@@ -40,3 +39,4 @@
   - text: Actions
   - checkbox "Toolbar" [checked]
   - text: Toolbar
+- button "Toggle"

--- a/playwright/snapshots/si-page-header.spec.ts-snapshots/si-page-header--si-page-header--small-nav-indented.yaml
+++ b/playwright/snapshots/si-page-header.spec.ts-snapshots/si-page-header--si-page-header--small-nav-indented.yaml
@@ -1,6 +1,5 @@
 - link "Jump to Main content"
 - link "Jump to Navigation"
-- button "Toggle"
 - banner:
   - link "Siemens logo":
     - /url: "#/"
@@ -39,3 +38,4 @@
   - text: Actions
   - checkbox "Toolbar" [checked]
   - text: Toolbar
+- button "Toggle"

--- a/playwright/snapshots/si-page-header.spec.ts-snapshots/si-page-header--si-page-header--small-title-indented.yaml
+++ b/playwright/snapshots/si-page-header.spec.ts-snapshots/si-page-header--si-page-header--small-title-indented.yaml
@@ -1,6 +1,5 @@
 - link "Jump to Main content"
 - link "Jump to Navigation"
-- button "Toggle"
 - banner:
   - link "Siemens logo":
     - /url: "#/"
@@ -28,3 +27,4 @@
   - text: Actions
   - checkbox "Toolbar" [checked]
   - text: Toolbar
+- button "Toggle"

--- a/playwright/snapshots/si-page-header.spec.ts-snapshots/si-page-header--si-page-header--small.yaml
+++ b/playwright/snapshots/si-page-header.spec.ts-snapshots/si-page-header--si-page-header--small.yaml
@@ -1,6 +1,5 @@
 - link "Jump to Main content"
 - link "Jump to Navigation"
-- button "Toggle"
 - banner:
   - link "Siemens logo":
     - /url: "#/"
@@ -41,3 +40,4 @@
   - text: Actions
   - checkbox "Toolbar" [checked]
   - text: Toolbar
+- button "Toggle"

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode-no-backdrop.yaml
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode-no-backdrop.yaml
@@ -1,12 +1,3 @@
-- paragraph: Title
-- button "Enter fullscreen"
-- button "Close"
-- button "Hey there" [expanded]
-- region "Hey there": And here we have some content
-- button "Another one"
-- region "Another one"
-- button "Number three"
-- region "Number three"
 - banner:
   - link "Siemens logo":
     - /url: "#/"
@@ -56,3 +47,12 @@
   - text: input.
 - checkbox "disableBackdrop" [checked]
 - text: disableBackdrop
+- paragraph: Title
+- button "Enter fullscreen"
+- button "Close"
+- button "Hey there" [expanded]
+- region "Hey there": And here we have some content
+- button "Another one"
+- region "Another one"
+- button "Number three"
+- region "Number three"

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode.yaml
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--over-mode.yaml
@@ -1,12 +1,3 @@
-- paragraph: Title
-- button "Enter fullscreen"
-- button "Close"
-- button "Hey there" [expanded]
-- region "Hey there": And here we have some content
-- button "Another one"
-- region "Another one"
-- button "Number three"
-- region "Number three"
 - banner:
   - link "Siemens logo":
     - /url: "#/"
@@ -56,3 +47,12 @@
   - text: input.
 - checkbox "disableBackdrop"
 - text: disableBackdrop
+- paragraph: Title
+- button "Enter fullscreen"
+- button "Close"
+- button "Hey there" [expanded]
+- region "Hey there": And here we have some content
+- button "Another one"
+- region "Another one"
+- button "Number three"
+- region "Number three"

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--scroll-mode.yaml
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel--scroll-mode.yaml
@@ -1,12 +1,3 @@
-- paragraph: Title
-- button "Enter fullscreen"
-- button "Close"
-- button "Hey there" [expanded]
-- region "Hey there": And here we have some content
-- button "Another one"
-- region "Another one"
-- button "Number three"
-- region "Number three"
 - banner:
   - link "Siemens logo":
     - /url: "#/"
@@ -56,3 +47,12 @@
   - text: input.
 - checkbox "disableBackdrop"
 - text: disableBackdrop
+- paragraph: Title
+- button "Enter fullscreen"
+- button "Close"
+- button "Hey there" [expanded]
+- region "Hey there": And here we have some content
+- button "Another one"
+- region "Another one"
+- button "Number three"
+- region "Number three"

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible--closed.yaml
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible--closed.yaml
@@ -1,9 +1,3 @@
-- button "Toggle"
-- button "Out of Service"
-- button "Event source active, ack"
-- button "Properties"
-- button "Documents"
-- button "Graphics"
 - banner:
   - link "Siemens logo":
     - /url: "#/"
@@ -46,3 +40,10 @@
   - text: Expanded width for complex forms and content.
   - code: "Extended (Responsive):"
   - text: Adaptive width scaling from mobile full-width to desktop 912px max.
+- button "Toggle"
+- button "Properties"
+- button "Documents"
+- button "Graphics"
+- button "Out of Service"
+- button "•" [disabled]
+- button "Event source active, ack"

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible--open.yaml
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible--open.yaml
@@ -1,19 +1,3 @@
-- paragraph: Cooling coil
-- menubar:
-  - menuitem "Path"
-  - menuitem "Edit"
-  - menuitem "Toggle"
-- button "Enter fullscreen"
-- button "Toggle"
-- button "Out of Service"
-- button "Event source active, ack"
-- textbox "Search..."
-- button "Properties 5" [expanded]
-- region "Properties 5": And here we have some content
-- button "Documents"
-- region "Documents"
-- button "Graphics"
-- region "Graphics"
 - banner:
   - link "Siemens logo":
     - /url: "#/"
@@ -56,3 +40,20 @@
   - text: Expanded width for complex forms and content.
   - code: "Extended (Responsive):"
   - text: Adaptive width scaling from mobile full-width to desktop 912px max.
+- paragraph: Cooling coil
+- menubar:
+  - menuitem "Path"
+  - menuitem "Edit"
+  - menuitem "Toggle"
+- button "Enter fullscreen"
+- button "Toggle" [expanded]
+- textbox "Search..."
+- button "Properties 5" [expanded]
+- region "Properties 5": And here we have some content
+- button "Documents"
+- region "Documents"
+- button "Graphics"
+- region "Graphics"
+- button "Out of Service"
+- button "•" [disabled]
+- button "Event source active, ack"

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible-legacy-status-actions--legacy-closed.yaml
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible-legacy-status-actions--legacy-closed.yaml
@@ -1,11 +1,3 @@
-- button "Toggle"
-- link "Out of Service":
-  - /url: ""
-- link "Event source active, ack":
-  - /url: ""
-- button "Properties"
-- button "Documents"
-- button "Graphics"
 - banner:
   - link "Siemens logo":
     - /url: "#/"
@@ -48,3 +40,11 @@
   - text: Expanded width for complex forms and content.
   - code: "Extended (Responsive):"
   - text: Adaptive width scaling from mobile full-width to desktop 912px max.
+- button "Toggle"
+- link "Out of Service":
+  - /url: ""
+- link "Event source active, ack":
+  - /url: ""
+- button "Properties"
+- button "Documents"
+- button "Graphics"

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible-legacy-status-actions--legacy-open.yaml
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-collapsible-legacy-status-actions--legacy-open.yaml
@@ -1,21 +1,3 @@
-- paragraph: Cooling coil
-- menubar:
-  - menuitem "Path"
-  - menuitem "Edit"
-  - menuitem "Toggle"
-- button "Enter fullscreen"
-- button "Toggle"
-- link "Out of Service":
-  - /url: ""
-- link "Event source active, ack":
-  - /url: ""
-- textbox "Search..."
-- button "Properties 5" [expanded]
-- region "Properties 5": And here we have some content
-- button "Documents"
-- region "Documents"
-- button "Graphics"
-- region "Graphics"
 - banner:
   - link "Siemens logo":
     - /url: "#/"
@@ -58,3 +40,21 @@
   - text: Expanded width for complex forms and content.
   - code: "Extended (Responsive):"
   - text: Adaptive width scaling from mobile full-width to desktop 912px max.
+- paragraph: Cooling coil
+- menubar:
+  - menuitem "Path"
+  - menuitem "Edit"
+  - menuitem "Toggle"
+- button "Enter fullscreen"
+- button "Toggle" [expanded]
+- link "Out of Service":
+  - /url: ""
+- link "Event source active, ack":
+  - /url: ""
+- textbox "Search..."
+- button "Properties 5" [expanded]
+- region "Properties 5": And here we have some content
+- button "Documents"
+- region "Documents"
+- button "Graphics"
+- region "Graphics"

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel.yaml
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel.yaml
@@ -1,11 +1,3 @@
-- paragraph: Title
-- button "Close"
-- button "Hey there" [expanded]
-- region "Hey there": And here we have some content
-- button "Another one"
-- region "Another one"
-- button "Number three"
-- region "Number three"
 - banner:
   - heading "Side panel" [level=1]
   - button "Layout"
@@ -53,3 +45,11 @@
   - text: input.
 - checkbox "disableBackdrop"
 - text: disableBackdrop
+- paragraph: Title
+- button "Close"
+- button "Hey there" [expanded]
+- region "Hey there": And here we have some content
+- button "Another one"
+- region "Another one"
+- button "Number three"
+- region "Number three"

--- a/playwright/snapshots/si-tour.spec.ts-snapshots/si-tour--si-tour--first-step.yaml
+++ b/playwright/snapshots/si-tour.spec.ts-snapshots/si-tour--si-tour--first-step.yaml
@@ -18,10 +18,6 @@
   - link "Test Coverage":
     - /url: "#/viewer/viewer/coverage"
 - main:
-  - button "Toggle"
-  - button "Properties"
-  - button "Documents"
-  - button "Graphics"
   - text: /4 Security \d+ Update \d+ Information/
   - navigation "Breadcrumbs":
     - list:
@@ -41,6 +37,10 @@
   - textbox "Search"
   - button "Toolbar item"
   - text: Placeholder for the content of the page, using the fixed height layout.
+  - button "Toggle"
+  - button "Properties"
+  - button "Documents"
+  - button "Graphics"
 - text: Status bar Page title Thank you
 - dialog "Status bar":
   - text: 1 of 7 Status bar

--- a/playwright/snapshots/si-tour.spec.ts-snapshots/si-tour--si-tour--last-step.yaml
+++ b/playwright/snapshots/si-tour.spec.ts-snapshots/si-tour--si-tour--last-step.yaml
@@ -18,10 +18,6 @@
   - link "Test Coverage":
     - /url: "#/viewer/viewer/coverage"
 - main:
-  - button "Toggle"
-  - button "Properties"
-  - button "Documents"
-  - button "Graphics"
   - text: /4 Security \d+ Update \d+ Information/
   - navigation "Breadcrumbs":
     - list:
@@ -41,6 +37,10 @@
   - textbox "Search"
   - button "Toolbar item"
   - text: Placeholder for the content of the page, using the fixed height layout.
+  - button "Toggle"
+  - button "Properties"
+  - button "Documents"
+  - button "Graphics"
 - text: Status bar Page title Thank you
 - dialog "Tour completed":
   - text: 7 of 7 Tour completed

--- a/playwright/snapshots/si-tour.spec.ts-snapshots/si-tour--si-tour--open-menu.yaml
+++ b/playwright/snapshots/si-tour.spec.ts-snapshots/si-tour--si-tour--open-menu.yaml
@@ -24,10 +24,6 @@
   - link "Test Coverage":
     - /url: "#/viewer/viewer/coverage"
 - main:
-  - button "Toggle"
-  - button "Properties"
-  - button "Documents"
-  - button "Graphics"
   - text: /4 Security \d+ Update \d+ Information/
   - navigation "Breadcrumbs":
     - list:
@@ -47,6 +43,10 @@
   - textbox "Search"
   - button "Toolbar item"
   - text: Placeholder for the content of the page, using the fixed height layout.
+  - button "Toggle"
+  - button "Properties"
+  - button "Documents"
+  - button "Graphics"
 - text: Status bar Page title Thank you
 - dialog "Help menu":
   - text: 6 of 7 Help menu

--- a/playwright/snapshots/si-tour.spec.ts-snapshots/si-tour--si-tour--second-step.yaml
+++ b/playwright/snapshots/si-tour.spec.ts-snapshots/si-tour--si-tour--second-step.yaml
@@ -18,10 +18,6 @@
   - link "Test Coverage":
     - /url: "#/viewer/viewer/coverage"
 - main:
-  - button "Toggle"
-  - button "Properties"
-  - button "Documents"
-  - button "Graphics"
   - text: /4 Security \d+ Update \d+ Information/
   - navigation "Breadcrumbs":
     - list:
@@ -41,6 +37,10 @@
   - textbox "Search"
   - button "Toolbar item"
   - text: Placeholder for the content of the page, using the fixed height layout.
+  - button "Toggle"
+  - button "Properties"
+  - button "Documents"
+  - button "Graphics"
 - text: Status bar Page title Thank you
 - dialog "Page title":
   - text: 2 of 7 Page title

--- a/playwright/snapshots/static.spec.ts-snapshots/si-electron-titlebar--si-fixed-height-layout-side-panel.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-electron-titlebar--si-fixed-height-layout-side-panel.yaml
@@ -23,10 +23,6 @@
   - link "Test Coverage":
     - /url: "#/viewer/viewer/coverage"
 - main:
-  - button "Toggle"
-  - button "Properties"
-  - button "Documents"
-  - button "Graphics"
   - text: /4 Emergency \d+ Trouble \d+ Success/
   - button "Expand"
   - heading "Here is a title" [level=2]
@@ -81,3 +77,7 @@
     - listitem:
       - status "user in status danger"
       - text: Vestibulum at eros
+  - button "Toggle"
+  - button "Properties"
+  - button "Documents"
+  - button "Graphics"

--- a/projects/element-ng/side-panel/si-side-panel-actions.component.scss
+++ b/projects/element-ng/side-panel/si-side-panel-actions.component.scss
@@ -6,6 +6,7 @@
   align-items: center;
   justify-content: space-between;
   padding-inline: map.get(variables.$spacers, 6);
+  order: -1;
 }
 
 :host-context(.collapsible .collapsed) {

--- a/projects/element-ng/side-panel/si-side-panel-content.component.html
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.html
@@ -119,7 +119,6 @@
       }
     </div>
   }
-  <ng-content select="si-side-panel-actions" />
   @if (searchable() && focusable()) {
     <div class="nav-search px-6 auto-hide">
       <si-search-bar
@@ -139,4 +138,5 @@
       <ng-content />
     </div>
   }
+  <ng-content select="si-side-panel-actions" />
 </div>

--- a/projects/element-ng/side-panel/si-side-panel-content.component.scss
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.scss
@@ -86,6 +86,10 @@
   align-items: center;
 }
 
+.rpanel-statusactions {
+  order: -1;
+}
+
 .rpanel-header {
   justify-content: space-between;
 }

--- a/projects/element-ng/side-panel/si-side-panel.component.html
+++ b/projects/element-ng/side-panel/si-side-panel.component.html
@@ -1,7 +1,17 @@
 @if (showBackdrop()) {
   <div class="modal-backdrop" animate.leave="backdrop-leave" (click)="toggleSidePanel()"></div>
 }
-<div #sidePanel class="side-panel focus-none" tabindex="-1">
+<div #content class="main-content si-layout-inner">
+  <ng-content />
+</div>
+<div
+  #sidePanel
+  class="side-panel focus-none"
+  tabindex="-1"
+  [cdkTrapFocus]="shouldTrapFocus()"
+  [cdkTrapFocusAutoCapture]="shouldTrapFocus()"
+  [attr.inert]="sidePanelInert() ? '' : null"
+>
   <div class="inner" [class.d-none]="showTempContent()">
     <ng-content select="si-side-panel-content, element-side-panel-content" />
     <ng-container #portalOutlet cdkPortalOutlet />
@@ -9,7 +19,4 @@
   <div class="inner" [class.d-none]="!showTempContent()">
     <ng-container #tmpPortalOutlet cdkPortalOutlet />
   </div>
-</div>
-<div #content class="main-content si-layout-inner">
-  <ng-content />
 </div>

--- a/projects/element-ng/side-panel/si-side-panel.component.ts
+++ b/projects/element-ng/side-panel/si-side-panel.component.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
+import { CdkTrapFocus } from '@angular/cdk/a11y';
 import { CdkPortalOutlet, Portal, PortalModule } from '@angular/cdk/portal';
 import { isPlatformBrowser } from '@angular/common';
 import {
@@ -41,7 +42,7 @@ import { SidePanelMode, SidePanelSize } from './side-panel.model';
 
 @Component({
   selector: 'si-side-panel',
-  imports: [PortalModule],
+  imports: [CdkTrapFocus, PortalModule],
   templateUrl: './si-side-panel.component.html',
   styleUrl: './si-side-panel.component.scss',
   host: {
@@ -162,6 +163,10 @@ export class SiSidePanelComponent implements OnInit, OnDestroy, OnChanges {
   });
   protected readonly showBackdrop = computed(
     () => !this.disableBackdrop() && this.isOverMode() && !this.isCollapsed()
+  );
+  protected readonly shouldTrapFocus = computed(() => this.isOverMode() && !this.isCollapsed());
+  protected readonly sidePanelInert = computed(
+    () => this.isOverMode() && this.isCollapsed() && !this.collapsible()
   );
   protected readonly isXs = signal(false);
   protected readonly isSm = signal(false);


### PR DESCRIPTION
Closes #1841 

Fix keyboard tab order and focus management in si-side-panel. Main content is now rendered before .side-panel in the DOM so tab order matches visual layout (app header before side panel). cdkTrapFocus prevents focus escaping when the panel is open as an overlay. An inert attribute eliminates ghost tab stops during the close animation in non-collapsible over mode. si-side-panel-actions is moved to the end of the DOM and repositioned visually with CSS order: -1, so collapsed accordion headers are tabbed before action buttons, matching their visual order in the icon-strip state.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2044/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2044/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2044/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2044/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2044/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2044/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2044/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2044/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2044/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2044/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



