### PR TITLE
refactor(icon): remove disableSvgIcons from provideIconConfig() options

### DIFF
--- a/api-goldens/element-ng/icon/index.api.md
+++ b/api-goldens/element-ng/icon/index.api.md
@@ -27,14 +27,6 @@ export const addIcons: <T extends string>(icons: Record<T, string>) => Record<T,
 export const elementCheckedImageShape = "data:image/svg+xml;base64,PHN2ZyBpZD0iSWNvbiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiI+CiAgPHRpdGxlPm9rPC90aXRsZT4KICA8cGF0aCBkPSJNMzc5LjUxLDE1Ni43NmwtMTczLDE3My03NC03NGExMiwxMiwwLDEsMC0xNywxN2w4Mi41LDgyLjVhMTIsMTIsMCwwLDAsMTcsMGwxODEuNS0xODEuNWExMiwxMiwwLDAsMC0xNy0xN1oiLz4KPC9zdmc+Cg==";
 
 // @public
-export interface IconConfig {
-    disableSvgIcons?: boolean;
-}
-
-// @public
-export const provideIconConfig: (config: IconConfig) => Provider;
-
-// @public
 export class SiIconComponent {
     readonly icon: _angular_core.InputSignal<string>;
 }

--- a/projects/element-ng/icon/si-icon.component.spec.ts
+++ b/projects/element-ng/icon/si-icon.component.spec.ts
@@ -7,7 +7,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SiThemeService } from '@siemens/element-ng/theme';
 
-import { provideIconConfig, SiIconComponent } from './si-icon.component';
+import { SiIconComponent } from './si-icon.component';
 import { addIcons, IconService } from './si-icons';
 
 // It seems like the debug element is not able to query the SVGs.
