### PR TITLE
chore(navbar-vertical-next): rename Settings to Configuration in examples

### DIFF
--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:293653d5a3991f54acfab8e29ed86809a18a05c811e2ec122b287bbe381ae3a4
-size 33528
+oid sha256:bd7bd24c34f1203a51fd061c202592f472fed61d598f5ab1bd7452b0591a62d5
+size 33252

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:364277cf5fa1bac0b157a375f29163043230b308bff777ada7115fb79e40027d
-size 32779
+oid sha256:6bc190db8c8e8a5af01e14221c4e044b390ea3b3a26a35bf575c89bdcda999b2
+size 32547

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--always-flyout.yaml
@@ -25,8 +25,8 @@
   - button "Documentation"
   - group "Documentation"
   - button "Action"
-  - link "Settings":
-    - /url: "#/viewer/viewer/settings"
+  - link "Configuration":
+    - /url: "#/viewer/viewer/configuration"
 - main:
   - heading "Here is a title" [level=2]
   - text: Content with path 'home' Control panel

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a1068b7798c3d5e4c96c6f297eaf31360b7aa55f1d4ae54dc83bfb9048910c5
-size 17767
+oid sha256:abe85ef3ea57a6deb844d3d77a9ff70eab1aa1b3c6c03eaf3cea5f8f076500ed
+size 17113

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b97591a66060df6218a815bd4cc4fbf5a9baeda77b3163beb0fe6ce58acc8fa8
-size 17272
+oid sha256:ec35347c7878830a56cb3ebdb72fa2688343e052fe4b38d62b930f5d32b5973b
+size 16705

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:53b8e1199c603bb68ef2f5f487d97b9a9266fb0aac05ccf6a01c5d1032916161
-size 22055
+oid sha256:553ebb17ad7008cf5eece9c0aeb2da87f59cb63c5c9ced96459a5a4f699cd907
+size 21444

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d7af4f7f8602241b323aeca910d6b79221b03c3a5d85717d3c388a6d9dfe6e9f
-size 21756
+oid sha256:88bb882da380d8a95d17776828396e4bd14cdb85c14e3b3e7ae90e90a9a2aa82
+size 21215

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed-flyout.yaml
@@ -24,8 +24,8 @@
   - button "Documentation"
   - group "Documentation"
   - button "Action"
-  - link "Settings":
-    - /url: "#/viewer/viewer/settings"
+  - link "Configuration":
+    - /url: "#/viewer/viewer/configuration"
 - main:
   - heading "Here is a title" [level=2]
   - text: Content with path 'subItem2' Control panel

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--collapsed.yaml
@@ -18,8 +18,8 @@
   - button "Documentation"
   - group "Documentation"
   - button "Action"
-  - link "Settings":
-    - /url: "#/viewer/viewer/settings"
+  - link "Configuration":
+    - /url: "#/viewer/viewer/configuration"
 - main:
   - heading "Here is a title" [level=2]
   - text: Content with path 'subItem2' Control panel

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7efb84ab9b585f05ad74437670c65093d9dfc173b698be2577d5aaf76cd6ae4
-size 25725
+oid sha256:b354bc0d34a24c45a6bf0386ba92fbc93a32539ccdfd483f020a37ddb00579f4
+size 25480

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b80b4b3b7fb4dece0ddc34679b29197a6d3222bfd77442a974bec106862abb18
-size 24685
+oid sha256:baefad5d39bc30de3fd213f70e80f7cbf4b45cae001d2d8fe747ef20845c6606
+size 24485

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--mobile-expanded.yaml
@@ -16,7 +16,7 @@
   - group "User management"
   - link "Test coverage":
     - /url: "#/viewer/viewer/coverage"
-  - button "Documentation"
+  - button "Documentation" [expanded]
   - group "Documentation":
     - link "Sub item 4":
       - /url: "#/viewer/viewer/subItem4"
@@ -25,8 +25,8 @@
     - link "Sub item 6":
       - /url: "#/viewer/viewer/subItem6"
   - button "Action"
-  - link "Settings":
-    - /url: "#/viewer/viewer/settings"
+  - link "Configuration":
+    - /url: "#/viewer/viewer/configuration"
 - main:
   - heading "Here is a title" [level=2]
   - text: Content with path 'subItem4' Control panel

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47c3e9d2da909b7f02cc530c773011c1bd929cd350809799203ab440903983ad
-size 22843
+oid sha256:fac94c70212b9739c4a41b4fdb65de1efbf5334d2d5182e757aa45bc6957f61a
+size 22234

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c712869d191b4de9d296b3b65e52c9da126057d5f0ebbd55614628cb915d730
-size 22086
+oid sha256:610669a94d54f8463051e510a5c6ffdc67155dce94d365d7571470e3de3d76ff
+size 21552

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07e4d4806dc3adf269b227c95fb8503c3de7fdacb2d9e642fb46abd3fb5a0a39
-size 30068
+oid sha256:36a3b73802ea39741fbec56d03a08b1646b80913e98c3c0c155be160833d9bc7
+size 29456

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a721d244516dfbdfc67b71eaeb2d8a762b8cbed5bf6da10ca04a425857ea981
-size 29302
+oid sha256:399fd1be6113c677b9e175f61f2ca5c187ace453331a133d2ff29f043f863489
+size 28749

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed-flyout.yaml
@@ -25,8 +25,8 @@
     - /url: "#/viewer/viewer/success"
   - link /Danger emphasis badge \+\d+/:
     - /url: "#/viewer/viewer/danger"
