### PR TITLE
feat(tabs): show tooltip in icon mode

### DIFF
--- a/playwright/snapshots/si-tabs.spec.ts-snapshots/si-tabs--si-tabs-flex--tabs-scroll.yaml
+++ b/playwright/snapshots/si-tabs.spec.ts-snapshots/si-tabs--si-tabs-flex--tabs-scroll.yaml
@@ -1,8 +1,8 @@
 - tablist:
   - tab "Basic title"
-  - tab
-  - tab "5" [selected]
-- tabpanel "5":
+  - tab "Favorites"
+  - tab "notifications 5" [selected]
+- tabpanel "notifications 5":
   - paragraph: Basic content 3
   - paragraph: Vulputate lectus Habitasse venenatis. Rutrum mus iaculis. Ad a, montes. Luctus augue eros scelerisque tellus pellentesque tincidunt, arcu est ornare vel Ad sit platea. Eget cum Vulputate sollicitudin curabitur cursus bibendum, commodo lacinia facilisis parturient diam augue sociis sem dolor, augue eros odio, nonummy sit sapien taciti primis eleifend enim massa in mi. Feugiat. Nulla. Pellentesque felis mollis curabitur. Pretium suspendisse nec senectus proin sit eget feugiat placerat tincidunt praesent nec eu gravida nullam per hendrerit rutrum potenti aenean proin a tempor, eget bibendum ultrices lacinia, torquent duis quisque in Aptent vivamus fusce quisque. Nec mollis mus nascetur ligula, ridiculus convallis nonummy sodales lacus dictum auctor semper penatibus morbi. Urna taciti id auctor penatibus A. Facilisis et. Amet, augue tortor vehicula. Sapien quam augue suspendisse blandit ac litora dictum gravida fusce nulla purus platea id ridiculus augue praesent eros ligula elementum magna. Curabitur vel vel aliquet eget mollis nostra nulla vehicula viverra etiam.
   - paragraph: Ornare. Litora. Hendrerit nonummy lacus. Vulputate proin sapien hendrerit egestas ullamcorper commodo pretium. Aenean, porta elementum sollicitudin suspendisse augue metus aptent lacus conubia elit dictum ipsum sem non fusce tellus consectetuer, magna semper, ante justo commodo pellentesque. Conubia platea ullamcorper euismod sagittis nullam. A, et viverra vehicula nec faucibus eu vel pretium auctor inceptos. Inceptos tellus eleifend velit habitant. Commodo blandit morbi.

--- a/playwright/snapshots/si-tabs.spec.ts-snapshots/si-tabs--si-tabs-icons--tabs-icons.yaml
+++ b/playwright/snapshots/si-tabs.spec.ts-snapshots/si-tabs--si-tabs-icons--tabs-icons.yaml
@@ -1,7 +1,7 @@
 - tablist:
-  - tab /\d+/ [selected]
-  - tab
-  - tab
-  - tab "1"
-- tabpanel /\d+/:
+  - tab /Reception \d+/ [selected]
+  - tab "Conference"
+  - tab "Lobby"
+  - tab "Pantry 1"
+- tabpanel /Reception \d+/:
   - paragraph: Content for Reception

--- a/projects/element-ng/tabs/si-tab-base.directive.ts
+++ b/projects/element-ng/tabs/si-tab-base.directive.ts
@@ -20,6 +20,7 @@ import {
 } from '@angular/core';
 import { elementCancel } from '@siemens/element-icons';
 import { addIcons } from '@siemens/element-ng/icon';
