### PR TITLE
feat(phone-number-input): show national (trunk) prefix indicator

### DIFF
--- a/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form--large-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form--large-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:079e46a559e383253e1ee05008ffd8083ca3f01a07f49bb4f3d8b8d4b0fd0bb4
-size 40939
+oid sha256:91fff3d13b1fdf12f61a5e01b7b8e7075e0069329ad11b542e49af847b07f31e
+size 41472

--- a/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form--large-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form--large-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f1cf1e58bad04a0acd631d0f895c38ff0e1d5433350a9e4986ab6a3b62b334f
-size 40378
+oid sha256:ed0e5f2e4f8694288486c67c1ea49376d1fc2af0e09f26f02d6f3022fa916be3
+size 40900

--- a/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form--large-validated-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form--large-validated-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f694a59f4547f396bb6e56f24ad1cb2141a42cdad418f49f56feae60a53c11e5
-size 56290
+oid sha256:ac2f92607f5a1dac2b49bd395bb69e7969c2fdfc7bcba5ff5425f4952f3614ba
+size 56844

--- a/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form--large-validated-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form--large-validated-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1afed6cf552f53215a98c849ff78fcddc0a145484c181692dfa2ac9fdb847fec
-size 56244
+oid sha256:ca8d50e66673c99dca76e950dd4313d28ddb4d759c79bf907d2b0950c2feda40
+size 56805

--- a/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:085c28c4532da0b60125b1a39bf8049e3fc7662b178809d36c505520c41fa64f
-size 38716
+oid sha256:b12433fc1c74c8f5b873eadaf1216a545a5bd1adee82fad0e6313ce0869f8f59
+size 39223

--- a/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-form.spec.ts-snapshots/si-form--si-form-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d21b48aa38739861f9a96270f2b356d9ce7ec77da19ae8decb73177d5312e3c1
-size 37883
+oid sha256:4494a5f0afc7f6e571c8d0b57d37528ee47f4857eeeba61eb5eece65b4c0c212
+size 38493

--- a/playwright/snapshots/static.spec.ts-snapshots/si-phone-number-input--si-phone-number-input-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-phone-number-input--si-phone-number-input-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b91dae51befccb6fc0105145deda4045d85c0a917b2ce4ef0bda497b2c7226a
-size 13783
+oid sha256:4ee27c6a1fe24bb77b12f35c6a60b131efcb12cbc5672c34b8dad36c47678e04
+size 14380

--- a/playwright/snapshots/static.spec.ts-snapshots/si-phone-number-input--si-phone-number-input-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-phone-number-input--si-phone-number-input-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d190706e911dfda2effd20b7db4db7fe7fd27832d8a677104465bea306c6be79
-size 13672
+oid sha256:9e7a055434eae01e1531348c57b1c1308f7c24c26eed9c502554066125545f18
+size 14284

--- a/projects/element-ng/phone-number/si-phone-number-input.component.html
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.html
@@ -17,7 +17,7 @@
     [attr.aria-labelledby]="id() + '-aria-label ' + id() + '-value'"
     [attr.aria-expanded]="open"
     [options]="countryList()"
-    [value]="selectedCountry"
+    [value]="selectedCountry()"
     [tabindex]="disabled() ? '-1' : '0'"
     [attr.aria-controls]="id() + '-listbox'"
     (valueChange)="countryInput($event)"
@@ -30,12 +30,12 @@
     }}</span>
     <span
       aria-hidden="true"
-      [class]="`fi fi-${(selectedCountry?.isoCode | lowercase) ?? 'xx'}`"
+      [class]="`fi fi-${(selectedCountry()?.isoCode | lowercase) ?? 'xx'}`"
     ></span>
