### PR TITLE
docs(dashboards): remove obsolete gridstack-extra.css reference

### DIFF
--- a/projects/dashboards-ng/README.md
+++ b/projects/dashboards-ng/README.md
@@ -75,8 +75,7 @@ the `angular.json` file.
 ```json
 "styles": [
   "src/styles.scss",
-  "node_modules/gridstack/dist/gridstack.css",
-  "node_modules/gridstack/dist/gridstack-extra.css"
+  "node_modules/gridstack/dist/gridstack.css"
 ],
 "allowedCommonJsDependencies": [
   "gridstack"


### PR DESCRIPTION
The gridstack-extra.css file no longer ships in gridstack 12.x, so the setup instructions should reference only gridstack.css.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2252/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2252/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2252/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2252/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2252/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2252/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2252/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2252/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2252/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2252/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
