### PR TITLE
fix(application-header): declare launchpad as `role="dialog"`

### DIFF
--- a/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad--medium-size.yaml
+++ b/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad--medium-size.yaml
@@ -7,17 +7,18 @@
     - link "Item 2":
       - /url: "#/viewer/viewer/item2"
   - button "Help"
-  - button "Jane Smith"
-- paragraph: Switch applications
-- paragraph: Access all your apps
-- button "Close launchpad"
-- link "Assets":
-  - /url: .
-- link "Water":
-  - /url: .
-- link "Rocket":
-  - /url: .
-- link "Statistics":
-  - /url: .
-- link "Add more":
-  - /url: https://example.org
+  - button "Jane Smith": JS
+- dialog "Launchpad":
+  - paragraph: Switch applications
+  - paragraph: Access all your apps
+  - button "Close launchpad"
+  - link "Assets":
+    - /url: .
+  - link "Water":
+    - /url: .
+  - link "Rocket":
+    - /url: .
+  - link "Statistics":
+    - /url: .
+  - link "Add more":
+    - /url: https://example.org

--- a/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad-categories.yaml
+++ b/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad-categories.yaml
@@ -9,23 +9,24 @@
     - link "Item 2":
       - /url: "#/viewer/viewer/item2"
   - button "Help"
-  - button "Jane Smith"
-- paragraph: Switch applications
-- paragraph: Access all your apps
-- button "Close launchpad"
-- text: Favorites
-- link "Water":
-  - /url: .
-- button "Show less"
-- text: Phishing Apps
-- link "Water":
-  - /url: .
-- text: Other Apps
-- link "Assets":
-  - /url: .
-- link "Rocket":
-  - /url: .
-- link "Statistics":
-  - /url: .
-- link "Add more":
-  - /url: https://example.org
+  - button "Jane Smith": JS
+- dialog "Launchpad":
+  - paragraph: Switch applications
+  - paragraph: Access all your apps
+  - button "Close launchpad"
+  - text: Favorites
+  - link "Water":
+    - /url: .
+  - button "Show less"
+  - text: Phishing Apps
+  - link "Water":
+    - /url: .
+  - text: Other Apps
+  - link "Assets":
+    - /url: .
+  - link "Rocket":
+    - /url: .
+  - link "Statistics":
+    - /url: .
+  - link "Add more":
+    - /url: https://example.org

--- a/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad.yaml
+++ b/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad.yaml
@@ -9,17 +9,18 @@
     - link "Item 2":
       - /url: "#/viewer/viewer/item2"
   - button "Help"
-  - button "Jane Smith"
-- paragraph: Switch applications
-- paragraph: Access all your apps
-- button "Close launchpad"
-- link "Assets":
-  - /url: .
-- link "Water":
-  - /url: .
-- link "Rocket":
-  - /url: .
-- link "Statistics":
-  - /url: .
-- link "Add more":
-  - /url: https://example.org
+  - button "Jane Smith": JS
+- dialog "Launchpad":
+  - paragraph: Switch applications
+  - paragraph: Access all your apps
+  - button "Close launchpad"
+  - link "Assets":
+    - /url: .
+  - link "Water":
+    - /url: .
+  - link "Rocket":
+    - /url: .
+  - link "Statistics":
+    - /url: .
+  - link "Add more":
+    - /url: https://example.org

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile.yaml
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile.yaml
@@ -2,53 +2,54 @@
   - button "Launchpad" [expanded]
   - link "Siemens logo":
     - /url: "#/"
