### PR TITLE
refactor: drop usages of TranslateModule

### DIFF
--- a/projects/dashboards-ng/README.md
+++ b/projects/dashboards-ng/README.md
@@ -150,7 +150,7 @@ export function createTranslateLoader(_httpBackend: HttpBackend) {
 
 ...
 
-TranslateModule.forRoot({
+provideTranslateService({
   loader: {
     provide: TranslateLoader,
     useFactory: (createTranslateLoader),

--- a/projects/element-ng/select/selection/si-select-multi-value.directive.spec.ts
+++ b/projects/element-ng/select/selection/si-select-multi-value.directive.spec.ts
@@ -6,7 +6,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { provideTranslateService } from '@ngx-translate/core';
 import { SelectItem, SiSelectModule } from '@siemens/element-ng/select';
 
 import { SiSelectHarness } from '../testing/si-select.harness';
@@ -48,13 +48,10 @@ describe('SiSelectMultiValueDirective', () => {
   let component: TestComponent;
   let selectHarness: SiSelectHarness;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [SiSelectModule, ReactiveFormsModule, TranslateModule.forRoot(), TestComponent]
-    }).compileComponents();
-  });
-
   beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideTranslateService()]
+    }).compileComponents();
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentInstance;
     selectHarness = await TestbedHarnessEnvironment.loader(fixture).getHarness(SiSelectHarness);

--- a/projects/element-translate-ng/ngx-translate/si-translate-ngxt.spec.ts
+++ b/projects/element-translate-ng/ngx-translate/si-translate-ngxt.spec.ts
@@ -4,14 +4,13 @@
  */
 import { Component, DOCUMENT, Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterModule, RouterOutlet } from '@angular/router';
+import { provideRouter, RouterOutlet } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
 import {
   MissingTranslationHandler,
   MissingTranslationHandlerParams,
   provideTranslateService,
   TranslateLoader,
-  TranslateModule,
   TranslateService,
   Translation
 } from '@ngx-translate/core';
@@ -60,9 +59,9 @@ describe('SiTranslateNgxT', () => {
   describe('with multiple translation services', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [
-          SiTranslateNgxTModule,
-          TranslateModule.forRoot({
+        imports: [SiTranslateNgxTModule, HostComponent],
+        providers: [
+          provideTranslateService({
             defaultLanguage: 'test',
             useDefaultLang: true,
             missingTranslationHandler: provideMissingTranslationHandlerForElement(),
@@ -78,16 +77,15 @@ describe('SiTranslateNgxT', () => {
               } as TranslateLoader
             }
           }),
-          RouterModule.forRoot([
+          provideRouter([
             {
               path: '',
               loadChildren: () =>
                 import('./si-translate-ngxt.test-module.mock').then(m => m.TestModule)
             }
           ]),
-          HostComponent
-        ],
-        providers: [RootTestService]
+          RootTestService
+        ]
       });
     });
 
@@ -110,9 +108,9 @@ describe('SiTranslateNgxT', () => {
     beforeEach(() => {
       translateLoader$ = new Subject();
       TestBed.configureTestingModule({
-        imports: [
-          SiTranslateNgxTModule,
-          TranslateModule.forRoot({
+        imports: [SiTranslateNgxTModule],
+        providers: [
+          provideTranslateService({
             defaultLanguage: 'test',
             useDefaultLang: true,
             missingTranslationHandler: provideMissingTranslationHandlerForElement(),
@@ -250,9 +248,9 @@ describe('SiTranslateNgxT', () => {
   describe('without missing translation service', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [
-          SiTranslateNgxTModule,
-          TranslateModule.forRoot({
+        imports: [SiTranslateNgxTModule],
+        providers: [
+          provideTranslateService({
             defaultLanguage: 'test',
             useDefaultLang: true,
             loader: {

--- a/projects/element-translate-ng/ngx-translate/si-translate-ngxt.test-module.mock.ts
+++ b/projects/element-translate-ng/ngx-translate/si-translate-ngxt.test-module.mock.ts
@@ -4,11 +4,12 @@
  */
 import { ChangeDetectionStrategy, Component, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+// eslint-disable-next-line no-restricted-imports
+import { TranslateLoader, TranslateModule, TranslatePipe } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
 @Component({
-  imports: [TranslateModule],
+  imports: [TranslatePipe],
   template: `{{ 'KEY-1' | translate }}`,
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/src/app/examples/datatable/datatable-row-dragging.ts
+++ b/src/app/examples/datatable/datatable-row-dragging.ts
@@ -5,7 +5,8 @@
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { DatePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
+// eslint-disable-next-line no-restricted-imports
+import { TranslatePipe } from '@ngx-translate/core';
 import { elementMenu } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { DatatableRowDefDirective, NgxDatatableModule } from '@siemens/ngx-datatable';
@@ -16,7 +17,7 @@ import { DatatableRowDefDirective, NgxDatatableModule } from '@siemens/ngx-datat
     NgxDatatableModule,
     DatatableRowDefDirective,
     DragDropModule,
-    TranslateModule,
+    TranslatePipe,
     DatePipe,
     SiIconComponent
   ],

--- a/src/app/examples/si-form/si-form.ts
+++ b/src/app/examples/si-form/si-form.ts
@@ -13,7 +13,8 @@ import {
   ValidatorFn,
   Validators
 } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+// eslint-disable-next-line no-restricted-imports
+import { TranslatePipe } from '@ngx-translate/core';
 import { SiCardComponent } from '@siemens/element-ng/card';
 import {
   DateRange,
@@ -96,7 +97,7 @@ export const noEconomy: ValidatorFn = control => {
     SiPhoneNumberInputComponent,
     SiSelectModule,
     SiTimepickerComponent,
-    TranslateModule
+    TranslatePipe
   ],
   templateUrl: './si-form.html',
   providers: [JsonPipe],

--- a/src/app/examples/si-landing-page/si-landing-page-basic-login.ts
+++ b/src/app/examples/si-landing-page/si-landing-page-basic-login.ts
@@ -11,7 +11,6 @@ import {
   OnDestroy
 } from '@angular/core';
 import { ActivatedRoute, Route, Router, RouterOutlet } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
 import { CopyrightDetails } from '@siemens/element-ng/copyright-notice';
 import {
   AlertConfig,
@@ -25,7 +24,7 @@ const loginAlert = signal<AlertConfig | undefined>(undefined);
 
 @Component({
   selector: 'app-login-basic-wrapper',
-  imports: [TranslateModule, SiLoginBasicComponent],
+  imports: [SiLoginBasicComponent],
   template: `
     <si-login-basic
       usernameLabel="FORM.USERNAME"
@@ -84,7 +83,7 @@ export const ROUTES: Route[] = [
 
 @Component({
   selector: 'app-sample',
-  imports: [SiLandingPageComponent, TranslateModule, RouterOutlet],
+  imports: [SiLandingPageComponent, RouterOutlet],
   templateUrl: './si-landing-page-basic-login.html',
   providers: [provideExampleRoutes(ROUTES)],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/examples/si-landing-page/si-landing-page-change-password.ts
+++ b/src/app/examples/si-landing-page/si-landing-page-change-password.ts
@@ -11,7 +11,6 @@ import {
   OnDestroy
 } from '@angular/core';
 import { ActivatedRoute, Route, Router, RouterOutlet } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
 import { CopyrightDetails } from '@siemens/element-ng/copyright-notice';
 import {
   AlertConfig,
@@ -28,7 +27,7 @@ const loginAlert = signal<AlertConfig | undefined>(undefined);
 
 @Component({
   selector: 'app-login-basic-wrapper',
-  imports: [SiLoginBasicComponent, TranslateModule],
+  imports: [SiLoginBasicComponent],
   template: `
     <si-login-basic
       usernameLabel="FORM.USERNAME"
@@ -76,7 +75,7 @@ export class AppLoginBasicComponent {
 
 @Component({
   selector: 'app-change-password-wrapper',
-  imports: [SiChangePasswordComponent, TranslateModule],
+  imports: [SiChangePasswordComponent],
   template: `
     <si-change-password
       [passwordPolicyContent]="passwordPolicyContent"
@@ -164,7 +163,7 @@ export const ROUTES: Route[] = [
 
 @Component({
   selector: 'app-sample',
-  imports: [SiLandingPageComponent, TranslateModule, RouterOutlet],
+  imports: [SiLandingPageComponent, RouterOutlet],
   templateUrl: './si-landing-page-change-password.html',
   providers: [provideExampleRoutes(ROUTES)],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/examples/si-landing-page/si-landing-page-custom.ts
+++ b/src/app/examples/si-landing-page/si-landing-page-custom.ts
@@ -4,7 +4,6 @@
  */
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
 import { CopyrightDetails } from '@siemens/element-ng/copyright-notice';
 import { AlertConfig, SiLandingPageComponent } from '@siemens/element-ng/landing-page';
 import { SiPasswordToggleModule } from '@siemens/element-ng/password-toggle';
@@ -12,13 +11,7 @@ import { SiSystemBannerComponent } from '@siemens/element-ng/system-banner';
 
 @Component({
   selector: 'app-sample',
-  imports: [
-    SiLandingPageComponent,
-    SiPasswordToggleModule,
-    TranslateModule,
-    RouterLink,
-    SiSystemBannerComponent
-  ],
+  imports: [SiLandingPageComponent, SiPasswordToggleModule, RouterLink, SiSystemBannerComponent],
   templateUrl: './si-landing-page-custom.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/src/app/examples/si-landing-page/si-landing-page-eula.ts
+++ b/src/app/examples/si-landing-page/si-landing-page-eula.ts
@@ -11,7 +11,6 @@ import {
   OnDestroy
 } from '@angular/core';
 import { ActivatedRoute, Route, Router, RouterOutlet } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
 import { CopyrightDetails } from '@siemens/element-ng/copyright-notice';
 import {
   AlertConfig,
@@ -26,7 +25,7 @@ const loginAlert = signal<AlertConfig | undefined>(undefined);
 
 @Component({
   selector: 'app-login-basic-wrapper',
-  imports: [SiLoginBasicComponent, TranslateModule],
+  imports: [SiLoginBasicComponent],
   template: `
     <si-login-basic
       usernameLabel="FORM.USERNAME"
@@ -186,7 +185,7 @@ export const ROUTES: Route[] = [
 
 @Component({
   selector: 'app-sample',
-  imports: [SiLandingPageComponent, RouterOutlet, TranslateModule],
+  imports: [SiLandingPageComponent, RouterOutlet],
   templateUrl: './si-landing-page-eula.html',
   providers: [provideExampleRoutes(ROUTES)],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/examples/si-landing-page/si-landing-page-single-sign-on-login.ts
+++ b/src/app/examples/si-landing-page/si-landing-page-single-sign-on-login.ts
@@ -10,7 +10,7 @@ import {
   signal,
   viewChild
 } from '@angular/core';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslateService } from '@ngx-translate/core';
 import { CopyrightDetails } from '@siemens/element-ng/copyright-notice';
 import {
   AlertConfig,
@@ -20,7 +20,7 @@ import {
 
 @Component({
   selector: 'app-sample',
-  imports: [SiLandingPageComponent, TranslateModule, SiLoginSingleSignOnComponent],
+  imports: [SiLandingPageComponent, SiLoginSingleSignOnComponent],
   templateUrl: './si-landing-page-single-sign-on-login.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/src/app/examples/si-landing-page/si-landing-page-two-step-login.ts
+++ b/src/app/examples/si-landing-page/si-landing-page-two-step-login.ts
@@ -11,7 +11,6 @@ import {
   OnDestroy
 } from '@angular/core';
 import { ActivatedRoute, Route, Router, RouterOutlet } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
 import { CopyrightDetails } from '@siemens/element-ng/copyright-notice';
 import {
   AlertConfig,
@@ -26,7 +25,7 @@ const loginAlert = signal<AlertConfig | undefined>(undefined);
 
 @Component({
   selector: 'app-two-step-login-wrapper',
-  imports: [SiLoginBasicComponent, TranslateModule],
+  imports: [SiLoginBasicComponent],
   template: `
     <si-login-basic
       usernameLabel="FORM.USERNAME"
@@ -108,7 +107,7 @@ export const ROUTES: Route[] = [
 
 @Component({
   selector: 'app-sample',
-  imports: [SiLandingPageComponent, TranslateModule, RouterOutlet],
+  imports: [SiLandingPageComponent, RouterOutlet],
   templateUrl: './si-landing-page-two-step-login.html',
   providers: [provideExampleRoutes(ROUTES)],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/examples/si-localization/si-localization.ts
+++ b/src/app/examples/si-localization/si-localization.ts
@@ -5,7 +5,8 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+// eslint-disable-next-line no-restricted-imports
+import { TranslatePipe } from '@ngx-translate/core';
 import { SiDatepickerDirective } from '@siemens/element-ng/datepicker';
 import { SiFormModule } from '@siemens/element-ng/form';
 import { SiLanguageSwitcherComponent } from '@siemens/element-ng/language-switcher';
@@ -18,10 +19,10 @@ export const DATE_PATTERN_ENABLE = 'date-pattern.enable';
   imports: [
     CommonModule,
     SiLanguageSwitcherComponent,
-    TranslateModule,
     SiDatepickerDirective,
     SiFormModule,
-    FormsModule
+    FormsModule,
+    TranslatePipe
   ],
   templateUrl: './si-localization.html',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/examples/si-phone-number-input/si-phone-number-input.ts
+++ b/src/app/examples/si-phone-number-input/si-phone-number-input.ts
@@ -5,12 +5,13 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+// eslint-disable-next-line no-restricted-imports
+import { TranslatePipe } from '@ngx-translate/core';
 import { PhoneDetails, SiPhoneNumberInputComponent } from '@siemens/element-ng/phone-number';
 
 @Component({
   selector: 'app-sample',
-  imports: [CommonModule, SiPhoneNumberInputComponent, ReactiveFormsModule, TranslateModule],
+  imports: [CommonModule, SiPhoneNumberInputComponent, ReactiveFormsModule, TranslatePipe],
   templateUrl: './si-phone-number-input.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/src/app/examples/si-select/si-select.ts
+++ b/src/app/examples/si-select/si-select.ts
@@ -5,7 +5,8 @@
 import { PercentPipe, TitleCasePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+// eslint-disable-next-line no-restricted-imports
+import { TranslatePipe } from '@ngx-translate/core';
 import {
   SelectItem,
   SiSelectActionDirective,
@@ -34,7 +35,7 @@ import { LOG_EVENT } from '@siemens/live-preview';
     SiSelectOptionTemplateDirective,
     SiSelectGroupTemplateDirective,
     TitleCasePipe,
-    TranslateModule
+    TranslatePipe
   ],
   templateUrl: './si-select.html',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2210/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2210/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2210/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2210/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2210/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2210/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2210/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2210/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2210/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2210/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