@@ -41,9 +41,6 @@ describe('SiSvgIconComponent', () => {
 
     describe('with enabled svg icons', () => {
       beforeEach(async () => {
-        TestBed.configureTestingModule({
-          providers: [provideIconConfig({ disableSvgIcons: false })]
-        });
         fixture = TestBed.createComponent(TestHostComponent);
         component = fixture.componentInstance;
         fixture.detectChanges();
@@ -107,24 +104,6 @@ describe('SiSvgIconComponent', () => {
           fixture.detectChanges();
           expect(getIconHostStyle()).toContain('svg-oem');
         });
-      });
-    });
-
-    describe('with disabled svg icons', () => {
-      beforeEach(() => {
-        TestBed.configureTestingModule({
-          providers: [provideIconConfig({ disableSvgIcons: true })]
-        });
-        fixture = TestBed.createComponent(TestHostComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-      });
-
-      it('should always use the icon-font', () => {
-        component.icon.set('element-svg');
-        fixture.detectChanges();
-        expect(getIconHostStyle()).toBe('');
-        expect(fixture.debugElement.query(By.css('.element-svg'))).toBeTruthy();
       });
     });
   });

--- a/projects/element-ng/icon/si-icon.component.ts
+++ b/projects/element-ng/icon/si-icon.component.ts
@@ -2,42 +2,9 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  InjectionToken,
-  input,
-  Provider
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 
 import { IconService } from './si-icons';
-
-/**
- * Global configuration for icons.
- */
-export interface IconConfig {
-  /**
-   * If true, the si-icon component will always render the icon font instead of the svg.
-   *
-   * @defaultValue false
-   */
-  disableSvgIcons?: boolean;
-}
-
-const ICON_CONFIG = new InjectionToken<IconConfig>('ICON_CONFIG', {
-  providedIn: 'root',
-  factory: () => ({ disableSvgIcons: false })
-});
-
-/**
- * Configure how Element handles icons. Provide only once in your global configuration.
- */
-export const provideIconConfig = (config: IconConfig): Provider => ({
-  provide: ICON_CONFIG,
-  useValue: config
-});
 
 /**
  * Component to render a font or SVG icon depending on the configuration.
@@ -82,11 +49,10 @@ export class SiIconComponent {
    */
   readonly icon = input.required<string>();
 
-  private readonly config = inject(ICON_CONFIG);
   private readonly iconService = inject(IconService);
 
   protected readonly svgIcon = computed(() => {
-    const icon = this.config.disableSvgIcons ? undefined : this.iconService.getIcon(this.icon());
+    const icon = this.iconService.getIcon(this.icon());
     if (!icon) {
       return undefined;
     }

--- a/projects/element-ng/schematics/migrations/data/element-migration-data.ts
+++ b/projects/element-ng/schematics/migrations/data/element-migration-data.ts
@@ -2,12 +2,12 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-
 import { ATTRIBUTE_SELECTORS_MIGRATION } from './attribute-selectors.js';
 import { CLASS_MEMBER_REPLACEMENTS_MIGRATION } from './class-member-replacement.js';
 import { COMPONENT_PROPERTY_NAMES_MIGRATION } from './component-property-names.js';
 import { ELEMENT_CLASS_CHANGES_MIGRATION } from './element-class-changes.js';
 import { ELEMENT_SELECTORS_MIGRATION } from './element-selectors.js';
+import { PROVIDER_FUNCTION_REMOVALS_MIGRATION } from './provider-function-removals.js';
 import { SYMBOL_REMOVALS_MIGRATION } from './symbol-removals.js';
 import { SYMBOL_RENAMING_MIGRATION } from './symbol-renaming.js';
 
@@ -17,6 +17,7 @@ export type ElementMigrationData = {
   componentPropertyNameChanges: typeof COMPONENT_PROPERTY_NAMES_MIGRATION;
   elementClassChanges: typeof ELEMENT_CLASS_CHANGES_MIGRATION;
   elementSelectorChanges: typeof ELEMENT_SELECTORS_MIGRATION;
+  providerFunctionRemovalChanges: typeof PROVIDER_FUNCTION_REMOVALS_MIGRATION;
   symbolRemovalChanges: typeof SYMBOL_REMOVALS_MIGRATION;
   symbolRenamingChanges: typeof SYMBOL_RENAMING_MIGRATION;
 };
@@ -27,6 +28,7 @@ export const getElementMigrationData = (): ElementMigrationData => ({
   componentPropertyNameChanges: COMPONENT_PROPERTY_NAMES_MIGRATION,
   elementClassChanges: ELEMENT_CLASS_CHANGES_MIGRATION,
   elementSelectorChanges: ELEMENT_SELECTORS_MIGRATION,
+  providerFunctionRemovalChanges: PROVIDER_FUNCTION_REMOVALS_MIGRATION,
   symbolRemovalChanges: SYMBOL_REMOVALS_MIGRATION,
   symbolRenamingChanges: SYMBOL_RENAMING_MIGRATION
 });

--- a/projects/element-ng/schematics/migrations/data/index.ts
+++ b/projects/element-ng/schematics/migrations/data/index.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-
 export type { ElementMigrationData } from './element-migration-data.js';
 export { getElementMigrationData } from './element-migration-data.js';
 
@@ -11,5 +10,6 @@ export type { ClassMemberReplacementInstruction } from './class-member-replaceme
 export type { ComponentPropertyNamesInstruction } from './component-property-names.js';
 export type { ElementClassChangeInstruction } from './element-class-changes.js';
 export type { ElementSelectorInstruction } from './element-selectors.js';
+export type { ProviderFunctionRemovalInstruction } from './provider-function-removals.js';
 export type { SymbolRemovalInstruction } from './symbol-removals.js';
 export type { SymbolRenamingInstruction } from './symbol-renaming.js';

--- a/projects/element-ng/schematics/migrations/data/migration-test-data.ts
+++ b/projects/element-ng/schematics/migrations/data/migration-test-data.ts
@@ -2,13 +2,13 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-
 import {
   AttributeSelectorInstruction,
   SymbolRenamingInstruction,
   ComponentPropertyNamesInstruction,
   ElementMigrationData,
   ElementSelectorInstruction,
+  ProviderFunctionRemovalInstruction,
   SymbolRemovalInstruction,
   ClassMemberReplacementInstruction,
   ElementClassChangeInstruction
@@ -265,6 +265,13 @@ const ELEMENT_CLASS_CHANGES_MIGRATION: ElementClassChangeInstruction[] = [
   }
 ];
 
+const PROVIDER_FUNCTION_REMOVALS_MIGRATION: ProviderFunctionRemovalInstruction[] = [
+  {
+    module: /@(siemens)\/element-ng(\/icon)?/,
+    names: ['provideIconConfig']
+  }
+];
+
 /**
  * Stable migration data for testing.
  * This data is frozen and used for testing to ensure test stability.
@@ -276,6 +283,7 @@ export const getElementMigrationTestData = (): ElementMigrationData => ({
   componentPropertyNameChanges: COMPONENT_PROPERTY_NAMES_MIGRATION,
   elementClassChanges: ELEMENT_CLASS_CHANGES_MIGRATION,
   elementSelectorChanges: ELEMENT_SELECTORS_MIGRATION,
+  providerFunctionRemovalChanges: PROVIDER_FUNCTION_REMOVALS_MIGRATION,
   symbolRemovalChanges: SYMBOL_REMOVALS_MIGRATION,
   symbolRenamingChanges: SYMBOL_RENAMING_MIGRATION
 });

--- a/projects/element-ng/schematics/migrations/data/provider-function-removals.ts
+++ b/projects/element-ng/schematics/migrations/data/provider-function-removals.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+export interface ProviderFunctionRemovalInstruction {
+  /** Module that the provider function was imported from. */
+  module: RegExp;
+  /** Names of the provider functions to remove. */
+  names: string[];
+}
+
+export const PROVIDER_FUNCTION_REMOVALS_MIGRATION: ProviderFunctionRemovalInstruction[] = [
+  // v49 to v51
+  {
+    module: /@(siemens|simpl)\/element-ng(\/icon)?/,
+    names: ['provideIconConfig']
+  }
+];

--- a/projects/element-ng/schematics/migrations/element-migration/element-migration.spec.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/element-migration.spec.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-
 import { Tree, callRule } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import { readFileSync } from 'fs';
@@ -158,5 +157,17 @@ describe('to legacy migration', () => {
 
   it('should migrate element classes in inline template', async () => {
     await checkTemplateMigration(['element-class-inline-template.ts']);
+  });
+
+  it('should remove provideIconConfig from a providers array and drop its import', async () => {
+    await checkTemplateMigration(['provide-icon-config.ts']);
+  });
+
+  it('should remove provideIconConfig when it is the sole provider', async () => {
+    await checkTemplateMigration(['provide-icon-config-sole-provider.ts']);
+  });
+
+  it('should remove provideIconConfig but keep other symbols from the same import', async () => {
+    await checkTemplateMigration(['provide-icon-config-mixed-import.ts']);
   });
 });

--- a/projects/element-ng/schematics/migrations/element-migration/element-migration.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/element-migration.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-
 import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 
 import { discoverSourceFiles } from '../../utils/index.js';
@@ -13,6 +12,7 @@ import {
   applyClassMemberReplacementMigration,
   applyComponentPropertyNameMigration,
   applyElementSelectorMigration,
+  applyProviderFunctionRemovalMigration,
   applySymbolRemovalMigration,
   applySymbolRenamingMigration
 } from '../utilities/index.js';
@@ -42,7 +42,8 @@ export const elementMigrationRule = (
         elementSelectorChanges,
         symbolRemovalChanges,
         elementClassChanges,
-        classMemberReplacementChanges
+        classMemberReplacementChanges,
+        providerFunctionRemovalChanges
       } = migrationData;
 
       applyComponentPropertyNameMigration(migrationContext, componentPropertyNameChanges);
@@ -52,6 +53,7 @@ export const elementMigrationRule = (
       applySymbolRemovalMigration(migrationContext, symbolRemovalChanges);
       applyElementClassMigration(migrationContext, elementClassChanges);
       applyClassMemberReplacementMigration(migrationContext, classMemberReplacementChanges);
+      applyProviderFunctionRemovalMigration(migrationContext, providerFunctionRemovalChanges);
 
       tree.commitUpdate(recorder);
     }

--- a/projects/element-ng/schematics/migrations/element-migration/files/expected.provide-icon-config-mixed-import.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/expected.provide-icon-config-mixed-import.ts
@@ -1,0 +1,9 @@
+import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
+import { addIcons } from '@siemens/element-ng/icon';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZonelessChangeDetection(),
+    { provide: 'ICONS', useValue: addIcons({ 'icon': 'icon' }) }
+  ]
+};

