### PR TITLE
docs(localization): document translate CLI key extraction

### DIFF
--- a/docs/fundamentals/localization.md
+++ b/docs/fundamentals/localization.md
@@ -264,3 +264,51 @@ Note that this hash key will only be appended to the translation based JSON file
 ### Translatable keys in Element
 
 <si-docs-type name="SiTranslatableKeys"></si-docs-type>
+
+### Extracting translatable keys
+
+An important part of the translation tooling is the extraction of translatable keys as a TypeScript
+interface as well as the extraction of a JSON messages file with default translations. This is
+provided by the `@siemens/element-translate-cli` package, which exposes the
+`update-translatable-keys` command. Install it as a dev dependency:
+
+```sh
+npm install --save-dev @siemens/element-translate-cli
+```
+
+The extraction happens on compiled files. I.e. make sure to run the build first. Then, to run these
+extractions:
+
+```sh
+npx update-translatable-keys
+```
+
+By default, this will pick up the configuration from a file `element-translate.conf.json`. To use a
+different config file, pass it as the only argument to the command.
+
+The config file looks like this:
+
+```json
+{
+  "files": "dist/@siemens/**/fesm2022/**/*.mjs",
+  "configs": [
+    {
+      "name": "element",
+      "locationPrefix": "projects/element-ng",
+      "keysFile": "projects/element-ng/translate/si-translatable-keys.interface.ts",
+      "keysInterfaceName": "SiTranslatableKeys",
+      "messagesFile": "dist/@siemens/element-ng/template-i18n.json"
+    }
+  ]
+}
+```
+
+- `files` is a glob pattern for defining the files to scan.
+- `configs` is an array of configs. For mono-repos building multiple libraries, they can be
+  separated into different configs. All keys are required:
+  - `name` is a unique name.
+  - `locationPrefix` defines the path prefix of the source files, important to distinguish between
+    different libraries in a mono-repo.
+  - `keysFile` defines the path of the generated TypeScript interfaces file.
+  - `keysInterfaceName` defines the name of the TypeScript `interface`.
+  - `messagesFile` defines the path of the generated messages JSON file.

--- a/projects/element-translate-ng/README.md
+++ b/projects/element-translate-ng/README.md
@@ -17,43 +17,11 @@ Install the library as follows:
 npm install --save @siemens/element-translate-ng
 ```
 
-An important part of the library is the extraction of translatable keys as a TypeScript interface
-as well as extracting a JSON messages file with default translations. The extraction happens on
-compiled files. I.e. make sure to run the build first. Then, to run these extractions
-
-```sh
-npx update-translatable-keys
-```
-
-By default, this will pick of the configuration from a file `element-translate.conf.json`. To
-use a different config file, pass as the only argument to the command.
-
-The config file looks like this
-
-```json
-{
-  "files": "dist/@simpl/**/fesm2022/**/*.mjs",
-  "configs": [
-    {
-      "name": "element",
-      "locationPrefix": "projects/element-ng",
-      "keysFile": "projects/element-ng/translate/si-translatable-keys.interface.ts",
-      "keysInterfaceName": "SiTranslatableKeys",
-      "messagesFile": "dist/@siemens/element-ng/template-i18n.json"
-    }
-  ]
-}
-```
-
-- `files` is a glob pattern for defining the files to scan
-- `configs` is an array of configs. For mono-repos building multiple libraries, they can be
-  separated into different configs. All keys are required:
-  - `name` is a unique name
-  - `locationsPrefix` defines the path prefix of the source files, important to distinguish
-    between different libraries in a mono-repo
-  - `keysFile` defines the path of the generated TypeScript interfaces file
-  - `keysInterfaceName` defines the name of the TypeScript `interface`
-  - `messagesFile` defines the path of the generated messages JSON file
+An important part of the translation tooling is the extraction of translatable keys as a TypeScript
+interface as well as extracting a JSON messages file with default translations. This is provided by
+the separate `@siemens/element-translate-cli` package via the `update-translatable-keys` CLI. See
+[Extracting translatable keys](https://element.siemens.io/fundamentals/localization/#extracting-translatable-keys)
+for details on how to run it and how to configure it.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Moves the `update-translatable-keys` CLI documentation out of the `element-translate-ng` package README and into the real localization documentation.

- Adds an **Extracting translatable keys** subsection to `docs/fundamentals/localization.md`, covering the `update-translatable-keys` command and the `element-translate.conf.json` config schema.
- Clarifies that the CLI ships as the separate `@siemens/element-translate-cli` package (including the dev-dependency install step).
- Trims the duplicated CLI/config content from `projects/element-translate-ng/README.md`, replacing it with a short paragraph linking to the docs section.
- Fixes a typo in the config field name (`locationsPrefix` -> `locationPrefix`).

## Rationale

CLI tooling documentation belongs in the maintained docs site rather than a package README, where it is easier to discover and keep up to date.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2247/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2247/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2247/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2247/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2247/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2247/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2247/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2247/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2247/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2247/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
