### PR TITLE
fix(dashboard): correct heading input type to TranslatableString

### DIFF
--- a/api-goldens/element-ng/dashboard/index.api.md
+++ b/api-goldens/element-ng/dashboard/index.api.md
@@ -47,7 +47,7 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
     constructor();
     readonly enableExpandInteractions: _angular_core.InputSignalWithTransform<boolean, unknown>;
     expand(card: SiDashboardCardComponent): void;
-    readonly heading: _angular_core.InputSignal<string | undefined>;
+    readonly heading: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly hideMenubar: _angular_core.InputSignalWithTransform<boolean, unknown>;
     get isExpanded(): boolean;
     restore(): void;

--- a/projects/element-ng/dashboard/si-dashboard.component.ts
+++ b/projects/element-ng/dashboard/si-dashboard.component.ts
@@ -27,7 +27,7 @@ import {
   ElementDimensions,
   ResizeObserverService
 } from '@siemens/element-ng/resize-observer';
-import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { Subject, takeUntil } from 'rxjs';
 
 import { SiDashboardCardComponent } from './si-dashboard-card.component';
@@ -48,7 +48,7 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
   /**
    * Heading for the dashboard page.
    */
-  readonly heading = input<string>();
+  readonly heading = input<TranslatableString>();
 
   /**
    * Opt-in to enable expand interaction for all cards.


### PR DESCRIPTION
The heading input already supported translatable strings at runtime but its type was declared as string.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2056/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2056/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2056/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2056/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2056/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2056/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2056/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2056/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2056/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2056/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