--- a/projects/element-ng/schematics/migrations/element-migration/files/expected.provide-icon-config-sole-provider.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/expected.provide-icon-config-sole-provider.ts
@@ -1,0 +1,5 @@
+import { ApplicationConfig } from '@angular/core';
+
+export const appConfig: ApplicationConfig = {
+  providers: []
+};

--- a/projects/element-ng/schematics/migrations/element-migration/files/expected.provide-icon-config.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/expected.provide-icon-config.ts
@@ -1,0 +1,5 @@
+import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideZonelessChangeDetection()]
+};

--- a/projects/element-ng/schematics/migrations/element-migration/files/provide-icon-config-mixed-import.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/provide-icon-config-mixed-import.ts
@@ -1,0 +1,10 @@
+import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
+import { addIcons, provideIconConfig } from '@siemens/element-ng/icon';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZonelessChangeDetection(),
+    provideIconConfig({ disableSvgIcons: true }),
+    { provide: 'ICONS', useValue: addIcons({ 'icon': 'icon' }) }
+  ]
+};

--- a/projects/element-ng/schematics/migrations/element-migration/files/provide-icon-config-sole-provider.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/provide-icon-config-sole-provider.ts
@@ -1,0 +1,6 @@
+import { ApplicationConfig } from '@angular/core';
+import { provideIconConfig } from '@siemens/element-ng/icon';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideIconConfig({ disableSvgIcons: true })]
+};

