### PR TITLE
test(dashboards-ng): resolve flaky gridstack test

### DIFF
--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
@@ -30,7 +30,9 @@ describe('SiGridstackWrapperComponent', () => {
   let widgetCatalogMap: WritableSignal<Map<string, Widget>>;
 
   beforeEach(async () => {
-    page.viewport(600, 600);
+    // Use a viewport comfortably above the responsive 1-column breakpoint (576px)
+    // so gridstack does not intermittently collapse the layout to a single column.
+    page.viewport(1024, 768);
     await TestBed.configureTestingModule({
       imports: [TestingModule],
       providers: [SiActionDialogService]


### PR DESCRIPTION
Currently, the test
 `SiGridstackWrapperComponent > #getWidgetLayout() > should return layout for a given widget id` is very flaky.
This is potentially caused by having the viewport close to the breakpoint. Having a larger size should resolve that problem.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2208/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2208/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2208/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2208/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2208/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2208/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2208/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2208/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2208/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2208/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
