### PR TITLE
test(photo-upload): replace fixed waits with expect.poll to fix flakiness

### DIFF
--- a/projects/element-ng/photo-upload/si-photo-upload.component.spec.ts
+++ b/projects/element-ng/photo-upload/si-photo-upload.component.spec.ts
@@ -141,11 +141,8 @@ describe(`SiPhotoUploadComponent`, () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     await fixture.whenStable();
-    const modal = document.querySelector('si-modal');
-    expect(modal).toBeInTheDocument();
-    // cannot use vi.useFakeTimers here
-    await new Promise(resolve => setTimeout(resolve, 100)); // Allow cropping lib to process
-    expect(modal?.querySelector('img')).toBeInTheDocument();
+    // expect.poll auto-retries until the cropping lib has decoded the image
+    await expect.poll(() => document.querySelector('si-modal img')).toBeInTheDocument();
   });
 
   it('should apply photo', async () => {
@@ -165,8 +162,9 @@ describe(`SiPhotoUploadComponent`, () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    // cannot use vi.useFakeTimers here
-    await new Promise(resolve => setTimeout(resolve, 100)); // Allow cropping lib to process
+    // expect.poll auto-retries until the cropping lib has decoded the image,
+    // so the Apply button produces a cropped result instead of a no-op.
+    await expect.poll(() => document.querySelector('si-modal img')).toBeInTheDocument();
 
     getButton(document.querySelector('si-modal')!, 'Apply').click();
     fixture.detectChanges();


### PR DESCRIPTION
The cropping tests used fixed setTimeout(100) waits, which were timing-dependent and flaky. Use Vitest's auto-retrying expect.poll to wait deterministically until the cropper's decoded image appears.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2241/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2241/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2241/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2241/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2241/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2241/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2241/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2241/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2241/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2241/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