-- paragraph: Switch applications
-- button "Close launchpad"
-- text: Favorites
-- link "Assets System name":
-  - /url: .
-- link "Fischbach System name":
-  - /url: .
-- link "Statistics System name":
-  - /url: "#/viewer/viewer/stats"
-- link "Rocket System name":
-  - /url: .
-- button "Show less"
-- link "Assets System name":
-  - /url: .
-- link "Fischbach System name":
-  - /url: .
-- link "Statistics System name":
-  - /url: "#/viewer/viewer/stats"
-- link "Rocket System name":
-  - /url: .
-- link "This is a really long name External application System name":
-  - /url: .
-  - text: ""
-- link "App name 1 External application System name":
-  - /url: .
-  - text: ""
-- link "App name 2 System name":
-  - /url: .
-- link "App name 3 System name":
-  - /url: .
-- link "This is a really long name External application System name":
-  - /url: .
-  - text: ""
-- link "App name 4 System name":
-  - /url: .
-- link "App name 5 System name":
-  - /url: .
-- link "App name 6 This is a really long name":
-  - /url: .
-- link "App name 7 System name":
-  - /url: .
-- link "App name 8 System name":
-  - /url: .
-- link "App name 9 System name":
-  - /url: .
-- link /App name \d+ System name/:
-  - /url: .
+- dialog "Launchpad":
+  - paragraph: Switch applications
+  - button "Close launchpad"
+  - text: Favorites
+  - link "Assets System name":
+    - /url: .
+  - link "Fischbach System name":
+    - /url: .
+  - link "Statistics System name":
+    - /url: "#/viewer/viewer/stats"
+  - link "Rocket System name":
+    - /url: .
+  - button "Show less"
+  - link "Assets System name":
+    - /url: .
+  - link "Fischbach System name":
+    - /url: .
+  - link "Statistics System name":
+    - /url: "#/viewer/viewer/stats"
+  - link "Rocket System name":
+    - /url: .
+  - link "This is a really long name External application System name":
+    - /url: .
+    - text: This is a really long name System name
+  - link "App name 1 External application System name":
+    - /url: .
+    - text: App name 1 System name
+  - link "App name 2 System name":
+    - /url: .
+  - link "App name 3 System name":
+    - /url: .
+  - link "This is a really long name External application System name":
+    - /url: .
+    - text: This is a really long name System name
+  - link "App name 4 System name":
+    - /url: .
+  - link "App name 5 System name":
+    - /url: .
+  - link "App name 6 This is a really long name":
+    - /url: .
+  - link "App name 7 System name":
+    - /url: .
+  - link "App name 8 System name":
+    - /url: .
+  - link "App name 9 System name":
+    - /url: .
+  - link /App name \d+ System name/:
+    - /url: .
 - heading "Launchpad Configuration" [level=2]
 - paragraph: Configure your launchpad settings and test different display modes.
 - checkbox "Enable Favorites" [checked]

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite.yaml
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite.yaml
@@ -2,51 +2,52 @@
   - button "Launchpad" [expanded]
   - link "Siemens logo":
     - /url: "#/"
-- paragraph: Switch applications
-- button "Close launchpad"
-- text: Favorites
-- link "Assets System name":
-  - /url: .
-- link "Statistics System name":
-  - /url: "#/viewer/viewer/stats"
-- link "Rocket System name":
-  - /url: .
-- button "Show less"
-- link "Assets System name":
-  - /url: .
-- link "Fischbach System name":
-  - /url: .
-- link "Statistics System name":
-  - /url: "#/viewer/viewer/stats"
-- link "Rocket System name":
-  - /url: .
-- link "This is a really long name External application System name":
-  - /url: .
-  - text: ""
-- link "App name 1 External application System name":
-  - /url: .
-  - text: ""
-- link "App name 2 System name":
-  - /url: .
-- link "App name 3 System name":
-  - /url: .
-- link "This is a really long name External application System name":
-  - /url: .
-  - text: ""
-- link "App name 4 System name":
-  - /url: .
-- link "App name 5 System name":
-  - /url: .
-- link "App name 6 This is a really long name":
-  - /url: .
-- link "App name 7 System name":
-  - /url: .
-- link "App name 8 System name":
-  - /url: .
-- link "App name 9 System name":
-  - /url: .
-- link /App name \d+ System name/:
-  - /url: .
+- dialog "Launchpad":
+  - paragraph: Switch applications
+  - button "Close launchpad"
+  - text: Favorites
+  - link "Assets System name":
+    - /url: .
+  - link "Statistics System name":
+    - /url: "#/viewer/viewer/stats"
+  - link "Rocket System name":
+    - /url: .
+  - button "Show less"
+  - link "Assets System name":
+    - /url: .
+  - link "Fischbach System name":
+    - /url: .
+  - link "Statistics System name":
+    - /url: "#/viewer/viewer/stats"
+  - link "Rocket System name":
+    - /url: .
+  - link "This is a really long name External application System name":
+    - /url: .
+    - text: This is a really long name System name
+  - link "App name 1 External application System name":
+    - /url: .
+    - text: App name 1 System name
+  - link "App name 2 System name":
+    - /url: .
+  - link "App name 3 System name":
+    - /url: .
+  - link "This is a really long name External application System name":
+    - /url: .
+    - text: This is a really long name System name
+  - link "App name 4 System name":
+    - /url: .
+  - link "App name 5 System name":
+    - /url: .
+  - link "App name 6 This is a really long name":
+    - /url: .
+  - link "App name 7 System name":
+    - /url: .
+  - link "App name 8 System name":
+    - /url: .
+  - link "App name 9 System name":
+    - /url: .
+  - link /App name \d+ System name/:
+    - /url: .
 - heading "Launchpad Configuration" [level=2]
 - paragraph: Configure your launchpad settings and test different display modes.
 - checkbox "Enable Favorites" [checked]

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad.yaml
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad.yaml
@@ -2,53 +2,54 @@
   - button "Launchpad" [expanded]
   - link "Siemens logo":
     - /url: "#/"