--- a/projects/element-ng/schematics/migrations/element-migration/files/provide-icon-config.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/provide-icon-config.ts
@@ -1,0 +1,6 @@
+import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
+import { provideIconConfig } from '@siemens/element-ng/icon';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideZonelessChangeDetection(), provideIconConfig({ disableSvgIcons: true })]
+};

--- a/projects/element-ng/schematics/migrations/utilities/import-removal.ts
+++ b/projects/element-ng/schematics/migrations/utilities/import-removal.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import ts from 'typescript';
+
+/**
+ * Describes an edit that removes one or more named import specifiers from an import
+ * declaration.
+ *
+ * - When `newNode` is `undefined`, the range should be removed without any
+ *   replacement (the whole import declaration is dropped).
+ * - Otherwise the range should be replaced with the printed `newNode` (the import
+ *   declaration rebuilt without the removed specifiers).
+ */
+export interface ImportRemovalEdit {
+  start: number;
+  width: number;
+  newNode?: ts.Node;
+}
+
+/**
+ * Builds an edit that removes the given named import specifiers from an import
+ * declaration.
+ *
+ * If no specifiers remain after the removal, the whole import declaration is removed
+ * (including its trailing newline). Otherwise the import is rebuilt without the removed
+ * specifiers while preserving the remaining specifiers and their aliases.
+ */
+export const removeImportSpecifiers = (
+  sourceFile: ts.SourceFile,
+  importDeclaration: ts.ImportDeclaration,
+  specifiers: ts.ImportSpecifier[]
+): ImportRemovalEdit => {
+  const namedBindings = importDeclaration.importClause?.namedBindings;
+
+  const remainingElements =
+    namedBindings && ts.isNamedImports(namedBindings)
+      ? namedBindings.elements.filter(element => !specifiers.includes(element))
+      : [];
+
+  if (remainingElements.length === 0) {
+    // No named binding remains: remove the whole import declaration including the
+    // trailing newline so no empty line is left behind.
+    const start = importDeclaration.getStart(sourceFile);
+    let end = importDeclaration.getEnd();
+    const fullText = sourceFile.getFullText();
+    if (fullText[end] === '\r') {
+      end++;
+    }
+    if (fullText[end] === '\n') {
+      end++;
+    }
+
+    return { start, width: end - start };
+  }
+
+  const updatedImport = ts.factory.createImportDeclaration(
+    importDeclaration.modifiers,
+    ts.factory.createImportClause(
+      importDeclaration.importClause!.isTypeOnly,
+      importDeclaration.importClause!.name,
+      ts.factory.createNamedImports(
+        remainingElements.map(element =>
+          ts.factory.createImportSpecifier(element.isTypeOnly, element.propertyName, element.name)
+        )
+      )
+    ),
+    importDeclaration.moduleSpecifier,
+    importDeclaration.attributes
+  );
+
+  return {
+    start: importDeclaration.getStart(sourceFile),
+    width: importDeclaration.getWidth(sourceFile),
+    newNode: updatedImport
+  };
+};

