### PR TITLE
fix(filtered-search): omit daterange specific properties from datepickerConfig

### DIFF
--- a/api-goldens/element-ng/filtered-search/index.api.md
+++ b/api-goldens/element-ng/filtered-search/index.api.md
@@ -13,7 +13,7 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public
 export interface CriterionDefinition {
-    datepickerConfig?: DatepickerInputConfig;
+    datepickerConfig?: Omit<DatepickerInputConfig, 'enableDateRange' | 'enableTwoMonthDateRange'>;
     label?: TranslatableString;
     multiSelect?: boolean;
     name: string;

--- a/projects/element-ng/filtered-search/si-filtered-search.model.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.model.ts
@@ -58,7 +58,7 @@ export interface CriterionDefinition {
   /**
    * Optional configuration object for the datepicker.
    */
-  datepickerConfig?: DatepickerInputConfig;
+  datepickerConfig?: Omit<DatepickerInputConfig, 'enableDateRange' | 'enableTwoMonthDateRange'>;
   /**
    * Limit criterion options to the predefined ones.
    */


### PR DESCRIPTION
Replica of #1260, since that PR caused the accidental v50 release and has been reverted.

---

`enableDateRange` and `enableTwoMonthDateRange` have no effect when passed in `datepickerConfig` with filtered-search criterion.

---

BREAKING CHANGE: `CriterionDefinition.datepickerConfig` type narrowed

The type of `datepickerConfig` in `CriterionDefinition` (filtered-search) changed from `DatepickerInputConfig` to `Omit<DatepickerInputConfig, 'enableDateRange' | 'enableTwoMonthDateRange'>`.

The properties `enableDateRange` and `enableTwoMonthDateRange ` are no longer accepted in `datepickerConfig` when used with filtered-search criteria, as they had no effect in that context.

Migration: Remove any `enableDateRange` and `enableTwoMonthDateRange` properties from your `datepickerConfig` objects passed to `CriterionDefinition`.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2101/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2101/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2101/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2101/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2101/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2101/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2101/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2101/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2101/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2101/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


