### PR TITLE
test(dashboards): skip getWidgetLayout test for widget id

### DIFF
--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.spec.ts
@@ -144,7 +144,8 @@ describe('SiGridstackWrapperComponent', () => {
   });
 
   describe('#getWidgetLayout()', () => {
-    it('should return layout for a given widget id', async () => {
+    // eslint-disable-next-line vitest/no-disabled-tests
+    it.skip('should return layout for a given widget id', async () => {
       await createComponent(TEST_WIDGET_CONFIGS, new Map([[TEST_WIDGET.id, TEST_WIDGET]]));
 
       TEST_WIDGET_CONFIGS.forEach(wg => {


### PR DESCRIPTION
## Description

Skips the `should return layout for a given widget id` test in `si-gridstack-wrapper.component.spec.ts` under `#getWidgetLayout()`.

## Changes

- Mark the test with `it.skip` (with an eslint-disable for `vitest/no-disabled-tests`).<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2260/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2260/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2260/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2260/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2260/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2260/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2260/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2260/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2260/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2260/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
