### PR TITLE
test(chat-messages): use non-deprecated vitest/browser import

### DIFF
--- a/projects/element-ng/chat-messages/si-chat-input.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-chat-input.component.spec.ts
@@ -15,7 +15,7 @@ import { By } from '@angular/platform-browser';
 import { FileUploadError, UploadFile } from '@siemens/element-ng/file-uploader';
 import { MenuItem } from '@siemens/element-ng/menu';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
-import { page } from '@vitest/browser/context';
+import { page } from 'vitest/browser';
 
 import { MessageAction } from './message-action.model';
 import {


### PR DESCRIPTION
## Summary

The `si-chat-input.component.spec.ts` test imported `page` from `@vitest/browser/context`, which emits a deprecation warning when running the test.

This change updates the import to `vitest/browser`, aligning with the modern API already used elsewhere in the codebase (e.g. `si-datepicker.directive.spec.ts`).

## Testing

```
npm run lib:test -- --include='**/chat-messages/si-chat-input.component.spec.ts' --no-watch
```

All 44 tests pass with no deprecation warning.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2178/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2178/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2178/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2178/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2178/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2178/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2178/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2178/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2178/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2178/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