--- a/projects/element-ng/schematics/migrations/utilities/index.ts
+++ b/projects/element-ng/schematics/migrations/utilities/index.ts
@@ -10,4 +10,6 @@ export * from './component-property-name.migration.js';
 export * from './element-selector.migration.js';
 export * from './symbol-renaming.migration.js';
 export * from './symbol-removal.migration.js';
+export * from './provider-function-removal.migration.js';
+export * from './import-removal.js';
 export * from './migration.interface.js';

--- a/projects/element-ng/schematics/migrations/utilities/provider-function-removal.migration.ts
+++ b/projects/element-ng/schematics/migrations/utilities/provider-function-removal.migration.ts
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+import ts from 'typescript';
+
+import { getImportSpecifiers } from '../../utils/index.js';
+import { ProviderFunctionRemovalInstruction } from '../data/index.js';
+import { removeImportSpecifiers } from './import-removal.js';
+import { MigrationContext } from './migration.interface.js';
+
+interface RemovalEdit {
+  start: number;
+  width: number;
+  newNode?: ts.Node;
+}
+
+export const applyProviderFunctionRemovalMigration = (
+  context: MigrationContext,
+  changes: ProviderFunctionRemovalInstruction[]
+): void => {
+  const { discoveredSourceFile, recorder } = context;
+
+  if (!changes?.length) {
+    return;
+  }
+
+  const { sourceFile } = discoveredSourceFile;
+
+  const edits: RemovalEdit[] = [];
+
+  for (const change of changes) {
+    const importSpecifiers = getImportSpecifiers(sourceFile, change.module, change.names);
+
+    if (!importSpecifiers.length) {
+      continue;
+    }
+
+    // Local names as they are used in the file (respecting import aliases).
+    const localNames = new Set(importSpecifiers.map(specifier => specifier.name.text));
+
+    const removedCall = collectArrayElementRemovals(sourceFile, localNames, edits);
+
+    // Only remove the import if at least one call was actually removed from a provider array.
+    if (removedCall) {
+      // Group the matched specifiers by their import declaration so a single edit is
+      // produced per declaration, even when multiple names are removed at once.
+      const specifiersByImport = new Map<ts.ImportDeclaration, ts.ImportSpecifier[]>();
+      for (const specifier of importSpecifiers) {
+        const importDeclaration = specifier.parent.parent.parent;
+        if (!ts.isImportDeclaration(importDeclaration)) {
+          continue;
+        }
+        const existing = specifiersByImport.get(importDeclaration) ?? [];
+        existing.push(specifier);
+        specifiersByImport.set(importDeclaration, existing);
+      }
+
+      for (const [importDeclaration, specifiers] of specifiersByImport) {
+        edits.push(removeImportSpecifiers(sourceFile, importDeclaration, specifiers));
+      }
+    }
+  }
+
+  if (!edits.length) {
+    return;
+  }
+
+  const printer = ts.createPrinter();
+
+  // Apply edits from bottom to top so earlier offsets stay valid.
+  edits.sort((a, b) => b.start - a.start);
+
+  for (const edit of edits) {
+    recorder.remove(edit.start, edit.width);
+    if (edit.newNode) {
+      recorder.insertLeft(
+        edit.start,
+        printer.printNode(ts.EmitHint.Unspecified, edit.newNode, sourceFile)
+      );
+    }
+  }
+};
+
+/**
+ * Finds all call expressions of the given local names that appear as direct elements of
+ * an array literal (e.g. a `providers: [...]` array) and records removal edits covering
+ * the call together with its adjacent comma and surrounding whitespace.
+ *
+ * @returns `true` if at least one call was scheduled for removal.
+ */
+const collectArrayElementRemovals = (
+  sourceFile: ts.SourceFile,
+  localNames: Set<string>,
+  edits: RemovalEdit[]
+): boolean => {
+  let removed = false;
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      localNames.has(node.expression.text) &&
+      ts.isArrayLiteralExpression(node.parent)
+    ) {
+      edits.push(getArrayElementRemovalRange(sourceFile, node.parent, node));
+      removed = true;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  return removed;
+};
+
+/**
+ * Computes the removal range for a single element of an array literal so that the
+ * remaining array stays syntactically valid (no dangling commas).
+ */
+const getArrayElementRemovalRange = (
+  sourceFile: ts.SourceFile,
+  array: ts.ArrayLiteralExpression,
+  element: ts.Node
+): RemovalEdit => {
+  const elements = array.elements;
+  const index = elements.indexOf(element as ts.Expression);
+  const text = sourceFile.getFullText();
+
+  const elementStart = element.getStart(sourceFile);
+  const elementEnd = element.getEnd();
+
+  const isLast = index === elements.length - 1;
+
+  if (!isLast) {
+    // Remove up to (and including) the comma before the next element, plus the
+    // whitespace that follows it.
+    let end = elementEnd;
+    while (end < text.length && text[end] !== ',') {
+      end++;
+    }
+    // Skip the comma itself.
+    if (text[end] === ',') {
+      end++;
+    }
+    // Skip whitespace before the next element.
+    while (end < text.length && /\s/.test(text[end])) {
+      end++;
+    }
+    return { start: elementStart, width: end - elementStart };
+  }
+
+  // Last element: also remove the comma and whitespace that precede it, so the previous
+  // element does not end up with a trailing comma.
+  let start = elementStart;
+  let cursor = elementStart - 1;
+  while (cursor >= 0 && /\s/.test(text[cursor])) {
+    cursor--;
+  }
+  if (cursor >= 0 && text[cursor] === ',') {
+    start = cursor;
+  }
+
+  return { start, width: elementEnd - start };
+};

