### PR TITLE
feat(navbar-vertical-next): add alwaysFlyout functionality to navbar items

### DIFF
--- a/api-goldens/element-ng/navbar-vertical-next/index.api.md
+++ b/api-goldens/element-ng/navbar-vertical-next/index.api.md
@@ -15,6 +15,7 @@ import { TemplateRef } from '@angular/core';
 // @public (undocumented)
 export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
     constructor();
+    readonly alwaysFlyout: _angular_core.InputSignalWithTransform<boolean, unknown>;
     collapse(): void;
     readonly collapsed: _angular_core.ModelSignal<boolean>;
     expand(): void;
@@ -43,7 +44,7 @@ export class SiNavbarVerticalNextGroupComponent {
 }
 
 // @public (undocumented)
-export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit {
+export class SiNavbarVerticalNextGroupTriggerDirective {
     constructor();
     // (undocumented)
     readonly expanded: _angular_core.WritableSignal<boolean>;

--- a/playwright/e2e/element-examples/navbar-vertical-next.spec.ts
+++ b/playwright/e2e/element-examples/navbar-vertical-next.spec.ts
@@ -34,6 +34,26 @@ test.describe('navbar vertical next', () => {
     await si.runVisualAndA11yTests('collapsed-flyout');
   });
 
+  test(example + ' always flyout toggle', async ({ page, si }) => {
+    await si.visitExample(example);
+
+    await page.getByRole('button', { name: 'User management' }).click();
+    await expect(page.getByRole('group', { name: 'User management' })).toBeVisible();
+
+    await page.getByRole('checkbox', { name: 'Always flyout' }).check();
+    await expect(page.getByRole('button', { name: 'User management' })).not.toHaveClass(/show/);
+    await expect(page.getByRole('button', { name: 'User management' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+
+    await page.getByRole('button', { name: 'User management' }).click();
+    await expect(page.getByRole('group', { name: 'User management' })).toBeVisible();
+
+    await si.waitForAllAnimationsToComplete();
+    await si.runVisualAndA11yTests('always-flyout');
+  });
+
   test.skip('it should show tooltip only on keyboard interaction', async ({ page, si }) => {
     await si.visitExample(example);
     await page.getByLabel('Toggle', { exact: true }).click();

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:293653d5a3991f54acfab8e29ed86809a18a05c811e2ec122b287bbe381ae3a4
+size 33528

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:364277cf5fa1bac0b157a375f29163043230b308bff777ada7115fb79e40027d
+size 32779

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout.yaml
@@ -5,14 +5,21 @@
     - /url: "#/"
   - heading "Navbar Vertical Next Example" [level=1]
 - navigation:
-  - button "Toggle"
-  - button "Search..."
+  - button "Toggle" [expanded]
+  - textbox "Search..."
   - link "Home":
     - /url: "#/viewer/viewer/home"
+  - text: Modules
   - link "Energy & sustainability":
     - /url: "#/viewer/viewer/energy"
   - button "User management"
-  - group "User management"
+  - group "User management":
+    - link "Sub item":
+      - /url: "#/viewer/viewer/subItem"
+    - link "Sub item 2":
+      - /url: "#/viewer/viewer/subItem2"
+    - link "Sub item 3":
+      - /url: "#/viewer/viewer/subItem3"
   - link "Test coverage":
     - /url: "#/viewer/viewer/coverage"
   - button "Documentation"
@@ -22,6 +29,6 @@
     - /url: "#/viewer/viewer/settings"
 - main:
   - heading "Here is a title" [level=2]
-  - text: Content with path 'subItem2' Control panel
-  - checkbox "Always flyout"
+  - text: Content with path 'home' Control panel
+  - checkbox "Always flyout" [checked]
   - text: Always flyout

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout.yaml
@@ -28,4 +28,6 @@
     - /url: "#/viewer/viewer/settings"
 - main:
   - heading "Here is a title" [level=2]
-  - text: Content with path 'subItem2'
+  - text: Content with path 'subItem2' Control panel
+  - checkbox "Always flyout"
+  - text: Always flyout

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-collapsed.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-collapsed.yaml
@@ -8,4 +8,6 @@
   - button "Toggle"
 - main:
   - heading "Here is a title" [level=2]
-  - text: Content with path 'home'
+  - text: Content with path 'home' Control panel
+  - checkbox "Always flyout"
+  - text: Always flyout

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded.yaml
@@ -16,7 +16,7 @@
   - group "User management"
   - link "Test coverage":
     - /url: "#/viewer/viewer/coverage"
-  - button "Documentation" [expanded]
+  - button "Documentation"
   - group "Documentation":
     - link "Sub item 4":
       - /url: "#/viewer/viewer/subItem4"
@@ -29,4 +29,6 @@
     - /url: "#/viewer/viewer/settings"
 - main:
   - heading "Here is a title" [level=2]
-  - text: Content with path 'subItem4'
+  - text: Content with path 'subItem4' Control panel
+  - checkbox "Always flyout"
+  - text: Always flyout

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout.yaml
@@ -29,4 +29,6 @@
     - /url: "#/viewer/viewer/settings"
 - main:
   - heading "Badge Examples" [level=2]
-  - text: Content with path 'sub-badge-2'
+  - text: Content with path 'sub-badge-2' Control panel
+  - checkbox "Always flyout"
+  - text: Always flyout

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed.yaml
@@ -23,4 +23,6 @@
     - /url: "#/viewer/viewer/settings"
 - main:
   - heading "Badge Examples" [level=2]
-  - text: Content with path 'sub-badge-2'
+  - text: Content with path 'sub-badge-2' Control panel
+  - checkbox "Always flyout"
+  - text: Always flyout

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges.yaml
@@ -30,4 +30,6 @@
     - /url: "#/viewer/viewer/settings"
 - main:
   - heading "Badge Examples" [level=2]
-  - text: Content with path 'sub-badge-1'
+  - text: Content with path 'sub-badge-1' Control panel
+  - checkbox "Always flyout"
+  - text: Always flyout

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next.yaml
@@ -29,4 +29,6 @@
     - /url: "#/viewer/viewer/settings"
 - main:
   - heading "Here is a title" [level=2]
-  - text: Content with path 'subItem4'
+  - text: Content with path 'subItem4' Control panel
+  - checkbox "Always flyout"
+  - text: Always flyout

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group-trigger.directive.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group-trigger.directive.ts
@@ -15,8 +15,6 @@ import {
   Injector,
   input,
   linkedSignal,
-  OnInit,
-  signal,
   TemplateRef,
   untracked,
   ViewContainerRef
@@ -53,7 +51,7 @@ class SiNavbarFlyoutAnchorComponent {
     '(click)': 'triggered()'
   }
 })
-export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit {
+export class SiNavbarVerticalNextGroupTriggerDirective {
   private static idCounter = 0;
 
   /** @internal */
@@ -67,24 +65,57 @@ export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit {
   readonly stateId = input<string>();
 
   /** @defaultValue false */
-  readonly expanded = linkedSignal({
+  readonly expanded = linkedSignal<
+    { uiState: boolean | undefined; alwaysFlyout: boolean },
+    boolean
+  >({
     source: () => {
       const stateId = this.stateId();
-      if (!stateId) {
-        return undefined;
-      }
-      return this.navbar.uiStateExpandedItems()[stateId];
+      return {
+        uiState: stateId ? this.navbar.uiStateExpandedItems()[stateId] : undefined,
+        alwaysFlyout: this.navbar.alwaysFlyout()
+      };
     },
-    computation: source => source ?? false
+    computation: (source, previous) => {
+      // `alwaysFlyout` toggled: reset expansion. When switching back to inline,
+      // surface the group that owns the active route.
+      if (previous && source.alwaysFlyout !== previous.source.alwaysFlyout) {
+        return !source.alwaysFlyout && untracked(() => this.active());
+      }
+      // First run or UIState (re)loaded: honor the persisted value when present,
+      // otherwise keep the user's current expansion.
+      if (source.uiState !== undefined) {
+        return source.uiState;
+      }
+      return previous?.value ?? false;
+    }
   });
 
-  /** @internal */
-  readonly flyout = signal(false);
+  /**
+   * Whether the group is currently rendered as a transient flyout overlay
+   * (true) or inline within the navbar (false). Automatically resets to
+   * `false` whenever the rendering mode changes.
+   * @internal
+   */
+  readonly flyout = linkedSignal({
+    source: () => this.flyoutMode(),
+    computation: () => false
+  });
 
-  /** @internal */
-  readonly active = signal(false);
+  /**
+   * Whether the open flyout overlay currently contains the active route.
+   * Reset together with `flyout` so it never lingers across mode changes.
+   * @internal
+   */
+  readonly active = linkedSignal<boolean, boolean>({
+    source: () => this.flyout(),
+    computation: (open, previous) => (open ? (previous?.value ?? false) : false)
+  });
 
   protected readonly navbar = inject(SI_NAVBAR_VERTICAL_NEXT);
+
+  /** @internal */
+  readonly flyoutMode = computed(() => this.navbar.alwaysFlyout() || this.navbar.collapsed());
 
   private flyoutOutsideClickSubscription?: Subscription;
   private readonly viewContainer = inject(ViewContainerRef);
@@ -99,42 +130,35 @@ export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit {
         { originX: 'end', originY: 'bottom', overlayX: 'start', overlayY: 'bottom' }
       ])
   });
-  private groupView!: EmbeddedViewRef<unknown>;
+  private groupView?: EmbeddedViewRef<unknown>;
   private flyoutAnchorComponentRef?: ComponentRef<SiNavbarFlyoutAnchorComponent>;
   private readonly templatePortal = computed(
     () => new TemplatePortal(this.groupTemplate(), this.viewContainer, undefined, this.injector)
   );
 
   constructor() {
-    // Sync expanded state from navbar UIState when it loads
+    // Manage the rendering of the inline projection / flyout overlay in
+    // response to mode changes. Only side effects belong here; the related
+    // signal state is propagated by `flyout` / `expanded` linked signals.
     effect(() => {
-      const stateId = this.stateId();
-      if (!stateId) return;
-      const state = this.navbar.uiStateExpandedItems()[stateId];
-      if (state !== undefined) {
-        untracked(() => this.expanded.set(state));
-      }
+      this.flyoutMode();
+      untracked(() => {
+        this.detachFlyout();
+        this.attachInline();
+      });
     });
-  }
-
-  ngOnInit(): void {
-    this.attachInline();
   }
 
   /** @internal */
   hideFlyout(): void {
-    if (this.flyout()) {
-      this.flyout.set(false);
-      this.active.set(false);
-      this.flyoutAnchorComponentRef?.destroy();
-      this.flyoutAnchorComponentRef = undefined;
-      this.attachInline();
-      this.flyoutOutsideClickSubscription?.unsubscribe();
-    }
+    if (!this.flyout()) return;
+    this.flyout.set(false);
+    this.detachFlyout();
+    this.attachInline();
   }
 
   protected triggered(): void {
-    if (this.navbar.collapsed()) {
+    if (this.flyoutMode()) {
       this.toggleFlyout();
     } else {
       this.expanded.set(!this.expanded());
@@ -153,14 +177,14 @@ export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit {
 
   private attachInline(): void {
     this.overlayRef.detach();
-    this.groupView?.destroy(); // we need ?. for first attachment
+    this.groupView?.destroy();
     this.groupView = this.viewContainer.createEmbeddedView(this.groupTemplate(), undefined, {
       injector: this.injector
     });
   }
 
   private attachFlyout(): void {
-    this.groupView.destroy();
+    this.groupView?.destroy();
     this.groupView = this.overlayRef.attach(this.templatePortal());
     this.flyoutAnchorComponentRef = this.viewContainer.createComponent(
       SiNavbarFlyoutAnchorComponent
@@ -169,5 +193,12 @@ export class SiNavbarVerticalNextGroupTriggerDirective implements OnInit {
     this.flyoutOutsideClickSubscription = this.overlayRef
       .outsidePointerEvents()
       .subscribe(() => this.hideFlyout());
+  }
+
+  private detachFlyout(): void {
+    this.flyoutAnchorComponentRef?.destroy();
+    this.flyoutAnchorComponentRef = undefined;
+    this.flyoutOutsideClickSubscription?.unsubscribe();
+    this.flyoutOutsideClickSubscription = undefined;
   }
 }

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group.component.ts
@@ -15,6 +15,7 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
   selector: 'si-navbar-vertical-next-group',
   imports: [CdkTrapFocus],
   template: `@if (visible()) {
+    @let flyout = groupTrigger.flyout();
     <div
       animate.leave="group-leave"
       [class.inline-group]="!flyout"
@@ -41,11 +42,8 @@ export class SiNavbarVerticalNextGroupComponent {
   protected readonly groupTrigger = inject(SiNavbarVerticalNextGroupTriggerDirective);
   private readonly routerLinkActive = inject(RouterLinkActive, { optional: true });
 
-  // Store initial value, as the mode for an instance never changes.
-  protected flyout = this.groupTrigger.flyout();
-
   protected readonly visible = computed(() => {
-    return this.flyout || (!this.navbar.collapsed() && this.groupTrigger.expanded());
+    return this.groupTrigger.flyout() || (!this.navbar.collapsed() && this.groupTrigger.expanded());
   });
 
   constructor() {

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.html
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.html
@@ -18,5 +18,8 @@
   >
 }
 @if (group) {
-  <si-icon aria-hidden="true" class="dropdown-caret me-0 text-body" [icon]="icons.elementDown2" />
+  <si-icon
+    class="dropdown-caret me-0 text-body"
+    [icon]="group.flyoutMode() ? icons.elementRight2 : icons.elementDown2"
+  />
 }

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.scss
@@ -86,6 +86,10 @@
   }
 }
 
+:host-context(.dropdown-menu) :host(.navbar-vertical-item) {
+  padding-inline-start: 0;
+}
+
 :host(.dropdown-item) {
   .item-title {
     font-weight: normal;

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.spec.ts
@@ -51,12 +51,14 @@ describe('SiNavbarVerticalNextItemComponent', () => {
   const mockNavbar = {
     collapsed: signal(false),
     textOnly: signal(false),
+    alwaysFlyout: signal(false),
     itemTriggered: vi.fn()
   };
 
   beforeEach(async () => {
     mockNavbar.collapsed.set(false);
     mockNavbar.textOnly.set(false);
+    mockNavbar.alwaysFlyout.set(false);
 
     await TestBed.configureTestingModule({
       providers: [{ provide: SI_NAVBAR_VERTICAL_NEXT, useValue: mockNavbar }]

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
@@ -12,7 +12,7 @@ import {
   OnInit
 } from '@angular/core';
 import { RouterLinkActive } from '@angular/router';
-import { elementDown2 } from '@siemens/element-icons';
+import { elementDown2, elementRight2 } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiLinkDirective } from '@siemens/element-ng/link';
 
@@ -29,15 +29,15 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'class': 'focus-inside',
-    '[class.dropdown-item]': 'this.parent?.group?.flyout()',
-    '[class.navbar-vertical-item]': '!this.parent?.group?.flyout()',
+    '[class.dropdown-item]': 'isDropdownItem()',
+    '[class.navbar-vertical-item]': '!isDropdownItem()',
     '[class.active]': 'active',
     '[class.hide-badge-collapsed]': 'hideBadgeWhenCollapsed()',
     '(click)': 'triggered()'
   }
 })
 export class SiNavbarVerticalNextItemComponent implements OnInit {
-  protected readonly icons = addIcons({ elementDown2 });
+  protected readonly icons = addIcons({ elementDown2, elementRight2 });
 
   /** Optional icon to render before the label. */
   readonly icon = input<string>();
@@ -91,6 +91,10 @@ export class SiNavbarVerticalNextItemComponent implements OnInit {
     }
     return badge.toString();
   });
+
+  protected readonly isDropdownItem = computed(
+    () => !this.navbar.alwaysFlyout() && !!this.parent?.group?.flyout()
+  );
 
   ngOnInit(): void {
     if (this.group && this.active) {

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
@@ -63,6 +63,15 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
   readonly textOnly = input(false, { transform: booleanAttribute });
 
   /**
+   * When `true`, item-groups always open as a transient flyout panel adjacent to the
+   * trigger, regardless of whether the navbar is collapsed or expanded.
+   * Flyouts open and close on click.
+   *
+   * @defaultValue false
+   */
+  readonly alwaysFlyout = input(false, { transform: booleanAttribute });
+
+  /**
    * List of vertical navigation items
    *
    * @deprecated Use the template-based declarative API with content projection instead. Use `<si-navbar-vertical-next-items>` and

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '@siemens/element-ng/common';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { page, userEvent } from 'vitest/browser';
 
 import {
   SiNavbarVerticalNextItemsComponent,
@@ -66,6 +67,7 @@ class EmptyComponent {}
       [textOnly]="textOnly()"
       [stateId]="stateId"
       [collapsed]="collapsed()"
+      [alwaysFlyout]="alwaysFlyout()"
     >
       <si-navbar-vertical-next-search [debounceTime]="0" (searchChange)="searchEvent($event)" />
       @if (showDeclarativeFlyoutGroup()) {
@@ -158,6 +160,7 @@ class TestHostComponent {
   readonly textOnly = signal(true);
   stateId?: string;
   readonly collapsed = signal(false);
+  readonly alwaysFlyout = signal(false);
   readonly showDeclarativeFlyoutGroup = signal(false);
   readonly showDeclarativeNavigationGroup = signal(false);
   readonly showDeclarativeStateGroups = signal(false);
@@ -297,6 +300,60 @@ describe('SiNavbarVerticalNext', () => {
       [subItem1, subItem2] = await item.getChildren();
       expect(await subItem1.isActive()).toBe(false);
       expect(await subItem2.isActive()).toBe(true);
+    });
+
+    it('should re-expand the active group when switching back from flyout to inline mode', async () => {
+      component.textOnly.set(false);
+      component.showDeclarativeNavigationGroup.set(true);
+      await fixture.whenStable();
+
+      await TestBed.inject(Router).navigate(['/item-1/sub-item-2/sub-path']);
+      await fixture.whenStable();
+
+      const item = page.getByRole('button', { name: 'item1' });
+
+      // Switch to flyout mode: groups collapse, overlays render on click.
+      component.alwaysFlyout.set(true);
+      await fixture.whenStable();
+      expect(item.element()).toHaveAttribute('aria-expanded', 'false');
+      const flyoutId = item.element().getAttribute('aria-controls');
+      expect(document.querySelector(`#${flyoutId} .dropdown-menu`)).toBeNull();
+
+      // Switch back to inline: the children re-mount and the active child's
+      // `ngOnInit` cascade re-expands the parent group automatically.
+      component.alwaysFlyout.set(false);
+      await fixture.whenStable();
+      expect(item.element()).toHaveAttribute('aria-expanded', 'true');
+      const subItem2 = page.getByRole('link', { name: 'sub-item2' });
+      expect(subItem2.element()).toHaveClass('active');
+    });
+
+    it('should restore manual group expansion after collapsing and re-expanding the navbar', async () => {
+      component.textOnly.set(false);
+      component.showDeclarativeNavigationGroup.set(true);
+      await fixture.whenStable();
+
+      const item = page.getByRole('button', { name: 'item1' });
+      const collapseToggle = page.getByRole('button', { name: 'Toggle' });
+
+      // User expands the group inline.
+      await userEvent.click(item);
+      await fixture.whenStable();
+      expect(item.element()).toHaveAttribute('aria-expanded', 'true');
+
+      // Collapsing the navbar switches to flyout overlays — inline expansion
+      // is hidden but the underlying state must be retained.
+      await userEvent.click(collapseToggle);
+      await fixture.whenStable();
+      expect(collapseToggle.element()).toHaveAttribute('aria-expanded', 'false');
+      const flyoutId = item.element().getAttribute('aria-controls');
+      expect(document.querySelector(`#${flyoutId} .dropdown-menu`)).toBeNull();
+
+      // Re-expanding the navbar restores the previous inline expansion.
+      await userEvent.click(collapseToggle);
+      await fixture.whenStable();
+      expect(collapseToggle.element()).toHaveAttribute('aria-expanded', 'true');
+      expect(item.element()).toHaveAttribute('aria-expanded', 'true');
     });
   });
 

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
@@ -6,7 +6,11 @@
     </si-header-brand>
   </si-application-header>
 
-  <si-navbar-vertical-next stateId="navbar-vertical-next-badges" toggleButtonText="Toggle">
+  <si-navbar-vertical-next
+    stateId="navbar-vertical-next-badges"
+    toggleButtonText="Toggle"
+    [alwaysFlyout]="alwaysFlyout"
+  >
     <si-navbar-vertical-next-search placeholder="Search..." />
     <si-navbar-vertical-next-items>
       <a
@@ -87,6 +91,14 @@
         <h2 class="si-layout-title si-layout-top-element">Badge Examples</h2>
       </div>
       <router-outlet />
+      <div class="card p-5 mt-8 e2e-ignore">
+        <div class="card-header">Control panel</div>
+        <div class="card-body">
+          <si-form-item label="Always flyout">
+            <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
+          </si-form-item>
+        </div>
+      </div>
     </div>
   </si-navbar-vertical-next>
 </div>
@@ -124,7 +136,7 @@
 </ng-template>
 
 <ng-template #groupItem>
-  <si-navbar-vertical-next-group>
+  <si-navbar-vertical-next-group routerLinkActive>
     <a si-navbar-vertical-next-item routerLink="sub-badge-4" routerLinkActive> Sub item </a>
     <a si-navbar-vertical-next-item routerLink="sub-badge-5" routerLinkActive> Sub item </a>
     <a si-navbar-vertical-next-item routerLink="sub-badge-6" routerLinkActive> Sub item </a>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import {
   ActivatedRoute,
   Router,
@@ -15,6 +16,7 @@ import {
   SiHeaderBrandDirective,
   SiHeaderLogoDirective
 } from '@siemens/element-ng/application-header';
+import { SiFormItemComponent } from '@siemens/element-ng/form';
 import {
   SiNavbarVerticalNextItemsComponent,
   SiNavbarVerticalNextSearchComponent,
@@ -43,6 +45,8 @@ import { LOG_EVENT } from '@siemens/live-preview';
     SiApplicationHeaderComponent,
     SiHeaderBrandDirective,
     SiHeaderLogoDirective,
+    SiFormItemComponent,
+    FormsModule,
     RouterLink,
     RouterLinkActive,
     RouterOutlet
@@ -54,6 +58,8 @@ export class SampleComponent implements OnInit {
   private activeRoute = inject(ActivatedRoute);
   private router = inject(Router);
   logEvent = inject(LOG_EVENT);
+
+  alwaysFlyout = false;
 
   ngOnInit(): void {
     this.router.navigate(['home'], { relativeTo: this.activeRoute });

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.html
@@ -29,6 +29,7 @@
     stateId="navbar-vertical-next-without-icons"
     toggleButtonText="Toggle"
     [textOnly]="true"
+    [alwaysFlyout]="alwaysFlyout"
   >
     <si-navbar-vertical-next-items>
       <button
@@ -61,12 +62,20 @@
         <h2 class="si-layout-title si-layout-top-element">Here is a title</h2>
       </div>
       Here goes the content
+      <div class="card p-5 mt-8 e2e-ignore">
+        <div class="card-header">Control panel</div>
+        <div class="card-body">
+          <si-form-item label="Always flyout">
+            <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
+          </si-form-item>
+        </div>
+      </div>
     </div>
   </si-navbar-vertical-next>
 </div>
 
 <ng-template #home>
-  <si-navbar-vertical-next-group>
+  <si-navbar-vertical-next-group routerLinkActive>
     <a si-navbar-vertical-next-item routerLink="subItem" routerLinkActive> Sub Item </a>
     <a si-navbar-vertical-next-item routerLink="subItem2" routerLinkActive> Sub Item 2 </a>
     <a si-navbar-vertical-next-item routerLink="subItem3" routerLinkActive> Sub Item 3 </a>
@@ -74,7 +83,7 @@
 </ng-template>
 
 <ng-template #documentation>
-  <si-navbar-vertical-next-group>
+  <si-navbar-vertical-next-group routerLinkActive>
     <a si-navbar-vertical-next-item routerLink="subItem4" routerLinkActive> Sub Item 4 </a>
     <a si-navbar-vertical-next-item routerLink="subItem5" routerLinkActive> Sub Item 5 </a>
     <a si-navbar-vertical-next-item routerLink="subItem6" routerLinkActive> Sub Item 6 </a>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import {
   SiApplicationHeaderComponent,
@@ -11,6 +12,7 @@ import {
   SiHeaderBrandDirective,
   SiHeaderLogoDirective
 } from '@siemens/element-ng/application-header';
+import { SiFormItemComponent } from '@siemens/element-ng/form';
 import {
   SiHeaderDropdownComponent,
   SiHeaderDropdownTriggerDirective
@@ -41,6 +43,8 @@ import {
     SiNavbarVerticalNextGroupComponent,
     SiNavbarVerticalNextGroupTriggerDirective,
     SiNavbarVerticalNextHeaderComponent,
+    SiFormItemComponent,
+    FormsModule,
     RouterLink,
     RouterLinkActive,
     SiHeaderLogoDirective
@@ -48,4 +52,6 @@ import {
   templateUrl: './si-navbar-vertical-next-text.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SampleComponent {}
+export class SampleComponent {
+  alwaysFlyout = false;
+}

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
@@ -6,7 +6,11 @@
     </si-header-brand>
   </si-application-header>
 
-  <si-navbar-vertical-next stateId="navbar-vertical-next-with-icons" toggleButtonText="Toggle">
+  <si-navbar-vertical-next
+    stateId="navbar-vertical-next-with-icons"
+    toggleButtonText="Toggle"
+    [alwaysFlyout]="alwaysFlyout"
+  >
     <si-navbar-vertical-next-search placeholder="Search..." />
     <si-navbar-vertical-next-items>
       <a si-navbar-vertical-next-item routerLink="home" routerLinkActive icon="element-home">
@@ -67,6 +71,14 @@
         <h2 class="si-layout-title si-layout-top-element">Here is a title</h2>
       </div>
       <router-outlet />
+      <div class="card p-5 mt-8 e2e-ignore">
+        <div class="card-header">Control panel</div>
+        <div class="card-body">
+          <si-form-item label="Always flyout">
+            <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
+          </si-form-item>
+        </div>
+      </div>
     </div>
   </si-navbar-vertical-next>
 </div>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import {
   ActivatedRoute,
   Router,
@@ -15,6 +16,7 @@ import {
   SiHeaderBrandDirective,
   SiHeaderLogoDirective
 } from '@siemens/element-ng/application-header';
+import { SiFormItemComponent } from '@siemens/element-ng/form';
 import {
   SiNavbarVerticalNextSearchComponent,
   SiNavbarVerticalNextItemsComponent,
@@ -42,6 +44,8 @@ import { LOG_EVENT } from '@siemens/live-preview';
     SiNavbarVerticalNextDividerComponent,
     SiApplicationHeaderComponent,
     SiHeaderBrandDirective,
+    SiFormItemComponent,
+    FormsModule,
     RouterLink,
     RouterLinkActive,
     RouterOutlet,
@@ -54,6 +58,8 @@ export class SampleComponent implements OnInit {
   private activeRoute = inject(ActivatedRoute);
   private router = inject(Router);
   logEvent = inject(LOG_EVENT);
+
+  alwaysFlyout = false;
 
   ngOnInit(): void {
     this.router.navigate(['home'], { relativeTo: this.activeRoute });


### PR DESCRIPTION
- Updated example components and templates to include a control for `alwaysFlyout`.

Related to #1944 

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2059/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2059/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2059/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2059/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2059/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2059/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2059/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2059/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2059/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2059/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->











