### PR TITLE
fix(live-preview): skip stackblitz source fetch when no example is set

### DIFF
--- a/projects/live-preview/components/stackblitz/si-stackblitz-button.component.ts
+++ b/projects/live-preview/components/stackblitz/si-stackblitz-button.component.ts
@@ -20,7 +20,9 @@ import { SI_STACKBLITZ_CONFIG } from './stackblitz.provider';
 })
 export class SiStackblitzButtonDirective {
   protected readonly config = inject(SI_STACKBLITZ_CONFIG, { optional: true });
-  private readonly exampleTs = httpResource.text(() => `${this.baseUrl()}${this.example()}.ts`);
+  private readonly exampleTs = httpResource.text(() =>
+    this.example() ? `${this.baseUrl()}${this.example()}.ts` : undefined
+  );
   private readonly isExample = computed(() => {
     if (this.exampleTs.hasValue()) {
       const content = this.exampleTs.value();


### PR DESCRIPTION
## Problem

Navigating to the live-preview app root (`localhost:4200`, which redirects to `viewer/editor`) produced a runtime console error:

```
GET http://localhost:4200/app/examples/undefined.ts 404 (Not Found)
```

## Cause

The stackblitz button directive's `httpResource` built its request URL unconditionally:

```ts
private readonly exampleTs = httpResource.text(() => `${this.baseUrl()}${this.example()}.ts`);
```

When no example was selected, `example()` is `undefined`, so the resource fetched `app/examples/undefined.ts`, returning a 404.

## Fix

Return `undefined` from the request factory when no example is set, which keeps the `httpResource` idle so no request is made until a real example is selected.

The button remains disabled when there is no example (already handled by `!this.example()` in the `disabled` computed).<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2248/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2248/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2248/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2248/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2248/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2248/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2248/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2248/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2248/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2248/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
