### PR TITLE
Feat/add pinned items to inline collapsed

### DIFF
--- a/api-goldens/element-ng/navbar-vertical-next/index.api.md
+++ b/api-goldens/element-ng/navbar-vertical-next/index.api.md
@@ -65,6 +65,7 @@ export class SiNavbarVerticalNextHeaderComponent {
 
 // @public (undocumented)
 export class SiNavbarVerticalNextItemComponent implements OnInit {
+    constructor();
     readonly active: _angular_core.Signal<boolean>;
     readonly activeOverride: _angular_core.InputSignal<boolean | undefined>;
     readonly badge: _angular_core.InputSignal<string | number | undefined>;
@@ -73,6 +74,7 @@ export class SiNavbarVerticalNextItemComponent implements OnInit {
     readonly group: SiNavbarVerticalNextGroupTriggerDirective | null;
     readonly hideBadgeWhenCollapsed: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly icon: _angular_core.InputSignal<string | undefined>;
+    readonly pinned: _angular_core.InputSignalWithTransform<boolean, unknown>;
 }
 
 // @public

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-chip-submenu-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-chip-submenu-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f3f51ec80829e160b0cc63b9d9850d6c21d7eb8c3bd15661e6bec209895ffb3
-size 16520
+oid sha256:268719f1b684cc6e92064e479989c3eb0f26925211938f4f0149a60aa59d7c5e
+size 17780

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-chip-submenu-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-chip-submenu-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98cb81ae571038770347dc3620a8e60a2b03f30c31f577c2b1e7edc4ab51c7cb
-size 16467
+oid sha256:88af6065da291067fd3db4688bdc12973d4ab1838eef0aa4bf9613476410aae4
+size 17620

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b767338a53481bf44a433b3d0e8ceb1dd1921a5883bfbbcad74f589ce023af3c
-size 13052
+oid sha256:c1b9159b6930c74120ace756b9b862366f7f2690297c06b3e0ec05d1901e78dc
+size 14016

--- a/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-vertical-next.spec.ts-snapshots/si-navbar-vertical-next--si-navbar-vertical-next--inline-collapse-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cdae2284c7983a482cef9f1b0295ad33158f32f9bff29c1f126b8b5f0f95f53a
-size 12712
+oid sha256:ba78e61ea03561c7ec31c5f01b49b7fb1bae40e3f770f1624c1baa15859239aa
+size 13593

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.html
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.html
@@ -2,7 +2,7 @@
 @if (icon) {
   <si-icon [class]="isChip() ? 'icon' : 'icon-lg'" [icon]="icon" />
 }
-<div class="item-title text-truncate si-h5">
+<div #itemTitle class="item-title text-truncate si-h5">
   <ng-content />
 </div>
 @if (!isChip() && !navbar.textOnly() && formattedBadge()) {

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '@siemens/element-theme/src/styles/variables';
+@use '@siemens/element-theme/src/styles/all-variables' as variables;
 @use '@siemens/element-theme/src/styles/bootstrap/mixins/badge-text';
 @use '@siemens/element-theme/src/styles/bootstrap/mixins/visually-hidden';
 
@@ -138,10 +138,39 @@
 }
 
 // Within the chip slot: fuse the left edge with the toggle button
-// (segmented control) and fill the wrapper so the label can truncate.
+// (segmented control). The active chip grows to fill remaining space.
 :host-context(.chip).is-chip {
   border-start-start-radius: 0;
   border-end-start-radius: 0;
-  inline-size: 100%;
+  flex: 1;
   min-inline-size: 0;
+
+  &:focus-visible {
+    z-index: variables.$zindex-vertical-nav + 1;
+  }
+}
+
+// Pinned chips are icon-only: hide the label when an icon is present.
+// Using visually-hidden (not display:none) preserves the text as the
+// accessible name of the host <a>/<button> for screen readers.
+// The adjacent-sibling selector means items without an icon still show text.
+:host(.is-pinned-chip) si-icon + .item-title {
+  @include visually-hidden.visually-hidden();
+}
+
+// Pinned chips: also flush the right edge (the active chip follows).
+// They are auto-sized so each only consumes as much space as its label.
+:host-context(.chip).is-pinned-chip {
+  flex: none; // override the flex: 1 from .is-chip
+}
+
+:host-context(.chip).is-chip:not(:last-child) {
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
+}
+
+@include variables.media-breakpoint-down(sm) {
+  :host-context(.chip).is-pinned-chip {
+    display: none;
+  }
 }

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.spec.ts
@@ -4,6 +4,7 @@
  */
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SiTooltipDirective, SiTooltipService } from '@siemens/element-ng/tooltip';
 
 import { SiNavbarVerticalNextItemComponent } from './si-navbar-vertical-next-item.component';
 import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
@@ -290,6 +291,141 @@ describe('SiNavbarVerticalNextItemComponent', () => {
       badgeTestFixture.detectChanges();
       linkElement = badgeTestFixture.nativeElement.querySelector('a.navbar-vertical-item');
       expect(linkElement).not.toHaveClass('hide-badge-collapsed');
+    });
+  });
+
+  describe('pinned input', () => {
+    @Component({
+      imports: [SiNavbarVerticalNextItemComponent],
+      template: `<a
+        si-navbar-vertical-next-item
+        [pinned]="pinned()"
+        [activeOverride]="activeOverride()"
+      >
+        Pinned Test Item
+      </a>`
+    })
+    class TestHostWithPinnedComponent {
+      readonly pinned = signal(false);
+      readonly activeOverride = signal<boolean | undefined>(undefined);
+    }
+
+    @Component({
+      imports: [SiNavbarVerticalNextItemComponent, SiTooltipDirective],
+      template: `<a si-navbar-vertical-next-item [pinned]="pinned()" [siTooltip]="tooltipText()">
+        Pinned Test Item
+      </a>`
+    })
+    class TestHostWithPinnedAndConsumerTooltipComponent {
+      readonly pinned = signal(false);
+      readonly tooltipText = signal('Consumer tooltip');
+    }
+
+    let pinnedFixture: ComponentFixture<TestHostWithPinnedComponent>;
+    let pinnedComponent: TestHostWithPinnedComponent;
+
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+      mockNavbar.chipMode.set(false);
+      mockNavbar.chipPortalAttached.set(false);
+      await TestBed.configureTestingModule({
+        providers: [{ provide: SI_NAVBAR_VERTICAL_NEXT, useValue: mockNavbar }]
+      }).compileComponents();
+
+      pinnedFixture = TestBed.createComponent(TestHostWithPinnedComponent);
+      pinnedComponent = pinnedFixture.componentInstance;
+      pinnedFixture.detectChanges();
+    });
+
+    afterEach(() => vi.restoreAllMocks());
+
+    it('should not add is-pinned-chip class when chipMode is false', async () => {
+      pinnedComponent.pinned.set(true);
+      await pinnedFixture.whenStable();
+
+      const link = pinnedFixture.nativeElement.querySelector('a');
+      expect(link).not.toHaveClass('is-pinned-chip');
+      expect(link).not.toHaveClass('is-chip');
+    });
+
+    it('should add is-pinned-chip class when chipMode is true and item is not active', async () => {
+      mockNavbar.chipMode.set(true);
+      pinnedComponent.pinned.set(true);
+      await pinnedFixture.whenStable();
+
+      const link = pinnedFixture.nativeElement.querySelector('a');
+      expect(link).toHaveClass('is-pinned-chip');
+      expect(link).toHaveClass('is-chip');
+    });
+
+    it('should not add is-pinned-chip class when chipMode is true but item is active', async () => {
+      mockNavbar.chipMode.set(true);
+      pinnedComponent.pinned.set(true);
+      pinnedComponent.activeOverride.set(true);
+      await pinnedFixture.whenStable();
+
+      const link = pinnedFixture.nativeElement.querySelector('a');
+      expect(link).not.toHaveClass('is-pinned-chip');
+    });
+
+    it('should not add is-pinned-chip class when item is not pinned', async () => {
+      mockNavbar.chipMode.set(true);
+      pinnedComponent.pinned.set(false);
+      await pinnedFixture.whenStable();
+
+      const link = pinnedFixture.nativeElement.querySelector('a');
+      expect(link).not.toHaveClass('is-pinned-chip');
+    });
+
+    it('should not add is-pinned-chip class when textOnly is true', async () => {
+      mockNavbar.chipMode.set(true);
+      mockNavbar.textOnly.set(true);
+      pinnedComponent.pinned.set(true);
+      await pinnedFixture.whenStable();
+
+      const link = pinnedFixture.nativeElement.querySelector('a');
+      expect(link).not.toHaveClass('is-pinned-chip');
+      expect(link).not.toHaveClass('is-chip');
+    });
+
+    it('should attach a tooltip with the projected label when item becomes a pinned chip', async () => {
+      const createTooltipSpy = vi
+        .spyOn(SiTooltipService.prototype, 'createTooltip')
+        .mockImplementation(() => ({ destroy: vi.fn() }));
+
+      mockNavbar.chipMode.set(true);
+      pinnedComponent.pinned.set(true);
+      await pinnedFixture.whenStable();
+
+      expect(createTooltipSpy).toHaveBeenCalledTimes(1);
+      const config = createTooltipSpy.mock.calls[0][0];
+      expect(config).toMatchObject({ placement: 'bottom' });
+
+      const tooltipSource = config.tooltip() as { nativeElement: HTMLElement };
+      expect(tooltipSource.nativeElement.textContent?.trim()).toBe('Pinned Test Item');
+    });
+
+    it('should not attach an auto-tooltip when consumer applies an active [siTooltip]', async () => {
+      const createTooltipSpy = vi
+        .spyOn(SiTooltipService.prototype, 'createTooltip')
+        .mockImplementation(() => ({ destroy: vi.fn() }));
+
+      const consumerFixture = TestBed.createComponent(
+        TestHostWithPinnedAndConsumerTooltipComponent
+      );
+      consumerFixture.detectChanges();
+
+      mockNavbar.chipMode.set(true);
+      consumerFixture.componentInstance.pinned.set(true);
+      await consumerFixture.whenStable();
+
+      // The consumer's SiTooltipDirective also calls createTooltip (with `placement: 'auto'`).
+      // Verify the component did not add its own tooltip on top by checking no call
+      // used the component's `placement: 'bottom'`.
+      const autoTooltipCall = createTooltipSpy.mock.calls.find(
+        ([config]) => config.placement === 'bottom'
+      );
+      expect(autoTooltipCall).toBeUndefined();
     });
   });
 });

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
@@ -8,15 +8,19 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
+  EffectCleanupRegisterFn,
   ElementRef,
   inject,
   input,
