### PR TITLE
refactor(dashboards): deprecate SimplDashboardsNgModule alias

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -168,10 +168,8 @@ export const SI_WIDGET_ID_PROVIDER: InjectionToken<SiWidgetIdProvider>;
 export const SI_WIDGET_STORE: InjectionToken<SiWidgetStorage>;
 
 // @public (undocumented)
-class SiDashboardsNgModule {
+export class SiDashboardsNgModule {
 }
-export { SiDashboardsNgModule }
-export { SiDashboardsNgModule as SimplDashboardsNgModule }
 
 // @public
 export class SiDefaultWidgetStorage extends SiWidgetStorage {
@@ -237,6 +235,12 @@ export class SiGridComponent implements OnInit, OnChanges, OnDestroy {
     readonly widgetInstanceEdit: _angular_core.OutputEmitterRef<WidgetConfig>;
     readonly widgetInstanceEditorDialogComponent: _angular_core.InputSignal<Type<SiWidgetInstanceEditorDialogComponent> | undefined>;
 }
+
+// @public @deprecated (undocumented)
+export const SimplDashboardsNgModule: typeof SiDashboardsNgModule;
+
+// @public @deprecated (undocumented)
+export type SimplDashboardsNgModule = SiDashboardsNgModule;
 
 // @public
 export class SiWidgetCatalogComponent extends SiWidgetEditorBase implements OnInit {

--- a/projects/dashboards-ng/src/public-api.module.ts
+++ b/projects/dashboards-ng/src/public-api.module.ts
@@ -25,4 +25,13 @@ import { SiWidgetInstanceEditorDialogComponent } from './components/widget-insta
 })
 export class SiDashboardsNgModule {}
 
-export { SiDashboardsNgModule as SimplDashboardsNgModule };
+/**
+ * @deprecated Use {@link SiDashboardsNgModule} instead. The `Simpl` prefix is deprecated and will be removed in v51.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const SimplDashboardsNgModule = SiDashboardsNgModule;
+
+/**
+ * @deprecated Use {@link SiDashboardsNgModule} instead. The `Simpl` prefix is deprecated and will be removed in v51.
+ */
+export type SimplDashboardsNgModule = SiDashboardsNgModule;


### PR DESCRIPTION
Export SimplDashboardsNgModule as a value alias of SiDashboardsNgModule with a @deprecated tag so consumers get a proper deprecation strikethrough at usage sites. The previous re-export specifier form did not surface the deprecation in the TypeScript language service.

DEPRECATED:
The `SimplDashboardsNgModule` should no longer be used. Use `SiDashboardsNgModule` instead. The `Simpl` prefix is deprecated and will be removed in v51.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2253/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2253/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2253/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2253/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2253/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2253/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2253/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2253/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2253/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2253/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
