### PR TITLE
feat(navbar-vertical-next): unify subitem styling inside flyouts

### DIFF
--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b83aa0e683f720f5a7ddf98b72b56c73128efc5a4e6bd3f03f4338c77d3b9357
-size 22023
+oid sha256:53b8e1199c603bb68ef2f5f487d97b9a9266fb0aac05ccf6a01c5d1032916161
+size 22055

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:edc968319bd3081a5c8b5a720798188b3fc6b5faf4803a1db687c0f52411f2f8
-size 21674
+oid sha256:d7af4f7f8602241b323aeca910d6b79221b03c3a5d85717d3c388a6d9dfe6e9f
+size 21756

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3d2eb05f462377e20c501a088e56702bfcf9686a75114d4fda27867807294598
-size 29916
+oid sha256:07e4d4806dc3adf269b227c95fb8503c3de7fdacb2d9e642fb46abd3fb5a0a39
+size 30068

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1208b8188d181d21581202066c563f320f41272ad0fdc4e99325a583954a5a63
-size 29176
+oid sha256:7a721d244516dfbdfc67b71eaeb2d8a762b8cbed5bf6da10ca04a425857ea981
+size 29302

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.scss
@@ -88,9 +88,7 @@
 
 :host-context(.dropdown-menu) :host(.navbar-vertical-item) {
   padding-inline-start: 0;
-}
 
-:host(.dropdown-item) {
   .item-title {
     font-weight: normal;
   }

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
@@ -28,9 +28,7 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
   styleUrl: './si-navbar-vertical-next-item.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    'class': 'focus-inside',
-    '[class.dropdown-item]': 'isDropdownItem()',
-    '[class.navbar-vertical-item]': '!isDropdownItem()',
+    'class': 'focus-inside navbar-vertical-item',
     '[class.active]': 'active',
     '[class.hide-badge-collapsed]': 'hideBadgeWhenCollapsed()',
     '(click)': 'triggered()'
@@ -91,10 +89,6 @@ export class SiNavbarVerticalNextItemComponent implements OnInit {
     }
     return badge.toString();
   });
-
-  protected readonly isDropdownItem = computed(
-    () => !this.navbar.alwaysFlyout() && !!this.parent?.group?.flyout()
-  );
 
   ngOnInit(): void {
     if (this.group && this.active) {

--- a/projects/element-ng/navbar-vertical-next/testing/si-navbar-vertical-next-item.harness.ts
+++ b/projects/element-ng/navbar-vertical-next/testing/si-navbar-vertical-next-item.harness.ts
@@ -14,7 +14,7 @@ export interface SiNavbarVerticalNextItemHarnessFilters extends BaseHarnessFilte
 }
 
 export class SiNavbarVerticalNextItemHarness extends ComponentHarness {
-  static hostSelector = '.dropdown-item, .navbar-vertical-item';
+  static hostSelector = '.navbar-vertical-item';
 
   static with(
     filters: SiNavbarVerticalNextItemHarnessFilters = {}


### PR DESCRIPTION
- Sub-items rendered inside a flyout panel were inconsistently styled depending on whether the flyout was triggered by `alwaysFlyout` or by the collapsed state.
- Items now always use the `navbar-vertical-item` class, ensuring consistent appearance regardless of the trigger.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2093/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2093/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2093/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2093/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2093/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2093/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2093/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2093/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2093/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2093/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->




