### PR TITLE
refactor: explicitly define change detection strategy for various com…

### DIFF
--- a/projects/element-ng/result-details-list/si-result-details-list.component.ts
+++ b/projects/element-ng/result-details-list/si-result-details-list.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import {
   elementCircleFilled,
   elementNotChecked,
@@ -20,7 +20,8 @@ import { ResultDetailStep } from './si-result-details-list.datamodel';
   selector: 'si-result-details-list',
   imports: [SiLoadingSpinnerComponent, SiIconComponent, SiTranslatePipe],
   templateUrl: './si-result-details-list.component.html',
-  styleUrl: './si-result-details-list.component.scss'
+  styleUrl: './si-result-details-list.component.scss',
+  changeDetection: ChangeDetectionStrategy.Default
 })
 export class SiResultDetailsListComponent {
   /**

--- a/projects/element-ng/search-bar/si-search-bar.component.spec.ts
+++ b/projects/element-ng/search-bar/si-search-bar.component.spec.ts
@@ -2,7 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, inputBinding, outputBinding, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inputBinding,
+  outputBinding,
+  signal,
+  viewChild
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { userEvent } from 'vitest/browser';
@@ -26,7 +33,8 @@ describe('SiSearchBarComponent', () => {
         [formControl]="search"
         [debounceTime]="debounceTime()"
         [prohibitedCharacters]="prohibitedCharacters()"
-      />`
+      />`,
+      changeDetection: ChangeDetectionStrategy.OnPush
     })
     class TestComponent {
       readonly placeholder = signal('Placeholder');

--- a/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
+++ b/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Observable, of } from 'rxjs';
@@ -24,7 +24,8 @@ describe('SelectLazyOptionsDirective', () => {
       ReactiveFormsModule,
       SiSelectMultiValueDirective
     ],
-    template: ` <si-select multi hasFilter [optionSource]="optionSource" [formControl]="control" />`
+    template: `<si-select multi hasFilter [optionSource]="optionSource" [formControl]="control" />`,
+    changeDetection: ChangeDetectionStrategy.OnPush
   })
   class TestHostComponent {
     readonly optionSource: SelectOptionSource<string> = {

--- a/projects/element-ng/select/si-custom-select.directive.spec.ts
+++ b/projects/element-ng/select/si-custom-select.directive.spec.ts
@@ -54,7 +54,8 @@ class SiTestSelectComponent {
 
 @Component({
   imports: [SiTestSelectComponent, ReactiveFormsModule],
-  template: `<si-test-select [formControl]="control" />`
+  template: `<si-test-select [formControl]="control" />`,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class FormHostComponent {
   readonly control = new FormControl<string | undefined>(undefined);

--- a/projects/element-ng/select/si-select.component.spec.ts
+++ b/projects/element-ng/select/si-select.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader, TestKey } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -31,7 +31,8 @@ const OPTIONS_LIST_NEXT: SelectOption<number>[] = [
     <form [formGroup]="form">
       <si-select #select formControlName="input" [options]="options" />
     </form>
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class FormHostComponent {
   readonly form = new FormGroup({
@@ -53,7 +54,8 @@ class FormHostComponent {
       [hasFilter]="hasFilter()"
       [(value)]="value"
     />
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class TestHostComponent {
   readonly selectComponent = viewChild.required(SiSelectComponent);
@@ -77,7 +79,8 @@ class TestHostComponent {
       [hasFilter]="hasFilter()"
       [(value)]="value"
     />
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class TestHostNumberComponent {
   readonly selectComponent = viewChild.required(SiSelectComponent);
@@ -105,7 +108,8 @@ class TestHostNumberComponent {
       [(value)]="values"
       (valueChange)="selectionChanged($event)"
     />
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class TestHostMultiComponent {
   readonly selectComponent = viewChild.required(SiSelectComponent);
@@ -143,7 +147,8 @@ class TestHostMultiComponent {
         </button>
       </ng-template>
     </si-select>
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class TestHostCustomActionComponent {
   readonly options = signal<SelectOption<string>[] | undefined>(OPTIONS_LIST);

--- a/projects/element-ng/shadow-root/si-shadow-root.directive.spec.ts
+++ b/projects/element-ng/shadow-root/si-shadow-root.directive.spec.ts
@@ -3,7 +3,13 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
-import { Component, input, signal, ViewEncapsulation } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+  ViewEncapsulation
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiShadowRootDirective } from './si-shadow-root.directive';
@@ -25,6 +31,7 @@ describe('ShadowRootDirective', () => {
         color: #fff;
       }
     `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.ShadowDom,
     hostDirectives: [SiShadowRootDirective]
   })
@@ -42,7 +49,8 @@ describe('ShadowRootDirective', () => {
       .test-style {
         color: #000 !important;
       }
-    `
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush
   })
   class TestHostComponent {
     readonly open = signal(false);

--- a/projects/element-ng/side-panel/si-side-panel-content.component.ts
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.ts
@@ -5,6 +5,7 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
 import {
   booleanAttribute,
+  ChangeDetectionStrategy,
   Component,
   computed,
   DestroyRef,
@@ -84,6 +85,7 @@ export interface StatusItem extends MenuItemLegacy {
   templateUrl: './si-side-panel-content.component.html',
   styleUrl: './si-side-panel-content.component.scss',
   providers: [SiAccordionHCollapseService],
+  changeDetection: ChangeDetectionStrategy.Default,
   host: {
     '[class.collapsed]': 'isCollapsed()',
     '[class.expanded]': 'isExpanded()',

--- a/projects/element-ng/side-panel/si-side-panel-service.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel-service.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkPortal, PortalModule } from '@angular/cdk/portal';
-import { Component, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiSidePanelService } from './si-side-panel.service';
@@ -14,7 +14,8 @@ import { SiSidePanelService } from './si-side-panel.service';
   template: `<ng-template #helpPanel cdkPortal>
       <h3>Help Panel</h3>
     </ng-template>
-    <div>Test Mock Component</div>`
+    <div>Test Mock Component</div>`,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class MockComponent {
   readonly helpPanel = viewChild.required<CdkPortal, CdkPortal>('helpPanel', { read: CdkPortal });

--- a/projects/element-ng/side-panel/si-side-panel.component.ts
+++ b/projects/element-ng/side-panel/si-side-panel.component.ts
@@ -6,6 +6,7 @@ import { CdkPortalOutlet, Portal, PortalModule } from '@angular/cdk/portal';
 import { isPlatformBrowser } from '@angular/common';
 import {
   booleanAttribute,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -44,6 +45,7 @@ import { SidePanelMode, SidePanelSize } from './side-panel.model';
   imports: [PortalModule],
   templateUrl: './si-side-panel.component.html',
   styleUrl: './si-side-panel.component.scss',
+  changeDetection: ChangeDetectionStrategy.Default,
   host: {
     class: 'si-layout-inner',
     '[class.enable-mobile]': 'enableMobile()',

--- a/projects/element-ng/skip-links/si-skip-links.spec.ts
+++ b/projects/element-ng/skip-links/si-skip-links.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiSkipLinkTargetDirective } from './si-skip-link-target.directive';
@@ -12,7 +12,8 @@ import { SiSkipLinkTargetDirective } from './si-skip-link-target.directive';
   template: `
     <button siSkipLinkTarget="T1" type="button">Target 1</button>
     <button siSkipLinkTarget="T2" type="button">Target 2</button>
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class TestHostComponent {}
 

--- a/projects/element-ng/slider/si-slider.component.spec.ts
+++ b/projects/element-ng/slider/si-slider.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
@@ -22,7 +22,8 @@ import { SiSliderComponent } from './si-slider.component';
       display: block;
       width: 300px;
     }
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class HostComponent {
   readonly value = signal<number | undefined>(10);
@@ -36,7 +37,8 @@ class HostComponent {
   imports: [FormsModule, ReactiveFormsModule, SiSliderComponent],
   template: `<form [formGroup]="form">
     <si-slider formControlName="slider" />
-  </form>`
+  </form>`,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class FormHostComponent {
   readonly form: FormGroup;

--- a/projects/element-ng/sort-bar/si-sort-bar.component.ts
+++ b/projects/element-ng/sort-bar/si-sort-bar.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { HttpParams } from '@angular/common/http';
-import { Component, input, OnInit, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, OnInit, output } from '@angular/core';
 import { elementSortDown, elementSortUp } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -22,7 +22,8 @@ export interface SortCriteria {
   selector: 'si-sort-bar',
   imports: [SiIconComponent, SiTranslatePipe],
   templateUrl: './si-sort-bar.component.html',
-  styleUrl: './si-sort-bar.component.scss'
+  styleUrl: './si-sort-bar.component.scss',
+  changeDetection: ChangeDetectionStrategy.Default
 })
 export class SiSortBarComponent implements OnInit {
   /**

--- a/projects/element-ng/split/si-split-part.component.ts
+++ b/projects/element-ng/split/si-split-part.component.ts
@@ -6,6 +6,7 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
+  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -29,6 +30,7 @@ import { Action, CollapseTo, PartState, Scale, SplitOrientation } from './si-spl
   imports: [NgTemplateOutlet, SiIconComponent, SiTranslatePipe],
   templateUrl: './si-split-part.component.html',
   styleUrl: './si-split-part.component.scss',
+  changeDetection: ChangeDetectionStrategy.Default,
   // Signals cannot be used directly with @HostBinding. See: https://github.com/angular/angular/issues/53888#issuecomment-1888935225
   // Having every binding here for consistency.
   host: {

--- a/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.ts
+++ b/projects/element-ng/status-bar/si-status-bar-item/si-status-bar-item.component.ts
@@ -4,6 +4,7 @@
  */
 import {
   booleanAttribute,
+  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -23,6 +24,7 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
   imports: [SiIconComponent, SiTranslatePipe],
   templateUrl: './si-status-bar-item.component.html',
   styleUrl: './si-status-bar-item.component.scss',
+  changeDetection: ChangeDetectionStrategy.Default,
   host: {
     '[class.clickable]': 'clickable()'
   }

--- a/projects/element-ng/status-toggle/si-status-toggle.component.spec.ts
+++ b/projects/element-ng/status-toggle/si-status-toggle.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -11,7 +11,8 @@ import { StatusToggleItem } from './status-toggle.model';
 
 @Component({
   imports: [SiStatusToggleComponent],
-  template: `<si-status-toggle #toggle [items]="items" [disabled]="disabled" [(value)]="value" />`
+  template: `<si-status-toggle #toggle [items]="items" [disabled]="disabled" [(value)]="value" />`,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class HostComponent {
   disabled = false;
@@ -26,7 +27,8 @@ class HostComponent {
 
 @Component({
   imports: [SiStatusToggleComponent, ReactiveFormsModule],
-  template: `<si-status-toggle #toggle [items]="items" [formControl]="formControl" />`
+  template: `<si-status-toggle #toggle [items]="items" [formControl]="formControl" />`,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class FormHostComponent {
   readonly formControl = new FormControl('A');

--- a/projects/element-ng/tabs-legacy/si-tabset/si-tabset-legacy.component.spec.ts
+++ b/projects/element-ng/tabs-legacy/si-tabset/si-tabset-legacy.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -28,7 +28,8 @@ import { SiTabsetLegacyComponent } from './si-tabset-legacy.component';
     .tab-wrapper {
       width: 200px;
     }
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class TestComponent {
   readonly tabButtonMaxWidth = signal<number | undefined>(undefined);

--- a/projects/element-ng/tabs/si-tabset.component.spec.ts
+++ b/projects/element-ng/tabs/si-tabset.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader, TestKey } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, RouterLink, RouterOutlet } from '@angular/router';
 
@@ -30,7 +30,8 @@ interface TabData {
 
 @Component({
   selector: 'si-tab-route',
-  template: `Content by routing`
+  template: `Content by routing`,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class SiTabRouteComponent {}
 
@@ -54,7 +55,8 @@ class SiTabRouteComponent {}
         </si-tabset>
       }
     </div>
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.Default
 })
 class TestComponent {
   readonly tabButtonMaxWidth = signal<number | undefined>(undefined);
@@ -101,7 +103,8 @@ class TestComponent {
         </si-tabset>
       }
     </div>
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class TestRoutingComponent {
   readonly tabButtonMaxWidth = signal<number | undefined>(undefined);
@@ -453,7 +456,8 @@ describe('SiTabset with portal content', () => {
 
         <si-tab-portal [tabset]="tabset" />
       </div>
-    `
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush
   })
   class TestPortalContentComponent {
     protected readonly tabsObject = signal<

--- a/projects/element-ng/threshold/si-readonly-threshold-option.component.ts
+++ b/projects/element-ng/threshold/si-readonly-threshold-option.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SelectOption } from '@siemens/element-ng/select';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
@@ -21,6 +21,7 @@ import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
     }
     <span class="text-truncate">{{ label() | translate }}</span>`,
   styleUrl: './si-readonly-threshold-option.component.scss',
+  changeDetection: ChangeDetectionStrategy.Default,
   host: { class: 'd-flex align-items-center py-2 my-4 px-4 si-h5' }
 })
 export class SiReadonlyThresholdOptionComponent {

--- a/projects/element-ng/threshold/si-threshold.component.ts
+++ b/projects/element-ng/threshold/si-threshold.component.ts
@@ -5,6 +5,7 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
+  ChangeDetectionStrategy,
   Component,
   computed,
   input,
@@ -56,6 +57,7 @@ export interface ThresholdStep {
   ],
   templateUrl: './si-threshold.component.html',
   styleUrl: './si-threshold.component.scss',
+  changeDetection: ChangeDetectionStrategy.Default,
   host: {
     '[class.add-remove]': 'canAddRemoveSteps()',
     '[class.horizontal]': 'horizontalLayout()',

--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.ts
@@ -2,7 +2,16 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, computed, HostListener, inject, input, output, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  HostListener,
+  inject,
+  input,
+  output,
+  signal
+} from '@angular/core';
 import { elementCancel } from '@siemens/element-icons';
 import {
   addIcons,
@@ -19,7 +28,8 @@ import { SI_TOAST_AUTO_HIDE_DELAY, SiToast } from '../si-toast.model';
   selector: 'si-toast-notification',
   imports: [SiLinkModule, SiIconComponent, SiStatusIconComponent, SiTranslatePipe],
   templateUrl: './si-toast-notification.component.html',
-  styleUrl: './si-toast-notification.component.scss'
+  styleUrl: './si-toast-notification.component.scss',
+  changeDetection: ChangeDetectionStrategy.Default
 })
 export class SiToastNotificationComponent {
   private readonly statusIcons = inject(STATUS_ICON_CONFIG);

--- a/projects/element-ng/tooltip/si-tooltip.component.ts
+++ b/projects/element-ng/tooltip/si-tooltip.component.ts
@@ -4,7 +4,15 @@
  */
 import { ConnectedOverlayPositionChange } from '@angular/cdk/overlay';
 import { NgComponentOutlet, NgTemplateOutlet } from '@angular/common';
-import { Component, computed, ElementRef, inject, signal, TemplateRef } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ElementRef,
+  inject,
+  signal,
+  TemplateRef
+} from '@angular/core';
 import { calculateOverlayArrowPosition, OverlayArrowPosition } from '@siemens/element-ng/common';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
@@ -15,6 +23,7 @@ import { SI_TOOLTIP_CONFIG } from './si-tooltip.model';
   imports: [NgTemplateOutlet, SiTranslatePipe, NgComponentOutlet],
   templateUrl: './si-tooltip.component.html',
   styleUrl: './si-tooltip.component.scss',
+  changeDetection: ChangeDetectionStrategy.Default,
   host: {
     'animate.leave': 'tooltip-leave'
   }

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -19,7 +19,8 @@ describe('SiTooltipDirective', () => {
       imports: [SiTooltipModule],
       template: `<button type="button" [siTooltip]="tooltipText()" [isDisabled]="isDisabled()">
         Test
-      </button>`
+      </button>`,
+      changeDetection: ChangeDetectionStrategy.OnPush
     })
     class TestHostComponent {
       readonly isDisabled = signal(false);
@@ -134,7 +135,8 @@ describe('SiTooltipDirective', () => {
       template: `<button type="button" [siTooltip]="template" [tooltipContext]="tooltipContext()">
           Test
         </button>
-        <ng-template #template let-tooltip="tooltip">Template content {{ tooltip }}</ng-template>`
+        <ng-template #template let-tooltip="tooltip">Template content {{ tooltip }}</ng-template>`,
+      changeDetection: ChangeDetectionStrategy.OnPush
     })
     class TestHostComponent {
       readonly tooltipContext = signal<Record<string, unknown>>({});

--- a/projects/element-ng/tour/si-tour.service.spec.ts
+++ b/projects/element-ng/tour/si-tour.service.spec.ts
@@ -2,13 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiTourService } from './si-tour.service';
 
 @Component({
-  template: `<div class="h-10">Test</div>`
+  template: `<div class="h-10">Test</div>`,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 class TestHostComponent {
   readonly tourService = inject(SiTourService);

--- a/projects/element-ng/wizard/si-wizard.component.spec.ts
+++ b/projects/element-ng/wizard/si-wizard.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SiResizeObserverModule } from '@siemens/element-ng/resize-observer';
@@ -32,7 +32,8 @@ import { SiWizardStepComponent, SiWizardComponent as TestComponent } from './ind
       display: block;
       width: 1200px;
     }
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.Default
 })
 class TestHostComponent {
   readonly steps = signal<string[]>([]);


### PR DESCRIPTION
…ponents

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2207/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2207/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2207/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2207/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2207/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2207/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2207/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2207/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2207/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2207/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
