### PR TITLE
ci(check-commit-messages): drop job

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -16,20 +16,6 @@ env:
   MAPTILER_URL: https://api.maptiler.com/maps/voyager/style.json?key=${{ secrets.MAPTILER_KEY }}
 
 jobs:
-  check-commit-messages:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          fetch-depth: 0
-      - name: Check for forbidden commit messages
-        run: |
-          FORBIDDEN_MSG="fix(filtered-search): omit daterange specific properties from datepickerConfig"
-          if git log --format='%s' origin/${{ github.base_ref }}..HEAD | grep -qF "$FORBIDDEN_MSG"; then
-            echo "::error::PR contains a commit with forbidden message: $FORBIDDEN_MSG"
-            exit 1
-          fi
-
   build:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
The element v51 breaking changes window has opened and this job was only a temporary safety solution. The required check for `build-and-test/check-commit-messages` in the repository settings needs to be removed as well.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2265/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2265/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2265/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2265/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2265/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2265/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2265/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2265/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2265/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2265/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
