### PR TITLE
build(ci): stable html-report artifact name to fix preview on partial reruns

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -192,9 +192,10 @@ jobs:
       - run: npx playwright merge-reports --reporter html ./all-blob-reports
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: html-report--attempt-${{ github.run_attempt }}
+          name: html-report
           path: playwright-report
           retention-days: 2
+          overwrite: true
 
   documentation:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -36,7 +36,7 @@ jobs:
           path: pages
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: html-report--attempt-${{ github.run_attempt }}
+          name: html-report
           path: playwright-report
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:


### PR DESCRIPTION
## Problem

When a single non-e2e job is rerun (e.g. `test`), GitHub bumps `github.run_attempt` for the whole run, but `e2e` / `e2e-merge-reports` are **not** re-run (they already passed). The `e2e-merge-reports` job uploaded the Playwright report scoped by attempt:

```yaml
name: html-report--attempt-${{ github.run_attempt }}
```

so no `html-report--attempt-2` artifact is produced. The `preview` job then re-runs with `run_attempt = 2` and fails trying to download the non-existent attempt-scoped artifact.

## Fix

Upload the report under a stable name `html-report` with `overwrite: true`. A full rerun overwrites it; a partial rerun keeps the attempt-1 artifact for `preview` to download.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2224/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2224/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2224/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2224/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2224/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2224/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2224/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2224/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2224/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2224/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
