### PR TITLE
fix(chat-messages): use base-input background in focus state

### DIFF
--- a/projects/element-ng/chat-messages/si-chat-input.component.scss
+++ b/projects/element-ng/chat-messages/si-chat-input.component.scss
@@ -15,7 +15,8 @@
   gap: map.get(variables.$spacers, 5);
 
   &:hover,
-  &:active {
+  &:active,
+  &:focus-within {
     background-color: variables.$element-base-input-experimental;
     border-color: variables.$element-ui-1;
   }
@@ -53,7 +54,6 @@
 
 .input-wrapper:has(.chat-textarea:focus-visible) {
   @include variables.make-outline-focus();
-  border-color: variables.$element-ui-1;
 }
 
 .disclaimer-wrapper:empty {


### PR DESCRIPTION
## Description

The chat input now uses the `base-input` background in the active/focus state, aligning it with the design and other similar inputs. Implemented via `:focus-within` alongside the existing `:hover`/`:active` states.

Closes #2176<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2184/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2184/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2184/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2184/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2184/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2184/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2184/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2184/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2184/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2184/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

