### PR TITLE
ci(docs): publish development docs from main to S3

### DIFF
--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -39,3 +39,29 @@ jobs:
         with:
           path: 'dist/design'
       - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+
+  # Publishes the documentation built from main to the "development" path of the
+  # versioned S3 bucket (https://element.siemens.io/development/) and refreshes
+  # versions.json so the "Development" entry stays on top of the version selector.
+  publish-development-documentation:
+    runs-on: ubuntu-24.04
+    needs:
+      - build-and-test
+    permissions:
+      id-token: write
+    env:
+      VERSIONED_BUCKET_NAME: simpl-element-release
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: pages
+          path: pages
+      - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: arn:aws:iam::974483672234:role/simpl-element-release
+          role-session-name: element-development-docs
+          aws-region: eu-west-1
+      - run: >-
+          tools/release/publish-development-docs.sh
+          "${{ env.VERSIONED_BUCKET_NAME }}"

--- a/tools/release/generate-versions.js
+++ b/tools/release/generate-versions.js
@@ -23,4 +23,8 @@ if (deployLatest) {
   payload.unshift({ version: '', title: `${numericTitle}.x` });
 }
 
+// The development docs (built from the main branch) are always available and
+// listed on top of the version selector.
+payload.unshift({ version: 'development', title: 'Development' });
+
 writeFileSync('versions.json', JSON.stringify(payload, null, 2));

--- a/tools/release/publish-development-docs.sh
+++ b/tools/release/publish-development-docs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Publishes the documentation built from the main branch to the "development"
+# path of the versioned S3 bucket and refreshes versions.json so that the
+# "Development" entry stays on top of the version selector.
+
+set -euo pipefail
+
+VERSIONED_BUCKET_NAME="$1"
+
+# Determine the current "latest" major version so the regenerated versions.json
+# keeps pointing the root entry at the correct release.
+aws s3 cp "s3://${VERSIONED_BUCKET_NAME}/latest-version.txt" latest-version.txt || true
+
+LATEST_VERSION=""
+if [[ -f latest-version.txt ]]; then
+  LATEST_VERSION=$(tr -d '\r\n' < latest-version.txt)
+fi
+
+# Collect the existing released major versions from the bucket.
+aws s3 ls "s3://${VERSIONED_BUCKET_NAME}/" | grep "PRE v" | awk '{print $2}' | sed 's/\/$//' | sed 's/^v//' > s3-versions.txt || true
+
+# Generate versions.json. We are not deploying a release, so deploy_latest is
+# false and the root entry falls back to the current latest version. The
+# "Development" entry is always prepended by the script itself.
+node tools/release/generate-versions.js "false" "" "$LATEST_VERSION"
+
+# Publish the development documentation and the updated versions.json.
+aws s3 sync --quiet --no-progress --delete "pages/" "s3://${VERSIONED_BUCKET_NAME}/development/"
+aws s3 cp versions.json "s3://${VERSIONED_BUCKET_NAME}/versions.json"


### PR DESCRIPTION
Extend the main documentation workflow to also publish to the versioned
S3 bucket under /development, and add a 'Development' entry on top of the
version selector in versions.json.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2238/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2238/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2238/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2238/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2238/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2238/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2238/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2238/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2238/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2238/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

