### PR TITLE
docs: add element-members as owners of .agents directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,6 +29,7 @@ api-goldens/element-ng/threshold/ @siemens/siemens-element-owners @dr-itz
 api-goldens/element-ng/tour/ @siemens/siemens-element-owners @dr-itz
 api-goldens/element-ng/typeahead/ @siemens/siemens-element-owners @spliffone
 
+.agents/ @siemens/siemens-element-owners @siemens/siemens-element-members
 playwright/ @siemens/siemens-element-owners @siemens/siemens-element-members
 docs/ @siemens/siemens-element-owners @siemens/siemens-element-members
 src/ @siemens/siemens-element-owners @siemens/siemens-element-members

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,7 @@ api-goldens/element-ng/tour/ @siemens/siemens-element-owners @dr-itz
 api-goldens/element-ng/typeahead/ @siemens/siemens-element-owners @spliffone
 
 .agents/ @siemens/siemens-element-owners @siemens/siemens-element-members
+AGENTS.md @siemens/siemens-element-owners @siemens/siemens-element-members
 playwright/ @siemens/siemens-element-owners @siemens/siemens-element-members
 docs/ @siemens/siemens-element-owners @siemens/siemens-element-members
 src/ @siemens/siemens-element-owners @siemens/siemens-element-members


### PR DESCRIPTION
Adds `@siemens/siemens-element-members` as owners of the `.agents/` directory in CODEOWNERS, consistent with the existing ownership of `playwright/`, `docs/`, `src/`, and `projects/`.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2259/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2259/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2259/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2259/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2259/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2259/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2259/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2259/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2259/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2259/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

