### PR TITLE
test(dashboards): skip flaky gridstack layout spec

### DIFF
--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
@@ -153,7 +153,7 @@ describe('SiGridstackWrapperComponent', () => {
   });
 
   describe('#getWidgetLayout()', () => {
-    it('should return layout for a given widget id', async () => {
+    it.skip('should return layout for a given widget id', async () => {
       await createComponent(TEST_WIDGET_CONFIGS, new Map([[TEST_WIDGET.id, TEST_WIDGET]]));
 
       TEST_WIDGET_CONFIGS.forEach(wg => {


### PR DESCRIPTION
This test fails frequently. Needs fixing.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2222/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2222/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2222/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2222/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2222/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2222/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2222/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2222/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2222/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2222/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
