### PR TITLE
fix(si-map-tooltip): replace three dots with ellipsis character

### DIFF
--- a/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.spec.ts
@@ -57,6 +57,6 @@ describe('SiMapTooltipComponent', () => {
     const longLabel = 'This is too long label, which will be trimmed 50 ch';
     component.setTooltip(longLabel);
     const tooltip = fixture.debugElement.query(By.css('.si-map-tooltip'));
-    expect(tooltip.nativeElement.innerHTML).toContain('...');
+    expect(tooltip.nativeElement.innerHTML).toContain('…');
   });
 });

--- a/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.ts
+++ b/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.ts
@@ -75,7 +75,7 @@ export class SiMapTooltipComponent {
 
   private getLabelSnippet(label: string): string {
     if (this.maxLabelLength() != -1 && label.length > this.maxLabelLength()) {
-      return `<div>${label.substring(0, this.maxLabelLength())}...</div>`;
+      return `<div>${label.substring(0, this.maxLabelLength())}…</div>`;
     } else {
       return `<div>${label}</div>`;
     }


### PR DESCRIPTION
Make it consistent with other places were ellipsis are used due to UX writing recommendation _Use horizontal ellipses (…) after the verb without a space instead of adding three full stops_



<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2148/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2148/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2148/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2148/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2148/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2148/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2148/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2148/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2148/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2148/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
