### PR TITLE
refactor(tooltip): make `describedBy` optional

### DIFF
--- a/projects/element-ng/tooltip/si-tooltip.model.ts
+++ b/projects/element-ng/tooltip/si-tooltip.model.ts
@@ -8,7 +8,7 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 export type SiTooltipContent = TranslatableString | TemplateRef<any> | Type<any> | null | undefined;
 
 export interface SiTooltipConfig {
-  id: string;
+  id?: string;
   tooltip: () => SiTooltipContent;
   tooltipContext: () => unknown;
 }

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -42,7 +42,7 @@ class BrowserTooltipRef {
 
   constructor(
     private config: {
-      describedBy: string;
+      describedBy?: string;
       element: ElementRef;
       injector?: Injector;
       overlay: Overlay;
@@ -191,7 +191,7 @@ export class SiTooltipService {
   private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   createTooltip(config: {
-    describedBy: string;
+    describedBy?: string;
     element: ElementRef;
     placement: keyof typeof positions;
     injector?: Injector;


### PR DESCRIPTION
Tooltips are sometimes used for an icon only action. In those cases an aria-label is already present,
so no aria-describedby is configured.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2220/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2220/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2220/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2220/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2220/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2220/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2220/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2220/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2220/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2220/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
