### PR TITLE
test(tooltip): fix flaky hover tests caused by real cursor leakage

### DIFF
--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -5,11 +5,17 @@
 import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { userEvent } from 'vitest/browser';
 
 import { SiTooltipModule } from './si-tooltip.module';
 
 describe('SiTooltipDirective', () => {
+  // NOTE: Do NOT use `userEvent.hover()` to trigger hover behavior here. In browser
+  // mode it moves the real OS cursor and parks it over the element. Because the
+  // cursor position persists across tests, a button rendered at the same
+  // coordinates in a later test receives a spurious real `mouseenter`, which starts
+  // the hover tooltip timer and makes the focus-based tests flaky. Dispatch a
+  // synthetic `new MouseEvent('mouseenter')` instead (the `:hover` state is mocked
+  // via `button.matches`, so real hover is not needed).
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setTimerTickMode('nextTimerAsync');
@@ -97,7 +103,7 @@ describe('SiTooltipDirective', () => {
 
     it('should cancel the pending hover tooltip on focusout', async () => {
       vi.setTimerTickMode('manual');
-      await userEvent.hover(button);
+      button.dispatchEvent(new MouseEvent('mouseenter'));
       vi.advanceTimersByTime(250);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).not.toBeInTheDocument();
@@ -112,7 +118,7 @@ describe('SiTooltipDirective', () => {
     });
 
     it('should hide a hover-visible tooltip on focusout', async () => {
-      await userEvent.hover(button);
+      button.dispatchEvent(new MouseEvent('mouseenter'));
       vi.advanceTimersByTime(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).toBeInTheDocument();
@@ -123,7 +129,7 @@ describe('SiTooltipDirective', () => {
     });
 
     it('should hide the tooltip on touchstart', async () => {
-      await userEvent.hover(button);
+      button.dispatchEvent(new MouseEvent('mouseenter'));
       vi.advanceTimersByTime(500);
       await fixture.whenStable();
       expect(document.querySelector('.tooltip')).toBeInTheDocument();


### PR DESCRIPTION
## Problem

`SiTooltipDirective` tests were flaky — e.g. `with template > should render the template with context` intermittently failed at `expect(document.querySelector('.tooltip')).not.toBeInTheDocument()` after `focusout`.

## Root cause

In browser mode, `userEvent.hover()` moves the **real OS cursor** and leaves it parked over the element. The cursor position persists across tests, so a button rendered at the same coordinates in a later test receives a **spurious real `mouseenter`**. That starts the tooltip's 500ms hover timer, which the test then advances via `vi.advanceTimersByTimeAsync(500)`, racing with the synthetic `focus`/`focusout` events and keeping the tooltip attached.

Verified:
- Reproduced flakiness (~3/10 failures in isolation).
- Diagnostics showed the tooltip still attached after `focusout` with `activeElement === BODY` (re-shown via the hover path).
- Skipping the `with text` block (the only `userEvent.hover` users) made it stable, isolating the leak.

## Fix

Replace the three `userEvent.hover(button)` calls with synthetic `button.dispatchEvent(new MouseEvent('mouseenter'))`, matching the pattern already used by other hover tests in the same block. Since `button.matches` is mocked (real `:hover` is not exercised), coverage is equivalent but no real cursor is moved. Added a warning comment documenting why `userEvent.hover()` must not be used here.

## Verification

0 failures across 20 consecutive runs of the spec.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2225/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2225/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2225/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2225/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2225/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2225/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2225/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2225/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2225/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2225/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
