### PR TITLE
test(tooltip): add unit test that covers touchstart

### DIFF
--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -101,6 +101,17 @@ describe('SiTooltipDirective', () => {
       expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
     });
 
+    it('should hide the tooltip on touchstart', async () => {
+      await userEvent.hover(button);
+      vi.advanceTimersByTime(500);
+      await fixture.whenStable();
+      expect(document.querySelector('.tooltip')).toBeInTheDocument();
+
+      button.dispatchEvent(new Event('touchstart'));
+
+      expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
+    });
+
     it('should update tooltip content while open', async () => {
       button.dispatchEvent(new Event('focus'));
       vi.advanceTimersByTime(0);


### PR DESCRIPTION
Tooltips are dismissed on outside `touchstart` event. But this was never covered in a test. Now it is.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2177/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2177/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2177/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2177/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2177/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2177/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2177/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2177/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2177/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2177/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
