### PR TITLE
test(tooltip): cover focusout cancelling hover timer and hiding hovered tooltip

### DIFF
--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -5,6 +5,7 @@
 import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { userEvent } from 'vitest/browser';
 
 import { SiTooltipModule } from './si-tooltip.module';
 
@@ -71,6 +72,32 @@ describe('SiTooltipDirective', () => {
       expect(document.querySelector('.tooltip')).toBeInTheDocument();
 
       button.dispatchEvent(new MouseEvent('mouseleave'));
+      expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
+    });
+
+    it('should cancel the pending hover tooltip on focusout', async () => {
+      await userEvent.hover(button);
+      vi.advanceTimersByTime(250);
+      await fixture.whenStable();
+      expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
+
+      // focusout (e.g. user switched to keyboard navigation) must stop the
+      // pending hover timer so the tooltip never appears.
+      button.dispatchEvent(new Event('focusout'));
+      vi.advanceTimersByTime(500);
+      await fixture.whenStable();
+
+      expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
+    });
+
+    it('should hide a hover-visible tooltip on focusout', async () => {
+      await userEvent.hover(button);
+      vi.advanceTimersByTime(500);
+      await fixture.whenStable();
+      expect(document.querySelector('.tooltip')).toBeInTheDocument();
+
+      button.dispatchEvent(new Event('focusout'));
+
       expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
     });
 


### PR DESCRIPTION
Add unit tests verifying that a focusout cancels a pending hover tooltip
timer and hides an already hover-visible tooltip. This behavior was
previously uncovered by tests.

<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2165/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2165/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2165/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2165/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2165/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2165/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2165/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2165/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2165/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2165/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