-    @if (selectedCountry) {
+    @if (selectedCountry()) {
       <span class="si-body ms-4" [id]="id() + '-value'">
-        <span class="visually-hidden">{{ selectedCountry.name }}</span>
-        +{{ selectedCountry.countryCode }}
+        <span class="visually-hidden">{{ selectedCountry()!.name }}</span>
+        +{{ selectedCountry()!.countryCode }}
       </span>
     }
     <si-icon class="icon dropdown-caret" [icon]="icons.elementDown2" />
@@ -65,6 +65,11 @@
       {{ option.value.name }} +{{ option.value.countryCode }}
     </ng-template>
   </button>
+  @if (nationalPrefix()) {
+    <span class="national-prefix d-flex align-items-center" aria-hidden="true"
+      >({{ nationalPrefix() }})</span
+    >
+  }
   <input
     #phoneInput
     type="tel"

--- a/projects/element-ng/phone-number/si-phone-number-input.component.scss
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.scss
@@ -44,6 +44,17 @@
   }
 }
 
+.national-prefix {
+  color: all-variables.$element-text-secondary;
+  white-space: nowrap;
+  cursor: default;
+  user-select: none;
+}
+
+.disabled .national-prefix {
+  color: all-variables.$element-text-disabled;
+}
+
 .phone-number {
   background-color: transparent;
   inline-size: inherit;

--- a/projects/element-ng/phone-number/si-phone-number-input.component.spec.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.spec.ts
@@ -241,6 +241,55 @@ describe('SiPhoneNumberInputComponent', () => {
     expect(component.form.controls.workPhone.errors).toBeFalsy();
   });
 
+  it('should keep the mobile token visible for numbers that only expose it in international format', async () => {
+    // Argentine mobile numbers carry a `9` after the country code in international
+    // format (`+54 9 11 ...`). The national format hides it as a `15` infix, so the
+    // input must display the international significant number to keep the `9` visible.
+    component.supportedCountries.set(null);
+    await fixture.whenStable();
+    component.form.controls.workPhone.setValue('+5491123456789');
+    await fixture.whenStable();
+
+    expect(component.country()).toBe('AR');
+    expect(inputElement.value).toEqual('9 11 2345-6789');
+  });
+
+  describe('national (trunk) prefix indicator', () => {
+    const getNationalPrefix = (): HTMLElement | null =>
+      element.querySelector<HTMLElement>('.national-prefix');
+
+    beforeEach(async () => {
+      component.supportedCountries.set(null);
+      await fixture.whenStable();
+    });
+
+    it('should show the indicator for numbers with a droppable `0` trunk prefix', async () => {
+      component.form.controls.workPhone.setValue('+4917612345678');
+      await fixture.whenStable();
+      expect(getNationalPrefix()).toHaveTextContent('(0)');
+    });
+
+    it('should not show the indicator for countries without a droppable `0` trunk prefix', async () => {
+      component.form.controls.workPhone.setValue('+12025550173');
+      await fixture.whenStable();
+      expect(getNationalPrefix()).toBeNull();
+    });
+
+    it('should show the indicator for an Argentine landline', async () => {
+      component.form.controls.workPhone.setValue('+541143211234');
+      await fixture.whenStable();
+      expect(getNationalPrefix()).toHaveTextContent('(0)');
+    });
+
+    it('should not show the indicator for an Argentine mobile', async () => {
+      // The international `9` mobile token and the domestic `0 … 15` marker are different
+      // encodings, so `+54 (0) 9 …` would be misleading.
+      component.form.controls.workPhone.setValue('+5491123456789');
+      await fixture.whenStable();
+      expect(getNationalPrefix()).toBeNull();
+    });
+  });
+
   describe('with control disabled', () => {
     let phoneInput: HTMLElement;
 

--- a/projects/element-ng/phone-number/si-phone-number-input.component.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.ts
@@ -191,8 +191,38 @@ export class SiPhoneNumberInputComponent
   readonly errormessageId = input(`${this.id()}-errormessage`);
 
   protected readonly phoneInput = viewChild.required<ElementRef<HTMLInputElement>>('phoneInput');
-  protected selectedCountry?: CountryInfo;
+  protected readonly selectedCountry = signal<CountryInfo | undefined>(undefined);
   protected placeholder = '';
+  /**
+   * The national (trunk) prefix of the currently entered number, shown as a non-editable
+   * `(0)` indicator. The phone number itself is displayed in international format without
+   * the country code, so the leading trunk `0` is never part of the input and is instead
+   * represented by this indicator.
+   *
+   * The indicator is number-aware: it is only shown when the droppable `0` trunk prefix
+   * genuinely prepends the displayed number (i.e. the national format equals `0` + the
+   * displayed significant number). This keeps it for e.g. German numbers and Argentine
+   * landlines, but hides it for Argentine mobiles, where the international `9` mobile token
+   * and the domestic `0 … 15` marker are different encodings and must not be combined
+   * (`+54 (0) 9 …` would be wrong). Countries without a droppable `0` trunk prefix (e.g. US
+   * with `1`, or Italy where the leading `0` is part of the number) yield an empty string.
+   */
+  protected readonly nationalPrefix = computed(() => {
+    const country = this.selectedCountry();
+    const number = this.phoneNumber();
+    if (!country || !number) {
+      return '';
+    }
+
+    if (this.phoneUtil.getNddPrefixForRegion(country.isoCode, true) !== '0') {
+      return '';
+    }
+
+    const onlyDigits = (value: string): string => value.replace(/\D/g, '');
+    const nationalDigits = onlyDigits(this.phoneUtil.format(number, PhoneNumberFormat.NATIONAL));
+    const displayedDigits = onlyDigits(this.formatWithoutCountryCode(number));
+    return nationalDigits === '0' + displayedDigits ? '0' : '';
+  });
   protected readonly countryFocused = signal(false);
   protected open = false;
   protected overlayWidth = 0;
@@ -221,7 +251,7 @@ export class SiPhoneNumberInputComponent
   );
   private readonly disabledNgControl = signal(false);
   private isValidNumber = true;
-  private phoneNumber?: PhoneNumber;
+  private readonly phoneNumber = signal<PhoneNumber | undefined>(undefined);
   private onChange: (val: string) => void = () => {};
   private onTouched: () => void = () => {};
 
@@ -233,8 +263,8 @@ export class SiPhoneNumberInputComponent
 
   /** @internal */
   writeValue(value: string | undefined): void {
-    this.phoneNumber = this.parseNumber(value);
-    if (this.phoneNumber) {
+    this.phoneNumber.set(this.parseNumber(value));
+    if (this.phoneNumber()) {
       this.writeValueToInput();
       this.country.set(this.getRegionCode());
     } else {
@@ -268,13 +298,14 @@ export class SiPhoneNumberInputComponent
     }
 
     this.isValidNumber = false;
-    if (!this.phoneNumber || !this.phoneUtil.isValidNumber(this.phoneNumber)) {
+    const number = this.phoneNumber();
+    if (!number || !this.phoneUtil.isValidNumber(number)) {
       return {
         invalidPhoneNumberFormat: true
       };
     }
 
-    if (!this.countryList().some(c => c.value.isoCode === this.selectedCountry!.isoCode)) {
+    if (!this.countryList().some(c => c.value.isoCode === this.selectedCountry()!.isoCode)) {
       return {
         notSupportedPhoneNumberCountry: true
       };
@@ -286,9 +317,10 @@ export class SiPhoneNumberInputComponent
 
   protected input(): void {
     const rawNumber = this.phoneInput().nativeElement.value;
-    this.phoneNumber = this.parseNumber(rawNumber);
+    const number = this.parseNumber(rawNumber);
+    this.phoneNumber.set(number);
 
-    if (this.phoneNumber) {
+    if (number) {
       const regionCode = this.getRegionCode();
       let countryInfo = this.countryList().find(
         country => regionCode === country.value.isoCode
@@ -296,15 +328,15 @@ export class SiPhoneNumberInputComponent
       if (!countryInfo && regionCode) {
         countryInfo = {
           name: this.getCountryName(regionCode),
-          countryCode: this.phoneNumber.getCountryCode()!,
+          countryCode: number.getCountryCode()!,
           isoCode: regionCode
         };
       }
-      if (countryInfo && this.selectedCountry?.isoCode !== countryInfo.isoCode) {
-        this.selectedCountry = countryInfo;
+      if (countryInfo && this.selectedCountry()?.isoCode !== countryInfo.isoCode) {
+        this.selectedCountry.set(countryInfo);
       }
     } else if (rawNumber.trim().startsWith('+')) {
-      this.selectedCountry = undefined;
+      this.selectedCountry.set(undefined);
     }
 
     this.handleChange();
@@ -315,14 +347,14 @@ export class SiPhoneNumberInputComponent
     this.onTouched();
     this.writeValueToInput();
     this.valueChange.emit({
-      country: this.selectedCountry,
+      country: this.selectedCountry(),
       phoneNumber: this.formatPhoneNumber(PhoneNumberFormat.INTERNATIONAL),
       isValid: this.isValidNumber
     });
   }
 
   protected countryInput(num: CountryInfo): void {
-    this.selectedCountry = num;
+    this.selectedCountry.set(num);
     this.updatePlaceholder();
     this.refreshValueAfterCountryChange();
     this.handleChange();
@@ -342,21 +374,22 @@ export class SiPhoneNumberInputComponent
 
   private writeCountry(): void {
     const currentCountry = this.country()!;
-    this.selectedCountry = this.countryList().find(
+    let country = this.countryList().find(
       country => country.value.isoCode === currentCountry
     )?.value;
-    if (!this.selectedCountry) {
+    if (!country) {
       const countryCode = this.phoneUtil.getCountryCodeForRegion(
         currentCountry ?? this.defaultCountry() ?? 'XX'
       );
       if (countryCode) {
-        this.selectedCountry = {
+        country = {
           isoCode: currentCountry,
           countryCode,
           name: this.getCountryName(currentCountry)
         };
       }
     }
+    this.selectedCountry.set(country);
     this.updatePlaceholder();
     this.refreshValueAfterCountryChange();
   }
@@ -371,21 +404,31 @@ export class SiPhoneNumberInputComponent
   }
 
   private updatePlaceholder(): void {
-    if (this.selectedCountry) {
-      this.placeholder = this.phoneUtil
-        .format(
-          this.phoneUtil.getExampleNumber(this.selectedCountry.isoCode),
-          PhoneNumberFormat.NATIONAL
-        )
-        .replace(/^0/, '');
+    if (this.selectedCountry()) {
+      this.placeholder = this.formatWithoutCountryCode(
+        this.phoneUtil.getExampleNumber(this.selectedCountry()!.isoCode)
+      );
     }
+  }
+
+  /**
+   * Formats the given number in international format but without the leading
+   * `+<countryCode>` prefix (which is already shown by the country selector).
+   * Unlike the national format, this keeps mobile tokens that only appear in the
+   * international representation visible, e.g. the `9` in Argentine mobile numbers
+   * (`+54 9 351 ...` instead of the national `0351 15-...`).
+   */
+  private formatWithoutCountryCode(number: PhoneNumber): string {
+    return this.phoneUtil
+      .format(number, PhoneNumberFormat.INTERNATIONAL)
+      .replace(new RegExp(`^\\+${number.getCountryCode()}\\s*`), '');
   }
 
   private parseNumber(rawNumber: string | undefined): PhoneNumber | undefined {
     try {
       let regionCodeForParsing: string | undefined;
       if (!rawNumber?.trim().startsWith('+')) {
-        regionCodeForParsing = this.selectedCountry?.isoCode;
+        regionCodeForParsing = this.selectedCountry()?.isoCode;
       }
       return this.phoneUtil.parse(rawNumber, regionCodeForParsing);
     } catch (e) {
@@ -399,49 +442,52 @@ export class SiPhoneNumberInputComponent
    * This Method fakes a complete number to force PhoneUtil returning a proper region code.
    */
   private getRegionCode(): string | undefined {
-    if (this.phoneNumber) {
-      const regionCode = this.phoneUtil.getRegionCodeForNumber(this.phoneNumber);
+    const number = this.phoneNumber();
+    if (number) {
+      const regionCode = this.phoneUtil.getRegionCodeForNumber(number);
       if (regionCode) {
         return regionCode;
       }
 
-      const nationalNumber = this.phoneNumber.getNationalNumber() + '';
+      const nationalNumber = number.getNationalNumber() + '';
       if (
         // USA, CANADA, ...
-        (this.phoneNumber.getCountryCode() === 1 && nationalNumber.length >= 3) ||
+        (number.getCountryCode() === 1 && nationalNumber.length >= 3) ||
         // UK, ...
-        (this.phoneNumber.getCountryCode() === 44 && nationalNumber.length >= 4)
+        (number.getCountryCode() === 44 && nationalNumber.length >= 4)
       ) {
         return this.phoneUtil.getRegionCodeForNumber(
           this.phoneUtil.parse(
             '+' +
-              this.phoneNumber.getCountryCode() +
+              number.getCountryCode() +
               nationalNumber +
               new Array(10 - nationalNumber.length).fill(5).join('')
           )
         );
       }
 
-      return this.phoneUtil.getRegionCodeForCountryCode(this.phoneNumber.getCountryCode()!);
+      return this.phoneUtil.getRegionCodeForCountryCode(number.getCountryCode()!);
     }
 
     return undefined;
   }
 
   private formatPhoneNumber(format: PhoneNumberFormat): string | undefined {
-    if (this.phoneNumber) {
-      return this.phoneUtil.format(this.phoneNumber, format);
+    const number = this.phoneNumber();
+    if (number) {
+      return this.phoneUtil.format(number, format);
     }
 
     return undefined;
   }
 
   private handleChange(): void {
-    if (this.selectedCountry && this.country() !== this.selectedCountry?.isoCode) {
-      this.country.set(this.selectedCountry?.isoCode);
+    const selectedCountry = this.selectedCountry();
+    if (selectedCountry && this.country() !== selectedCountry.isoCode) {
+      this.country.set(selectedCountry.isoCode);
     }
 
-    if (this.phoneNumber) {
+    if (this.phoneNumber()) {
       this.onChange(this.formatPhoneNumber(PhoneNumberFormat.INTERNATIONAL)!);
     } else {
       this.onChange('');
@@ -455,14 +501,16 @@ export class SiPhoneNumberInputComponent
    * Format and update input text or clear input text if the input value is undefined.
    */
   private writeValueToInput(): void {
-    if (this.phoneNumber) {
-      this.writeTextToInput(this.formatPhoneNumber(PhoneNumberFormat.NATIONAL)!.replace(/^0/, ''));
+    const number = this.phoneNumber();
+    if (number) {
+      this.writeTextToInput(this.formatWithoutCountryCode(number));
     }
   }
 
   private refreshValueAfterCountryChange(): void {
-    if (this.selectedCountry) {
-      this.phoneNumber?.setCountryCode(this.selectedCountry?.countryCode);
+    const selectedCountry = this.selectedCountry();
+    if (selectedCountry) {
+      this.phoneNumber()?.setCountryCode(selectedCountry.countryCode);
       this.writeValueToInput();
     }
   }


### PR DESCRIPTION
Display a non-editable `(0)` indicator between the country code and the
phone number input for countries that use a droppable `0` trunk prefix
(e.g. Germany), producing numbers like `+49 (0) 176 ...`. The prefix is
detected via libphonenumber's national direct dialing prefix and is
omitted for countries without a `0` trunk prefix (e.g. US, Italy).<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2242/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2242/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2242/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2242/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2242/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2242/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2242/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2242/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2242/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2242/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

