### PR TITLE
fix(file-uploader): use button for click to upload trigger

### DIFF
--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--added.yaml
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--added.yaml
@@ -1,4 +1,6 @@
-- text: "/Drop files here or click to upload Max\\. [\\d,.]+[bkmBKM]+ upload size\\. Accepted file types: image\\/\\*\\. siemens-healthineers-logo\\.svg [\\d,.]+[bkmBKM]+ 0 %/"
+- text: Drop files here or
+- button "click to upload"
+- text: "/Max\\. [\\d,.]+[bkmBKM]+ upload size\\. Accepted file types: image\\/\\*\\. siemens-healthineers-logo\\.svg [\\d,.]+[bkmBKM]+ 0 %/"
 - progressbar "Uploading"
 - button "Remove"
 - text: /simpl-44x44\.png [\d,.]+[bkmBKM]+ 0 %/
@@ -18,9 +20,9 @@
 - text: Auto-upload mode
 - checkbox "Upload directory"
 - text: Upload directory Max. files
-- spinbutton "Max. files"
+- spinbutton "Max. files": /\d+/
 - text: Max. concurrent uploads
-- spinbutton "Max. concurrent uploads"
+- spinbutton "Max. concurrent uploads": "3"
 - text: Demo settings
 - checkbox "Upload shall fail"
 - text: Upload shall fail

--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--initial.yaml
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--initial.yaml
@@ -1,4 +1,6 @@
-- text: "/Drop files here or click to upload Max\\. [\\d,.]+[bkmBKM]+ upload size\\. Accepted file types: image\\/\\*\\./"
+- text: Drop files here or
+- button "click to upload"
+- text: "/Max\\. [\\d,.]+[bkmBKM]+ upload size\\. Accepted file types: image\\/\\*\\./"
 - button "Clear" [disabled]
 - button "Upload" [disabled]
 - text: si-file-uploader settings
@@ -8,9 +10,9 @@
 - text: Auto-upload mode
 - checkbox "Upload directory"
 - text: Upload directory Max. files
-- spinbutton "Max. files"
+- spinbutton "Max. files": /\d+/
 - text: Max. concurrent uploads
-- spinbutton "Max. concurrent uploads"
+- spinbutton "Max. concurrent uploads": "3"
 - text: Demo settings
 - checkbox "Upload shall fail"
 - text: Upload shall fail

--- a/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--uploaded.yaml
+++ b/playwright/snapshots/si-file-uploader.spec.ts-snapshots/si-file-uploader--si-file-uploader--uploaded.yaml
@@ -1,4 +1,6 @@
-- text: "/Drop files here or click to upload Max\\. [\\d,.]+[bkmBKM]+ upload size\\. Accepted file types: image\\/\\*\\. siemens-healthineers-logo\\.svg [\\d,.]+[bkmBKM]+ Danger Upload failed/"
+- text: Drop files here or
+- button "click to upload"
+- text: "/Max\\. [\\d,.]+[bkmBKM]+ upload size\\. Accepted file types: image\\/\\*\\. siemens-healthineers-logo\\.svg [\\d,.]+[bkmBKM]+ Danger Upload failed/"
 - button "Upload"
 - button "Remove"
 - text: /simpl-44x44\.png [\d,.]+[bkmBKM]+ \d+ %/
@@ -17,9 +19,9 @@
 - text: Auto-upload mode
 - checkbox "Upload directory"
 - text: Upload directory Max. files
-- spinbutton "Max. files"
+- spinbutton "Max. files": /\d+/
 - text: Max. concurrent uploads
-- spinbutton "Max. concurrent uploads"
+- spinbutton "Max. concurrent uploads": "3"
 - text: Demo settings
 - checkbox "Upload shall fail"
 - text: Upload shall fail

--- a/projects/element-ng/file-uploader/si-file-dropzone.component.html
+++ b/projects/element-ng/file-uploader/si-file-dropzone.component.html
@@ -9,27 +9,25 @@
   <span class="drag-and-drop-description si-h5 d-flex">
     <span>{{ uploadDropText() | translate }}</span>
     &nbsp;
