### PR TITLE
chore(deps): upgrade docs-theme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 requires-python = ">=3.11, <4"
 readme = "README.md"
 dependencies = [
-    "mkdocs-code-siemens-code-docs-theme>=8,<9",
+    "mkdocs-code-siemens-code-docs-theme>=8.1,<9",
     "mkdocs-minify-html-plugin==0.3.10",
     "mkdocs-element-docs-builder",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -161,7 +161,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mkdocs-code-siemens-code-docs-theme", specifier = ">=8,<9", index = "https://code.siemens.com/api/v4/groups/3259/-/packages/pypi/simple" },
+    { name = "mkdocs-code-siemens-code-docs-theme", specifier = ">=8.1,<9", index = "https://code.siemens.com/api/v4/groups/3259/-/packages/pypi/simple" },
     { name = "mkdocs-element-docs-builder", editable = "projects/element-docs-builder" },
     { name = "mkdocs-minify-html-plugin", specifier = "==0.3.10" },
 ]
@@ -326,15 +326,15 @@ wheels = [
 
 [[package]]
 name = "mkdocs-code-siemens-code-docs-theme"
-version = "8.0.2"
+version = "8.1.0"
 source = { registry = "https://code.siemens.com/api/v4/groups/3259/-/packages/pypi/simple" }
 dependencies = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
 ]
-sdist = { url = "https://code.siemens.com/api/v4/groups/3259/-/packages/pypi/files/70c6811b508cd90ebfaedd334abda78de68b171501eed47fa967ea64f1f6a072/mkdocs_code_siemens_code_docs_theme-8.0.2.tar.gz", hash = "sha256:70c6811b508cd90ebfaedd334abda78de68b171501eed47fa967ea64f1f6a072" }
+sdist = { url = "https://code.siemens.com/api/v4/groups/3259/-/packages/pypi/files/422ffe4585ec8334a4d8bae60648ee7d1b15732b362cba68c0cd31de51006024/mkdocs_code_siemens_code_docs_theme-8.1.0.tar.gz", hash = "sha256:422ffe4585ec8334a4d8bae60648ee7d1b15732b362cba68c0cd31de51006024" }
 wheels = [
-    { url = "https://code.siemens.com/api/v4/groups/3259/-/packages/pypi/files/b84a1a86ea9e1e8a210576ac430972b138211c688611c8de0409b22c736aa7c9/mkdocs_code_siemens_code_docs_theme-8.0.2-py3-none-any.whl", hash = "sha256:b84a1a86ea9e1e8a210576ac430972b138211c688611c8de0409b22c736aa7c9" },
+    { url = "https://code.siemens.com/api/v4/groups/3259/-/packages/pypi/files/9360e8efe1db85020605852f43c3aa1a4dc42ab5429cc6e48af1757c5ae06d11/mkdocs_code_siemens_code_docs_theme-8.1.0-py3-none-any.whl", hash = "sha256:9360e8efe1db85020605852f43c3aa1a4dc42ab5429cc6e48af1757c5ae06d11" },
 ]
 
 [[package]]


### PR DESCRIPTION
Docs-theme was updated to use semantic-tokens and newer colors (slight differences in look).
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2130/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2130/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2130/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2130/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2130/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2130/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2130/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2130/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2130/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2130/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

