### PR TITLE
fix(drag-drop): support cdkDropListHasAnchor placeholder styling

### DIFF
--- a/docs/patterns/drag-and-drop.md
+++ b/docs/patterns/drag-and-drop.md
@@ -158,6 +158,7 @@ fit. For example:
 
 <si-docs-component base="si-tree-view" height="400">
   <si-docs-tab example="si-tree-view-drag-drop-move" heading="Moving between trees"></si-docs-tab>
+  <si-docs-tab example="si-tree-view-drag-drop-copy" heading="Copying between trees"></si-docs-tab>
   <si-docs-tab example="si-tree-view-drag-drop-reorder" heading="Reordering"></si-docs-tab>
   <si-docs-tab example="si-tree-view-drag-drop-assign" heading="Assignment"></si-docs-tab>
 </si-docs-component>

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.scss
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.scss
@@ -3,6 +3,25 @@
 @use '@siemens/element-theme/src/styles/variables';
 @use '../si-tree-view-variables';
 
+:host-context(.cdk-drop-list[cdkDropListHasAnchor]) {
+  :host.cdk-drag-placeholder {
+    block-size: auto !important; // stylelint-disable-line declaration-no-important
+    margin-inline: 0;
+    margin-block: revert !important; // stylelint-disable-line declaration-no-important
+    min-block-size: revert;
+    position: static;
+    z-index: auto;
+
+    &::after {
+      content: none !important; // stylelint-disable-line declaration-no-important
+    }
+
+    > * {
+      display: revert;
+    }
+  }
+}
+
 :host {
   display: block;
 
@@ -10,8 +29,8 @@
     block-size: 0;
     margin-inline: 8px;
     margin-block: 0 !important; // stylelint-disable-line declaration-no-important
-    opacity: 1;
-    min-block-size: 0;
+    opacity: 1 !important; // stylelint-disable-line declaration-no-important
+    min-block-size: 0 !important; // stylelint-disable-line declaration-no-important
     position: relative;
     z-index: 999;
 

--- a/projects/element-theme/src/styles/components/_drag_drop.scss
+++ b/projects/element-theme/src/styles/components/_drag_drop.scss
@@ -68,7 +68,7 @@ body:has(.cdk-drag-preview, .ui-draggable-dragging) {
   }
 }
 
