### PR TITLE
chore(deps): update marocchino/sticky-pull-request-comment digest to 0ea0beb

### DIFF
--- a/.github/workflows/vrt-update.yaml
+++ b/.github/workflows/vrt-update.yaml
@@ -236,7 +236,7 @@ jobs:
 
       - name: Comment on PR with download link
         if: success() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           message: |
             [⬇️ Download VRTs](${{ steps.artifact.outputs.download_url }})


### PR DESCRIPTION
Updates the digest for `marocchino/sticky-pull-request-comment` to resolve Renovate warning about digest lookup.

- Updates digest from `d4d6b093` to `0ea0beb` (v3.0.4)
- Fixes Renovate warning: "Could not determine new digest for update"<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2145/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2145/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2145/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2145/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2145/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2145/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2145/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2145/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2145/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2145/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
