### PR TITLE
test(resize-observer): use vitest viewport instead of MockResizeObserver

### DIFF
--- a/projects/element-ng/resize-observer/resize-observer.service.spec.ts
+++ b/projects/element-ng/resize-observer/resize-observer.service.spec.ts
@@ -2,32 +2,21 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, ElementRef, signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subscription } from 'rxjs';
 import { Mock } from 'vitest';
+import { page } from 'vitest/browser';
 
 import { ElementDimensions, ResizeObserverService } from './resize-observer.service';
-import {
-  MockResizeObserver,
-  mockResizeObserver,
-  restoreResizeObserver
-} from './testing/resize-observer.mock';
 
 @Component({
-  template: `<div #theDiv [style.width.px]="width()" [style.height.px]="height()">Testli</div>`
+  template: `<div #theDiv class="w-100 vh-100">Testli</div>`,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class TestHostComponent {
   readonly theDiv = viewChild.required<ElementRef>('theDiv');
-  readonly width = signal(100);
-  readonly height = signal(100);
 }
-
-// A timeout that works with `await`. We have to use `waitForAsync()``
-// in the tests below because `tick()` doesn't work because `ResizeObserver`
-// operates outside of the zone
-const timeout = async (ms: number): Promise<void> =>
-  new Promise(resolve => setTimeout(resolve, ms));
 
 describe('ResizeObserverService', () => {
   let fixture: ComponentFixture<TestHostComponent>;
@@ -42,66 +31,59 @@ describe('ResizeObserverService', () => {
       .subscribe(dim => spy(dim));
   };
 
-  const detectSizeChange = (inlineSize: number = 100, blockSize: number = 100): void => {
-    component.width.set(inlineSize);
-    component.height.set(blockSize);
-    fixture.detectChanges();
-    MockResizeObserver.triggerResize({});
-    fixture.detectChanges();
-  };
-
-  beforeEach(() => {
-    mockResizeObserver();
+  beforeEach(async () => {
+    await page.viewport(100, 100);
     service = TestBed.inject(ResizeObserverService);
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
-
+    await fixture.whenStable();
     spy = vi.fn();
+
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
     subscription?.unsubscribe();
-    restoreResizeObserver();
+    vi.useRealTimers();
   });
 
   it('emits initial size event when asked', async () => {
     subscribe(true);
-    await timeout(10);
+    vi.advanceTimersByTime(10);
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ width: 100, height: 100 }));
   });
 
   it('emits no initial size event when not asked', async () => {
     subscribe(false);
-    await timeout(10);
+    vi.advanceTimersByTime(10);
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it.skipIf(!document.hasFocus())('emits on width change', async () => {
+  it('emits on width change', async () => {
     subscribe(false);
-    detectSizeChange(200, 100);
+    await page.viewport(200, 100);
 
     // with throttling, this shouldn't fire just yet
-    await timeout(20);
+    vi.advanceTimersByTime(20);
     expect(spy).not.toHaveBeenCalled();
 
-    await timeout(150);
+    vi.advanceTimersByTime(150);
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ width: 200, height: 100 }));
   });
 
-  it.skipIf(!document.hasFocus())('emits on height change', async () => {
+  it('emits on height change', async () => {
     subscribe(false);
-    detectSizeChange(100, 200);
+    await page.viewport(100, 200);
 
     // with throttling, this shouldn't fire just yet
-    await timeout(20);
+    vi.advanceTimersByTime(20);
     expect(spy).not.toHaveBeenCalled();
 
-    await timeout(150);
+    vi.advanceTimersByTime(150);
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ width: 100, height: 200 }));
   });
 
-  it.skipIf(!document.hasFocus())('can handle multiple subscriptions on same element', async () => {
+  it('can handle multiple subscriptions on same element', async () => {
     subscribe(true);
 
     const spy2: Mock<(dim: ElementDimensions) => void> = vi.fn();
@@ -109,13 +91,13 @@ describe('ResizeObserverService', () => {
       .observe(component.theDiv().nativeElement, 50, true)
       .subscribe(dim => spy2(dim));
 
-    await timeout(20);
+    vi.advanceTimersByTime(20);
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ width: 100, height: 100 }));
     expect(spy2).toHaveBeenCalledWith(expect.objectContaining({ width: 100, height: 100 }));
 
-    detectSizeChange(200, 100);
+    await page.viewport(200, 100);
 
-    await timeout(150);
+    vi.advanceTimersByTime(150);
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ width: 200, height: 100 }));
     expect(spy2).toHaveBeenCalledWith(expect.objectContaining({ width: 200, height: 100 }));
 

--- a/projects/element-ng/resize-observer/si-resize-observer.directive.spec.ts
+++ b/projects/element-ng/resize-observer/si-resize-observer.directive.spec.ts
@@ -5,23 +5,18 @@
 import { Component, ElementRef, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockInstance } from 'vitest';
+import { page } from 'vitest/browser';
 
 import { ElementDimensions } from './index';
 import { SiResizeObserverDirective } from './si-resize-observer.directive';
-import {
-  MockResizeObserver,
-  mockResizeObserver,
-  restoreResizeObserver
-} from './testing/resize-observer.mock';
 
 @Component({
   imports: [SiResizeObserverDirective],
   template: `
     <div
       #theDiv
-      [style.width.px]="width()"
-      [style.height.px]="height()"
-      [emitInitial]="emitInitial"
+      class="vh-100 w-100"
+      [emitInitial]="emitInitial()"
       (siResizeObserver)="resizeHandler($event)"
     >
       Testli
@@ -30,9 +25,7 @@ import {
 })
 class TestHostComponent {
   readonly theDiv = viewChild.required<ElementRef>('theDiv');
-  readonly width = signal(100);
-  readonly height = signal(100);
-  emitInitial = true;
+  readonly emitInitial = signal(true);
 
   resizeHandler(dim: ElementDimensions): void {}
 }
@@ -42,56 +35,38 @@ describe('SiResizeObserverDirective', () => {
   let component: TestHostComponent;
   let spy: MockInstance;
 
-  const detectSizeChange = (inlineSize: number = 100, blockSize: number = 100): void => {
-    component.width.set(inlineSize);
-    component.height.set(blockSize);
-    fixture.detectChanges();
-    MockResizeObserver.triggerResize({});
-    fixture.detectChanges();
-  };
-
-  beforeEach(() => {
-    vi.useFakeTimers();
-    mockResizeObserver();
+  beforeEach(async () => {
+    await page.viewport(100, 100);
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
     spy = vi.spyOn(component, 'resizeHandler');
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
     spy.mockClear();
-    restoreResizeObserver();
     vi.useRealTimers();
   });
 
   it('emits initial size event', async () => {
-    fixture.detectChanges();
-    vi.advanceTimersByTime(100);
     await fixture.whenStable();
+    vi.advanceTimersByTime(100);
     expect(component.resizeHandler).toHaveBeenCalledWith({ width: 100, height: 100 });
   });
 
   it('emits on width change', async () => {
-    detectSizeChange(200, 100);
-
+    await page.viewport(200, 100);
     expect(component.resizeHandler).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(100);
-    fixture.detectChanges();
-    await fixture.whenStable();
-
     expect(component.resizeHandler).toHaveBeenCalledWith({ width: 200, height: 100 });
   });
 
   it('emits on height change', async () => {
-    detectSizeChange(100, 200);
-
+    await page.viewport(100, 200);
     expect(component.resizeHandler).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(100);
-    fixture.detectChanges();
-    await fixture.whenStable();
-
     expect(component.resizeHandler).toHaveBeenCalledWith({ width: 100, height: 200 });
   });
 });
@@ -104,7 +79,7 @@ describe('SiResizeObserverDirective with emitInitial=false', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
-    component.emitInitial = false;
+    component.emitInitial.set(false);
     spy = vi.spyOn(component, 'resizeHandler');
     fixture.detectChanges();
   });

--- a/projects/element-ng/resize-observer/si-responsive-container.directive.spec.ts
+++ b/projects/element-ng/resize-observer/si-responsive-container.directive.spec.ts
@@ -2,28 +2,25 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { page } from 'vitest/browser';
 
 import { SiResponsiveContainerDirective } from './index';
-import {
-  MockResizeObserver,
-  mockResizeObserver,
-  restoreResizeObserver
-} from './testing/resize-observer.mock';
 
 @Component({
   imports: [SiResponsiveContainerDirective],
   template: `
     <div
       siResponsiveContainer
-      style="width: 100px"
+      class="vh-100 w-100"
       [resizeThrottle]="10"
       [style.width.px]="width()"
     >
       Testli
     </div>
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class TestHostComponent {
   readonly width = signal(100);
@@ -31,37 +28,32 @@ class TestHostComponent {
 
 describe('SiResponsiveContainerDirective', () => {
   let fixture: ComponentFixture<TestHostComponent>;
-  let component: TestHostComponent;
   let element: HTMLElement;
 
-  beforeEach(() => {
-    mockResizeObserver();
+  beforeEach(async () => {
+    await page.viewport(100, 100);
     fixture = TestBed.createComponent(TestHostComponent);
-    component = fixture.componentInstance;
     element = fixture.nativeElement;
   });
 
-  afterEach(() => restoreResizeObserver());
-
-  const testSize = async (size: number, clazz: string): Promise<void> => {
+  const testSize = async (size: string | number, clazz: string | number): Promise<void> => {
     vi.useFakeTimers();
-    component.width.set(size);
-    fixture.detectChanges();
-    MockResizeObserver.triggerResize({});
+    await page.viewport(parseInt(size as string, 10), 100);
 
     vi.advanceTimersByTime(100);
-    fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(element.querySelector<HTMLElement>('div')!).toHaveClass(clazz);
+    expect(element.querySelector<HTMLElement>('div')!).toHaveClass(clazz.toString());
     vi.useRealTimers();
   };
 
-  it('sets correct si-container-* class', async () => {
-    await testSize(100, 'si-container-xs');
-    await testSize(580, 'si-container-sm');
-    await testSize(780, 'si-container-md');
-    await testSize(1000, 'si-container-lg');
-    await testSize(1200, 'si-container-xl');
+  it.for([
+    [100, 'si-container-xs'],
+    [580, 'si-container-sm'],
+    [780, 'si-container-md'],
+    [1000, 'si-container-lg'],
+    [1200, 'si-container-xl']
+  ])('width %i sets %s class', async ([size, expected]) => {
+    await testSize(size, expected);
   });
 });


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2206/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2206/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2206/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2206/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2206/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2206/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2206/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2206/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2206/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2206/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

