### PR TITLE
build(agents): add more precise e2e test instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,20 +82,22 @@ Run `npm run schematics:test` (uses Vitest). Config: `projects/element-ng/vitest
 
 ### E2E Tests
 
-E2E tests require Docker and a running dev server. They are executed via `./e2e-local.sh`.
+Use `./e2e-local.sh` to run e2e test. If you run a specific test always include the '--project=...' in addition.
+Always check if the DEV server is already running before starting.
 
 ```shell
-# 1. Start the dev server (in one terminal)
+# 1. Start the dev server, port 4200
 npm run start -- --allowed-hosts true --host 0.0.0.0
 
-# 2. For dashboards tests, also start dashboards artifacts
-npm run dashboards-demo:build-and-run-all      # webpack
-npm run dashboards-demo:build-and-run-all:esm   # ESM
+# 2. Only if running dashboards test:
+npm run dashboards-demo:build-and-run-all       # webpack, port 4201
+npm run dashboards-demo:build-and-run-all:esm   # ESM, port 4204
 
-# 3. Run e2e tests (in another terminal)
+# 3. Run e2e tests
 ./e2e-local.sh                                          # run all
-./e2e-local.sh run '--project=dashboards-demo/*'        # specific project
-./e2e-local.sh run '--project=dashboards-demo-esm/*'    # ESM project
+./e2e-local.sh run '--project=element-examples/*'       # examples project
+./e2e-local.sh run '--project=dashboards-demo/*'        # dashboards-webpack project
+./e2e-local.sh run '--project=dashboards-demo-esm/*'    # dashboards-esm project
 ./e2e-local.sh vrt                                      # visual regression only
 ./e2e-local.sh a11y                                     # accessibility only
 
@@ -106,9 +108,6 @@ npm run dashboards-demo:build-and-run-all:esm   # ESM
 
 # Run specific static test
 PLAYWRIGHT_staticTest=buttons/buttons:badges/badges ./e2e-local.sh run static
-
-# Use Podman instead of Docker (Linux)
-DOCKER=podman ./e2e-local.sh
 ```
 
 ## State Management


### PR DESCRIPTION
Previously Opus is failing to properly run the e2e tests. This update should hopefully drop the check if docker is running and ensure that a project suffix is always appended.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2271/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2271/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2271/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2271/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2271/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2271/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2271/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2271/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2271/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2271/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
