### PR TITLE
refactor(datepicker): explicitly define change detection strategy

### DIFF
--- a/projects/element-ng/datepicker/components/si-calendar-body.component.ts
+++ b/projects/element-ng/datepicker/components/si-calendar-body.component.ts
@@ -5,6 +5,7 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import {
   booleanAttribute,
+  ChangeDetectionStrategy,
   Component,
   computed,
   input,
@@ -141,6 +142,7 @@ class RangeSelectionStrategy extends SelectionStrategy {
   selector: '[si-calendar-body]',
   imports: [A11yModule, SiCalendarDateCellDirective],
   templateUrl: './si-calendar-body.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'si-calendar-body'
   },

--- a/projects/element-ng/datepicker/components/si-initial-focus.component.ts
+++ b/projects/element-ng/datepicker/components/si-initial-focus.component.ts
@@ -5,6 +5,7 @@
 import {
   AfterViewInit,
   booleanAttribute,
+  ChangeDetectionStrategy,
   Component,
   input,
   model,
@@ -19,7 +20,8 @@ import { Cell, SiCalendarBodyComponent } from './si-calendar-body.component';
  * Helper directive to set the initial focus to the calendar body cell.
  */
 @Component({
-  template: ''
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SiInitialFocusComponent implements AfterViewInit {
   /** The cell which has the mouse hover. */

--- a/projects/element-ng/datepicker/si-date-range.component.ts
+++ b/projects/element-ng/datepicker/si-date-range.component.ts
@@ -6,6 +6,7 @@ import { A11yModule } from '@angular/cdk/a11y';
 import {
   AfterViewInit,
   booleanAttribute,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ComponentRef,
@@ -76,6 +77,7 @@ import { DatepickerInputConfig, DateRange } from './si-datepicker.model';
       useExisting: SiDateRangeComponent
     }
   ],
+  changeDetection: ChangeDetectionStrategy.Default,
   host: {
     class: 'form-control d-flex align-items-center',
     role: 'group',

--- a/projects/element-ng/datepicker/si-datepicker.component.ts
+++ b/projects/element-ng/datepicker/si-datepicker.component.ts
@@ -6,6 +6,7 @@ import { getLocaleFirstDayOfWeek, WeekDay } from '@angular/common';
 import {
   AfterViewInit,
   booleanAttribute,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -69,7 +70,8 @@ export type RangeType = 'START' | 'END' | undefined;
     SiTranslatePipe
   ],
   templateUrl: './si-datepicker.component.html',
-  styleUrl: './si-datepicker.component.scss'
+  styleUrl: './si-datepicker.component.scss',
+  changeDetection: ChangeDetectionStrategy.Default
 })
 export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
   private readonly locale = inject(LOCALE_ID).toString();

--- a/projects/element-ng/datepicker/si-timepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -22,7 +22,8 @@ import { SiTimepickerComponent as TestComponent } from './index';
       [showMeridian]="showMeridian()"
       (inputCompleted)="onInputCompleted()"
     />
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class WrapperComponent {
   readonly picker = viewChild.required<TestComponent>(TestComponent);


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2199/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2199/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2199/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2199/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2199/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2199/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2199/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2199/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2199/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2199/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

