### PR TITLE
fix(chat-messages): revert padding to see if test fails

### DIFF
--- a/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-container-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-container-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f50563410762eac81d2279c1f1ae92118c3bd0a4b6e15e32a7b375663a25328
-size 42912
+oid sha256:fe9552c7e92709d1a0fcd561b6521f7aad836efea4b02543f771743090bbe989
+size 42911

--- a/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-container-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-container-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b87afbbe37f14403b5064a6fd10fb1232b2f7e1ced059cd47e6a90db36cae705
-size 42086
+oid sha256:f696afceabc07166348d0b4925566e86d90ab03106542c0c07741cb4d38e7187
+size 42092

--- a/projects/element-ng/chat-messages/si-chat-container.component.scss
+++ b/projects/element-ng/chat-messages/si-chat-container.component.scss
@@ -44,7 +44,6 @@
 .messages-container {
   overflow-y: auto;
   overflow-x: visible;
-  padding-inline: map.get(variables.$spacers, 4);
   // Ensure the messages can still be seen on very short screens
   min-block-size: 5rem;
   gap: map.get(variables.$spacers, 9) + map.get(variables.$spacers, 4);


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2111/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2111/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2111/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2111/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2111/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2111/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2111/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2111/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2111/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2111/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
