### PR TITLE
test(e2e): resolve flaky tour tests

### DIFF
--- a/playwright/e2e/element-examples/si-tour.spec.ts
+++ b/playwright/e2e/element-examples/si-tour.spec.ts
@@ -11,11 +11,8 @@ test.describe('si-tour', () => {
     const nextClick = (): Promise<any> =>
       page.locator('si-tour button', { hasText: 'Next' }).click();
 
-    const waitForTourStep = async (hasArrow = true): Promise<void> => {
+    const waitForTourStep = async (): Promise<void> => {
       await expect(page.locator('si-tour .tour-content.show')).toBeVisible();
-      if (hasArrow) {
-        await expect(page.locator('si-tour .popover-arrow')).toBeVisible();
-      }
     };
 
     await si.visitExample(example);
@@ -33,7 +30,7 @@ test.describe('si-tour', () => {
     await waitForTourStep();
     await si.runVisualAndA11yTests('open-menu');
     await nextClick();
-    await waitForTourStep(false);
+    await waitForTourStep();
     await si.runVisualAndA11yTests('last-step');
   });
 });

--- a/playwright/e2e/element-examples/si-tour.spec.ts
+++ b/playwright/e2e/element-examples/si-tour.spec.ts
@@ -11,22 +11,29 @@ test.describe('si-tour', () => {
     const nextClick = (): Promise<any> =>
       page.locator('si-tour button', { hasText: 'Next' }).click();
 
+    const waitForTourStep = async (hasArrow = true): Promise<void> => {
+      await expect(page.locator('si-tour .tour-content.show')).toBeVisible();
+      if (hasArrow) {
+        await expect(page.locator('si-tour .popover-arrow')).toBeVisible();
+      }
+    };
+
     await si.visitExample(example);
-    await expect(page.locator('.tour-content')).toBeVisible();
+    await waitForTourStep();
     await si.runVisualAndA11yTests('first-step');
 
     await nextClick();
-    await expect(page.locator('.tour-content')).toBeVisible();
+    await waitForTourStep();
     await si.runVisualAndA11yTests('second-step');
 
     await nextClick();
     await nextClick();
     await nextClick();
     await nextClick();
-    await expect(page.locator('.tour-content')).toBeVisible();
+    await waitForTourStep();
     await si.runVisualAndA11yTests('open-menu');
     await nextClick();
-    await expect(page.locator('.tour-content')).toBeVisible();
+    await waitForTourStep(false);
     await si.runVisualAndA11yTests('last-step');
   });
 });

--- a/projects/element-ng/tour/si-tour.component.ts
+++ b/projects/element-ng/tour/si-tour.component.ts
@@ -54,6 +54,7 @@ export class SiTourComponent implements OnDestroy {
   private elementRef: ElementRef<HTMLElement> = inject(ElementRef);
   private subscription?: Subscription;
   private prevFocus: Element | null = null;
+  private lastPositionChange: PositionChange | undefined;
 
   private readonly focusTrap = viewChild<CdkTrapFocus>('focusTrap');
   private document = inject(DOCUMENT);
@@ -70,6 +71,9 @@ export class SiTourComponent implements OnDestroy {
     });
     this.subscription.add(
       this.tourToken.positionChange.subscribe(update => this.updatePosition(update))
+    );
+    this.subscription.add(
+      this.tourToken.sizeChange.subscribe(() => this.updatePosition(this.lastPositionChange))
     );
   }
 
@@ -110,6 +114,7 @@ export class SiTourComponent implements OnDestroy {
   }
 
   private updatePosition(update: PositionChange | undefined): void {
+    this.lastPositionChange = update;
     if (!update) {
       this.positionClass.set('');
       this.arrowPos.set(undefined);

--- a/projects/element-ng/tour/si-tour.service.ts
+++ b/projects/element-ng/tour/si-tour.service.ts
@@ -224,11 +224,11 @@ export class SiTourService {
         { originX: 'start', overlayX: 'end', originY: 'center', overlayY: 'center' },
         { originX: 'end', overlayX: 'start', originY: 'center', overlayY: 'center' }
       ]);
-    this.overlayRef!.updatePositionStrategy(positionStrategy);
     this.positionChangeSub = positionStrategy.positionChanges
       .pipe(map(change => ({ change, anchor })))
       // We only want to forward the next channel, as the positionChanges completes when setting a new origin.
       .subscribe(value => this.tourToken.positionChange.next(value));
+    this.overlayRef!.updatePositionStrategy(positionStrategy);
   }
 
   private createOrUpdateOverlays(): void {


### PR DESCRIPTION
tour e2e sometimes failing due to setTimeout in arrow pos calculation.
see https://github.com/siemens/element/actions/runs/25797160585

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2058/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2058/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2058/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2058/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2058/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2058/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2058/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2058/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2058/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2058/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->