-.cdk-drag-placeholder {
+.cdk-drop-list:not([cdkDropListHasAnchor]) .cdk-drag-placeholder {
   opacity: 0.3;
   background-color: variables.$element-base-information !important;
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
@@ -77,6 +77,13 @@ body:has(.cdk-drag-preview, .ui-draggable-dragging) {
   * {
     visibility: hidden;
   }
+}
+
+// The anchor is a clone of the placeholder left behind in the source list when
+// `cdkDropListHasAnchor` is used. Make sure it always renders like the original item.
+.cdk-drag-anchor,
+.cdk-drag-anchor * {
+  visibility: visible;
 }
 
 .cdk-drop-list-dragging .cdk-drag {

--- a/src/app/examples/si-tree-view/si-tree-view-drag-drop-copy.html
+++ b/src/app/examples/si-tree-view/si-tree-view-drag-drop-copy.html
@@ -1,0 +1,61 @@
+<h3>Provisioning sites from a device template catalog</h3>
+<p
+  >Drag a device template from the catalog onto a building in the site configuration to provision
+  it. Templates remain in the catalog so the same device type can be reused across multiple
+  buildings.</p
+>
+<div class="d-flex h-100" style="width: 600px">
+  <div>
+    <h4>Device template catalog</h4>
+
+    <si-tree-view
+      #catalog
+      ariaLabel="Device template catalog"
+      class="me-8"
+      style="width: 300px; height: 500px"
+      [enableSelection]="false"
+      [items]="catalogList"
+      [flatTree]="false"
+    >
+      <div
+        cdkDropList
+        cdkDropListHasAnchor
+        cdkDropListSortingDisabled
+        [cdkDropListConnectedTo]="siteDropList"
+        [cdkDropListData]="catalog.dropListItems"
+      >
+        <ng-template let-item="treeItem" siTreeViewItem>
+          <si-tree-view-item cdkDrag [cdkDragDisabled]="item.state !== 'leaf'" [cdkDragData]="item">
+            <si-tree-view-item *cdkDragPreview />
+          </si-tree-view-item>
+        </ng-template>
+      </div>
+    </si-tree-view>
+  </div>
+  <div>
+    <h4>Site configuration</h4>
+
+    <si-tree-view
+      #site
+      ariaLabel="Site configuration"
+      style="width: 300px; height: 500px"
+      [enableSelection]="true"
+      [items]="siteList"
+      [flatTree]="false"
+    >
+      <div
+        #siteDropList="cdkDropList"
+        cdkDropList
+        [cdkDropListData]="site.dropListItems"
+        [cdkDropListEnterPredicate]="allowDropOnSite"
+        (cdkDropListDropped)="itemDroppedOnSite($event)"
+      >
+        <ng-template let-item="treeItem" siTreeViewItem>
+          <si-tree-view-item cdkDrag cdkDragDisabled>
+            <si-tree-view-item *cdkDragPreview />
+          </si-tree-view-item>
+        </ng-template>
+      </div>
+    </si-tree-view>
+  </div>
+</div>

--- a/src/app/examples/si-tree-view/si-tree-view-drag-drop-copy.ts
+++ b/src/app/examples/si-tree-view/si-tree-view-drag-drop-copy.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { CdkDrag, CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  reorderTreeItem,
+  SiTreeViewComponent,
+  SiTreeViewItemComponent,
+  SiTreeViewItemDirective,
+  transferTreeItem,
+  TreeItem
+} from '@siemens/element-ng/tree-view';
+
+const templateCatalog: TreeItem[] = [
+  {
+    label: 'HVAC',
+    icon: 'element-air',
+    state: 'expanded',
+    customData: { locatorId: 'cat-hvac' },
+    children: [
+      { label: 'Temperature sensor', icon: 'element-temperature', state: 'leaf' },
+      { label: 'HVAC unit', icon: 'element-vrf', state: 'leaf' },
+      { label: 'Air quality sensor', icon: 'element-indoor-air-quality', state: 'leaf' }
+    ]
+  },
+  {
+    label: 'Lighting',
+    icon: 'element-sun',
+    state: 'expanded',
+    customData: { locatorId: 'cat-lighting' },
+    children: [
+      { label: 'LED panel', icon: 'element-light', state: 'leaf' },
+      { label: 'Motion sensor', icon: 'element-occupancy-sensor', state: 'leaf' }
+    ]
+  },
+  {
+    label: 'Security',
+    icon: 'element-lock',
+    state: 'expanded',
+    customData: { locatorId: 'cat-security' },
+    children: [
+      { label: 'Security camera', icon: 'element-security-cam', state: 'leaf' },
+      { label: 'Door sensor', icon: 'element-door', state: 'leaf' }
+    ]
+  }
+];
+
+const siteConfiguration: TreeItem[] = [
+  {
+    label: 'Headquarters Zug',
+    icon: 'element-project',
+    state: 'expanded',
+    customData: { locatorId: 'site-zug' },
+    children: [
+      {
+        label: 'Building A',
+        icon: 'element-building',
+        state: 'expanded',
+        customData: { locatorId: 'site-zug-a' },
+        children: [{ label: 'Temperature sensor', icon: 'element-temperature', state: 'leaf' }]
+      },
+      {
+        label: 'Building B',
+        icon: 'element-building',
+        state: 'expanded',
+        customData: { locatorId: 'site-zug-b' },
+        children: [{ label: 'LED panel', icon: 'element-light', state: 'leaf' }]
+      }
+    ]
+  },
+  {
+    label: 'Office Milano',
+    icon: 'element-project',
+    state: 'expanded',
+    customData: { locatorId: 'site-milano' },
+    children: [
+      {
+        label: 'Building 1',
+        icon: 'element-building',
+        state: 'expanded',
+        customData: { locatorId: 'site-milano-1' },
+        children: [{ label: 'Security camera', icon: 'element-security-cam', state: 'leaf' }]
+      }
+    ]
+  }
+];
+
+@Component({
+  selector: 'app-sample',
+  imports: [SiTreeViewComponent, SiTreeViewItemComponent, SiTreeViewItemDirective, DragDropModule],
+  templateUrl: './si-tree-view-drag-drop-copy.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'p-5' }
+})
+// NOTE: This example is to demonstrate CDK drag drop API capabilities with SiTreeViewItemNextComponent
+// and it is not yet production ready.
+export class SampleComponent {
+  protected catalogList = templateCatalog;
+  protected siteList = siteConfiguration;
+
+  protected itemDroppedOnSite(event: CdkDragDrop<TreeItem[]>): void {
+    let targetIndex = event.currentIndex - 1;
+    if (event.container === event.previousContainer) {
+      targetIndex =
+        event.currentIndex < event.previousIndex ? event.currentIndex - 1 : event.currentIndex;
+    }
+
+    const dragItem = event.previousContainer.data[event.previousIndex];
+    const targetItem = event.container.data[targetIndex];
+
+    if (!this.isValidDrop(dragItem, targetItem)) {
+      return;
+    }
+    if (event.container === event.previousContainer) {
+      this.siteList = [...reorderTreeItem(this.siteList, event)];
+    } else {
+      const updated = transferTreeItem(this.catalogList, this.siteList, event, false);
+      this.catalogList = [...updated.sourceTree];
+      this.siteList = [...updated.targetTree];
+    }
+  }
+
+  protected allowDropOnSite(dragItem: CdkDrag<TreeItem>): boolean {
+    // Only device templates (leaves) from the catalog can be copied
+    return dragItem.data.state === 'leaf';
+  }
+
+  private isValidDrop(source: TreeItem, target: TreeItem): boolean {
+    if (!target || source.state !== 'leaf') {
+      return false;
+    }
+    // Drop into a building (expanded level-1 node) or next to a device inside one
+    if (target.state === 'expanded' && target.level === 1) {
+      return true;
+    }
+    if (target.state === 'leaf' && target.level === 2) {
+      return true;
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
Adjust drag placeholder styles so that drop lists using `cdkDropListHasAnchor` keep the original item visible as an anchor in the source list while still hiding the placeholder in plain drop lists. Also make the anchor clone always render like the original item.

Related to https://github.com/siemens/element/pull/2106
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2110/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2110/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2110/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2110/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2110/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2110/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2110/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2110/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2110/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2110/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