+import { SiTooltipDirective, SiTooltipService, TooltipRef } from '@siemens/element-ng/tooltip';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SI_TABSET } from './si-tabs-tokens';
@@ -90,6 +91,9 @@ export abstract class SiTabBaseDirective implements OnDestroy, FocusableOption {
 
   private static tabCounter = 0;
   private indexBeforeClose = -1;
+  private readonly tooltipService = inject(SiTooltipService);
+  private readonly existingTooltip = inject(SiTooltipDirective, { optional: true });
+  private tooltipRef?: TooltipRef;
 
   /** @internal */
   tabId = `${SiTabBaseDirective.tabCounter++}`;
@@ -98,6 +102,8 @@ export abstract class SiTabBaseDirective implements OnDestroy, FocusableOption {
   private readonly index = computed(() => this.tabset.tabPanels().indexOf(this));
 
   constructor() {
+    this.setupIconTooltip();
+
     // Update the focusKeyManager if a tab is added that is active or if the tab is set active by the app.
     // This effect should not run, if active was already applied to the focusKeyManager.
     effect(() => {
@@ -107,6 +113,32 @@ export abstract class SiTabBaseDirective implements OnDestroy, FocusableOption {
         if (active && this.tabset.focusKeyManager.activeItem !== this) {
           this.tabset.focusKeyManager.updateActiveItem(this.index());
         }
+      });
+    });
+  }
+
+  private setupIconTooltip(): void {
+    effect(onCleanup => {
+      const icon = this.icon();
+      // Only add an automatic tooltip if the consumer has not already applied an
+      // active `siTooltip` directive (i.e. one that is not disabled and has a tooltip).
+      const hasActiveTooltip =
+        !!this.existingTooltip &&
+        !this.existingTooltip.isDisabled() &&
+        !!this.existingTooltip.siTooltip();
+
+      if (icon && !hasActiveTooltip) {
+        this.tooltipRef = this.tooltipService.createTooltip({
+          element: this.tabButton,
+          placement: 'auto',
+          tooltip: () => this.heading(),
+          tooltipContext: () => undefined
+        });
+      }
+
+      onCleanup(() => {
+        this.tooltipRef?.destroy();
+        this.tooltipRef = undefined;
       });
     });
   }

--- a/projects/element-ng/tabs/si-tab-link.component.ts
+++ b/projects/element-ng/tabs/si-tab-link.component.ts
@@ -6,6 +6,7 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { SiIconComponent } from '@siemens/element-ng/icon';
+import { SiTooltipService } from '@siemens/element-ng/tooltip';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 import { startWith } from 'rxjs/operators';
 
@@ -30,7 +31,7 @@ import { SiTabBaseDirective } from './si-tab-base.directive';
   imports: [SiIconComponent, SiTranslatePipe, SiTabBadgeComponent],
   templateUrl: './si-tab.component.html',
   styleUrl: './si-tab.component.scss',
-  providers: [{ provide: SiTabBaseDirective, useExisting: SiTabLinkComponent }],
+  providers: [SiTooltipService, { provide: SiTabBaseDirective, useExisting: SiTabLinkComponent }],
   changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     {

--- a/projects/element-ng/tabs/si-tab.component.html
+++ b/projects/element-ng/tabs/si-tab.component.html
@@ -1,8 +1,7 @@
 @let icon = this.icon();
+<span class="text-truncate" [class.visually-hidden]="!!icon">{{ heading() | translate }}</span>
 @if (icon) {
-  <si-icon class="tab-icon" [icon]="icon" [attr.title]="heading() | translate" />
-} @else {
-  <span class="text-truncate">{{ heading() | translate }}</span>
+  <si-icon class="tab-icon" [icon]="icon" />
 }
 <si-tab-badge [badgeColor]="badgeColor()" [badgeContent]="badgeContent()" />
 @if (closable() && !disabledTab()) {

--- a/projects/element-ng/tabs/si-tab.component.ts
+++ b/projects/element-ng/tabs/si-tab.component.ts
@@ -4,6 +4,7 @@
  */
 import { ChangeDetectionStrategy, Component, input, model, OnDestroy } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
+import { SiTooltipService } from '@siemens/element-ng/tooltip';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiTabBadgeComponent } from './si-tab-badge.component';
@@ -26,7 +27,7 @@ import { SiTabBaseDirective } from './si-tab-base.directive';
   imports: [SiIconComponent, SiTranslatePipe, SiTabBadgeComponent],
   templateUrl: './si-tab.component.html',
   styleUrl: './si-tab.component.scss',
-  providers: [{ provide: SiTabBaseDirective, useExisting: SiTabComponent }],
+  providers: [SiTooltipService, { provide: SiTabBaseDirective, useExisting: SiTabComponent }],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '(click)': 'selectTabByUser()',

--- a/projects/element-ng/tabs/si-tabset.component.spec.ts
+++ b/projects/element-ng/tabs/si-tabset.component.spec.ts
@@ -7,6 +7,8 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, RouterLink, RouterOutlet } from '@angular/router';
+import { SiTooltipDirective } from '@siemens/element-ng/tooltip';
+import { page } from '@vitest/browser/context';
 
 import {
   MockResizeObserver,
@@ -21,6 +23,7 @@ import { SiTabsetHarness } from './testing/si-tabset.harness';
 
 interface TabData {
   heading: string;
+  icon?: string;
   closable?: true;
   routerLinkUrl?: string;
   active?: boolean;
@@ -45,6 +48,7 @@ class SiTabRouteComponent {}
             <si-tab
               [active]="tab.active ?? false"
               [heading]="tab.heading"
+              [icon]="tab.icon"
               [closable]="!!tab.closable"
               [style.max-width.px]="tabButtonMaxWidth()"
               [canDeactivate]="tab.canDeactivate"
@@ -187,6 +191,24 @@ describe('SiTabset', () => {
 
     expect(await tabsetHarness.isTabItemActive(0)).toEqual(false);
     expect(await tabsetHarness.isTabItemActive(1)).toEqual(true);
+  });
+
+  it('should show the heading as tooltip for icon tabs', async () => {
+    vi.setTimerTickMode('nextTimerAsync');
+    testComponent.tabs = [{ heading: 'Tab 1', icon: 'element-options' }];
+    await fixture.whenStable();
+
+    const tabButtonLocator = page.getByRole('tab', { name: 'Tab 1' });
+    await expect.element(tabButtonLocator).toBeInTheDocument();
+    const tabButton = await tabButtonLocator.element();
+    expect(tabButton.querySelector('.text-truncate')).toHaveClass('visually-hidden');
+    expect(tabButton.querySelector('.tab-icon')).toBeTruthy();
+
+    tabButton.dispatchEvent(new MouseEvent('mouseenter'));
+    await vi.advanceTimersByTimeAsync(500);
+    await fixture.whenStable();
+
+    await expect.element(page.getByRole('tooltip', { name: 'Tab 1' })).toBeInTheDocument();
   });
 
   it('should remove tab on destroy', async () => {
@@ -572,5 +594,60 @@ describe('SiTabset with portal content', () => {
 
     const portalHarness = await tabsetHarness.getExternalTabPortal();
     expect(await portalHarness!.hasTabPanel()).toBe(false);
+  });
+});
+
+describe('SiTabset with custom tooltip', () => {
+  @Component({
+    imports: [SiTabsetComponent, SiTabComponent, SiTooltipDirective],
+    template: `
+      <si-tabset>
+        <si-tab heading="Tab 1" icon="element-options" [siTooltip]="tooltip()" />
+      </si-tabset>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush
+  })
+  class TooltipHostComponent {
+    readonly tooltip = signal('Custom tooltip');
+  }
+
+  let fixture: ComponentFixture<TooltipHostComponent>;
+  let hostComponent: TooltipHostComponent;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setTimerTickMode('nextTimerAsync');
+    fixture = TestBed.createComponent(TooltipHostComponent);
+    hostComponent = fixture.componentInstance;
+    fixture.autoDetectChanges();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not add an own tooltip when an active siTooltip directive is present', async () => {
+    await fixture.whenStable();
+
+    const tabButton = fixture.nativeElement.querySelector('[role="tab"]') as HTMLElement;
+    tabButton.dispatchEvent(new MouseEvent('mouseenter'));
+    await vi.advanceTimersByTimeAsync(500);
+    await fixture.whenStable();
+
+    await expect.element(page.getByRole('tooltip')).toHaveLength(1);
+    await expect.element(page.getByRole('tooltip')).toHaveTextContent('Custom tooltip');
+  });
+
+  it('should fall back to the heading tooltip when the siTooltip directive is empty', async () => {
+    hostComponent.tooltip.set('');
+    await fixture.whenStable();
+
+    const tabButton = fixture.nativeElement.querySelector('[role="tab"]') as HTMLElement;
+    tabButton.dispatchEvent(new MouseEvent('mouseenter'));
+    await vi.advanceTimersByTimeAsync(500);
+    await fixture.whenStable();
+
+    await expect.element(page.getByRole('tooltip')).toHaveLength(1);
+    await expect.element(page.getByRole('tooltip')).toHaveTextContent('Tab 1');
   });
 });


### PR DESCRIPTION
Automatically apply a tooltip to tabs,
if an icon is configured and thus no visible text
is configured.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2231/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2231/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2231/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2231/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2231/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2231/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2231/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2231/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2231/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2231/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