-  - link "Settings":
-    - /url: "#/viewer/viewer/settings"
+  - link "Configuration":
+    - /url: "#/viewer/viewer/configuration"
 - main:
   - heading "Badge Examples" [level=2]
   - text: Content with path 'sub-badge-2' Control panel

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges--collapsed.yaml
@@ -19,8 +19,8 @@
     - /url: "#/viewer/viewer/success"
   - link /Danger emphasis badge \+\d+/:
     - /url: "#/viewer/viewer/danger"
-  - link "Settings":
-    - /url: "#/viewer/viewer/settings"
+  - link "Configuration":
+    - /url: "#/viewer/viewer/configuration"
 - main:
   - heading "Badge Examples" [level=2]
   - text: Content with path 'sub-badge-2' Control panel

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa316a4a3ce21b3470dfb17ef71b597ec2cbff41cc40a5890522655b4eaf438b
-size 44348
+oid sha256:040dc7d13ffbfc14003f9a97d7e5f622831eefa65c04b027f97e0eeff03f0b5e
+size 44117

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cca4965b85eafbb419a11a25da27b5c4db451e23ddf1bd254b9e4ab2e486e6a0
-size 42583
+oid sha256:4c53e8059780c99a78563f0077b00d94e7bc7fabda012544d11bd19b45920c35
+size 42402

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-badges.yaml
@@ -26,8 +26,8 @@
     - /url: "#/viewer/viewer/success"
   - link /Danger emphasis badge \+\d+/:
     - /url: "#/viewer/viewer/danger"
-  - link "Settings":
-    - /url: "#/viewer/viewer/settings"
+  - link "Configuration":
+    - /url: "#/viewer/viewer/configuration"
 - main:
   - heading "Badge Examples" [level=2]
   - text: Content with path 'sub-badge-1' Control panel

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a0cf0185957905b2d6fb591b47ebaa99757deb3a915a836230e79ee8326536f
-size 32688
+oid sha256:fdefc9a51ff24d9be8e630230d631d3ef37e366c109be981ba650aa3a6d7e124
+size 32444

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9cf40264ed1fb4151dffa029077e51f0936803748e58d726d2160a53ae899d8b
-size 31506
+oid sha256:d0304da832594f8dbe34521bff2536ba5699e3f5e56ff9b7103d0e9cacd7655d
+size 31295

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next.yaml
@@ -25,8 +25,8 @@
     - link "Sub item 6":
       - /url: "#/viewer/viewer/subItem6"
   - button "Action"
-  - link "Settings":
-    - /url: "#/viewer/viewer/settings"
+  - link "Configuration":
+    - /url: "#/viewer/viewer/configuration"
 - main:
   - heading "Here is a title" [level=2]
   - text: Content with path 'subItem4' Control panel

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
@@ -78,11 +78,11 @@
     <si-navbar-vertical-next-footer-items>
       <a
         si-navbar-vertical-next-item
-        routerLink="settings"
+        routerLink="configuration"
         routerLinkActive
-        icon="element-settings"
+        icon="element-parameter"
       >
-        Settings
+        Configuration
       </a>
     </si-navbar-vertical-next-footer-items>
 

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-routing.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-routing.html
@@ -33,11 +33,11 @@
     <si-navbar-vertical-next-footer-items>
       <a
         si-navbar-vertical-next-item
-        routerLink="settings"
+        routerLink="configuration"
         routerLinkActive
-        icon="element-settings"
+        icon="element-parameter"
       >
-        Settings
+        Configuration
       </a>
     </si-navbar-vertical-next-footer-items>
 

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.html
@@ -55,7 +55,9 @@
       <a si-navbar-vertical-next-item routerLink="coverage" routerLinkActive> Test Coverage </a>
     </si-navbar-vertical-next-items>
     <si-navbar-vertical-next-footer-items>
-      <a si-navbar-vertical-next-item routerLink="settings" routerLinkActive> Settings </a>
+      <a si-navbar-vertical-next-item routerLink="configuration" routerLinkActive>
+        Configuration
+      </a>
     </si-navbar-vertical-next-footer-items>
     <div class="si-layout-main-padding">
       <div class="si-layout-header">

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
@@ -58,11 +58,11 @@
     <si-navbar-vertical-next-footer-items>
       <a
         si-navbar-vertical-next-item
-        routerLink="settings"
+        routerLink="configuration"
         routerLinkActive
-        icon="element-settings"
+        icon="element-parameter"
       >
-        Settings
+        Configuration
       </a>
     </si-navbar-vertical-next-footer-items>
 


### PR DESCRIPTION
- Rename the footer item label from "Settings" to "Configuration" and swap the icon from `element-settings` to `element-parameter` across the navbar-vertical-next examples.
- The `routerLink` path is updated accordingly to keep the example consistent with the displayed label.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2096/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2096/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2096/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2096/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2096/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2096/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2096/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2096/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2096/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2096/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


