### PR TITLE
refactor(chat-messages): use CdkTextareaAutosize for chat input

### DIFF
--- a/projects/element-ng/chat-messages/si-chat-input.component.html
+++ b/projects/element-ng/chat-messages/si-chat-input.component.html
@@ -19,6 +19,9 @@
     <label class="form-label d-none" [for]="id">{{ label() | translate }}</label>
     <textarea
       #textInput
+      cdkTextareaAutosize
+      cdkAutosizeMinRows="1"
+      cdkAutosizeMaxRows="8"
       class="chat-textarea w-100 border-0"
       rows="1"
       [id]="id"
@@ -27,7 +30,6 @@
       [maxlength]="maxLength() || null"
       [(ngModel)]="value"
       (keydown)="onKeyDown($event)"
-      (input)="adjustTextareaHeight($event)"
     ></textarea>
   </div>
 

--- a/projects/element-ng/chat-messages/si-chat-input.component.scss
+++ b/projects/element-ng/chat-messages/si-chat-input.component.scss
@@ -29,11 +29,13 @@
 .chat-textarea {
   // Prevent layout shift on first input
   min-block-size: 1lh;
+  max-block-size: 30vh;
   font-family: inherit;
   padding-block: 0;
   display: block;
   outline: none;
   resize: none;
+  overflow-y: auto;
   background-color: transparent;
 
   &::placeholder {

--- a/projects/element-ng/chat-messages/si-chat-input.component.ts
+++ b/projects/element-ng/chat-messages/si-chat-input.component.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkMenuTrigger } from '@angular/cdk/menu';
+import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import {
   AfterViewInit,
   booleanAttribute,
@@ -80,6 +81,7 @@ export interface ChatInputAttachment extends Attachment {
   selector: 'si-chat-input',
   imports: [
     CdkMenuTrigger,
+    CdkTextareaAutosize,
     FormsModule,
     SiIconComponent,
     SiTranslatePipe,
@@ -436,21 +438,12 @@ export class SiChatInputComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
     const textarea = this.textInput();
-    if (textarea?.nativeElement) {
-      this.setTextareaHeight(textarea.nativeElement);
-
-      if (this.autoFocus()) {
-        // Use setTimeout to ensure the element is fully rendered
-        setTimeout(() => {
-          textarea.nativeElement.focus();
-        }, 0);
-      }
+    if (textarea?.nativeElement && this.autoFocus()) {
+      // Use setTimeout to ensure the element is fully rendered
+      setTimeout(() => {
+        textarea.nativeElement.focus();
+      }, 0);
     }
-  }
-
-  protected adjustTextareaHeight(event: Event): void {
-    const textarea = event.target as HTMLTextAreaElement;
-    this.setTextareaHeight(textarea);
   }
 
   /**
@@ -486,25 +479,5 @@ export class SiChatInputComponent implements AfterViewInit {
     event.preventDefault();
     event.stopPropagation();
     this.dragOver = true;
-  }
-
-  private setTextareaHeight(textarea: HTMLTextAreaElement): void {
-    textarea.style.blockSize = 'auto';
-
-    const computedStyle = window.getComputedStyle(textarea);
-    const lineHeight =
-      parseInt(computedStyle.lineHeight, 10) || parseInt(computedStyle.fontSize, 10) * 1.2;
-    const paddingTop = parseInt(computedStyle.paddingBlockStart, 10) || 0;
-    const paddingBottom = parseInt(computedStyle.paddingBlockEnd, 10) || 0;
-    const minHeight = lineHeight + paddingTop + paddingBottom;
-
-    const viewportHeight = window.innerHeight;
-    const maxViewportHeight = viewportHeight * 0.3;
-    const maxLinesHeight = lineHeight * 8;
-    const maxHeight = Math.min(maxViewportHeight, maxLinesHeight) + paddingTop + paddingBottom;
-
-    const scrollHeight = textarea.scrollHeight;
-    const finalHeight = Math.max(Math.min(scrollHeight, maxHeight), minHeight);
-    textarea.style.height = finalHeight + 'px';
   }
 }


### PR DESCRIPTION
Replace the hand-rolled textarea auto-resize logic in SiChatInputComponent with Angular CDK's CdkTextareaAutosize directive (cdkAutosizeMinRows="1", cdkAutosizeMaxRows="8"). The 30vh viewport cap is preserved via CSS (max-block-size + overflow-y: auto) instead of JS.

Removes setTextareaHeight/adjustTextareaHeight and the (input) handler; behavior (min 1 row, max 8 rows, capped at 30% viewport) is unchanged.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2112/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2112/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2112/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2112/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2112/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2112/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2112/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2112/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2112/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2112/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


