### PR TITLE
feat(tree-view): add copy-drag directive for non-destructive drag operations

### DIFF
--- a/projects/element-ng/tree-view/index.ts
+++ b/projects/element-ng/tree-view/index.ts
@@ -10,3 +10,4 @@ export * from './si-tree-view.model';
 export * from './si-tree-view.utils';
 export * from './si-tree-view-item/si-tree-view-item.directive';
 export * from './drag-drop.util';
+export * from './si-copy-drag.directive';

--- a/projects/element-ng/tree-view/si-copy-drag.directive.ts
+++ b/projects/element-ng/tree-view/si-copy-drag.directive.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { CdkDrag } from '@angular/cdk/drag-drop';
+import { DestroyRef, Directive, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+/**
+ * Add alongside `cdkDrag` to keep the source element visible during drag,
+ * providing copy-drag semantics for tree-view items.
+ *
+ * The directive clones the CDK placeholder so the original item remains
+ * visible while being dragged to another tree.
+ *
+ * @example
+ * ```html
+ * <si-tree-view-item cdkDrag siCopyDrag [cdkDragData]="item">
+ *   <si-tree-view-item *cdkDragPreview />
+ * </si-tree-view-item>
+ * ```
+ */
+@Directive({
+  selector: '[siCopyDrag]',
+  host: {
+    class: 'si-copy-drag'
+  }
+})
+export class SiCopyDragDirective {
+  private clone: HTMLElement | null = null;
+
+  constructor() {
+    const drag = inject(CdkDrag);
+    const destroyRef = inject(DestroyRef);
+
+    drag.started.pipe(takeUntilDestroyed(destroyRef)).subscribe(() => {
+      const placeholder = drag.getPlaceholderElement();
+      this.clone = placeholder.cloneNode(true) as HTMLElement;
+      this.clone.classList.remove('cdk-drag-placeholder');
+      this.clone.style.pointerEvents = 'none';
+      this.clone.removeAttribute('id');
+      placeholder.after(this.clone);
+    });
+
+    drag.ended.pipe(takeUntilDestroyed(destroyRef)).subscribe(() => {
+      this.clone?.remove();
+      this.clone = null;
+    });
+  }
+}

--- a/projects/element-ng/tree-view/si-copy-drag.directive.ts
+++ b/projects/element-ng/tree-view/si-copy-drag.directive.ts
@@ -33,6 +33,10 @@ export class SiCopyDragDirective {
     const drag = inject(CdkDrag);
     const destroyRef = inject(DestroyRef);
 
+    destroyRef.onDestroy(() => {
+      this.clone?.remove();
+    });
+
     drag.started.pipe(takeUntilDestroyed(destroyRef)).subscribe(() => {
       const placeholder = drag.getPlaceholderElement();
       this.clone = placeholder.cloneNode(true) as HTMLElement;

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
@@ -378,8 +378,7 @@ describe('transferTreeItem copy semantics', () => {
     copiedItem.label = 'Modified';
     copiedItem.customData.id = 99;
 
-    expect(sensor.label).toBe('Sensor A');
-    expect(sensor.customData.id).toBe(42);
+    expect(sensor).toMatchObject({ label: 'Sensor A', customData: { id: 42 } });
   });
 
   it('copies the same item multiple times as separate clones', () => {
@@ -405,8 +404,8 @@ describe('transferTreeItem copy semantics', () => {
 
     expect(target.children).toHaveLength(3);
     expect(target.children![0]).not.toBe(target.children![1]);
-    expect(target.children![0].label).toBe('Sensor A');
-    expect(target.children![1].label).toBe('Sensor A');
+    expect(target.children![0]).toMatchObject({ label: 'Sensor A' });
+    expect(target.children![1]).toMatchObject({ label: 'Sensor A' });
   });
 
   it('inserts copy as child when target is expanded', () => {
@@ -425,8 +424,7 @@ describe('transferTreeItem copy semantics', () => {
     transferTreeItem(sourceItems, targetItems, event, false);
 
     expect(target.children).toHaveLength(2);
-    expect(target.children![0].label).toBe('Sensor A');
-    expect(target.children![0].parent).toBe(target);
+    expect(target.children![0]).toMatchObject({ label: 'Sensor A', parent: target });
   });
 
   it('inserts copy as sibling when target is a leaf', () => {
@@ -445,9 +443,8 @@ describe('transferTreeItem copy semantics', () => {
     transferTreeItem(sourceItems, targetItems, event, false);
 
     expect(parent.children).toHaveLength(2);
-    expect(parent.children![0].label).toBe('Room 101');
-    expect(parent.children![1].label).toBe('Sensor A');
-    expect(parent.children![1].parent).toBe(parent);
+    expect(parent.children![0]).toMatchObject({ label: 'Room 101' });
+    expect(parent.children![1]).toMatchObject({ label: 'Sensor A', parent });
   });
 
   it('does not modify trees when source item is not found', () => {

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
@@ -8,6 +8,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { removeItemFromTree, reorderTreeItem, transferTreeItem } from '../drag-drop.util';
+import { SiCopyDragDirective } from '../si-copy-drag.directive';
 import { SiTreeViewComponent } from '../si-tree-view.component';
 import { TreeItem } from '../si-tree-view.model';
 import { SiTreeViewItemComponent } from './si-tree-view-item.component';
@@ -254,5 +255,218 @@ describe('SiTreeViewComponentWithDragDrop', () => {
         .nativeElement.textContent
     ).toBe('Company2');
     expect(debugElement.query(By.css('si-tree-view-item')).nativeElement.tabIndex).toBe(0);
+  });
+});
+
+describe('SiCopyDragDirective', () => {
+  @Component({
+    imports: [
+      SiTreeViewComponent,
+      SiTreeViewItemComponent,
+      SiTreeViewItemDirective,
+      DragDropModule,
+      SiCopyDragDirective
+    ],
+    template: `<div style="height: 300px">
+      <si-tree-view
+        #tree
+        cdkDropList
+        [items]="items()"
+        [cdkDropListData]="treeComponent().dropListItems"
+      >
+        <ng-template siTreeViewItem>
+          <si-tree-view-item cdkDrag siCopyDrag />
+        </ng-template>
+      </si-tree-view>
+    </div>`,
+    changeDetection: ChangeDetectionStrategy.OnPush
+  })
+  class CopyDragWrapperComponent {
+    readonly treeComponent = viewChild.required('tree', { read: SiTreeViewComponent });
+    readonly items = signal<TreeItem[]>([
+      { label: 'Item 1', state: 'leaf' },
+      { label: 'Item 2', state: 'leaf' }
+    ]);
+  }
+
+  it('renders items with siCopyDrag directive', async () => {
+    const fixture = TestBed.createComponent(CopyDragWrapperComponent);
+    await fixture.whenStable();
+
+    const items = fixture.debugElement.queryAll(By.css('si-tree-view-item'));
+    expect(items).toHaveLength(2);
+    expect(items[0].nativeElement.classList).toContain('si-copy-drag');
+  });
+});
+
+describe('transferTreeItem copy semantics', () => {
+  const initTree = (items: TreeItem[], parent?: TreeItem, level = 0): void => {
+    for (const item of items) {
+      item.parent = parent;
+      item.level = level;
+      if (item.children) {
+        initTree(item.children, item, level + 1);
+      }
+    }
+  };
+
+  const flatten = (items: TreeItem[]): TreeItem[] => {
+    const result: TreeItem[] = [];
+    for (const item of items) {
+      result.push(item);
+      if (item.children && item.state === 'expanded') {
+        result.push(...flatten(item.children));
+      }
+    }
+    return result;
+  };
+
+  const makeDrop = (
+    sourceData: TreeItem[],
+    targetData: TreeItem[],
+    previousIndex: number,
+    currentIndex: number
+  ): CdkDragDrop<TreeItem[]> =>
+    ({
+      container: { data: targetData } as CdkDropList<TreeItem[]>,
+      previousContainer: { data: sourceData } as CdkDropList<TreeItem[]>,
+      previousIndex,
+      currentIndex
+    }) as CdkDragDrop<TreeItem[]>;
+
+  it('does not remove source item when removeFromSource is false', () => {
+    const sensor: TreeItem = { label: 'Sensor A', state: 'leaf' };
+    const sourceItems = [sensor];
+    initTree(sourceItems);
+
+    const target: TreeItem = {
+      label: 'Floor 1',
+      state: 'expanded',
+      children: [{ label: 'Room 101', state: 'leaf' }]
+    };
+    const targetItems = [target];
+    initTree(targetItems);
+
+    const targetFlat = flatten(targetItems);
+    const event = makeDrop(sourceItems, targetFlat, 0, 1);
+
+    const result = transferTreeItem(sourceItems, targetItems, event, false);
+
+    expect(result.sourceTree).toHaveLength(1);
+    expect(result.sourceTree[0].label).toBe('Sensor A');
+  });
+
+  it('creates an independent deep clone of the copied item', () => {
+    const sensor: TreeItem = { label: 'Sensor A', state: 'leaf', customData: { id: 42 } };
+    const sourceItems = [sensor];
+    initTree(sourceItems);
+
+    const target: TreeItem = {
+      label: 'Floor 1',
+      state: 'expanded',
+      children: [{ label: 'Room 101', state: 'leaf' }]
+    };
+    const targetItems = [target];
+    initTree(targetItems);
+
+    const targetFlat = flatten(targetItems);
+    const event = makeDrop(sourceItems, targetFlat, 0, 1);
+
+    transferTreeItem(sourceItems, targetItems, event, false);
+
+    const copiedItem = target.children![0];
+    copiedItem.label = 'Modified';
+    copiedItem.customData.id = 99;
+
+    expect(sensor.label).toBe('Sensor A');
+    expect(sensor.customData.id).toBe(42);
+  });
+
+  it('copies the same item multiple times as separate clones', () => {
+    const sensor: TreeItem = { label: 'Sensor A', state: 'leaf' };
+    const sourceItems = [sensor];
+    initTree(sourceItems);
+
+    const target: TreeItem = {
+      label: 'Floor 1',
+      state: 'expanded',
+      children: [{ label: 'Room 101', state: 'leaf' }]
+    };
+    const targetItems = [target];
+    initTree(targetItems);
+
+    const targetFlat1 = flatten(targetItems);
+    const event1 = makeDrop(sourceItems, targetFlat1, 0, 1);
+    transferTreeItem(sourceItems, targetItems, event1, false);
+
+    const targetFlat2 = flatten(targetItems);
+    const event2 = makeDrop(sourceItems, targetFlat2, 0, 1);
+    transferTreeItem(sourceItems, targetItems, event2, false);
+
+    expect(target.children).toHaveLength(3);
+    expect(target.children![0]).not.toBe(target.children![1]);
+    expect(target.children![0].label).toBe('Sensor A');
+    expect(target.children![1].label).toBe('Sensor A');
+  });
+
+  it('inserts copy as child when target is expanded', () => {
+    const sensor: TreeItem = { label: 'Sensor A', state: 'leaf' };
+    const sourceItems = [sensor];
+    initTree(sourceItems);
+
+    const existing: TreeItem = { label: 'Existing', state: 'leaf' };
+    const target: TreeItem = { label: 'Floor 1', state: 'expanded', children: [existing] };
+    const targetItems = [target];
+    initTree(targetItems);
+
+    const targetFlat = flatten(targetItems);
+    const event = makeDrop(sourceItems, targetFlat, 0, 1);
+
+    transferTreeItem(sourceItems, targetItems, event, false);
+
+    expect(target.children).toHaveLength(2);
+    expect(target.children![0].label).toBe('Sensor A');
+    expect(target.children![0].parent).toBe(target);
+  });
+
+  it('inserts copy as sibling when target is a leaf', () => {
+    const sensor: TreeItem = { label: 'Sensor A', state: 'leaf' };
+    const sourceItems = [sensor];
+    initTree(sourceItems);
+
+    const leaf: TreeItem = { label: 'Room 101', state: 'leaf' };
+    const parent: TreeItem = { label: 'Floor 1', state: 'expanded', children: [leaf] };
+    const targetItems = [parent];
+    initTree(targetItems);
+
+    const targetFlat = flatten(targetItems);
+    const event = makeDrop(sourceItems, targetFlat, 0, 2);
+
+    transferTreeItem(sourceItems, targetItems, event, false);
+
+    expect(parent.children).toHaveLength(2);
+    expect(parent.children![0].label).toBe('Room 101');
+    expect(parent.children![1].label).toBe('Sensor A');
+    expect(parent.children![1].parent).toBe(parent);
+  });
+
+  it('does not modify trees when source item is not found', () => {
+    vi.spyOn(console, 'error');
+
+    const orphan: TreeItem = { label: 'Orphan', state: 'leaf' };
+    const sourceItems: TreeItem[] = [{ label: 'Other', state: 'leaf' }];
+    initTree(sourceItems);
+
+    const target: TreeItem = { label: 'Floor 1', state: 'expanded', children: [] };
+    const targetItems = [target];
+    initTree(targetItems);
+
+    const targetFlat = flatten(targetItems);
+    const event = makeDrop([orphan], targetFlat, 0, 1);
+
+    transferTreeItem(sourceItems, targetItems, event, false);
+
+    expect(target.children).toHaveLength(0);
+    expect(console.error).toHaveBeenCalledWith('Source tree item not found');
   });
 });

--- a/src/app/examples/si-tree-view/si-tree-view-drag-drop-copy.html
+++ b/src/app/examples/si-tree-view/si-tree-view-drag-drop-copy.html
@@ -1,0 +1,65 @@
+<h3>Copy between trees</h3>
+<p
+  >Drag equipment from the catalog into a room. Items are copied (not moved) and inserted as
+  children of the drop target. The <code>siCopyDrag</code> directive keeps the catalog item visible
+  during drag.</p
+>
+<div class="d-flex h-100" style="width: 600px">
+  <div>
+    <h4>Building tree</h4>
+
+    <si-tree-view
+      #buildingTree
+      ariaLabel="Building tree"
+      class="me-8"
+      style="width: 300px; height: 500px"
+      [enableDataField1]="true"
+      [enableSelection]="true"
+      [expandCollapseAll]="true"
+      [items]="buildingItems"
+      [flatTree]="false"
+    >
+      <div
+        #buildingDropList="cdkDropList"
+        cdkDropList
+        [cdkDropListConnectedTo]="equipmentDropList"
+        [cdkDropListData]="buildingTree.dropListItems"
+        (cdkDropListDropped)="onBuildingDrop($event)"
+      >
+        <ng-template let-item="treeItem" siTreeViewItem>
+          <si-tree-view-item cdkDrag [cdkDragData]="item">
+            <si-tree-view-item *cdkDragPreview />
+          </si-tree-view-item>
+        </ng-template>
+      </div>
+    </si-tree-view>
+  </div>
+  <div>
+    <h4>Equipment catalog</h4>
+
+    <si-tree-view
+      #equipmentTree
+      ariaLabel="Equipment catalog"
+      style="width: 300px; height: 500px"
+      [enableDataField1]="true"
+      [enableSelection]="true"
+      [items]="equipmentItems"
+      [flatTree]="true"
+    >
+      <div
+        #equipmentDropList="cdkDropList"
+        cdkDropList
+        [cdkDropListConnectedTo]="buildingDropList"
+        [cdkDropListData]="equipmentTree.dropListItems"
+        [cdkDropListEnterPredicate]="rejectBuildingItems"
+        [cdkDropListSortingDisabled]="true"
+      >
+        <ng-template let-item="treeItem" siTreeViewItem>
+          <si-tree-view-item cdkDrag siCopyDrag [cdkDragData]="item">
+            <si-tree-view-item *cdkDragPreview />
+          </si-tree-view-item>
+        </ng-template>
+      </div>
+    </si-tree-view>
+  </div>
+</div>

--- a/src/app/examples/si-tree-view/si-tree-view-drag-drop-copy.ts
+++ b/src/app/examples/si-tree-view/si-tree-view-drag-drop-copy.ts
@@ -74,9 +74,7 @@ export class SampleComponent {
     }
   ];
 
-  rejectBuildingItems(drag: CdkDrag<TreeItem>, drop: CdkDropList<TreeItem[]>): boolean {
-    return false;
-  }
+  rejectBuildingItems = (drag: CdkDrag<TreeItem>, drop: CdkDropList<TreeItem[]>): boolean => false;
 
   onBuildingDrop(event: CdkDragDrop<TreeItem[]>): void {
     if (event.container === event.previousContainer) {

--- a/src/app/examples/si-tree-view/si-tree-view-drag-drop-copy.ts
+++ b/src/app/examples/si-tree-view/si-tree-view-drag-drop-copy.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { CdkDrag, CdkDragDrop, CdkDropList, DragDropModule } from '@angular/cdk/drag-drop';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  reorderTreeItem,
+  SiCopyDragDirective,
+  SiTreeViewComponent,
+  SiTreeViewItemComponent,
+  SiTreeViewItemDirective,
+  transferTreeItem,
+  TreeItem
+} from '@siemens/element-ng/tree-view';
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    DragDropModule,
+    SiCopyDragDirective,
+    SiTreeViewComponent,
+    SiTreeViewItemComponent,
+    SiTreeViewItemDirective
+  ],
+  templateUrl: './si-tree-view-drag-drop-copy.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'p-5' }
+})
+export class SampleComponent {
+  buildingItems: TreeItem[] = [
+    {
+      label: 'Building A',
+      icon: 'element-project',
+      state: 'expanded',
+      children: [
+        {
+          label: 'Floor 1',
+          icon: 'element-layer',
+          state: 'expanded',
+          children: [
+            { label: 'Room 101', icon: 'element-room', state: 'leaf' },
+            { label: 'Room 102', icon: 'element-room', state: 'leaf' }
+          ]
+        }
+      ]
+    }
+  ];
+
+  equipmentItems: TreeItem[] = [
+    {
+      label: 'PXC5.E003',
+      icon: 'element-automation-station',
+      state: 'leaf',
+      dataField1: 'Automation Station'
+    },
+    {
+      label: 'QMX3.P37',
+      icon: 'element-room-temperature',
+      state: 'leaf',
+      dataField1: 'Room Sensor'
+    },
+    {
+      label: 'RDG160KN',
+      icon: 'element-room-unit',
+      state: 'leaf',
+      dataField1: 'Room Thermostat'
+    },
+    {
+      label: 'GDB161.1E',
+      icon: 'element-motor',
+      state: 'leaf',
+      dataField1: 'Damper Actuator'
+    }
+  ];
+
+  rejectBuildingItems(drag: CdkDrag<TreeItem>, drop: CdkDropList<TreeItem[]>): boolean {
+    return false;
+  }
+
+  onBuildingDrop(event: CdkDragDrop<TreeItem[]>): void {
+    if (event.container === event.previousContainer) {
+      this.buildingItems = [...reorderTreeItem(this.buildingItems, event)];
+    } else {
+      const result = transferTreeItem(this.equipmentItems, this.buildingItems, event, false);
+      this.buildingItems = [...result.targetTree];
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds a new `SiCopyDragDirective` that enables copy-drag for tree-view items. When applied alongside cdkDrag, the source item remains visible during the drag operation instead of being hidden by CDK's default placeholder behavior and remains in the sources tree to be dragged again to a new location.

This is useful for scenarios like dragging items from a catalog/palette into a working tree without removing them from the source. This could be used to assign devices to locations or creating an entire building hierarchy via drag and drop.

## Usage
Pair with transferTreeItem(..., { removeFromSource: false }) in the drop handler to preserve the source data model.

## Changes
New: `SiCopyDragDirective` — standalone directive that clones the CDK placeholder so the original item stays visible during drag
New: `si-tree-view-drag-drop-copy example` — demo with two side-by-side trees (building tree + equipment catalog) showing copy-drag in action
New: 7 unit tests covering the directive and transferTreeItem copy semantics (source preservation, deep clone independence, child/sibling insertion)
Export: Added `SiCopyDragDirective` to the tree-view public API

## How it works
The directive subscribes to CDK Drag's `started`/`ended` events. On drag start, it clones the placeholder element (which CDK inserts to replace the dragged item), removes the `cdk-drag-placeholder` class so it isn't hidden by existing CSS, and inserts it after the placeholder. On drag end, the clone is removed.

## Testing
16/16 tree-view tests pass (9 existing + 7 new)
No changes to existing APIs or behavior

<img width="1437" height="1098" alt="tree-drag-and-drop-copy" src="https://github.com/user-attachments/assets/548a92b2-725d-4ec5-b726-6b66344db6ad" />