### PR TITLE
fix(datepicker): keep AM/PM input visible after re-enabling time

### DIFF
--- a/projects/element-ng/datepicker/date-time-helper.ts
+++ b/projects/element-ng/datepicker/date-time-helper.ts
@@ -803,6 +803,6 @@ export const maxDate = (first?: Date, second?: Date): Date | undefined => {
  * Indicate whether the time use the 12-hour format
  */
 export const is12HourFormat = (locale: string, config: DatepickerInputConfig): boolean => {
-  const dateFormat = getDatepickerFormat(locale, config, true);
+  const dateFormat = getDatepickerFormat(locale, { ...config, disabledTime: false }, true);
   return dateFormat?.includes('a') ?? false;
 };

--- a/projects/element-ng/datepicker/si-datepicker.directive.spec.ts
+++ b/projects/element-ng/datepicker/si-datepicker.directive.spec.ts
@@ -8,6 +8,7 @@ import { ChangeDetectionStrategy, Component, ElementRef, signal, viewChild } fro
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl } from '@angular/forms';
 import type { Mock } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
 
 import { SiDatepickerOverlayDirective } from './si-datepicker-overlay.directive';
 import { SiDatepickerDirective } from './si-datepicker.directive';
@@ -262,5 +263,32 @@ describe('SiDatepickerDirective', () => {
       await fixture.whenStable();
       expect(document.querySelector('si-datepicker-overlay')).not.toBeInTheDocument();
     });
+  });
+
+  it('should keep the AM/PM input after disabling, reopening and re-enabling time', async () => {
+    const meridianCombo = page.getByRole('combobox', { name: 'Period' });
+    await updateConfig({
+      showTime: true,
+      showSeconds: true,
+      dateFormat: 'MM/dd/yyyy',
+      dateTimeFormat: 'MM/dd/yyyy, h:mm:ss a'
+    });
+
+    await userEvent.click(getInput());
+    await fixture.whenStable();
+    await expect.element(meridianCombo).toBeVisible();
+
+    await userEvent.click(page.getByRole('switch', { name: 'Consider Time' }));
+    await fixture.whenStable();
+
+    await backdropClick(fixture);
+
+    await userEvent.click(getInput());
+    await fixture.whenStable();
+
+    await userEvent.click(page.getByRole('switch', { name: 'Ignore time' }));
+    await fixture.whenStable();
+
+    await expect.element(meridianCombo).toBeVisible();
   });
 });


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->

Fixes https://code.siemens.com/simpl/simpl-element/-/work_items/2712
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2127/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2127/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2127/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2127/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2127/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2127/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2127/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2127/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2127/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2127/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
