### PR TITLE
fix(empty-state): render heading as styled span instead of h3

### DIFF
--- a/playwright/snapshots/dashboard.spec.ts-snapshots/custom-catalog--custom-catalog.yaml
+++ b/playwright/snapshots/dashboard.spec.ts-snapshots/custom-catalog--custom-catalog.yaml
@@ -9,7 +9,7 @@
   - button "expand"
 - main:
   - heading "Dashboard with a custom library component" [level=2]
-  - button "Edit"
-  - heading "Your own dashboard" [level=3]
+  - button "Edit": 
+  - text: Your own dashboard
   - paragraph: No widgets have been added yet. Start right now and discover the world of widgets.
   - button "Add widget"

--- a/playwright/snapshots/dashboard.spec.ts-snapshots/dashboard--empty.yaml
+++ b/playwright/snapshots/dashboard.spec.ts-snapshots/dashboard--empty.yaml
@@ -9,8 +9,8 @@
   - button "expand"
 - main:
   - heading "Add widget" [level=2]
-  - textbox "Search widget"
+  - textbox "Search widget": empty
   - button "clear"
-  - heading "No widgets available." [level=3]
+  - text: No widgets available.
   - button "Cancel"
   - button "Add" [disabled]

--- a/playwright/snapshots/static.spec.ts-snapshots/ag-grid--ag-grid-empty-state.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/ag-grid--ag-grid-empty-state.yaml
@@ -10,5 +10,5 @@
   - rowgroup
   - rowgroup
   - rowgroup
-  - heading "No data to display" [level=3]
+  - text: No data to display
   - paragraph: There are currently no rows to display in this table.

--- a/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-list-widget.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-dashboard--si-list-widget.yaml
@@ -191,7 +191,7 @@
 - text: Heading
 - menubar:
   - menuitem "Sort descending"
-- heading "No buildings found." [level=3]
+- text: No buildings found.
 - paragraph: Please refine your search.
 - link "Home":
   - /url: "#/"

--- a/playwright/snapshots/static.spec.ts-snapshots/si-empty-state--si-empty-state.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-empty-state--si-empty-state.yaml
@@ -1,4 +1,4 @@
-- heading "No users" [level=3]
+- text: No users
 - paragraph: There are no users within this group. Add users to get started.
 - paragraph:
   - button "Learn more"

--- a/playwright/snapshots/static.spec.ts-snapshots/si-wizard--si-wizard-dynamical.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-wizard--si-wizard-dynamical.yaml
@@ -9,5 +9,11 @@
   - /url: "#"
 - link "Step 6":
   - /url: "#"
-- heading "Occupied" [level=3]
+- link "Step 7":
+  - /url: "#"
+- link "Step 8":
+  - /url: "#"
+- link "Step 9":
+  - /url: "#"
+- text: Occupied
 - button "Next"

--- a/projects/element-ng/empty-state/si-empty-state.component.html
+++ b/projects/element-ng/empty-state/si-empty-state.component.html
@@ -1,6 +1,6 @@
 <div class="list-group-item-empty">
   <si-icon class="state-icon" [icon]="icon()" />
-  <h3 class="my-6 text-center">{{ heading() | translate }}</h3>
+  <span class="si-h3 my-6 text-center">{{ heading() | translate }}</span>
   @if (content()) {
     <p class="text-pre-wrap text-center mb-6">{{ content() | translate }}</p>
   }

--- a/projects/element-ng/empty-state/si-empty-state.component.spec.ts
+++ b/projects/element-ng/empty-state/si-empty-state.component.spec.ts
@@ -33,7 +33,7 @@ describe('SiEmptyStateComponent', () => {
   it('should display the correct data', async () => {
     await fixture.whenStable();
 
-    expect(element.querySelector('h3')!).toHaveTextContent('No Devices');
+    expect(element.querySelector('.si-h3')!).toHaveTextContent('No Devices');
     expect(element.querySelector('p')!).toHaveTextContent(
       'No devices were detected. Please retry!'
     );


### PR DESCRIPTION
## Description

The empty state heading (e.g. "No data to display") was rendered as an `<h3>`, which introduced a misleading heading into the document outline and broke the heading hierarchy for assistive technologies.

This renders the heading as a styled `<span>` using the `si-h3` typography class, preserving the visual appearance without the heading semantics.

Closes #2174

## Changes

- `si-empty-state.component.html`: `<h3>` → `<span class="si-h3 ...">`
- Updated unit test selector accordingly
- Updated affected Playwright snapshots<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2181/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2181/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2181/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2181/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2181/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2181/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2181/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2181/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2181/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2181/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
