### PR TITLE
fix(tooltip): reposition overlay when content changes dynamically

### DIFF
--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
@@ -104,7 +104,8 @@ export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
         providers: [{ provide: SI_FORM_VALIDATION_TOOLTIP_DATA, useValue: this.errors }]
       }),
       tooltip: () => SiFormValidationTooltipComponent,
-      tooltipContext: () => undefined
+      // Not actually used, but errors in the context triggers a resize if the errors changes.
+      tooltipContext: () => this.errors()
     });
   }
 

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
@@ -2,10 +2,11 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
+import { Overlay } from '@angular/cdk/overlay';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 
 import { SiFormValidationTooltipHarness } from '../testing/si-form-validation-tooltip.harness';
 import { SiFormValidationTooltipDirective } from './si-form-validation-tooltip.directive';
@@ -79,5 +80,25 @@ describe('SiFormValidationTooltipDirective', () => {
     fixture.componentInstance.control.markAsUntouched();
     await fixture.whenStable();
     expect(await harness.getTooltip()).toBeFalsy();
+  });
+
+  it('should reposition the overlay when the validation errors change while open', async () => {
+    const control = fixture.componentInstance.control;
+    control.addValidators(Validators.minLength(5));
+    const createSpy = vi.spyOn(Overlay.prototype, 'create');
+
+    control.markAsTouched();
+    await fixture.whenStable();
+    await harness.focus();
+    expect(await harness.getTooltip()).toBe('Required');
+
+    const overlayRef = createSpy.mock.results.at(-1)!.value as ReturnType<Overlay['create']>;
+    const repositionSpy = vi.spyOn(overlayRef, 'updatePosition');
+
+    await harness.sendKeys('ab');
+    await fixture.whenStable();
+    expect(await harness.getTooltip()).toBe('Min. 5 characters');
+
+    expect(repositionSpy).toHaveBeenCalled();
   });
 });

--- a/projects/element-ng/tooltip/si-tooltip.component.ts
+++ b/projects/element-ng/tooltip/si-tooltip.component.ts
@@ -2,9 +2,10 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ConnectedOverlayPositionChange } from '@angular/cdk/overlay';
+import { ConnectedOverlayPositionChange, OverlayRef } from '@angular/cdk/overlay';
 import { NgComponentOutlet, NgTemplateOutlet } from '@angular/common';
 import {
+  afterRenderEffect,
   ChangeDetectionStrategy,
   Component,
   computed,
@@ -34,6 +35,26 @@ export class TooltipComponent {
 
   protected readonly config = inject(SI_TOOLTIP_CONFIG);
   private readonly elementRef = inject(ElementRef);
+  private readonly overlayRef = inject(OverlayRef);
+
+  private lastPositionChange?: ConnectedOverlayPositionChange;
+  private lastAnchor?: ElementRef;
+
+  constructor() {
+    let isFirstRun = true;
+    afterRenderEffect(() => {
+      this.config.tooltip();
+      this.config.tooltipContext();
+      if (isFirstRun) {
+        isFirstRun = false;
+        return;
+      }
+      this.overlayRef.updatePosition();
+      if (this.lastPositionChange) {
+        this.updateTooltipPosition(this.lastPositionChange, this.lastAnchor);
+      }
+    });
+  }
 
   protected readonly tooltipText = computed<string | null>(() => {
     const tooltip = this.config.tooltip();
@@ -52,6 +73,8 @@ export class TooltipComponent {
 
   /** @internal */
   updateTooltipPosition(change: ConnectedOverlayPositionChange, anchor?: ElementRef): void {
+    this.lastPositionChange = change;
+    this.lastAnchor = anchor;
     const arrowClassTooltip = `tooltip-${change.connectionPair.overlayX}-${change.connectionPair.overlayY}`;
     // need two updates as class changes affect the position
     if (arrowClassTooltip !== this.tooltipPositionClass()) {

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -150,6 +150,22 @@ describe('SiTooltipDirective', () => {
 
       expect(document.querySelector('.tooltip')).toHaveTextContent('updated tooltip');
     });
+
+    it('should reposition the overlay when content changes while open', async () => {
+      const createSpy = vi.spyOn(Overlay.prototype, 'create');
+
+      button.dispatchEvent(new FocusEvent('focus'));
+      await vi.advanceTimersByTimeAsync(0);
+      await fixture.whenStable();
+
+      const overlayRef = createSpy.mock.results.at(-1)!.value as ReturnType<Overlay['create']>;
+      const repositionSpy = vi.spyOn(overlayRef, 'updatePosition');
+
+      component.tooltipText.set('a much longer tooltip text that changes the width');
+      await fixture.whenStable();
+
+      expect(repositionSpy).toHaveBeenCalled();
+    });
   });
 
   describe('with template', () => {

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -151,7 +151,12 @@ class BrowserTooltipRef {
       return;
     }
 
-    const toolTipPortal = new ComponentPortal(TooltipComponent, undefined, this.config.injector);
+    const injector = Injector.create({
+      parent: this.config.injector,
+      providers: [{ provide: OverlayRef, useValue: overlayRef }]
+    });
+
+    const toolTipPortal = new ComponentPortal(TooltipComponent, undefined, injector);
     const tooltipRef: ComponentRef<TooltipComponent> = overlayRef.attach(toolTipPortal);
 
     const positionStrategy = getPositionStrategy(overlayRef);


### PR DESCRIPTION
The tooltip arrow and position became stale when the content changed
size while open, most notably with siFormValidationTooltip when the
validation errors change. The CDK only emits position changes on
attach/scroll, so the overlay was no longer centered on its anchor.

Reposition the overlay via an afterRenderEffect that reacts to the
tooltip content signals, and expose the OverlayRef to the tooltip
component through DI (mirroring the CDK Dialog ref). The validation
directive feeds its errors through tooltipContext so the effect reacts
to error changes. This intentionally avoids a ResizeObserver.

Closes #2219<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2228/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2228/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2228/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2228/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2228/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2228/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2228/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2228/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2228/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2228/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

