### PR TITLE
fix(phone-number): emit valueChange together with form control update

### DIFF
--- a/projects/element-ng/phone-number/si-phone-number-input.component.spec.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.spec.ts
@@ -132,11 +132,14 @@ describe('SiPhoneNumberInputComponent', () => {
 
   it('should show valid status on valid phone entry', async () => {
     await userEvent.type(inputElement, '30123456');
-    await userEvent.tab();
 
-    // Validate both the form control validity and also the final control value
+    // valueChange emits together with the form control model update on input, without needing blur
     expect(component.form.valid).toBe(true);
     expect(component.form.controls.workPhone.value).toEqual('+49 30 123456');
+    expect(component.currentValue).toMatchObject({
+      phoneNumber: '+49 30 123456',
+      isValid: true
+    });
   });
 
   it('should update the country code and phone number on setting it from the form control', async () => {

--- a/projects/element-ng/phone-number/si-phone-number-input.component.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.ts
@@ -324,11 +324,6 @@ export class SiPhoneNumberInputComponent
     this.countryFocused.set(false);
     this.onTouched();
     this.writeValueToInput();
-    this.valueChange.emit({
-      country: this.selectedCountry(),
-      phoneNumber: this.formatPhoneNumber(PhoneNumberFormat.INTERNATIONAL),
-      isValid: this.isValidNumber
-    });
   }
 
   protected countryInput(num: CountryInfo): void {
@@ -460,6 +455,12 @@ export class SiPhoneNumberInputComponent
     } else {
       this.onChange('');
     }
+
+    this.valueChange.emit({
+      country: this.selectedCountry(),
+      phoneNumber: this.formatPhoneNumber(PhoneNumberFormat.INTERNATIONAL),
+      isValid: this.isValidNumber
+    });
   }
 
   private writeTextToInput(value?: string): void {


### PR DESCRIPTION
Emit the valueChange output at the same time the form control model is updated on input, instead of only on blur.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2256/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2256/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2256/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2256/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2256/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2256/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2256/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2256/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2256/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2256/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
