### PR TITLE
build(e2e): skip serving report when run by an agent

### DIFF
--- a/e2e-local.sh
+++ b/e2e-local.sh
@@ -110,6 +110,13 @@ else
     playwright \
     test \
     $UPDATE_ARGS \
-    "$@" \
-  || npx playwright show-report playwright/results/preview
+    "$@"
+  STATUS=$?
+  # Only serve the HTML report on failure for interactive users. Agents set the
+  # AGENT env var; serving the report would block them since it starts a
+  # long-running web server.
+  if [ $STATUS -ne 0 ] && [ x"$AGENT" = "x" ]; then
+    npx playwright show-report playwright/results/preview
+  fi
+  exit $STATUS
 fi


### PR DESCRIPTION
The playwright HTML report was served on test failure, starting a
long-running web server that blocks agents. Only serve the report for
interactive users by skipping it when the AGENT env var is set, and
propagate the test exit status.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2269/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2269/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2269/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2269/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2269/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2269/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2269/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2269/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2269/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2269/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
