### PR TITLE
refactor(dashboards): migrate SiWidgetHostComponent to OnPush

### DIFF
--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.html
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.html
@@ -34,9 +34,9 @@
     [expandText]="labelExpand"
     [restoreText]="labelRestore"
     [heading]="widgetConfig().heading"
-    [primaryActions]="primaryActions"
-    [secondaryActions]="secondaryActions"
-    [actionBarViewType]="actionBarViewType"
+    [primaryActions]="primaryActions()"
+    [secondaryActions]="secondaryActions()"
+    [actionBarViewType]="actionBarViewType()"
     [enableExpandInteraction]="widgetConfig().expandable"
     [imgAlt]="widgetConfig().image?.alt"
     [imgDir]="widgetConfig().image?.dir"
@@ -59,10 +59,10 @@
     <div class="card-body overflow-auto" body>
       <ng-container #widgetHost />
     </div>
-
-    @if (widgetInstanceFooter) {
+    @let footer = widgetInstanceFooter();
+    @if (footer) {
       <div class="card-footer" footer>
-        <ng-container *ngTemplateOutlet="widgetInstanceFooter" />
+        <ng-container *ngTemplateOutlet="footer" />
       </div>
     }
   </si-dashboard-card>

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
@@ -4,18 +4,19 @@
  */
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA, WritableSignal, inputBinding, signal } from '@angular/core';
 import { outputToObservable } from '@angular/core/rxjs-interop';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
+import { WidgetComponentFactory } from '@siemens/dashboards-ng';
 import {
   DeleteConfirmationDialogResult,
   SiActionDialogService
 } from '@siemens/element-ng/action-modal';
-import { MenuItem } from '@siemens/element-ng/common';
 import { MenuItemAction } from '@siemens/element-ng/menu';
 import { GridItemHTMLElement } from 'gridstack';
 import { firstValueFrom, Observable, Subject } from 'rxjs';
