### PR TITLE
refactor(dashboard): prevent duplicate expandChange subscriptions in initCards

### DIFF
--- a/projects/element-ng/dashboard/si-dashboard.component.spec.ts
+++ b/projects/element-ng/dashboard/si-dashboard.component.spec.ts
@@ -123,6 +123,28 @@ describe('SiDashboardComponent', () => {
       expect(expandSpy).toHaveBeenCalled();
       expect(component.cardComponents().at(-1)!.hide).toBe(false);
     });
+
+    it('should not call expand multiple times after initCards re-subscriptions', async () => {
+      const expandSpy = vi.spyOn(component.dashboard(), 'expand');
+      const card = component.cardComponents().at(0)!;
+
+      // toggle enableExpandInteractions to trigger initCards re-subscriptions via ngOnChanges
+      component.enableExpandInteractions = false;
+      await fixture.whenStable();
+
+      component.enableExpandInteractions = true;
+      await fixture.whenStable();
+
+      component.enableExpandInteractions = false;
+      await fixture.whenStable();
+
+      component.enableExpandInteractions = true;
+      await fixture.whenStable();
+
+      // after multiple initCards cycles, expanding should only trigger expand once
+      card.expand();
+      expect(expandSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('resize should trigger setDashboardFrameEndPadding on resize', () => {

--- a/projects/element-ng/dashboard/si-dashboard.component.ts
+++ b/projects/element-ng/dashboard/si-dashboard.component.ts
@@ -20,7 +20,7 @@ import {
   SimpleChanges,
   viewChild
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { outputToObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ScrollbarHelper } from '@siemens/element-ng/common';
 import {
   BOOTSTRAP_BREAKPOINTS,
@@ -28,6 +28,7 @@ import {
   ResizeObserverService
 } from '@siemens/element-ng/resize-observer';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
+import { Subject, takeUntil } from 'rxjs';
 
 import { SiDashboardCardComponent } from './si-dashboard-card.component';
 import { SiDashboardService } from './si-dashboard.service';
@@ -86,6 +87,7 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
   private _isExpanded = false;
   private scrollPosition: [number, number] = [0, 0];
 
+  private readonly reinitCards$ = new Subject<void>();
   private cards: SiDashboardCardComponent[] = [];
   private readonly expandedPortalOutlet = viewChild.required('expandedPortalOutlet', {
     read: CdkPortalOutlet
@@ -108,6 +110,8 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
     this.dashboardService.cards$
       .pipe(takeUntilDestroyed())
       .subscribe(cards => this.subscribeToCards(cards));
+
+    this.destroyRef.onDestroy(() => this.reinitCards$.complete());
   }
 
   ngOnChanges(changes: SimpleChanges<this>): void {
@@ -133,6 +137,8 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
   }
 
   private initCards(): void {
+    this.reinitCards$.next();
+
     for (const card of this.cards) {
       // We only enforce expand if the dashboard value is true, otherwise we would remove the individual
       // card settings.
@@ -141,14 +147,16 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
         card.enableExpandInteractionInternal.set(enableExpandInteractions);
       }
 
-      card.expandChange.subscribe((expand: boolean) => {
-        if (expand) {
-          this.expand(card);
-        } else {
-          this.restoreDashboard();
-        }
-        this.cdRef.markForCheck();
-      });
+      outputToObservable(card.expandChange)
+        .pipe(takeUntil(this.reinitCards$), takeUntilDestroyed(this.destroyRef))
+        .subscribe((expand: boolean) => {
+          if (expand) {
+            this.expand(card);
+          } else {
+            this.restoreDashboard();
+          }
+          this.cdRef.markForCheck();
+        });
     }
   }
 
@@ -194,8 +202,6 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
     }
     // Restore the dashboard and scroll to previous position
     this.restoreDashboard();
-    // Subscribe to cards events again
-    this.initCards();
     this.cdRef.markForCheck();
   }
 


### PR DESCRIPTION
`initCards()` subscribes to `card.expandChange` but is called from multiple paths (`subscribeToCards`, `ngOnChanges`, `restore`) without unsubscribing previous subscriptions, causing handlers to fire multiple times.

Use `outputToObservable` with `takeUntil` to teardown previous subscriptions on reinit and `takeUntilDestroyed` for component destroy cleanup.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2063/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2063/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2063/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2063/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2063/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2063/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2063/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2063/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2063/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2063/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