-- paragraph: Switch applications
-- button "Close launchpad"
-- text: Favorites
-- link "Assets System name":
-  - /url: .
-- link "Fischbach System name":
-  - /url: .
-- link "Statistics System name":
-  - /url: "#/viewer/viewer/stats"
-- link "Rocket System name":
-  - /url: .
-- button "Show less"
-- link "Assets System name":
-  - /url: .
-- link "Fischbach System name":
-  - /url: .
-- link "Statistics System name":
-  - /url: "#/viewer/viewer/stats"
-- link "Rocket System name":
-  - /url: .
-- link "This is a really long name External application System name":
-  - /url: .
-  - text: ""
-- link "App name 1 External application System name":
-  - /url: .
-  - text: ""
-- link "App name 2 System name":
-  - /url: .
-- link "App name 3 System name":
-  - /url: .
-- link "This is a really long name External application System name":
-  - /url: .
-  - text: ""
-- link "App name 4 System name":
-  - /url: .
-- link "App name 5 System name":
-  - /url: .
-- link "App name 6 This is a really long name":
-  - /url: .
-- link "App name 7 System name":
-  - /url: .
-- link "App name 8 System name":
-  - /url: .
-- link "App name 9 System name":
-  - /url: .
-- link /App name \d+ System name/:
-  - /url: .
+- dialog "Launchpad":
+  - paragraph: Switch applications
+  - button "Close launchpad"
+  - text: Favorites
+  - link "Assets System name":
+    - /url: .
+  - link "Fischbach System name":
+    - /url: .
+  - link "Statistics System name":
+    - /url: "#/viewer/viewer/stats"
+  - link "Rocket System name":
+    - /url: .
+  - button "Show less"
+  - link "Assets System name":
+    - /url: .
+  - link "Fischbach System name":
+    - /url: .
+  - link "Statistics System name":
+    - /url: "#/viewer/viewer/stats"
+  - link "Rocket System name":
+    - /url: .
+  - link "This is a really long name External application System name":
+    - /url: .
+    - text: This is a really long name System name
+  - link "App name 1 External application System name":
+    - /url: .
+    - text: App name 1 System name
+  - link "App name 2 System name":
+    - /url: .
+  - link "App name 3 System name":
+    - /url: .
+  - link "This is a really long name External application System name":
+    - /url: .
+    - text: This is a really long name System name
+  - link "App name 4 System name":
+    - /url: .
+  - link "App name 5 System name":
+    - /url: .
+  - link "App name 6 This is a really long name":
+    - /url: .
+  - link "App name 7 System name":
+    - /url: .
+  - link "App name 8 System name":
+    - /url: .
+  - link "App name 9 System name":
+    - /url: .
+  - link /App name \d+ System name/:
+    - /url: .
 - heading "Launchpad Configuration" [level=2]
 - paragraph: Configure your launchpad settings and test different display modes.
 - checkbox "Enable Favorites" [checked]

--- a/projects/element-ng/application-header/si-application-header.component.html
+++ b/projects/element-ng/application-header/si-application-header.component.html
@@ -5,6 +5,7 @@
   @if (launchpad()) {
     <button
       type="button"
+      aria-haspopup="dialog"
       [class]="`header-toggle focus-inside d-${expandBreakpoint()}-block`"
       [class.show]="launchpadOpen()"
       [class.d-none]="hasNavigation()"
@@ -51,7 +52,12 @@
 </header>
 
 @if (launchpadOpen() && launchpad()) {
-  <div [id]="id + '-launchpad'">
+  <div
+    role="dialog"
+    aria-modal="true"
+    [id]="id + '-launchpad'"
+    [attr.aria-label]="launchpadLabel() | translate"
+  >
     <ng-template [ngTemplateOutlet]="launchpad()!" [ngTemplateOutletInjector]="injector" />
   </div>
 }


### PR DESCRIPTION
It already has the interaction pattern of a dialog. So just adding the role + `aria-haspopup`.

Closes #2152

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2170/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2170/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2170/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2170/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2170/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2170/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2170/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2170/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2170/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2170/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