+import { page, userEvent } from 'vitest/browser';
 
 import {
   TEST_WIDGET,
@@ -42,6 +43,7 @@ describe('SiWidgetHostComponent', () => {
       let component: SiWidgetHostComponent;
       let fixture: ComponentFixture<SiWidgetHostComponent>;
       let actionDialogService: SiActionDialogMockService;
+      let componentFactory: WritableSignal<WidgetComponentFactory | undefined>;
 
       beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -49,16 +51,18 @@ describe('SiWidgetHostComponent', () => {
           providers: [{ provide: SiActionDialogService, useClass: SiActionDialogMockService }],
           schemas: [NO_ERRORS_SCHEMA]
         }).compileComponents();
-      });
 
-      beforeEach(() => {
-        fixture = TestBed.createComponent(SiWidgetHostComponent);
+        componentFactory = signal(widget.componentFactory);
+        fixture = TestBed.createComponent(SiWidgetHostComponent, {
+          bindings: [
+            inputBinding('componentFactory', componentFactory),
+            inputBinding('widgetConfig', () => TEST_WIDGET_CONFIG_0)
+          ]
+        });
         component = fixture.componentInstance;
         actionDialogService = TestBed.inject(
           SiActionDialogService
         ) as unknown as SiActionDialogMockService;
-        fixture.componentRef.setInput('componentFactory', widget.componentFactory);
-        fixture.componentRef.setInput('widgetConfig', TEST_WIDGET_CONFIG_0);
       });
 
       it('should create', () => {
@@ -75,24 +79,12 @@ describe('SiWidgetHostComponent', () => {
       });
 
       it('should not create widget instance without widget', async () => {
-        fixture.componentRef.setInput('componentFactory', undefined);
+        componentFactory.set(undefined);
         vi.useFakeTimers();
         vi.advanceTimersByTime(0);
         await fixture.whenStable();
         expect(component.widgetHost()).toHaveLength(0);
         vi.useRealTimers();
-      });
-
-      it('#editAction should call onEdit', async () => {
-        fixture.detectChanges();
-        vi.useFakeTimers();
-        vi.advanceTimersByTime(0);
-        await fixture.whenStable();
-        vi.useRealTimers();
-        const spy = vi.spyOn(component, 'onEdit');
-        ((component.editAction as MenuItemAction).action! as (param?: any) => void)();
-
-        expect(spy).toHaveBeenCalled();
       });
 
       it('#onEdit() should emit #widgetConfig', async () => {
@@ -132,35 +124,54 @@ describe('SiWidgetHostComponent', () => {
       });
 
       describe('#setupEditable()', () => {
-        it('should setup default edit actions with widgets edit actions', async () => {
-          vi.useFakeTimers();
-          vi.advanceTimersByTime(0);
+        beforeEach(async () => {
+          // The widget host is `display: flex` and normally sized by gridstack. Without a grid
+          // placing the widget, the card collapses to its intrinsic content width, leaving the
+          // content action bar too narrow for the `siAutoCollapsableList` to reveal any button.
+          // Give the host an explicit width to mirror a real grid cell so the buttons can render.
+          fixture.nativeElement.style.width = '600px';
           await fixture.whenStable();
-          expect(component.primaryActions).toHaveLength(0);
-          fixture.changeDetectorRef.markForCheck();
-          fixture.detectChanges();
+        });
+
+        it('#editAction should call onEdit', async () => {
           component.setupEditable(true);
-          expect(component.primaryActions).toHaveLength(3);
-          expect((component.primaryActions[0] as MenuItem).title).toBe('Hello User');
-          expect(component.primaryActions[1]).toBe(component.editAction);
-          expect(component.primaryActions[2]).toBe(component.removeAction);
+          await fixture.whenStable();
+          const spy = vi.spyOn(component, 'onEdit');
+          const actionBar = fixture.nativeElement.querySelector('si-content-action-bar');
+          expect(actionBar).toBeInTheDocument();
+          const editButton = page.getByRole('menuitem', { name: 'Edit' });
+          await expect.element(editButton).toBeVisible();
+          await userEvent.click(editButton);
+          expect(spy).toHaveBeenCalled();
+        });
+
+        it('should setup default edit actions with widgets edit actions', async () => {
+          await fixture.whenStable();
+          let actionBar = fixture.nativeElement.querySelector('si-content-action-bar');
+          expect(actionBar).not.toBeInTheDocument();
+          component.setupEditable(true);
+          await fixture.whenStable();
+          actionBar = fixture.nativeElement.querySelector('si-content-action-bar');
+          expect(actionBar).toBeInTheDocument();
+          await expect.element(page.getByRole('menuitem', { name: 'Hello User' })).toBeVisible();
+          await expect.element(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible();
+          await expect.element(page.getByRole('menuitem', { name: 'Remove' })).toBeVisible();
           expect(component.widgetInstance!.editable).toBe(true);
-          vi.useRealTimers();
         });
 
         it('should setup default edit actions without widgets edit actions', async () => {
-          vi.useFakeTimers();
-          vi.advanceTimersByTime(0);
           await fixture.whenStable();
           component.widgetInstance!.primaryEditActions = undefined;
-          expect(component.primaryActions).toHaveLength(0);
+          let actionBar = fixture.nativeElement.querySelector('si-content-action-bar');
+          expect(actionBar).not.toBeInTheDocument();
 
           component.setupEditable(true);
-          expect(component.primaryActions).toHaveLength(2);
-          expect(component.primaryActions[0]).toBe(component.editAction);
-          expect(component.primaryActions[1]).toBe(component.removeAction);
+          await fixture.whenStable();
+          actionBar = fixture.nativeElement.querySelector('si-content-action-bar');
+          expect(actionBar).toBeInTheDocument();
+          await expect.element(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible();
+          await expect.element(page.getByRole('menuitem', { name: 'Remove' })).toBeVisible();
           expect(component.widgetInstance!.editable).toBe(true);
-          vi.useRealTimers();
         });
       });
     });

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
@@ -5,6 +5,7 @@
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { NgTemplateOutlet } from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   Component,
   ComponentRef,
   computed,
@@ -54,6 +55,7 @@ import { setupWidgetInstance } from '../../widget-loader';
   imports: [SiDashboardCardComponent, NgTemplateOutlet, SiTranslatePipe],
   templateUrl: './si-widget-host.component.html',
   styleUrl: './si-widget-host.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'grid-stack-item'
   }
@@ -131,15 +133,17 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
   widgetInstance?: WidgetInstance;
   widgetRef?: ComponentRef<WidgetInstance>;
   /** @defaultValue [] */
-  primaryActions: (MenuItemLegacy | ContentActionBarMainItem)[] = [];
+  protected readonly primaryActions = signal<(MenuItemLegacy | ContentActionBarMainItem)[]>([]);
   /** @defaultValue [] */
-  secondaryActions: (MenuItemLegacy | MenuItem)[] = [];
+  protected readonly secondaryActions = signal<(MenuItemLegacy | MenuItem)[]>([]);
   /** @defaultValue 'expanded' */
-  actionBarViewType: ViewType = 'expanded';
+  protected readonly actionBarViewType = signal<ViewType>('expanded');
   /** @defaultValue [] */
-  editablePrimaryActions: (MenuItemLegacy | ContentActionBarMainItem)[] = [];
+  private readonly editablePrimaryActions = signal<(MenuItemLegacy | ContentActionBarMainItem)[]>(
+    []
+  );
   /** @defaultValue [] */
-  editableSecondaryActions: (MenuItemLegacy | MenuItem)[] = [];
+  private readonly editableSecondaryActions = signal<(MenuItemLegacy | MenuItem)[]>([]);
 
   /**
    * @defaultValue
@@ -153,7 +157,7 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
    * }
    * ```
    */
-  editAction: ContentActionBarMainItem = {
+  private readonly editAction: ContentActionBarMainItem = {
     type: 'action',
     label: this.labelEdit,
     icon: 'element-edit',
@@ -179,7 +183,7 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
     iconOnly: true,
     action: () => this.onRemove()
   };
-  protected widgetInstanceFooter?: TemplateRef<unknown>;
+  protected readonly widgetInstanceFooter = signal<TemplateRef<unknown> | undefined>(undefined);
 
   protected readonly accentLine = computed(() => {
     const { accentLine } = this.widgetConfig();
@@ -376,7 +380,7 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
           } else {
             this.widgetInstance.config = this.widgetConfig();
           }
-          this.widgetInstanceFooter = this.widgetInstance.footer;
+          this.widgetInstanceFooter.set(this.widgetInstance.footer);
           this.setupEditable(this.editable());
         },
         error: error => console.error('Error: ', error)
@@ -397,31 +401,34 @@ export class SiWidgetHostComponent implements OnInit, OnChanges {
       secondaryEditActions: this.widgetInstance?.secondaryEditActions
     };
     if (editable) {
-      this.editablePrimaryActions = [];
+      this.editablePrimaryActions.set([]);
       if (this.isEditable()) {
-        this.editablePrimaryActions.push(this.editAction);
+        this.editablePrimaryActions.set([...this.editablePrimaryActions(), this.editAction]);
       }
       if (!this.widgetConfig().isNotRemovable) {
-        this.editablePrimaryActions.push(this.removeAction);
+        this.editablePrimaryActions.set([...this.editablePrimaryActions(), this.removeAction]);
       }
       if (widgetConfig.primaryEditActions) {
-        this.primaryActions = [...widgetConfig.primaryEditActions, ...this.editablePrimaryActions];
+        this.primaryActions.set([
+          ...widgetConfig.primaryEditActions,
+          ...this.editablePrimaryActions()
+        ]);
       } else {
-        this.primaryActions = this.editablePrimaryActions;
+        this.primaryActions.set(this.editablePrimaryActions());
       }
       if (widgetConfig.secondaryEditActions) {
-        this.secondaryActions = [
+        this.secondaryActions.set([
           ...widgetConfig.secondaryEditActions,
-          ...this.editableSecondaryActions
-        ];
+          ...this.editableSecondaryActions()
+        ]);
       } else {
-        this.secondaryActions = this.editableSecondaryActions;
+        this.secondaryActions.set(this.editableSecondaryActions());
       }
-      this.actionBarViewType = 'expanded';
+      this.actionBarViewType.set('expanded');
     } else {
-      this.actionBarViewType = this.widgetConfig().actionBarViewType ?? 'expanded';
-      this.primaryActions = widgetConfig.primaryActions ?? [];
-      this.secondaryActions = widgetConfig.secondaryActions ?? [];
+      this.actionBarViewType.set(this.widgetConfig().actionBarViewType ?? 'expanded');
+      this.primaryActions.set(widgetConfig.primaryActions ?? []);
+      this.secondaryActions.set(widgetConfig.secondaryActions ?? []);
     }
 
     if (this.widgetInstance?.editable !== undefined) {


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2167/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2167/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2167/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2167/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2167/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2167/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2167/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2167/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2167/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2167/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



