### PR TITLE
Feat/navbar vertical next inline collapse

### DIFF
--- a/api-goldens/element-ng/navbar-vertical-next/index.api.md
+++ b/api-goldens/element-ng/navbar-vertical-next/index.api.md
@@ -19,6 +19,7 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
     collapse(): void;
     readonly collapsed: _angular_core.ModelSignal<boolean>;
     expand(): void;
+    readonly inlineCollapse: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly skipLinkMainContentLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly skipLinkNavigationLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly stateId: _angular_core.InputSignal<string | undefined>;

--- a/playwright/e2e/element-examples/navbar-vertical-next.spec.ts
+++ b/playwright/e2e/element-examples/navbar-vertical-next.spec.ts
@@ -54,6 +54,22 @@ test.describe('navbar vertical next', () => {
     await si.runVisualAndA11yTests('always-flyout');
   });
 
+  test(example + ' inline collapse toggle', async ({ page, si }) => {
+    await si.visitExample(example);
+
+    await page.getByRole('checkbox', { name: 'Inline collapse' }).check();
+
+    await page.locator('si-navbar-vertical-next nav .collapse-toggle button').click();
+    await expect(
+      page.locator('si-navbar-vertical-next.nav-inline-collapse.nav-collapsed')
+    ).toBeVisible();
+    await expect(page.locator('si-navbar-vertical-next .nav-content[inert]')).toHaveCount(1);
+    await expect(page.locator('si-navbar-vertical-next .inline-collapse-toggle')).toBeVisible();
+
+    await si.waitForAllAnimationsToComplete();
+    await si.runVisualAndA11yTests('inline-collapse');
+  });
+
   test.skip('it should show tooltip only on keyboard interaction', async ({ page, si }) => {
     await si.visitExample(example);
     await page.getByLabel('Toggle', { exact: true }).click();

--- a/playwright/e2e/element-examples/static.spec.ts
+++ b/playwright/e2e/element-examples/static.spec.ts
@@ -80,6 +80,7 @@ test('si-layouts/content-full-layout-fixed-height', ({ si }) => si.static());
 test('si-layouts/content-tile-layout-full-scroll', ({ si }) => si.static());
 test('si-loading-spinner/si-loading-spinner', ({ si }) => si.static({ maxDiffPixels: 31 }));
 test('si-navbar-vertical/si-navbar-vertical-text', ({ si }) => si.static());
+test('si-navbar-vertical-next/si-navbar-vertical-next-text', ({ si }) => si.static());
 test('si-ncharts/si-micro-charts', ({ si }) => si.static());
 test('si-pagination/si-pagination', ({ si }) => si.static());
 test('si-phone-number-input/si-phone-number-input', ({ si }) => si.static());

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01171e71cdd0a107d2556eb73053cfdfe5a9c75d1e2b9baf4d942bf24fe4d28c
+size 11929

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b72d5b08d32ec75040808cc3252646ccf3f0cb116e83ca5d62e5ae2f7c019fdd
+size 11684

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse.yaml
@@ -1,0 +1,30 @@
+- link "Jump to Main content"
+- link "Jump to Navigation"
+- banner:
+  - link "Siemens logo":
+    - /url: "#/"
+  - heading "Navbar Vertical Next Example" [level=1]
+- navigation:
+  - button "Toggle"
+  - button "Search..."
+  - link "Home":
+    - /url: "#/viewer/viewer/home"
+  - link "Energy & sustainability":
+    - /url: "#/viewer/viewer/energy"
+  - button "User management"
+  - group "User management"
+  - link "Test coverage":
+    - /url: "#/viewer/viewer/coverage"
+  - button "Documentation"
+  - group "Documentation"
+  - button "Action"
+  - link "Configuration":
+    - /url: "#/viewer/viewer/configuration"
+- button "Toggle"
+- main:
+  - heading "Here is a title" [level=2]
+  - text: Content with path 'home' Control panel
+  - checkbox "Always flyout"
+  - text: Always flyout
+  - checkbox "Inline collapse" [checked]
+  - text: Inline collapse

--- a/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa850a90e3de0a77f0229170b712d1b7b3a70f22cf1179c978df7e7a5baf2e43
+size 22184

--- a/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dbe04b1ccb1a1746c6a22b1c944b5e2feafcfcdba41a949e4c247c0ac080f53
+size 21250

--- a/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text.yaml
@@ -1,0 +1,27 @@
+- link "Jump to Main content"
+- link "Jump to Navigation"
+- banner:
+  - link "Siemens logo":
+    - /url: "#/"
+  - heading "Navbar vertical next text only" [level=1]
+  - button "Jane Smith"
+- navigation:
+  - button "Toggle" [expanded]
+  - button "Home"
+  - group "Home"
+  - button "Documentation"
+  - group "Documentation"
+  - text: All the rest
+  - link "Energy & Operations":
+    - /url: "#/viewer/viewer/energy"
+  - link "Test Coverage":
+    - /url: "#/viewer/viewer/coverage"
+  - link "Configuration":
+    - /url: "#/viewer/viewer/configuration"
+- main:
+  - heading "Here is a title" [level=2]
+  - text: Here goes the content Control panel
+  - checkbox "Always flyout"
+  - text: Always flyout
+  - checkbox "Inline collapse"
+  - text: Inline collapse

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.html
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.html
@@ -2,6 +2,7 @@
   @if (smallScreen() && !collapsed()) {
     <div class="modal-backdrop" animate.leave="backdrop-leave" (click)="toggleCollapse()"></div>
   }
+  @let inlineCollapsed = inlineCollapse() && collapsed();
   <nav
     tabindex="-1"
     class="bg-base-1 focus-sub-inside"
@@ -12,23 +13,37 @@
     <div class="collapse-toggle ms-auto">
       <div class="mobile-drawer focus-inside navbar-vertical-no-collapse">
         <button
+          #navToggleButton
           type="button"
           class="btn btn-icon btn-tertiary-ghost"
           [attr.aria-label]="toggleButtonText() | translate"
           [attr.aria-expanded]="!collapsed()"
           (click)="toggleCollapse()"
         >
-          <si-icon
-            class="flip-rtl"
-            [icon]="collapsed() ? icons.elementDoubleRight : icons.elementDoubleLeft"
-          />
+          <si-icon class="flip-rtl" [icon]="toggleIcon()" />
         </button>
       </div>
     </div>
-    <ng-content select="si-navbar-vertical-next-search" />
-    <ng-content select="si-navbar-vertical-next-items" />
-    <ng-content select="si-navbar-vertical-next-footer-items" />
+    <div class="nav-content" [attr.inert]="inlineCollapsed ? '' : null">
+      <ng-content select="si-navbar-vertical-next-search" />
+      <ng-content select="si-navbar-vertical-next-items" />
+      <ng-content select="si-navbar-vertical-next-footer-items" />
+    </div>
   </nav>
+  @if (inlineCollapsed) {
+    <button
+      #inlineToggleButton
+      type="button"
+      class="btn btn-icon btn-tertiary-ghost bg-base-1 inline-collapse-toggle"
+      animate.enter="fade-enter"
+      animate.leave="fade-leave"
+      [attr.aria-label]="toggleButtonText() | translate"
+      [attr.aria-expanded]="false"
+      (click)="toggleCollapse()"
+    >
+      <si-icon class="flip-rtl" [icon]="icons.elementLayoutPane2" />
+    </button>
+  }
 }
 <main
   class="si-layout-inner focus-none"

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.scss
@@ -95,7 +95,7 @@ nav {
     --si-layout-header-first-element-offset: 0;
   }
 
-  :host:not(.nav-text-only) {
+  :host:not(.nav-text-only):not(.nav-inline-collapse) {
     padding-inline-start: $vertical-nav-collapsed-width;
 
     .mobile-drawer {
@@ -104,7 +104,7 @@ nav {
     }
   }
 
-  :host:not(.nav-text-only) {
+  :host:not(.nav-text-only):not(.nav-inline-collapse) {
     nav {
       inline-size: $vertical-nav-collapsed-width;
 
@@ -116,7 +116,58 @@ nav {
 }
 
 @include all-variables.media-breakpoint-up(lg) {
-  :host:not(.nav-collapsed) {
+  :host:not(.nav-collapsed):not(.nav-inline-collapse) {
     padding-inline-start: $vertical-nav-width;
+  }
+}
+
+.nav-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-block-size: 0;
+}
+
+:host(.nav-inline-collapse) {
+  nav {
+    // The in-nav toggle must clip out as the nav collapses to inline-size 0.
+    overflow: hidden;
+  }
+
+  &.nav-collapsed .mobile-drawer {
+    inline-size: 0;
+  }
+
+  @include all-variables.media-breakpoint-up(lg) {
+    &:not(.nav-collapsed) {
+      padding-inline-start: $vertical-nav-width;
+    }
+  }
+}
+
+.inline-collapse-toggle {
+  display: block;
+  margin-block-start: map.get(all-variables.$spacers, 6);
+  margin-inline-start: map.get(all-variables.$spacers, 9);
+  block-size: calc(1lh + (2 * map.get(all-variables.$spacers, 2)));
+  opacity: 1;
+  transition-property: opacity, block-size, margin-block-start;
+  transition-duration: all-variables.element-transition-duration(0.25s);
+  transition-delay: all-variables.element-transition-duration(0.25s);
+  transition-timing-function: ease;
+
+  &.fade-enter {
+    @starting-style {
+      opacity: 0;
+      block-size: 0;
+      margin-block-start: 0;
+    }
+  }
+
+  &.fade-leave {
+    opacity: 0;
+    block-size: 0;
+    margin-block-start: 0;
+    transition-delay: 0s;
   }
 }

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
@@ -8,6 +8,8 @@ import {
   booleanAttribute,
   ChangeDetectionStrategy,
   Component,
+  computed,
+  ElementRef,
   inject,
   Injector,
   input,
@@ -15,10 +17,16 @@ import {
   OnChanges,
   OnInit,
   signal,
-  SimpleChanges
+  SimpleChanges,
+  viewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { elementDoubleLeft, elementDoubleRight } from '@siemens/element-icons';
+import {
+  elementDoubleLeft,
+  elementDoubleRight,
+  elementLayoutPane2,
+  elementLayoutPane2Right
+} from '@siemens/element-icons';
 import { SI_UI_STATE_SERVICE } from '@siemens/element-ng/common';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { BOOTSTRAP_BREAKPOINTS } from '@siemens/element-ng/resize-observer';
@@ -45,12 +53,19 @@ interface UIState {
     class: 'si-layout-inner ready',
     '[class.nav-collapsed]': 'collapsed()',
     '[class.nav-text-only]': 'textOnly()',
+    '[class.nav-inline-collapse]': 'inlineCollapse()',
     '[class.visible]': 'visible()',
     '[class.ready]': 'ready()'
   }
 })
 export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
-  protected readonly icons = addIcons({ elementDoubleLeft, elementDoubleRight });
+  protected readonly icons = addIcons({
+    elementDoubleLeft,
+    elementDoubleRight,
+    elementLayoutPane2,
+    elementLayoutPane2Right
+  });
+
   /**
    * Whether the navbar-vertical is collapsed.
    *
@@ -66,9 +81,17 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
   readonly textOnly = input(false, { transform: booleanAttribute });
 
   /**
+   * Enables an alternative inline collapsed mode.
+   *
+   * inline control bar without rendering items, headers, the search slot or
+   * footer items.
+   *
+   * @defaultValue false
+   */
+  readonly inlineCollapse = input(false, { transform: booleanAttribute });
+
+  /**
    * When `true`, item-groups always open as a transient flyout panel adjacent to the
-   * trigger, regardless of whether the navbar is collapsed or expanded.
-   * Flyouts open and close on click.
    *
    * @defaultValue false
    */
@@ -131,6 +154,10 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
   protected readonly ready = signal(false);
   protected readonly smallScreen = signal(false);
 
+  private readonly navToggleButton = viewChild<ElementRef<HTMLButtonElement>>('navToggleButton');
+  private readonly inlineToggleButton =
+    viewChild<ElementRef<HTMLButtonElement>>('inlineToggleButton');
+
   /**
    * @defaultValue
    * ```
@@ -141,6 +168,13 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
 
   // Indicates if the user prefers a collapsed navbar. Relevant for resizing.
   private preferCollapse = false;
+
+  protected readonly toggleIcon = computed(() => {
+    if (this.inlineCollapse()) {
+      return this.collapsed() ? this.icons.elementLayoutPane2 : this.icons.elementLayoutPane2Right;
+    }
+    return this.collapsed() ? this.icons.elementDoubleRight : this.icons.elementDoubleLeft;
+  });
 
   constructor() {
     this.breakpointObserver
@@ -177,10 +211,26 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
   }
 
   protected toggleCollapse(): void {
-    if (this.collapsed()) {
+    const wasCollapsed = this.collapsed();
+    if (wasCollapsed) {
       this.expand();
     } else {
       this.collapse();
+    }
+    // In inline-collapse mode the visible toggle button swaps between the
+    // in-nav button (expanded) and the in-page button (collapsed). Move focus
+    // to the newly visible one after the view updates so keyboard users don't
+    // lose their place.
+    if (this.inlineCollapse()) {
+      afterNextRender(
+        () => {
+          const next = wasCollapsed
+            ? this.navToggleButton()?.nativeElement
+            : this.inlineToggleButton()?.nativeElement;
+          next?.focus();
+        },
+        { injector: this.injector }
+      );
     }
   }
 

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
@@ -67,6 +67,7 @@ class EmptyComponent {}
       [textOnly]="textOnly()"
       [stateId]="stateId"
       [collapsed]="collapsed()"
+      [inlineCollapse]="inlineCollapse()"
       [alwaysFlyout]="alwaysFlyout()"
     >
       <si-navbar-vertical-next-search [debounceTime]="0" (searchChange)="searchEvent($event)" />
@@ -160,6 +161,7 @@ class TestHostComponent {
   readonly textOnly = signal(true);
   stateId?: string;
   readonly collapsed = signal(false);
+  readonly inlineCollapse = signal(false);
   readonly alwaysFlyout = signal(false);
   readonly showDeclarativeFlyoutGroup = signal(false);
   readonly showDeclarativeNavigationGroup = signal(false);
@@ -399,6 +401,92 @@ describe('SiNavbarVerticalNext', () => {
       const harness = await harnessLoader.getHarness(SiNavbarVerticalNextHarness);
       breakpointObserver.isSmall.next(true);
       expect(await harness.isCollapsed()).toBe(true);
+    });
+  });
+
+  describe('with inlineCollapse', () => {
+    beforeEach(() => {
+      component.inlineCollapse.set(true);
+      component.textOnly.set(false);
+      component.showDeclarativeNavigationGroup.set(true);
+    });
+
+    it('should add nav-inline-collapse host class', async () => {
+      await fixture.whenStable();
+      const host = page.getByRole('navigation').element().closest('si-navbar-vertical-next')!;
+      expect(host).toHaveClass('nav-inline-collapse');
+    });
+
+    it('should render an in-page toggle when collapsed and not when expanded', async () => {
+      component.collapsed.set(true);
+      await fixture.whenStable();
+
+      const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+      expect(host.querySelector('.inline-collapse-toggle')).toBeInTheDocument();
+
+      component.collapsed.set(false);
+      await fixture.whenStable();
+      expect(host.querySelector('.inline-collapse-toggle')).not.toBeInTheDocument();
+    });
+
+    it('should drop inert when expanded', async () => {
+      component.collapsed.set(false);
+      await fixture.whenStable();
+
+      const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+      expect(host).not.toHaveClass('nav-collapsed');
+
+      const content = host.querySelector('.nav-content') as HTMLElement;
+      expect(content).not.toHaveAttribute('inert');
+    });
+
+    it('should move focus to the in-page toggle when collapsing', async () => {
+      component.collapsed.set(false);
+      await fixture.whenStable();
+
+      const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+      const navToggle = host.querySelector('nav .collapse-toggle button') as HTMLButtonElement;
+      navToggle.focus();
+      expect(document.activeElement).toBe(navToggle);
+
+      await userEvent.click(navToggle);
+      await fixture.whenStable();
+
+      const inlineToggle = host.querySelector('.inline-collapse-toggle') as HTMLButtonElement;
+      expect(inlineToggle).toBeInTheDocument();
+      expect(document.activeElement).toBe(inlineToggle);
+    });
+
+    it('should move focus to the in-nav toggle when expanding', async () => {
+      component.collapsed.set(true);
+      await fixture.whenStable();
+
+      const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+      const inlineToggle = host.querySelector('.inline-collapse-toggle') as HTMLButtonElement;
+      inlineToggle.focus();
+      expect(document.activeElement).toBe(inlineToggle);
+
+      await userEvent.click(inlineToggle);
+      await fixture.whenStable();
+
+      const navToggle = host.querySelector('nav .collapse-toggle button') as HTMLButtonElement;
+      expect(document.activeElement).toBe(navToggle);
+    });
+
+    it('should expose correct aria-expanded on both toggles', async () => {
+      component.collapsed.set(true);
+      await fixture.whenStable();
+
+      const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+      const navToggle = host.querySelector('nav .collapse-toggle button') as HTMLButtonElement;
+      const inlineToggle = host.querySelector('.inline-collapse-toggle') as HTMLButtonElement;
+
+      expect(navToggle).toHaveAttribute('aria-expanded', 'false');
+      expect(inlineToggle).toHaveAttribute('aria-expanded', 'false');
+
+      component.collapsed.set(false);
+      await fixture.whenStable();
+      expect(navToggle).toHaveAttribute('aria-expanded', 'true');
     });
   });
 });

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
@@ -10,6 +10,7 @@
     stateId="navbar-vertical-next-badges"
     toggleButtonText="Toggle"
     [alwaysFlyout]="alwaysFlyout"
+    [inlineCollapse]="inlineCollapse"
   >
     <si-navbar-vertical-next-search placeholder="Search..." />
     <si-navbar-vertical-next-items>
@@ -94,9 +95,18 @@
       <div class="card p-5 mt-8 e2e-ignore">
         <div class="card-header">Control panel</div>
         <div class="card-body">
-          <si-form-item label="Always flyout">
-            <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
-          </si-form-item>
+          <div class="row">
+            <div class="col-sm-auto">
+              <si-form-item label="Always flyout">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
+              </si-form-item>
+            </div>
+            <div class="col-sm-auto">
+              <si-form-item label="Inline collapse">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="inlineCollapse" />
+              </si-form-item>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.ts
@@ -60,6 +60,7 @@ export class SampleComponent implements OnInit {
   logEvent = inject(LOG_EVENT);
 
   alwaysFlyout = false;
+  inlineCollapse = false;
 
   ngOnInit(): void {
     this.router.navigate(['home'], { relativeTo: this.activeRoute });

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.html
@@ -30,6 +30,7 @@
     toggleButtonText="Toggle"
     [textOnly]="true"
     [alwaysFlyout]="alwaysFlyout"
+    [inlineCollapse]="inlineCollapse"
   >
     <si-navbar-vertical-next-items>
       <button
@@ -67,9 +68,18 @@
       <div class="card p-5 mt-8 e2e-ignore">
         <div class="card-header">Control panel</div>
         <div class="card-body">
-          <si-form-item label="Always flyout">
-            <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
-          </si-form-item>
+          <div class="row">
+            <div class="col-sm-auto">
+              <si-form-item label="Always flyout">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
+              </si-form-item>
+            </div>
+            <div class="col-sm-auto">
+              <si-form-item label="Inline collapse">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="inlineCollapse" />
+              </si-form-item>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.ts
@@ -54,4 +54,5 @@ import {
 })
 export class SampleComponent {
   alwaysFlyout = false;
+  inlineCollapse = false;
 }

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
@@ -10,6 +10,7 @@
     stateId="navbar-vertical-next-with-icons"
     toggleButtonText="Toggle"
     [alwaysFlyout]="alwaysFlyout"
+    [inlineCollapse]="inlineCollapse"
   >
     <si-navbar-vertical-next-search placeholder="Search..." />
     <si-navbar-vertical-next-items>
@@ -74,9 +75,18 @@
       <div class="card p-5 mt-8 e2e-ignore">
         <div class="card-header">Control panel</div>
         <div class="card-body">
-          <si-form-item label="Always flyout">
-            <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
-          </si-form-item>
+          <div class="row">
+            <div class="col-sm-auto">
+              <si-form-item label="Always flyout">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
+              </si-form-item>
+            </div>
+            <div class="col-sm-auto">
+              <si-form-item label="Inline collapse">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="inlineCollapse" />
+              </si-form-item>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.ts
@@ -60,6 +60,7 @@ export class SampleComponent implements OnInit {
   logEvent = inject(LOG_EVENT);
 
   alwaysFlyout = false;
+  inlineCollapse = false;
 
   ngOnInit(): void {
     this.router.navigate(['home'], { relativeTo: this.activeRoute });


### PR DESCRIPTION
- Add inline collapse mode
- The collapse/expand icons are switched to elementLayoutPane2 /
elementLayoutPane2Right in case of inlineCollapse mode
- Updated example components and templates to include a control for inlineCollapse.

Related https://github.com/siemens/element/issues/1945

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2087/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2087/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2087/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2087/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2087/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2087/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2087/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2087/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2087/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2087/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->