--- a/projects/element-ng/schematics/ng-update/index.spec.ts
+++ b/projects/element-ng/schematics/ng-update/index.spec.ts
@@ -69,6 +69,26 @@ export class TestComponent {
     expect(tree).toBeDefined();
   });
 
+  it('should remove provideIconConfig usage and its import', async () => {
+    const originalContent = `import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
+import { provideIconConfig } from '@siemens/element-ng/icon';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideZonelessChangeDetection(), provideIconConfig({ disableSvgIcons: true })]
+};`;
+
+    addTestFiles(appTree, {
+      '/projects/app/src/app.config.ts': originalContent
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+
+    const modifiedContent = tree.readContent('/projects/app/src/app.config.ts');
+    expect(modifiedContent).not.toContain('provideIconConfig');
+    expect(modifiedContent).not.toContain('@siemens/element-ng/icon');
+    expect(modifiedContent).toContain('providers: [provideZonelessChangeDetection()]');
+  });
+
   it('should pass options to sub-migrations', async () => {
     const customPath = '/custom/path';
     const options = { path: customPath };


### PR DESCRIPTION
fixes #1510

BREAKING CHANGE: removed `provideIconConfig()` provider

Consumer which want to provide their own custom icons must call `addIcons` during application bootstrap.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2239/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2239/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2239/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2239/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2239/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2239/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2239/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2239/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2239/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2239/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->