-  OnInit
+  OnInit,
+  viewChild
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLinkActive } from '@angular/router';
 import { elementDown2, elementRight2 } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
+import { SiTooltipDirective, SiTooltipService } from '@siemens/element-ng/tooltip';
 import { EMPTY, Observable } from 'rxjs';
 
 import { SiNavbarVerticalNextGroupTriggerDirective } from './si-navbar-vertical-next-group-trigger.directive';
@@ -29,14 +33,17 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
   imports: [SiIconComponent],
   templateUrl: './si-navbar-vertical-next-item.component.html',
   styleUrl: './si-navbar-vertical-next-item.component.scss',
+  providers: [SiTooltipService],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.focus-inside]': '!chipMode() || !!parent',
     '[class.navbar-vertical-item]': '!isChip()',
     '[class.active]': 'showActive()',
     '[class.is-chip]': 'isChip()',
+    '[class.is-pinned-chip]': 'isPinnedChip()',
     '[class.btn]': 'isChip()',
     '[class.btn-primary-ghost]': 'isChip()',
+    '[class.btn-icon]': 'isPinnedChip()',
     '[class.hide-badge-collapsed]': 'hideBadgeWhenCollapsed()',
     '(click)': 'triggered()'
   }
@@ -63,6 +70,16 @@ export class SiNavbarVerticalNextItemComponent implements OnInit {
   /** Override the active state. Useful for action items. */
   readonly activeOverride = input<boolean>();
 
+  /**
+   * When `true`, the item is always shown in the inline-collapse chip slot
+   * alongside the active item, regardless of which route is active.
+   *
+   * At screen widths less than or equal to `sm` only the active item is shown.
+   *
+   * @defaultValue false
+   */
+  readonly pinned = input(false, { transform: booleanAttribute });
+
   protected readonly navbar = inject(SI_NAVBAR_VERTICAL_NEXT);
   protected readonly parent = inject(SiNavbarVerticalNextItemComponent, {
     skipSelf: true,
@@ -84,6 +101,21 @@ export class SiNavbarVerticalNextItemComponent implements OnInit {
 
   /** @internal */
   private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  /** @internal */
+  private readonly tooltipService = inject(SiTooltipService);
+
+  /** @internal */
+  private readonly existingTooltip = inject(SiTooltipDirective, {
+    optional: true,
+    host: true
+  });
+
+  /** Template reference to the projected label container. Used as the tooltip source
+   * so the tooltip text mirrors the projected content.
+   * @internal
+   */
+  private readonly itemTitle = viewChild.required<ElementRef<HTMLElement>>('itemTitle');
 
   /** DOM portal relocated into the chip slot when collapsed.
    * @internal
@@ -165,10 +197,29 @@ export class SiNavbarVerticalNextItemComponent implements OnInit {
    */
   readonly isActiveRootItem = computed(() => !this.parent && this.isOnActiveRoute());
 
+  /** `true` when this is a root-level item (no parent item).
+   * @internal
+   */
+  readonly isRootItem = !this.parent;
+
+  /** `true` when this item is pinned and currently in the chip slot.
+   * @internal
+   */
+  readonly isPinnedChip = computed(
+    () =>
+      this.navbar.chipMode() &&
+      this.pinned() &&
+      this.isRootItem &&
+      !this.isActiveRootItem() &&
+      !this.navbar.textOnly()
+  );
+
   /** `true` when this item is currently rendered as a chip in the inline-collapse bar.
    * @internal
    */
-  readonly isChip = computed(() => this.navbar.chipPortalAttached() && this.isActiveRootItem());
+  readonly isChip = computed(
+    () => (this.navbar.chipPortalAttached() && this.isActiveRootItem()) || this.isPinnedChip()
+  );
 
   ngOnInit(): void {
     if (this.group && this.active()) {
@@ -176,10 +227,34 @@ export class SiNavbarVerticalNextItemComponent implements OnInit {
     }
   }
 
+  constructor() {
+    effect(onCleanup => this.setupTooltip(onCleanup));
+  }
+
   protected triggered(): void {
     this.parent?.group?.hideFlyout();
     if (!this.group) {
       this.navbar.itemTriggered();
     }
+  }
+
+  private setupTooltip(onCleanup: EffectCleanupRegisterFn): void {
+    if (!this.isPinnedChip()) {
+      return;
+    }
+    const hasActiveTooltip =
+      !!this.existingTooltip &&
+      !this.existingTooltip.isDisabled() &&
+      !!this.existingTooltip.siTooltip();
+    if (hasActiveTooltip) {
+      return;
+    }
+    const tooltipRef = this.tooltipService.createTooltip({
+      element: this.elementRef,
+      placement: 'bottom',
+      tooltip: this.itemTitle,
+      tooltipContext: () => undefined
+    });
+    onCleanup(() => tooltipRef.destroy());
   }
 }

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.html
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.html
@@ -24,15 +24,21 @@
         </button>
       </div>
     </div>
-    @if (inlineCollapse() && activeItem(); as item) {
+    @let activeItem = this.activeItem();
+    @if (inlineCollapse() && (pinnedItems().length > 0 || activeItem)) {
       <div
         class="chip"
         [class.chip-visible]="collapsed()"
         [attr.inert]="collapsed() ? null : ''"
         [attr.aria-hidden]="collapsed() ? null : 'true'"
       >
-        @if (chipPortalAttached()) {
-          <ng-container [cdkPortalOutlet]="item.hostPortal" />
+        @if (chipMode()) {
+          @for (pinnedItem of pinnedItems(); track pinnedItem) {
+            <ng-container [cdkPortalOutlet]="pinnedItem.hostPortal" />
+          }
+        }
+        @if (chipPortalAttached() && activeItem && !activeItem.pinned()) {
+          <ng-container [cdkPortalOutlet]="activeItem.hostPortal" />
         }
       </div>
       <ng-container #flyoutAnchorHost />

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.scss
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.scss
@@ -213,6 +213,9 @@ nav {
     position: fixed;
     z-index: 0;
     inset-block-start: $toggle-parked-block-start;
+    // Flex row so multiple items (pinned + active) sit side-by-side.
+    display: flex;
+    align-items: stretch;
     // Cap the chip width so long labels truncate via `.item-title.text-truncate`
     // instead of overflowing the viewport. Reserves space for the toggle slot
     // on the start and an equal end-gutter so the chip never butts the edge.
@@ -239,6 +242,7 @@ nav {
         #{$toggle-parked-inline-start} + #{$toggle-size} + #{$segmented-gap}
       );
       opacity: 1;
+      gap: $segmented-gap;
     }
   }
 

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
@@ -176,6 +176,15 @@ export class SiNavbarVerticalNextComponent implements OnChanges, OnInit {
    */
   readonly activeItem = computed(() => this.items().find(item => item.isActiveRootItem()));
 
+  /** All root items with `pinned: true`. Each gets a stable portal outlet in the chip slot;
+   * the active pinned item stays in this list and is styled as the active chip via `isActiveRootItem`.
+   * Excluded in `textOnly` mode as there are no icons to show icon-only chips.
+   * @internal
+   * */
+  readonly pinnedItems = computed(() =>
+    this.items().filter(item => item.pinned() && item.isRootItem && !this.textOnly())
+  );
+
   /** `true` when the active item's portal should occupy the chip slot.
    * @internal
    */

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
@@ -115,6 +115,13 @@ class EmptyComponent {}
           </button>
         </si-navbar-vertical-next-items>
       }
+      @if (showPinnedItems()) {
+        <si-navbar-vertical-next-items>
+          <a si-navbar-vertical-next-item routerLink="pinned-item" routerLinkActive [pinned]="true">
+            pinned-item
+          </a>
+        </si-navbar-vertical-next-items>
+      }
     </si-navbar-vertical-next>
 
     <ng-template #flyoutGroup>
@@ -167,6 +174,7 @@ class TestHostComponent {
   readonly showDeclarativeFlyoutGroup = signal(false);
   readonly showDeclarativeNavigationGroup = signal(false);
   readonly showDeclarativeStateGroups = signal(false);
+  readonly showPinnedItems = signal(false);
 
   searchEvent(event: string): void {}
 }
@@ -192,7 +200,8 @@ describe('SiNavbarVerticalNext', () => {
               { path: 'sub-item-2/sub-path', component: EmptyComponent }
             ]
           },
-          { path: 'somewhere-else', component: EmptyComponent }
+          { path: 'somewhere-else', component: EmptyComponent },
+          { path: 'pinned-item', component: EmptyComponent }
         ]),
         { provide: BreakpointObserver, useExisting: BreakpointObserverMock }
       ]
@@ -501,6 +510,79 @@ describe('SiNavbarVerticalNext', () => {
         const flyoutMenu = document.querySelector(`#${flyoutId} .dropdown-menu`);
         expect(flyoutMenu).toBeInTheDocument();
         expect(flyoutMenu!.textContent).toContain('sub-item1');
+      });
+    });
+
+    describe('pinned items', () => {
+      beforeEach(() => {
+        component.collapsed.set(true);
+        component.showPinnedItems.set(true);
+      });
+
+      it('should render pinned item in chip slot when collapsed', async () => {
+        await fixture.whenStable();
+
+        const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+        const chipWrapper = host.querySelector('.chip') as HTMLElement;
+        expect(chipWrapper).not.toHaveAttribute('inert');
+        const pinnedLink = page
+          .elementLocator(chipWrapper)
+          .getByRole('link', { name: 'pinned-item' });
+        await expect.element(pinnedLink).toBeVisible();
+        expect(pinnedLink.element()).toHaveClass('is-pinned-chip');
+      });
+
+      it('should not render pinned items in chip slot when expanded', async () => {
+        component.collapsed.set(false);
+        await fixture.whenStable();
+
+        const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+        const chipWrapper = host.querySelector('.chip') as HTMLElement;
+        // Chip container still renders because pinnedItems.length > 0, but is inert
+        expect(chipWrapper).not.toBeNull();
+        expect(chipWrapper).toHaveAttribute('inert', '');
+        // No items teleported into chip slot when chipMode is inactive
+        expect(chipWrapper.querySelectorAll('a, button')).toHaveLength(0);
+      });
+
+      it('should render both pinned and active items in chip slot', async () => {
+        await TestBed.inject(Router).navigate(['/item-1/sub-item-1']);
+        await fixture.whenStable();
+
+        const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+        const chipWrapper = host.querySelector('.chip') as HTMLElement;
+        const pinnedLink = page
+          .elementLocator(chipWrapper)
+          .getByRole('link', { name: 'pinned-item' });
+        const activeButton = page
+          .elementLocator(chipWrapper)
+          .getByRole('button', { name: 'item1' });
+        await expect.element(pinnedLink).toBeVisible();
+        await expect.element(activeButton).toBeVisible();
+        // pinned-item is not active here, so it keeps is-pinned-chip
+        expect(pinnedLink.element()).toHaveClass('is-pinned-chip');
+        // item1 is the active chip
+        expect(activeButton.element()).toHaveClass('is-chip');
+        expect(activeButton.element()).not.toHaveClass('is-pinned-chip');
+      });
+
+      it('should render pinned active item only once in chip slot', async () => {
+        await TestBed.inject(Router).navigate(['/pinned-item']);
+        await fixture.whenStable();
+
+        const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+        const chipWrapper = host.querySelector('.chip') as HTMLElement;
+        expect(chipWrapper.querySelectorAll('.is-chip')).toHaveLength(1);
+      });
+
+      it('should not render pinned items in chip slot when textOnly is true', async () => {
+        component.textOnly.set(true);
+        await fixture.whenStable();
+
+        const host = fixture.nativeElement.querySelector('si-navbar-vertical-next') as HTMLElement;
+        // pinnedItems is empty in textOnly mode; chip container only renders when there
+        // are pinned or active items, so it must not be present here.
+        expect(host.querySelector('.chip')).toBeNull();
       });
     });
   });

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
@@ -18,10 +18,17 @@
         Home
       </a>
       <si-navbar-vertical-next-header>Modules</si-navbar-vertical-next-header>
-      <a si-navbar-vertical-next-item routerLink="energy" routerLinkActive icon="element-trend">
+      <a
+        pinned
+        si-navbar-vertical-next-item
+        routerLink="energy"
+        routerLinkActive
+        icon="element-trend"
+      >
         Energy &amp; sustainability
       </a>
       <button
+        pinned
         type="button"
         si-navbar-vertical-next-item
         icon="element-user-group"


### PR DESCRIPTION
- add pinned input to always show items in inline-collapse chip slot
- items with `[pinned]="true"` appear as fixed chips in the inline-collapse bar alongside the active chip. 
- pinned items are hidden at sm and below.

Related #1945 

<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2141/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2141/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2141/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2141/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2141/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2141/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2141/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2141/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2141/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2141/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->















