### PR TITLE
feat(about): add translatable logoAlt input to SiAboutComponent

### DIFF
--- a/api-goldens/element-ng/about/index.api.md
+++ b/api-goldens/element-ng/about/index.api.md
@@ -9,6 +9,7 @@ import * as _angular_platform_browser from '@angular/platform-browser';
 import { CopyrightDetails } from '@siemens/element-ng/copyright-notice';
 import { Link } from '@siemens/element-ng/link';
 import { OnInit } from '@angular/core';
+import * as _siemens_element_translate_ng_translate from '@siemens/element-translate-ng/translate';
 
 // @public (undocumented)
 export interface ApiInfo {
@@ -40,6 +41,7 @@ export class SiAboutComponent implements OnInit {
     readonly imprintLink: _angular_core.InputSignal<Link | undefined>;
     readonly licenseInfo: _angular_core.InputSignal<LicenseInfo>;
     readonly links: _angular_core.InputSignal<Link[]>;
+    readonly logoAlt: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly privacyLink: _angular_core.InputSignal<Link | undefined>;
     readonly subheading: _angular_core.InputSignal<string[] | undefined>;
     readonly termsLink: _angular_core.InputSignal<Link | undefined>;

--- a/playwright/snapshots/si-about.spec.ts-snapshots/si-about--si-about-api.yaml
+++ b/playwright/snapshots/si-about.spec.ts-snapshots/si-about--si-about-api.yaml
@@ -1,5 +1,5 @@
 - text: About
-- img "Application title's Logo"
+- img "Application title logo"
 - heading "Application title" [level=3]
 - paragraph: app version v0.1.2.alpha4
 - paragraph: /© Siemens \d+-\d+/

--- a/playwright/snapshots/static.spec.ts-snapshots/si-about--si-about-api.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-about--si-about-api.yaml
@@ -1,5 +1,5 @@
 - text: About
-- img "Application title's Logo"
+- img "Application title logo"
 - heading "Application title" [level=3]
 - paragraph: app version v0.1.2.alpha4
 - paragraph: /© Siemens \d+-\d+/

--- a/playwright/snapshots/static.spec.ts-snapshots/si-about--si-about-text-api.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-about--si-about-text-api.yaml
@@ -1,5 +1,5 @@
 - text: About
-- img "Application title's Logo"
+- img "Application title logo"
 - heading "Application title" [level=3]
 - paragraph: app version v0.1.2.alpha4
 - paragraph: /© Siemens \d+-\d+/

--- a/projects/element-ng/about/si-about.component.html
+++ b/projects/element-ng/about/si-about.component.html
@@ -13,7 +13,7 @@
               class="rounded-circle"
               height="150"
               [src]="icon()"
-              [alt]="appName() + '\'s Logo'"
+              [alt]="logoAlt() | translate: { appName: appName() }"
             />
           } @else if (appIcon) {
             <si-icon class="app-icon" [icon]="appIcon" />

--- a/projects/element-ng/about/si-about.component.spec.ts
+++ b/projects/element-ng/about/si-about.component.spec.ts
@@ -25,6 +25,9 @@ describe('SiAboutComponent', () => {
   const cookieNoticeLink = signal<Link | undefined>(undefined);
   const termsLink = signal<Link | undefined>(undefined);
   const linksInput = signal<Link[]>([]);
+  const logoAlt = signal<string | undefined>(undefined);
+
+  const getLogoImg = (): HTMLImageElement | null => element.querySelector('img');
 
   const toggleCollapsePanel = (e?: HTMLElement): void =>
     (e ?? element).querySelector<HTMLElement>('.collapsible-header')?.click();
@@ -53,6 +56,7 @@ describe('SiAboutComponent', () => {
     cookieNoticeLink.set(undefined);
     termsLink.set(undefined);
     linksInput.set([]);
+    logoAlt.set(undefined);
     fixture = TestBed.createComponent(SiAboutComponent, {
       bindings: [
         inputBinding('aboutTitle', aboutTitle),
@@ -65,7 +69,8 @@ describe('SiAboutComponent', () => {
         inputBinding('privacyLink', privacyLink),
         inputBinding('cookieNoticeLink', cookieNoticeLink),
         inputBinding('termsLink', termsLink),
-        inputBinding('links', linksInput)
+        inputBinding('links', linksInput),
+        inputBinding('logoAlt', logoAlt)
       ]
     });
     element = fixture.nativeElement;
@@ -154,6 +159,17 @@ describe('SiAboutComponent', () => {
     expect(links).not.toContain('Terms and Conditions');
     expect(links).not.toContain('Some other link');
     expect(links).not.toContain('More information about stuff');
+  });
+
+  describe('logoAlt', () => {
+    it('should use custom logoAlt with appName interpolated', async () => {
+      appName.set('The');
+      iconInput.set('https://example.com/logo.png');
+      logoAlt.set('{{appName}} Application Logo');
+      await fixture.whenStable();
+
+      expect(getLogoImg()!.alt).toBe('The Application Logo');
+    });
   });
 
   describe('with iFrame mode', () => {

--- a/projects/element-ng/about/si-about.component.ts
+++ b/projects/element-ng/about/si-about.component.ts
@@ -19,7 +19,7 @@ import { SiCollapsiblePanelComponent } from '@siemens/element-ng/accordion';
 import { CopyrightDetails, SiCopyrightNoticeComponent } from '@siemens/element-ng/copyright-notice';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
-import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
 import { ApiInfo, LicenseInfo } from './si-about-data.model';
 
@@ -40,6 +40,16 @@ import { ApiInfo, LicenseInfo } from './si-about-data.model';
 export class SiAboutComponent implements OnInit {
   private http = inject(HttpClient);
   private sanitizer = inject(DomSanitizer);
+
+  /**
+   * Alt text for the application logo. Supports `{{appName}}` placeholder for interpolation.
+   *
+   * @defaultValue
+   * ```
+   * t(() => $localize`:@@SI_ABOUT.LOGO_ALT:{{appName}} logo`)
+   * ```
+   */
+  readonly logoAlt = input(t(() => $localize`:@@SI_ABOUT.LOGO_ALT:{{appName}} logo`));
 
   /**
    * Title shown above the about information.

--- a/projects/element-ng/translate/si-translatable-keys.interface.ts
+++ b/projects/element-ng/translate/si-translatable-keys.interface.ts
@@ -3,6 +3,7 @@
 // Auto-generated file. Run 'npx update-translatable-keys' to update.
 
 export interface SiTranslatableKeys {
+  'SI_ABOUT.LOGO_ALT'?: string;
   'SI_AI_MESSAGE.SECONDARY_ACTIONS'?: string;
   'SI_ALERT_DIALOG.OK'?: string;
   'SI_APPLICATION_HEADER.LAUNCHPAD'?: string;


### PR DESCRIPTION
Replace hardcoded logo alt text with a configurable `logoAlt` input that supports i18n via `TranslatableString` and `{{appName}}` interpolation.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2052/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2052/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2052/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2052/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2052/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2052/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2052/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2052/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2052/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2052/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->






