### PR TITLE
feat(navbar-vertical-next): add inline collapse mode

### DIFF
--- a/api-goldens/element-ng/navbar-vertical-next/index.api.md
+++ b/api-goldens/element-ng/navbar-vertical-next/index.api.md
@@ -19,6 +19,7 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
     collapse(): void;
     readonly collapsed: _angular_core.ModelSignal<boolean>;
     expand(): void;
+    readonly inlineCollapse: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly skipLinkMainContentLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly skipLinkNavigationLabel: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly stateId: _angular_core.InputSignal<string | undefined>;

--- a/playwright/e2e/element-examples/navbar-vertical-next.spec.ts
+++ b/playwright/e2e/element-examples/navbar-vertical-next.spec.ts
@@ -54,6 +54,22 @@ test.describe('navbar vertical next', () => {
     await si.runVisualAndA11yTests('always-flyout');
   });
 
+  test(example + ' inline collapse toggle', async ({ page, si }) => {
+    await si.visitExample(example);
+
+    await page.getByRole('checkbox', { name: 'Inline collapse' }).check();
+
+    await page.getByLabel('Toggle', { exact: true }).click();
+    await expect(page.getByLabel('Toggle', { exact: true })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    await expect(page.getByRole('link', { name: 'Home' })).toBeHidden();
+
+    await si.waitForAllAnimationsToComplete();
+    await si.runVisualAndA11yTests('inline-collapse');
+  });
+
   test.skip('it should show tooltip only on keyboard interaction', async ({ page, si }) => {
     await si.visitExample(example);
     await page.getByLabel('Toggle', { exact: true }).click();

--- a/playwright/e2e/element-examples/static.spec.ts
+++ b/playwright/e2e/element-examples/static.spec.ts
@@ -80,6 +80,7 @@ test('si-layouts/content-full-layout-fixed-height', ({ si }) => si.static());
 test('si-layouts/content-tile-layout-full-scroll', ({ si }) => si.static());
 test('si-loading-spinner/si-loading-spinner', ({ si }) => si.static({ maxDiffPixels: 31 }));
 test('si-navbar-vertical/si-navbar-vertical-text', ({ si }) => si.static());
+test('si-navbar-vertical-next/si-navbar-vertical-next-text', ({ si }) => si.static());
 test('si-ncharts/si-micro-charts', ({ si }) => si.static());
 test('si-pagination/si-pagination', ({ si }) => si.static());
 test('si-phone-number-input/si-phone-number-input', ({ si }) => si.static());

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5fa0e8a8d5551ffe9842413138a3d7d39da8ef6cfa74844ebf9c6e8759013d4
+size 12214

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a005f64fa0c5b05c1413e5a27b756fc313b319d1d6953dde0290455e319b6a4d
+size 11685

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse.yaml
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse.yaml
@@ -1,0 +1,15 @@
+- link "Jump to Main content"
+- link "Jump to Navigation"
+- banner:
+  - link "Siemens logo":
+    - /url: "#/"
+  - heading "Navbar Vertical Next Example" [level=1]
+- navigation:
+  - button "Toggle"
+- main:
+  - heading "Here is a title" [level=2]
+  - text: Content with path 'home' Control panel
+  - checkbox "Always flyout"
+  - text: Always flyout
+  - checkbox "Inline collapse" [checked]
+  - text: Inline collapse

--- a/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa850a90e3de0a77f0229170b712d1b7b3a70f22cf1179c978df7e7a5baf2e43
+size 22184

--- a/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dbe04b1ccb1a1746c6a22b1c944b5e2feafcfcdba41a949e4c247c0ac080f53
+size 21250

--- a/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next-text.yaml
@@ -1,0 +1,27 @@
+- link "Jump to Main content"
+- link "Jump to Navigation"
+- banner:
+  - link "Siemens logo":
+    - /url: "#/"
+  - heading "Navbar vertical next text only" [level=1]
+  - button "Jane Smith"
+- navigation:
+  - button "Toggle" [expanded]
+  - button "Home"
+  - group "Home"
+  - button "Documentation"
+  - group "Documentation"
+  - text: All the rest
+  - link "Energy & Operations":
+    - /url: "#/viewer/viewer/energy"
+  - link "Test Coverage":
+    - /url: "#/viewer/viewer/coverage"
+  - link "Configuration":
+    - /url: "#/viewer/viewer/configuration"
+- main:
+  - heading "Here is a title" [level=2]
+  - text: Here goes the content Control panel
+  - checkbox "Always flyout"
+  - text: Always flyout
+  - checkbox "Inline collapse"
+  - text: Inline collapse

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.html
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.html
@@ -9,7 +9,7 @@
 />
 <button
   type="button"
-  class="btn-search bg-base-0 px-3 mx-4 mobile navbar-vertical-no-collapse text-secondary"
+  class="btn-search bg-base-0 px-3 mx-4 mobile text-secondary"
   [attr.aria-label]="placeholder() | translate"
   (click)="expandForSearch()"
 >

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.html
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.html
@@ -2,6 +2,7 @@
   @if (smallScreen() && !collapsed()) {
     <div class="modal-backdrop" animate.leave="backdrop-leave" (click)="toggleCollapse()"></div>
   }
+  @let inlineCollapsed = inlineCollapse() && collapsed();
   <nav
     tabindex="-1"
     class="bg-base-1 focus-sub-inside"
@@ -10,25 +11,33 @@
     [class.text-only]="textOnly()"
   >
     <div class="collapse-toggle ms-auto">
-      <div class="mobile-drawer focus-inside navbar-vertical-no-collapse">
+      <div class="mobile-drawer focus-inside">
         <button
           type="button"
-          class="btn btn-icon btn-tertiary-ghost"
+          class="btn btn-icon toggle-button"
+          [class.btn-primary-ghost]="inlineCollapsed"
+          [class.btn-tertiary-ghost]="!inlineCollapsed"
           [attr.aria-label]="toggleButtonText() | translate"
           [attr.aria-expanded]="!collapsed()"
           (click)="toggleCollapse()"
         >
-          <si-icon
-            class="flip-rtl"
-            [icon]="collapsed() ? icons.elementDoubleRight : icons.elementDoubleLeft"
-          />
+          <si-icon class="flip-rtl" [icon]="toggleIcon()" />
         </button>
       </div>
     </div>
-    <ng-content select="si-navbar-vertical-next-search" />
-    <ng-content select="si-navbar-vertical-next-items" />
-    <ng-content select="si-navbar-vertical-next-footer-items" />
+    <div
+      class="nav-content"
+      [attr.inert]="inlineCollapsed ? '' : null"
+      [attr.aria-hidden]="inlineCollapsed ? 'true' : null"
+    >
+      <ng-content select="si-navbar-vertical-next-search" />
+      <ng-content select="si-navbar-vertical-next-items" />
+      <ng-content select="si-navbar-vertical-next-footer-items" />
+    </div>
   </nav>
+  @if (inlineCollapse()) {
+    <div class="toggle-placeholder" aria-hidden="true"></div>
+  }
 }
 <main
   class="si-layout-inner focus-none"

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.scss
@@ -4,6 +4,13 @@
 $vertical-nav-width: 240px;
 $vertical-nav-collapsed-width: calc(1.5rem + 2 * map.get(all-variables.$spacers, 5));
 $vertical-nav-transition-duration: all-variables.$element-default-transition-duration;
+$vertical-nav-top-offset: calc(
+  all-variables.$si-application-header-height + all-variables.$si-titlebar-spacing +
+    all-variables.$si-system-banner-spacing
+);
+$mobile-drawer-padding-block: map.get(all-variables.$spacers, 2);
+$mobile-drawer-padding-inline: map.get(all-variables.$spacers, 4);
+$mobile-drawer-margin-block-start: map.get(all-variables.$spacers, 4);
 
 :host {
   display: block;
@@ -25,10 +32,7 @@ nav {
   flex-direction: column;
   position: fixed;
   z-index: all-variables.$zindex-vertical-nav;
-  inset-block-start: calc(
-    all-variables.$si-application-header-height + all-variables.$si-titlebar-spacing +
-      all-variables.$si-system-banner-spacing
-  );
+  inset-block-start: $vertical-nav-top-offset;
   inset-block-end: 0;
   inset-inline-start: 0;
   inline-size: 0;
@@ -49,9 +53,9 @@ nav {
   border: 0;
   inline-size: $vertical-nav-collapsed-width;
   color: all-variables.$element-text-primary;
-  padding-block: 4px;
-  padding-inline: 8px;
-  margin-block-start: 8px;
+  padding-block: $mobile-drawer-padding-block;
+  padding-inline: $mobile-drawer-padding-inline;
+  margin-block-start: $mobile-drawer-margin-block-start;
   border-start-end-radius: all-variables.$border-radius;
   border-end-end-radius: all-variables.$border-radius;
 
@@ -62,16 +66,6 @@ nav {
 
   :host(:not(.nav-collapsed)) & {
     inline-size: $vertical-nav-width;
-  }
-}
-
-:host.nav-collapsed {
-  .mobile-drawer {
-    border: 0;
-    color: all-variables.$element-text-primary;
-    background: all-variables.$element-base-1;
-    text-align: end;
-    box-shadow: all-variables.$element-elevation-1;
   }
 }
 
@@ -89,22 +83,33 @@ nav {
   }
 }
 
+// Surface styling for the collapsed drawer when it floats over content:
+// the .nav-text-only sidebar and the mobile off-canvas drawer below sm.
+@mixin mobile-drawer-overlay {
+  background: all-variables.$element-base-1;
+  box-shadow: all-variables.$element-elevation-1;
+}
+
+:host(.nav-text-only:not(.nav-inline-collapse)).nav-collapsed .mobile-drawer {
+  @include mobile-drawer-overlay;
+}
+
+@include all-variables.media-breakpoint-down(sm) {
+  :host.nav-collapsed .mobile-drawer {
+    @include mobile-drawer-overlay;
+  }
+}
+
 @include all-variables.media-breakpoint-up(sm) {
   :host:not(.nav-text-only),
-  :host:not(.nav-collapsed) {
+  :host:not(.nav-collapsed),
+  :host(.nav-inline-collapse) {
     --si-layout-header-first-element-offset: 0;
   }
 
-  :host:not(.nav-text-only) {
+  :host:where(:not(.nav-text-only):not(.nav-inline-collapse)) {
     padding-inline-start: $vertical-nav-collapsed-width;
 
-    .mobile-drawer {
-      background: transparent;
-      box-shadow: none;
-    }
-  }
-
-  :host:not(.nav-text-only) {
     nav {
       inline-size: $vertical-nav-collapsed-width;
 
@@ -118,5 +123,62 @@ nav {
 @include all-variables.media-breakpoint-up(lg) {
   :host:not(.nav-collapsed) {
     padding-inline-start: $vertical-nav-width;
+  }
+}
+
+.nav-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-block-size: 0;
+}
+
+:host(.nav-inline-collapse) {
+  $toggle-size: calc(1lh + (2 * map.get(all-variables.$spacers, 4)));
+
+  nav {
+    overflow: hidden; // clip the drawer as it collapses to inline-size 0
+  }
+
+  .mobile-drawer::before {
+    content: '';
+    display: block;
+    block-size: $toggle-size;
+  }
+
+  .toggle-placeholder {
+    block-size: 0;
+    margin-block-start: 0;
+    transition:
+      block-size $vertical-nav-transition-duration ease,
+      margin-block-start $vertical-nav-transition-duration ease;
+  }
+
+  .toggle-button {
+    position: fixed;
+    z-index: all-variables.$zindex-vertical-nav;
+    inset-block-start: calc(
+      #{$vertical-nav-top-offset} + #{$mobile-drawer-margin-block-start} +
+        #{$mobile-drawer-padding-block}
+    );
+    inset-inline-start: calc(
+      #{$vertical-nav-width} - #{$toggle-size} - #{$mobile-drawer-padding-inline}
+    );
+    transition:
+      inset-inline-start $vertical-nav-transition-duration ease,
+      inset-block-start $vertical-nav-transition-duration ease;
+  }
+
+  // Parked state: nav collapsed, button + placeholder move to the in-page slot.
+  &.nav-collapsed {
+    .toggle-placeholder {
+      block-size: $toggle-size;
+      margin-block-start: map.get(all-variables.$spacers, 6);
+    }
+
+    .toggle-button {
+      inset-block-start: calc(#{$vertical-nav-top-offset} + #{map.get(all-variables.$spacers, 6)});
+      inset-inline-start: map.get(all-variables.$spacers, 9);
+    }
   }
 }

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
@@ -8,6 +8,7 @@ import {
   booleanAttribute,
   ChangeDetectionStrategy,
   Component,
+  computed,
   inject,
   Injector,
   input,
@@ -18,7 +19,12 @@ import {
   SimpleChanges
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { elementDoubleLeft, elementDoubleRight } from '@siemens/element-icons';
+import {
+  elementDoubleLeft,
+  elementDoubleRight,
+  elementLayoutPane2,
+  elementLayoutPane2Right
+} from '@siemens/element-icons';
 import { SI_UI_STATE_SERVICE } from '@siemens/element-ng/common';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { BOOTSTRAP_BREAKPOINTS } from '@siemens/element-ng/resize-observer';
@@ -45,12 +51,19 @@ interface UIState {
     class: 'si-layout-inner ready',
     '[class.nav-collapsed]': 'collapsed()',
     '[class.nav-text-only]': 'textOnly()',
+    '[class.nav-inline-collapse]': 'inlineCollapse()',
     '[class.visible]': 'visible()',
     '[class.ready]': 'ready()'
   }
 })
 export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
-  protected readonly icons = addIcons({ elementDoubleLeft, elementDoubleRight });
+  protected readonly icons = addIcons({
+    elementDoubleLeft,
+    elementDoubleRight,
+    elementLayoutPane2,
+    elementLayoutPane2Right
+  });
+
   /**
    * Whether the navbar-vertical is collapsed.
    *
@@ -64,6 +77,16 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
    * @defaultValue false
    */
   readonly textOnly = input(false, { transform: booleanAttribute });
+
+  /**
+   * Enables an alternative inline-collapse behavior.
+   *
+   * When collapsed, nav content becomes inert while the toggle remains
+   * available in the page flow.
+   *
+   * @defaultValue false
+   */
+  readonly inlineCollapse = input(false, { transform: booleanAttribute });
 
   /**
    * When `true`, item-groups always open as a transient flyout panel adjacent to the
@@ -141,6 +164,13 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
 
   // Indicates if the user prefers a collapsed navbar. Relevant for resizing.
   private preferCollapse = false;
+
+  protected readonly toggleIcon = computed(() => {
+    if (this.inlineCollapse()) {
+      return this.collapsed() ? this.icons.elementLayoutPane2 : this.icons.elementLayoutPane2Right;
+    }
+    return this.collapsed() ? this.icons.elementDoubleRight : this.icons.elementDoubleLeft;
+  });
 
   constructor() {
     this.breakpointObserver

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
@@ -67,6 +67,7 @@ class EmptyComponent {}
       [textOnly]="textOnly()"
       [stateId]="stateId"
       [collapsed]="collapsed()"
+      [inlineCollapse]="inlineCollapse()"
       [alwaysFlyout]="alwaysFlyout()"
     >
       <si-navbar-vertical-next-search [debounceTime]="0" (searchChange)="searchEvent($event)" />
@@ -160,6 +161,7 @@ class TestHostComponent {
   readonly textOnly = signal(true);
   stateId?: string;
   readonly collapsed = signal(false);
+  readonly inlineCollapse = signal(false);
   readonly alwaysFlyout = signal(false);
   readonly showDeclarativeFlyoutGroup = signal(false);
   readonly showDeclarativeNavigationGroup = signal(false);
@@ -399,6 +401,62 @@ describe('SiNavbarVerticalNext', () => {
       const harness = await harnessLoader.getHarness(SiNavbarVerticalNextHarness);
       breakpointObserver.isSmall.next(true);
       expect(await harness.isCollapsed()).toBe(true);
+    });
+  });
+
+  describe('with inlineCollapse', () => {
+    beforeEach(() => {
+      component.inlineCollapse.set(true);
+      component.textOnly.set(false);
+      component.showDeclarativeNavigationGroup.set(true);
+    });
+
+    it('should add nav-inline-collapse host class', async () => {
+      await fixture.whenStable();
+      const host = page.getByRole('navigation').element().closest('si-navbar-vertical-next')!;
+      expect(host).toHaveClass('nav-inline-collapse');
+    });
+
+    it('should inert the content when collapsed', async () => {
+      component.collapsed.set(true);
+      await fixture.whenStable();
+
+      const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+      expect(host).toHaveClass('nav-collapsed', 'nav-inline-collapse');
+
+      const nav = page.getByRole('navigation').element();
+      expect(nav).toHaveAttribute('tabindex', '-1');
+
+      const content = host.querySelector('.nav-content') as HTMLElement;
+      expect(content).toHaveAttribute('inert', '');
+
+      // Page reclaims its full inline-start space when collapsed.
+      expect(host).toHaveStyle({ paddingInlineStart: '0px' });
+    });
+
+    it('should drop inert when expanded', async () => {
+      component.collapsed.set(false);
+      await fixture.whenStable();
+
+      const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+      expect(host).not.toHaveClass('nav-collapsed');
+
+      const content = host.querySelector('.nav-content') as HTMLElement;
+      expect(content).not.toHaveAttribute('inert');
+    });
+
+    it('should expose correct aria-expanded on the toggle', async () => {
+      component.collapsed.set(true);
+      await fixture.whenStable();
+
+      const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+      const toggle = host.querySelector('.toggle-button') as HTMLButtonElement;
+
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+      component.collapsed.set(false);
+      await fixture.whenStable();
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
     });
   });
 });

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
@@ -10,6 +10,7 @@
     stateId="navbar-vertical-next-badges"
     toggleButtonText="Toggle"
     [alwaysFlyout]="alwaysFlyout"
+    [inlineCollapse]="inlineCollapse"
   >
     <si-navbar-vertical-next-search placeholder="Search..." />
     <si-navbar-vertical-next-items>
@@ -94,9 +95,18 @@
       <div class="card p-5 mt-8 e2e-ignore">
         <div class="card-header">Control panel</div>
         <div class="card-body">
-          <si-form-item label="Always flyout">
-            <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
-          </si-form-item>
+          <div class="row">
+            <div class="col-sm-auto">
+              <si-form-item label="Always flyout">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
+              </si-form-item>
+            </div>
+            <div class="col-sm-auto">
+              <si-form-item label="Inline collapse">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="inlineCollapse" />
+              </si-form-item>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.ts
@@ -60,6 +60,7 @@ export class SampleComponent implements OnInit {
   logEvent = inject(LOG_EVENT);
 
   alwaysFlyout = false;
+  inlineCollapse = false;
 
   ngOnInit(): void {
     this.router.navigate(['home'], { relativeTo: this.activeRoute });

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.html
@@ -30,6 +30,7 @@
     toggleButtonText="Toggle"
     [textOnly]="true"
     [alwaysFlyout]="alwaysFlyout"
+    [inlineCollapse]="inlineCollapse"
   >
     <si-navbar-vertical-next-items>
       <button
@@ -67,9 +68,18 @@
       <div class="card p-5 mt-8 e2e-ignore">
         <div class="card-header">Control panel</div>
         <div class="card-body">
-          <si-form-item label="Always flyout">
-            <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
-          </si-form-item>
+          <div class="row">
+            <div class="col-sm-auto">
+              <si-form-item label="Always flyout">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
+              </si-form-item>
+            </div>
+            <div class="col-sm-auto">
+              <si-form-item label="Inline collapse">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="inlineCollapse" />
+              </si-form-item>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.ts
@@ -54,4 +54,5 @@ import {
 })
 export class SampleComponent {
   alwaysFlyout = false;
+  inlineCollapse = false;
 }

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
@@ -10,6 +10,7 @@
     stateId="navbar-vertical-next-with-icons"
     toggleButtonText="Toggle"
     [alwaysFlyout]="alwaysFlyout"
+    [inlineCollapse]="inlineCollapse"
   >
     <si-navbar-vertical-next-search placeholder="Search..." />
     <si-navbar-vertical-next-items>
@@ -74,9 +75,18 @@
       <div class="card p-5 mt-8 e2e-ignore">
         <div class="card-header">Control panel</div>
         <div class="card-body">
-          <si-form-item label="Always flyout">
-            <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
-          </si-form-item>
+          <div class="row">
+            <div class="col-sm-auto">
+              <si-form-item label="Always flyout">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="alwaysFlyout" />
+              </si-form-item>
+            </div>
+            <div class="col-sm-auto">
+              <si-form-item label="Inline collapse">
+                <input type="checkbox" class="form-check-input" [(ngModel)]="inlineCollapse" />
+              </si-form-item>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.ts
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.ts
@@ -60,6 +60,7 @@ export class SampleComponent implements OnInit {
   logEvent = inject(LOG_EVENT);
 
   alwaysFlyout = false;
+  inlineCollapse = false;
 
   ngOnInit(): void {
     this.router.navigate(['home'], { relativeTo: this.activeRoute });


### PR DESCRIPTION
- The collapse/expand icons are switched to elementLayoutPane2 / elementLayoutPane2Right when `inlineCollapse` mode
- Updated example components and templates to include a control for inlineCollapse.

Related #1945

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2097/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2097/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2097/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2097/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2097/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2097/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2097/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2097/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2097/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2097/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


















