### PR TITLE
fix(chat-messages): use placeholder in attachment remove aria-label

### DIFF
--- a/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-attachment-list.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-attachment-list.yaml
@@ -1,18 +1,18 @@
 - group:
   - button "quarterly-report.xlsx"
-  - button "Remove attachment quarterly-report.xlsx"
+  - button "Remove attachment"
 - group:
   - button "screenshot.png"
-  - button "Remove attachment screenshot.png"
+  - button "Remove attachment"
 - group:
   - button "very-long-filename-that-demonstrates-text-truncation-behavior.pdf"
-  - button "Remove attachment very-long-filename-that-demonstrates-text-truncation-behavior.pdf"
+  - button "Remove attachment"
 - group:
   - button "data.csv"
-  - button "Remove attachment data.csv"
+  - button "Remove attachment"
 - group:
   - button "audio.mp3"
-  - button "Remove attachment audio.mp3"
+  - button "Remove attachment"
 - group:
   - button "final-report.docx"
 - group:

--- a/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-input.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-input.yaml
@@ -1,9 +1,9 @@
 - group:
   - text: project-spec.pdf
-  - button "Remove attachment project-spec.pdf"
+  - button "Remove project-spec.pdf"
 - group:
   - text: mockup.png
-  - button "Remove attachment mockup.png"
+  - button "Remove mockup.png"
 - textbox "Chat message input":
   - /placeholder: Enter a command, question or topic...
 - group:

--- a/projects/element-ng/chat-messages/si-attachment-list.component.html
+++ b/projects/element-ng/chat-messages/si-attachment-list.component.html
@@ -45,7 +45,7 @@
         <button
           type="button"
           class="btn btn-tertiary-ghost btn-sm btn-icon expand-button flex-shrink-0 ms-auto align-self-center focus-inside m-2"
-          [attr.aria-label]="(removeLabel() | translate) + ' ' + attachment.name"
+          [attr.aria-label]="removeLabel() | translate: { attachment: attachment.name }"
           (click)="remove.emit(attachment); $event.stopPropagation()"
         >
           <si-icon class="icon" [icon]="icons.elementStateClose" />

--- a/projects/element-ng/chat-messages/si-attachment-list.component.ts
+++ b/projects/element-ng/chat-messages/si-attachment-list.component.ts
@@ -84,15 +84,16 @@ export class SiAttachmentListComponent {
   readonly removable = input(false, { transform: booleanAttribute });
 
   /**
-   * Label for remove attachment button
+   * Label for remove attachment button.
+   * The attachment name is available with `{{attachment}}`.
    *
    * @defaultValue
    * ```
-   * t(() => $localize`:@@SI_ATTACHMENT_LIST.REMOVE_ATTACHMENT:Remove attachment`)
+   * t(() => $localize`:@@SI_ATTACHMENT_LIST.REMOVE_ATTACHMENT:Remove {{attachment}}`)
    * ```
    */
   readonly removeLabel = input(
-    t(() => $localize`:@@SI_ATTACHMENT_LIST.REMOVE_ATTACHMENT:Remove attachment`)
+    t(() => $localize`:@@SI_ATTACHMENT_LIST.REMOVE_ATTACHMENT:Remove {{attachment}}`)
   );
 
   /**

--- a/projects/element-ng/chat-messages/si-chat-input.component.ts
+++ b/projects/element-ng/chat-messages/si-chat-input.component.ts
@@ -255,15 +255,16 @@ export class SiChatInputComponent implements AfterViewInit {
   );
 
   /**
-   * Remove attachment aria label prefix
+   * Remove attachment aria label.
+   * The attachment name is available with `{{attachment}}`.
    *
    * @defaultValue
    * ```
-   * t(() => $localize`:@@SI_ATTACHMENT_LIST.REMOVE_ATTACHMENT:Remove attachment`)
+   * t(() => $localize`:@@SI_ATTACHMENT_LIST.REMOVE_ATTACHMENT:Remove {{attachment}}`)
    * ```
    */
   readonly removeAttachmentLabel = input<TranslatableString>(
-    t(() => $localize`:@@SI_ATTACHMENT_LIST.REMOVE_ATTACHMENT:Remove attachment`)
+    t(() => $localize`:@@SI_ATTACHMENT_LIST.REMOVE_ATTACHMENT:Remove {{attachment}}`)
   );
 
   /**


### PR DESCRIPTION
This is theoretically breaking, but the component is experimental. So using NOTE instead.

----

Replace the translatable string concatenation in the si-attachment-list
remove button aria-label with a `{{attachment}}` placeholder so the label
is fully translatable. Previously the attachment name was appended to the
translated label in the template.

Closes #2128

NOTE: Custom `removeLabel`/`removeAttachmentLabel` inputs on `si-attachment-list`
and `si-chat-input` should now include the `{{attachment}}` placeholder to embed
the attachment name in the remove button aria-label<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2258/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2258/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2258/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2258/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2258/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2258/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2258/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2258/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2258/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2258/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

