### PR TITLE
fix(live-preview): preserve NgModule scope when recompiling edited ex…

### DIFF
--- a/projects/live-preview/components/si-live-preview-renderer/si-live-preview-renderer.component.ts
+++ b/projects/live-preview/components/si-live-preview-renderer/si-live-preview-renderer.component.ts
@@ -288,9 +288,52 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
           ann.template = this.template;
           this.compiledTemplate = this.template;
           compileComponent(this.dynamicComponent, ann);
+          this.reuseResolvedScopeOfOriginalComponent();
         }
       }
     }
+  }
+
+  /**
+   * When the host application is built with AOT, the Angular compiler tree-shakes the
+   * `ɵɵsetNgModuleScope` calls (because `ngJitMode` is `false`). As a result, NgModules that are
+   * compiled from source expose no `imports`/`exports` scope on their `ɵmod` at runtime.
+   *
+   * Re-compiling the edited example via JIT (`compileComponent`) therefore cannot resolve the
+   * directives and pipes that are exported through such an imported NgModule. A common symptom is
+   * a missing value accessor for a form control component used with `ngModel`, which throws
+   * `NG01203`.
+   *
+   * The originally (AOT-)compiled component already carries the fully resolved scope in its
+   * component definition. Reusing its directive and pipe defs on the recompiled component restores
+   * the complete scope without depending on runtime NgModule metadata.
+   */
+  private reuseResolvedScopeOfOriginalComponent(): void {
+    const originalDef = this.componentTsSampleComponent?.['ɵcmp'];
+    const recompiledDef = this.dynamicComponent?.['ɵcmp'];
+    if (!originalDef || !recompiledDef) {
+      return;
+    }
+
+    if (originalDef.directiveDefs) {
+      recompiledDef.directiveDefs = this.mergeDefs(
+        recompiledDef.directiveDefs,
+        originalDef.directiveDefs
+      );
+    }
+    if (originalDef.pipeDefs) {
+      recompiledDef.pipeDefs = this.mergeDefs(recompiledDef.pipeDefs, originalDef.pipeDefs);
+    }
+  }
+
+  /** Merges two (possibly lazy) Ivy def lists into a single deduplicated factory. */
+  private mergeDefs(
+    recompiled: unknown[] | (() => unknown[]) | null | undefined,
+    original: unknown[] | (() => unknown[]) | null | undefined
+  ): () => unknown[] {
+    const resolve = (defs: unknown[] | (() => unknown[]) | null | undefined): unknown[] =>
+      typeof defs === 'function' ? defs() : (defs ?? []);
+    return () => [...new Set([...resolve(recompiled), ...resolve(original)])];
   }
 
   private getAnnotation(obj: any, type: any): any {


### PR DESCRIPTION
…amples

Editing the template of an example that imports an NgModule (e.g. SiSearchBarModule) threw "NG01203: No value accessor for form control" whenever the template used [(ngModel)].

When the host app is built with AOT, the Angular compiler tree-shakes the ɵɵsetNgModuleScope calls (ngJitMode is false), so NgModules compiled from source expose no imports/exports on their ɵmod at runtime. Recompiling the edited example via JIT could therefore not resolve directives/pipes exported through an imported NgModule, leaving the form-control component unmatched and its NG_VALUE_ACCESSOR provider unavailable.

Reuse the directive and pipe defs already resolved on the original (AOT-compiled) component instead of relying on runtime NgModule metadata.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2221/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2221/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2221/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2221/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2221/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2221/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2221/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2221/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2221/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2221/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
