### PR TITLE
Revert "refactor(dashboard): replace SiDashboardService with contentC…

### DIFF
--- a/api-goldens/element-ng/dashboard/index.api.md
+++ b/api-goldens/element-ng/dashboard/index.api.md
@@ -16,7 +16,9 @@ import { MenuItem } from '@siemens/element-ng/common';
 import { MenuItem as MenuItem_2 } from '@siemens/element-ng/menu';
 import { NavigationExtras } from '@angular/router';
 import { OnChanges } from '@angular/core';
+import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
+import * as rxjs from 'rxjs';
 import { SiCardComponent } from '@siemens/element-ng/card';
 import * as _siemens_element_ng_content_action_bar from '@siemens/element-ng/content-action-bar';
 import * as _siemens_element_translate_ng_translate from '@siemens/element-translate-ng/translate';
@@ -24,7 +26,8 @@ import { SimpleChanges } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public (undocumented)
-export class SiDashboardCardComponent extends SiCardComponent {
+export class SiDashboardCardComponent extends SiCardComponent implements OnDestroy {
+    constructor();
     // (undocumented)
     readonly displayContentActionBar: _angular_core.Signal<boolean>;
     readonly enableExpandInteraction: _angular_core.InputSignalWithTransform<boolean, unknown>;
@@ -53,6 +56,13 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
 
 // @public (undocumented)
 export class SiDashboardModule {
+}
+
+// @public (undocumented)
+export class SiDashboardService {
+    readonly cards$: rxjs.Observable<SiDashboardCardComponent[]>;
+    register(card: SiDashboardCardComponent): void;
+    unregister(card: SiDashboardCardComponent): void;
 }
 
 // @public

--- a/projects/element-ng/dashboard/index.ts
+++ b/projects/element-ng/dashboard/index.ts
@@ -5,6 +5,7 @@
 export * from './si-dashboard-card.component';
 export * from './si-dashboard.component';
 export * from './si-dashboard.module';
+export * from './si-dashboard.service';
 export * from './widgets/si-link-widget/si-link-widget.component';
 export * from './widgets/si-list-widget/si-list-widget.component';
 export * from './widgets/si-list-widget/si-list-widget-body.component';

--- a/projects/element-ng/dashboard/si-dashboard-card.component.ts
+++ b/projects/element-ng/dashboard/si-dashboard-card.component.ts
@@ -9,6 +9,7 @@ import {
   ElementRef,
   inject,
   input,
+  OnDestroy,
   output,
   signal
 } from '@angular/core';
@@ -18,6 +19,8 @@ import { MenuItem } from '@siemens/element-ng/common';
 import { ContentActionBarMainItem } from '@siemens/element-ng/content-action-bar';
 import { addIcons } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
+
+import { SiDashboardService } from './si-dashboard.service';
 
 @Component({
   selector: 'si-dashboard-card',
@@ -30,7 +33,7 @@ import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
     '[class.d-none]': 'hide'
   }
 })
-export class SiDashboardCardComponent extends SiCardComponent {
+export class SiDashboardCardComponent extends SiCardComponent implements OnDestroy {
   /**
    * Description of cancel button & action.
    *
@@ -174,6 +177,16 @@ export class SiDashboardCardComponent extends SiCardComponent {
   private readonly hasContentBarActions = computed(() => {
     return this.primaryActions()?.length > 0 || this.secondaryActions()?.length > 0;
   });
+  private dashboardService = inject(SiDashboardService, { optional: true });
+
+  constructor() {
+    super();
+    this.dashboardService?.register(this);
+  }
+
+  ngOnDestroy(): void {
+    this.dashboardService?.unregister(this);
+  }
 
   /**
    * Expand the dashboard card.

--- a/projects/element-ng/dashboard/si-dashboard.component.ts
+++ b/projects/element-ng/dashboard/si-dashboard.component.ts
@@ -10,17 +10,14 @@ import {
   ChangeDetectorRef,
   Component,
   computed,
-  contentChildren,
   DestroyRef,
   DOCUMENT,
-  effect,
   ElementRef,
   inject,
   input,
   OnChanges,
   signal,
   SimpleChanges,
-  untracked,
   viewChild
 } from '@angular/core';
 import { outputToObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -34,6 +31,7 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
 import { Subject, takeUntil } from 'rxjs';
 
 import { SiDashboardCardComponent } from './si-dashboard-card.component';
+import { SiDashboardService } from './si-dashboard.service';
 
 const FIX_SCROLL_PADDING_RESIZE_OBSERVER_THROTTLE = 10;
 
@@ -42,6 +40,7 @@ const FIX_SCROLL_PADDING_RESIZE_OBSERVER_THROTTLE = 10;
   imports: [PortalModule, SiTranslatePipe],
   templateUrl: './si-dashboard.component.html',
   styleUrl: './si-dashboard.component.scss',
+  providers: [SiDashboardService],
   host: { class: 'si-layout-fixed-height' }
 })
 export class SiDashboardComponent implements OnChanges, AfterViewInit {
@@ -89,7 +88,7 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
   private scrollPosition: [number, number] = [0, 0];
 
   private readonly reinitCards$ = new Subject<void>();
-  private readonly cards = computed(() => this.cardsComponents());
+  private cards: SiDashboardCardComponent[] = [];
   private readonly expandedPortalOutlet = viewChild.required('expandedPortalOutlet', {
     read: CdkPortalOutlet
   });
@@ -100,22 +99,19 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
   private dashboardDimensions?: ElementDimensions;
 
   private scroller = inject(ViewportScroller);
+  private dashboardService = inject(SiDashboardService);
   private resizeObserver = inject(ResizeObserverService);
   private scrollbarHelper = inject(ScrollbarHelper);
   private cdRef = inject(ChangeDetectorRef);
   private document = inject(DOCUMENT);
   private readonly hideMenubarInternal = signal(false);
-  private readonly cardsComponents = contentChildren(SiDashboardCardComponent, {
-    descendants: true
-  });
 
   constructor() {
+    this.dashboardService.cards$
+      .pipe(takeUntilDestroyed())
+      .subscribe(cards => this.subscribeToCards(cards));
+
     this.destroyRef.onDestroy(() => this.reinitCards$.complete());
-    effect(() => {
-      if (this.cards().length) {
-        untracked(() => this.initCards());
-      }
-    });
   }
 
   ngOnChanges(changes: SimpleChanges<this>): void {
@@ -135,10 +131,15 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
       .subscribe(dims => this.setDashboardFrameEndPadding(dims, this.dashboardDimensions));
   }
 
+  private subscribeToCards(cards: SiDashboardCardComponent[]): void {
+    this.cards = cards;
+    this.initCards();
+  }
+
   private initCards(): void {
     this.reinitCards$.next();
 
-    for (const card of this.cards()) {
+    for (const card of this.cards) {
       // We only enforce expand if the dashboard value is true, otherwise we would remove the individual
       // card settings.
       const enableExpandInteractions = this.enableExpandInteractions();
@@ -194,7 +195,7 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
    */
   public restore(): void {
     // Restore all cards
-    for (const card of this.cards()) {
+    for (const card of this.cards) {
       if (card.isExpanded()) {
         card.restore();
       }
@@ -232,7 +233,7 @@ export class SiDashboardComponent implements OnChanges, AfterViewInit {
   }
 
   private toggleCardsHide(expand: boolean): void {
-    for (const card of this.cards()) {
+    for (const card of this.cards) {
       card.hide = !card.isExpanded() && expand;
     }
   }

--- a/projects/element-ng/dashboard/si-dashboard.service.spec.ts
+++ b/projects/element-ng/dashboard/si-dashboard.service.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+
+import { SiDashboardCardComponent } from './si-dashboard-card.component';
+import { SiDashboardService as TestService } from './si-dashboard.service';
+
+describe('SiDashboardService', () => {
+  let service: TestService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: TestService }]
+    }).compileComponents();
+    service = TestBed.inject(TestService);
+  });
+
+  it('should initially have no cards registered', async () => {
+    const cards = await firstValueFrom(service.cards$);
+    expect(cards).toEqual([]);
+  });
+
+  it('should emit cards on registration', async () => {
+    const card = {} as SiDashboardCardComponent;
+    service.register(card);
+    const cards = await firstValueFrom(service.cards$);
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toBe(card);
+  });
+
+  it('should emit cards on unregistration', async () => {
+    const card1 = { name: '1' } as any as SiDashboardCardComponent;
+    const card2 = { name: '2' } as any as SiDashboardCardComponent;
+    service.register(card1);
+    service.register(card2);
+    service.unregister(card1);
+    const cards = await firstValueFrom(service.cards$);
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toBe(card2);
+  });
+});

--- a/projects/element-ng/dashboard/si-dashboard.service.ts
+++ b/projects/element-ng/dashboard/si-dashboard.service.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+import { SiDashboardCardComponent } from './si-dashboard-card.component';
+
+@Injectable()
+export class SiDashboardService {
+  private cards = new BehaviorSubject<SiDashboardCardComponent[]>([]);
+  /**
+   * Subject containing the current dashboard cards as a list.
+   *
+   * @defaultValue this.cards.asObservable()
+   */
+  readonly cards$ = this.cards.asObservable();
+
+  /**
+   * Registers a new dashboard card.
+   */
+  register(card: SiDashboardCardComponent): void {
+    const nextCards = this.cards.value;
+    nextCards.push(card);
+    this.cards.next(nextCards);
+  }
+
+  /**
+   * Removes a registered dashboard card.
+   */
+  unregister(card: SiDashboardCardComponent): void {
+    const nextCards = this.cards.value;
+    const index = nextCards.indexOf(card);
+    if (index > -1) {
+      nextCards.splice(index, 1);
+      this.cards.next(nextCards);
+    }
+  }
+}


### PR DESCRIPTION
…hildren query"

This reverts commit c562b76a65b8f270e6dc6fbb8195827bfbe2d54c.

contentChildren doesn't pick up the content projected by other nested component and we rely on that in flexible dashboard.
so this change added regression in flexible dashboard with broken expand/collapse behavior. 

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2171/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2171/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2171/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2171/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2171/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2171/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2171/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2171/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2171/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2171/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

