### PR TITLE
refactor(tooltip): support `ElementRef` as tooltip content

### DIFF
--- a/projects/element-ng/tooltip/si-tooltip.component.ts
+++ b/projects/element-ng/tooltip/si-tooltip.component.ts
@@ -58,7 +58,16 @@ export class TooltipComponent {
 
   protected readonly tooltipText = computed<string | null>(() => {
     const tooltip = this.config.tooltip();
-    return typeof tooltip === 'string' ? tooltip : null;
+    if (typeof tooltip === 'string') {
+      return tooltip;
+    }
+    // When an ElementRef is provided, read its current text content whenever the
+    // tooltip is shown, so dynamic content is always reflected.
+    // The tooltip content is not updated while being displayed.
+    if (tooltip instanceof ElementRef) {
+      return tooltip.nativeElement.textContent.trim();
+    }
+    return null;
   });
 
   protected readonly tooltipTemplate = computed<TemplateRef<any> | null>(() => {
@@ -68,7 +77,11 @@ export class TooltipComponent {
 
   protected readonly tooltipComponent = computed(() => {
     const tooltip = this.config.tooltip();
-    return !(tooltip instanceof TemplateRef) && typeof tooltip !== 'string' ? tooltip : null;
+    return !(tooltip instanceof TemplateRef) &&
+      !(tooltip instanceof ElementRef) &&
+      typeof tooltip !== 'string'
+      ? tooltip
+      : null;
   });
 
   /** @internal */

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -3,11 +3,19 @@
  * SPDX-License-Identifier: MIT
  */
 import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  inject,
+  signal,
+  viewChild
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { page } from 'vitest/browser';
 
 import { SiTooltipModule } from './si-tooltip.module';
+import { SiTooltipService } from './si-tooltip.service';
 
 describe('SiTooltipDirective', () => {
   // NOTE: Do NOT use `userEvent.hover()` to trigger hover behavior here. In browser
@@ -213,6 +221,73 @@ describe('SiTooltipDirective', () => {
       await vi.advanceTimersByTimeAsync(500);
       await fixture.whenStable();
       await expect.element(page.getByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with ElementRef', () => {
+    let fixture: ComponentFixture<TestHostComponent>;
+    let component: TestHostComponent;
+    let button: HTMLButtonElement;
+
+    @Component({
+      template: `<button #anchor type="button">Test</button>
+        <div #content>{{ contentText() }}</div>`,
+      providers: [SiTooltipService],
+      changeDetection: ChangeDetectionStrategy.OnPush
+    })
+    class TestHostComponent {
+      readonly contentText = signal('node tooltip');
+      readonly anchor = viewChild.required<ElementRef<HTMLButtonElement>>('anchor');
+      readonly content = viewChild.required<ElementRef<HTMLDivElement>>('content');
+      private readonly tooltipService = inject(SiTooltipService);
+
+      createTooltip(): void {
+        this.tooltipService.createTooltip({
+          element: this.anchor(),
+          placement: 'auto',
+          tooltip: this.content,
+          tooltipContext: () => undefined
+        });
+      }
+    }
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TestHostComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      button = component.anchor().nativeElement;
+      vi.spyOn(button, 'matches').mockImplementation(selector => selector === ':focus-visible');
+      component.createTooltip();
+    });
+
+    it('should read the referenced node text content when shown and re-read after updates', async () => {
+      // show tooltip
+      button.dispatchEvent(new FocusEvent('focus'));
+      await vi.advanceTimersByTimeAsync(0);
+      await fixture.whenStable();
+
+      // confirm correct content
+      await expect.element(page.getByRole('tooltip', { name: 'node tooltip' })).toBeInTheDocument();
+
+      // hide tooltip
+      button.dispatchEvent(new FocusEvent('focusout'));
+      await vi.advanceTimersByTimeAsync(500);
+      await fixture.whenStable();
+      await expect.element(page.getByRole('tooltip')).not.toBeInTheDocument();
+
+      // update dom node text
+      component.contentText.set('updated node tooltip');
+      await fixture.whenStable();
+
+      // show tooltip again
+      button.dispatchEvent(new FocusEvent('focus'));
+      await vi.advanceTimersByTimeAsync(0);
+      await fixture.whenStable();
+
+      // confirm updated content
+      await expect
+        .element(page.getByRole('tooltip', { name: 'updated node tooltip' }))
+        .toBeInTheDocument();
     });
   });
 

--- a/projects/element-ng/tooltip/si-tooltip.model.ts
+++ b/projects/element-ng/tooltip/si-tooltip.model.ts
@@ -2,10 +2,16 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { InjectionToken, TemplateRef, Type } from '@angular/core';
+import { ElementRef, InjectionToken, TemplateRef, Type } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
-export type SiTooltipContent = TranslatableString | TemplateRef<any> | Type<any> | null | undefined;
+export type SiTooltipContent =
+  | TranslatableString
+  | TemplateRef<any>
+  | Type<any>
+  | ElementRef<Element>
+  | null
+  | undefined;
 
 export interface SiTooltipConfig {
   id?: string;


### PR DESCRIPTION
We need to attach tooltips to Element where we have no `input()` of the content. Instead, content projection is used.
By supporting `ElementRef` as source, we can just pass the node which has the content. The tooltip will read the textContent every time it is actually shown. This will reduce the risk of showing outdated content in the tooltip.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2233/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2233/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2233/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2233/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2233/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2233/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2233/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2233/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2233/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2233/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



