### PR TITLE
fix(filtered-search): prevent free-text input from collapsing with multiple criteria

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search-input.component.scss
+++ b/projects/element-ng/filtered-search/si-filtered-search-input.component.scss
@@ -5,6 +5,10 @@ input {
   border: 0;
   padding-block: 0;
 
+  &:focus {
+    min-inline-size: 20ch;
+  }
+
   &:hover::placeholder {
     opacity: 1;
   }


### PR DESCRIPTION
Set min-inline-size: 20ch to ensure the free-text input maintains a minimum
width when multiple filter criteria are configured, improving usability and
visual stability.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2118/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2118/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2118/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2118/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2118/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2118/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2118/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2118/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2118/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2118/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->




