### PR TITLE
feat(dashboards): provide widget renderer component

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -264,6 +264,12 @@ export class SiWidgetInstanceEditorDialogComponent extends SiWidgetEditorBase im
 }
 
 // @public
+export class SiWidgetRendererComponent {
+    readonly widget: _angular_core.InputSignal<Widget>;
+    readonly widgetConfig: _angular_core.InputSignal<WidgetConfig>;
+}
+
+// @public
 export abstract class SiWidgetStorage {
     // @deprecated
     getToolbarMenuItems?: (dashboardId?: string) => {

--- a/docs/components/dashboards/flexible-dashboards.md
+++ b/docs/components/dashboards/flexible-dashboards.md
@@ -97,4 +97,26 @@ Direct [Link](https://element.siemens.io/dashboards-demo/#/dashboard) to dashboa
 
 <si-docs-api component="SiWidgetInstanceEditorDialogComponent" package="@siemens/dashboards-ng"></si-docs-api>
 
+### Widget renderer
+
+The `SiWidgetRendererComponent` is a presentational (dumb) component that renders
+a single widget instance from a `WidgetConfig`, without the surrounding dashboard
+or grid infrastructure. It takes the exact `Widget` definition to render and
+delegates the actual rendering to the widget host.
+
+Use it to display an individual widget outside of a flexible dashboard, for example
+in kiosk mode or within a custom layout such as a carousel. The component is a
+self-contained widget cell that can be placed anywhere a single widget needs to be
+shown.
+
+It requires two inputs: the `widgetConfig` describing the widget instance to render
+and the matching `widget` definition. The `widget` must match the config's `widgetId`.
+
+```html
+<!-- Render a single widget instance -->
+<si-widget-renderer [widgetConfig]="widgetConfig" [widget]="widget" />
+```
+
+<si-docs-api component="SiWidgetRendererComponent" package="@siemens/dashboards-ng"></si-docs-api>
+
 <si-docs-types></si-docs-types>

--- a/projects/dashboards-ng/src/components/widget-renderer/si-widget-renderer.component.html
+++ b/projects/dashboards-ng/src/components/widget-renderer/si-widget-renderer.component.html
@@ -1,0 +1,5 @@
+<si-widget-host
+  class="h-100"
+  [widgetConfig]="widgetConfig()"
+  [componentFactory]="widget().componentFactory"
+/>

--- a/projects/dashboards-ng/src/components/widget-renderer/si-widget-renderer.component.scss
+++ b/projects/dashboards-ng/src/components/widget-renderer/si-widget-renderer.component.scss
@@ -1,0 +1,6 @@
+si-widget-host ::ng-deep .grid-stack-item-content {
+  flex: 1 1 auto;
+  min-inline-size: 0;
+  min-block-size: 0;
+  padding: 0 !important; // stylelint-disable-line declaration-no-important
+}

--- a/projects/dashboards-ng/src/components/widget-renderer/si-widget-renderer.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-renderer/si-widget-renderer.component.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { page } from 'vitest/browser';
+
+import { TEST_WIDGET, TEST_WIDGET_CONFIG_0 } from '../../../test/test-widget/test-widget';
+import { SiWidgetHostComponent } from '../widget-host/si-widget-host.component';
+import { SiWidgetRendererComponent } from './si-widget-renderer.component';
+
+describe('SiWidgetRendererComponent', () => {
+  let fixture: ComponentFixture<SiWidgetRendererComponent>;
+
+  const getWidgetHost = (): SiWidgetHostComponent | undefined => {
+    const debugEl = fixture.debugElement.query(
+      (el: any) => el.componentInstance instanceof SiWidgetHostComponent
+    );
+    return debugEl?.componentInstance as SiWidgetHostComponent | undefined;
+  };
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SiWidgetRendererComponent);
+  });
+
+  describe('renders widget host', () => {
+    it('should pass the widgetConfig to the widget host', async () => {
+      fixture.componentRef.setInput('widgetConfig', {
+        ...TEST_WIDGET_CONFIG_0,
+        heading: 'Custom Heading'
+      });
+      fixture.componentRef.setInput('widget', TEST_WIDGET);
+      await fixture.whenStable();
+      const cardHeader = page.getByText('Custom Heading');
+      await expect.element(cardHeader).toBeInTheDocument();
+    });
+
+    it("should pass the widget's componentFactory to the widget host", async () => {
+      fixture.componentRef.setInput('widgetConfig', TEST_WIDGET_CONFIG_0);
+      fixture.componentRef.setInput('widget', TEST_WIDGET);
+      await fixture.whenStable();
+      const host = getWidgetHost();
+      expect(host!.componentFactory()).toEqual(TEST_WIDGET.componentFactory);
+    });
+  });
+});

--- a/projects/dashboards-ng/src/components/widget-renderer/si-widget-renderer.component.ts
+++ b/projects/dashboards-ng/src/components/widget-renderer/si-widget-renderer.component.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+import { Widget, WidgetConfig } from '../../model/widgets.model';
+import { SiWidgetHostComponent } from '../widget-host/si-widget-host.component';
+
+/**
+ * A presentational (dumb) component that renders a single widget instance from a
+ * {@link WidgetConfig} using the provided {@link Widget} definition. It delegates
+ * the actual rendering to the {@link SiWidgetHostComponent}.
+ *
+ * **Intended Usage**
+ *
+ * This component renders an individual widget outside of a dashboard or grid,
+ * without requiring manual host wiring. It is a self-contained widget cell that
+ * can be placed anywhere a single widget needs to be shown, for example in kiosk
+ * mode or within a custom layout such as a carousel.
+ *
+ * **Example**
+ *
+ * ```html
+ * <!-- Render a single widget instance -->
+ * <si-widget-renderer [widgetConfig]="widgetConfig" [widget]="widget" />
+ * ```
+ */
+@Component({
+  selector: 'si-widget-renderer',
+  imports: [SiWidgetHostComponent],
+  templateUrl: './si-widget-renderer.component.html',
+  styleUrl: './si-widget-renderer.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SiWidgetRendererComponent {
+  /** The configuration of the widget instance to render. */
+  readonly widgetConfig = input.required<WidgetConfig>();
+
+  /**
+   * The {@link Widget} definition used to render the given {@link widgetConfig}.
+   * It must match the config's `widgetId`.
+   */
+  readonly widget = input.required<Widget>();
+}

--- a/projects/dashboards-ng/src/public-api.ts
+++ b/projects/dashboards-ng/src/public-api.ts
@@ -6,6 +6,7 @@ export * from './components/flexible-dashboard/si-flexible-dashboard.component';
 export * from './components/grid/si-grid.component';
 export * from './components/widget-catalog/si-widget-catalog.component';
 export * from './components/widget-instance-editor-dialog/si-widget-instance-editor-dialog.component';
+export * from './components/widget-renderer/si-widget-renderer.component';
 
 export * from './model/configuration';
 export * from './model/gridstack.model';


### PR DESCRIPTION
Add a self-contained widget renderer component that resolves and renders a single widget from a WidgetConfig.

Developers can project multiple widget renderers into layouting components (carousels, slideshows, or full-screen containers) to achieve kiosk mode view without manual host wiring.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2123/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2123/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2123/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2123/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2123/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2123/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2123/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2123/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2123/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2123/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->








