### PR TITLE
fix(phone-number): truncate long country names

### DIFF
--- a/playwright/snapshots/static.spec.ts-snapshots/si-phone-number-input--si-phone-number-input-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-phone-number-input--si-phone-number-input-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b91dae51befccb6fc0105145deda4045d85c0a917b2ce4ef0bda497b2c7226a
-size 13783
+oid sha256:b755d12283fc5edcec4523f599224d66153353261888e14fdabdcdbb9e4018c2
+size 13787

--- a/playwright/snapshots/static.spec.ts-snapshots/si-phone-number-input--si-phone-number-input-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-phone-number-input--si-phone-number-input-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d190706e911dfda2effd20b7db4db7fe7fd27832d8a677104465bea306c6be79
-size 13672
+oid sha256:4e058781e958c181de6294d542f2bf71f1b6e787122759e9516f17d270f9a75d
+size 13676

--- a/projects/element-ng/phone-number/si-phone-number-input.component.html
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.html
@@ -48,7 +48,7 @@
       [cdkConnectedOverlayOpen]="open"
       [cdkConnectedOverlayFlexibleDimensions]="true"
       [cdkConnectedOverlayOffsetX]="-1"
-      [cdkConnectedOverlayWidth]="overlayWidth"
+      [cdkConnectedOverlayMinWidth]="overlayWidth"
       (backdropClick)="overlayDetach()"
       (detach)="overlayDetach()"
     >

--- a/src/app/examples/si-phone-number-input/si-phone-number-input.html
+++ b/src/app/examples/si-phone-number-input/si-phone-number-input.html
@@ -1,28 +1,17 @@
 <form class="p-5" [formGroup]="form">
-  <div class="form-group w-25">
-    <span id="phone-number-label" class="form-label">Phone number:</span>
-    <si-phone-number-input
-      class="form-control"
-      labelledby="phone-number-label"
-      formControlName="phoneNumber"
-      placeholderForSearch="FORM.SEARCH"
-      selectCountryAriaLabel="FORM.SELECT_COUNTRY"
-      aria-label="Phone Number"
-      defaultCountry="CH"
-      [supportedCountries]="['AU', 'CH', 'DE', 'FK', 'IN', 'US']"
-      (valueChange)="lastEventValue = $event"
-    />
-    <div class="invalid-feedback">
-      @if (form.controls.phoneNumber.errors?.invalidPhoneNumberFormat) {
-        <span>
-          {{ 'FORM.INVALID_PHONE' | translate }}
-        </span>
-      }
-      @if (form.controls.phoneNumber.errors?.notSupportedPhoneNumberCountry) {
-        <span>
-          {{ 'FORM.INVALID_PHONE_COUNTRY' | translate }}
-        </span>
-      }
+  <div class="row">
+    <div class="col-sm-6 col-lg-4">
+      <si-form-item label="Phone number:">
+        <si-phone-number-input
+          class="form-control"
+          formControlName="phoneNumber"
+          placeholderForSearch="FORM.SEARCH"
+          selectCountryAriaLabel="FORM.SELECT_COUNTRY"
+          defaultCountry="CH"
+          [supportedCountries]="['AU', 'CH', 'DE', 'FK', 'IN', 'US']"
+          (valueChange)="lastEventValue = $event"
+        />
+      </si-form-item>
     </div>
   </div>
   <hr />

--- a/src/app/examples/si-phone-number-input/si-phone-number-input.ts
+++ b/src/app/examples/si-phone-number-input/si-phone-number-input.ts
@@ -5,13 +5,12 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-// eslint-disable-next-line no-restricted-imports
-import { TranslatePipe } from '@ngx-translate/core';
+import { SiFormItemComponent } from '@siemens/element-ng/form';
 import { PhoneDetails, SiPhoneNumberInputComponent } from '@siemens/element-ng/phone-number';
 
 @Component({
   selector: 'app-sample',
-  imports: [CommonModule, SiPhoneNumberInputComponent, ReactiveFormsModule, TranslatePipe],
+  imports: [CommonModule, SiPhoneNumberInputComponent, ReactiveFormsModule, SiFormItemComponent],
   templateUrl: './si-phone-number-input.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })


### PR DESCRIPTION
On smaller screens not all country names fit
in the list.
Previously this was shrinking the flags and overflowing the dropdown.
Now they are truncated.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2255/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2255/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2255/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2255/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2255/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2255/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2255/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2255/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2255/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2255/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