-    <label class="select-file si-h5 mb-0">
-      <span tabindex="0" (keydown.enter)="inputEnterHandler()">{{
-        uploadTextFileSelect() | translate
-      }}</span>
-      <input
-        #fileInput
-        type="file"
-        tabindex="-1"
-        class="d-none"
-        siFileUpload
-        [accept]="accept()"
-        [maxFileSize]="maxFileSize()"
-        [multiple]="multiple()"
-        [directoryUpload]="directoryUpload()"
-        [errorTextFileType]="errorTextFileType()"
-        [errorTextFileMaxSize]="errorTextFileMaxSize()"
-        (filesAdded)="onFilesAdded($event)"
-        (fileError)="onFileError($event)"
-        (cancel)="$event.stopPropagation()"
-      />
-    </label>
+    <button type="button" class="select-file si-h5 mb-0" (click)="triggerFileSelect()">
+      {{ uploadTextFileSelect() | translate }}
+    </button>
+    <input
+      #fileInput
+      type="file"
+      tabindex="-1"
+      class="d-none"
+      siFileUpload
+      [accept]="accept()"
+      [maxFileSize]="maxFileSize()"
+      [multiple]="multiple()"
+      [directoryUpload]="directoryUpload()"
+      [errorTextFileType]="errorTextFileType()"
+      [errorTextFileMaxSize]="errorTextFileMaxSize()"
+      (filesAdded)="onFilesAdded($event)"
+      (fileError)="onFileError($event)"
+      (cancel)="$event.stopPropagation()"
+    />
   </span>
   @if (maxFileSize() || accept()) {
     <div class="allowed si-caption mt-6 text-center">

--- a/projects/element-ng/file-uploader/si-file-dropzone.component.scss
+++ b/projects/element-ng/file-uploader/si-file-dropzone.component.scss
@@ -6,6 +6,9 @@
 
 .select-file {
   margin-block-end: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
   cursor: pointer;
   color: variables.$element-ui-0;
 

--- a/projects/element-ng/file-uploader/si-file-dropzone.component.spec.ts
+++ b/projects/element-ng/file-uploader/si-file-dropzone.component.spec.ts
@@ -126,7 +126,7 @@ describe('SiFileDropzoneComponent', () => {
     uploadTextFileSelect.set('browse files');
     uploadDropText.set('droppi droppi');
     await fixture.whenStable();
-    expect(element.querySelector('.select-file span')!).toHaveTextContent('browse files');
+    expect(element.querySelector('.select-file')!).toHaveTextContent('browse files');
     expect(element.querySelector('.drag-and-drop-description')!).toHaveTextContent('droppi droppi');
   });
 
@@ -177,7 +177,7 @@ describe('SiFileDropzoneComponent', () => {
   it('should allow one to define accepted mime types', async () => {
     accept.set('image/*');
     await fixture.whenStable();
-    expect(element.querySelector('.select-file input')!).toHaveAttribute(
+    expect(element.querySelector('.select-file ~ input')!).toHaveAttribute(
       'accept',
       expect.stringContaining('image/*')
     );

--- a/projects/element-ng/file-uploader/si-file-dropzone.component.ts
+++ b/projects/element-ng/file-uploader/si-file-dropzone.component.ts
@@ -154,7 +154,7 @@ export class SiFileDropzoneComponent {
     this.dragOver = true;
   }
 
-  protected inputEnterHandler(): void {
+  protected triggerFileSelect(): void {
     this.fileUploadDirective().triggerClick();
   }
 

--- a/projects/element-ng/file-uploader/si-file-uploader.component.spec.ts
+++ b/projects/element-ng/file-uploader/si-file-uploader.component.spec.ts
@@ -135,7 +135,7 @@ describe('SiFileUploaderComponent', () => {
     clearButtonText.set('Reset');
     uploadButtonText.set('Do it');
     await fixture.whenStable();
-    expect(element.querySelector('.select-file span')!).toHaveTextContent('browse files');
+    expect(element.querySelector('.select-file')!).toHaveTextContent('browse files');
     expect(element.querySelector('.drag-and-drop-description')!).toHaveTextContent('droppi droppi');
     expect(getClearButton()).toHaveTextContent('Reset');
     expect(getUploadButton()).toHaveTextContent('Do it');
@@ -174,7 +174,7 @@ describe('SiFileUploaderComponent', () => {
   it('should allow one to define accepted mime types', async () => {
     accept.set('image/*');
     await fixture.whenStable();
-    expect(element.querySelector('.select-file input')!).toHaveAttribute(
+    expect(element.querySelector('.select-file ~ input')!).toHaveAttribute(
       'accept',
       expect.stringContaining('image/*')
     );


### PR DESCRIPTION
## Description

Fixes the accessibility of the "click to upload" trigger in `si-file-dropzone`.

Previously the trigger was rendered as a `<span tabindex="0">` without a semantic role or accessible name, so assistive technologies did not announce it as an interactive control. It also only responded to <kbd>Enter</kbd> (not <kbd>Space</kbd>).

It is now a native `<button type="button">`, which provides the correct role, focus behavior, accessible name (its text content) and Enter/Space keyboard activation for free.

## Changes

- **`si-file-dropzone.component.html`**: Replaced the `<label>` + focusable `<span>` with a native `<button>` that triggers the file dialog on click. The hidden file `<input>` is now a sibling of the button.
- **`si-file-dropzone.component.ts`**: Replaced `inputEnterHandler` with a simple `triggerFileSelect()` click handler.
- **`si-file-dropzone.component.scss`**: Reset native button styling so it still renders as the inline link-style trigger.
- **Tests**: Updated selectors and added tests asserting the trigger is a `<button type="button">` with the correct accessible name and that activating it opens the file dialog.

## Testing

- `npm run lib:test -- --include='**/file-uploader/si-file-dropzone.component.spec.ts' --no-watch` ✅
- `npm run lib:test -- --include='**/file-uploader/si-file-uploader.component.spec.ts' --no-watch` ✅

Closes #2173<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2180/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2180/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2180/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2180/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2180/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2180/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2180/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2180/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2180/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2180/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
