### PR TITLE
feat(form): support Angular's signal forms with new `si-form-field`

### DIFF
--- a/api-goldens/element-ng/form/index.api.md
+++ b/api-goldens/element-ng/form/index.api.md
@@ -9,6 +9,7 @@ import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
 import * as _angular_core from '@angular/core';
 import * as _angular_forms from '@angular/forms';
+import * as _angular_forms_signals from '@angular/forms/signals';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { FormGroup } from '@angular/forms';
@@ -21,11 +22,15 @@ import { OnInit } from '@angular/core';
 import { Provider } from '@angular/core';
 import { RequiredValidator } from '@angular/forms';
 import { Signal } from '@angular/core';
+import { SignalFormsConfig } from '@angular/forms/signals';
 import { SimpleChanges } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public
 export const provideFormValidationErrorMapper: (mapper: SiFormValidationErrorMapper) => Provider;
+
+// @public
+export const provideSiFormFieldConfig: (config?: SignalFormsConfig) => Provider[];
 
 // @public
 export const SI_FORM_ITEM_CONTROL: InjectionToken<SiFormItemControl>;
@@ -45,6 +50,12 @@ export class SiFormContainerComponent<TControl extends {
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
     get userInteractedWithForm(): boolean;
     get validFormContainerMessage(): boolean;
+}
+
+// @public
+export class SiFormFieldComponent {
+    constructor();
+    readonly label: _angular_core.InputSignal<TranslatableString>;
 }
 
 // @public (undocumented)

--- a/api-goldens/element-ng/formly-legacy/index.api.md
+++ b/api-goldens/element-ng/formly-legacy/index.api.md
@@ -7,6 +7,7 @@
 import { AbstractControl } from '@angular/forms';
 import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
+import * as _angular_forms_signals from '@angular/forms/signals';
 import { ConfigOption } from '@ngx-formly/core';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
@@ -29,6 +30,7 @@ import { OnInit } from '@angular/core';
 import { Provider } from '@angular/core';
 import { RequiredValidator } from '@angular/forms';
 import { Signal } from '@angular/core';
+import { SignalFormsConfig } from '@angular/forms/signals';
 import { SimpleChanges } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 

--- a/playwright/e2e/element-examples/si-signal-form.spec.ts
+++ b/playwright/e2e/element-examples/si-signal-form.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { expect, test } from '../../support/test-helpers';
+
+test.describe('si-signal-form', () => {
+  const example = 'si-signal-form/si-signal-form';
+
+  test(example, async ({ page, si }) => {
+    await si.visitExample(example, false);
+    await si.runVisualAndA11yTests(undefined);
+
+    // fill the name with an invalid value
+    const name = page.getByLabel('Name', { exact: true });
+    await name.fill('a');
+
+    await page.getByText('Save').click();
+
+    await si.runVisualAndA11yTests('validated');
+
+    // verify that the angular provided error messages are linked to the controls
+    await expect(await si.getDescription(name)).toHaveText(
+      'Minimum 3 characters  Name must start with an uppercase letter'
+    );
+    await expect(await si.getDescription(page.getByLabel('Day of birth'))).toHaveText(
+      'Day of birth required'
+    );
+    await expect(await si.getDescription(page.getByLabel('Fellow passengers'))).toHaveText(
+      'Minimum 2'
+    );
+    await expect(
+      await si.getDescription(page.getByLabel('I confirm that I accept all and everything'))
+    ).toHaveText('Accept terms before joining');
+
+    // fixing the name clears its errors
+    await name.fill('Alice');
+    await expect(await si.getDescription(name)).toHaveText('');
+  });
+});

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75d6a34801b74d3eece05e97f67d64fe8111ef59fe64e36c19428a2d89534cc5
+size 35474

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfa55617544c6df01fe77ab2285d57464f77ed3b97e23cc5cbe6f60f574ac72e
+size 34941

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated.yaml
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated.yaml
@@ -1,0 +1,27 @@
+- heading "Signal form" [level=2]
+- text: Name*
+- textbox "Name*" [invalid]
+- text: Minimum 3 characters Name must start with an uppercase letter Description
+- textbox "Description"
+- text: Day of birth*
+- textbox "Day of birth*" [invalid]
+- text: Day of birth required Arrival
+- textbox "Arrival"
+- text: Departure
+- textbox "Departure"
+- text: Class of service
+- combobox "Class of service":
+  - option "First class" [selected]
+  - option "Business"
+  - option "Economy"
+- text: Fellow passengers
+- spinbutton "Fellow passengers" [invalid]: "0"
+- text: Minimum 2
+- checkbox "I confirm that I accept all and everything*" [invalid]
+- text: I confirm that I accept all and everything* Accept terms before joining
+- checkbox "I confirm that I do not care about my privacy"
+- text: I confirm that I do not care about my privacy
+- button "Cancel"
+- button "Save"
+- heading "Debugging" [level=2]
+- paragraph: "Validation status: INVALID"

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27ce183cbb3f939a3f6e373a88fe69b40181ed0b65811796cde4338291c7223f
+size 26198

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd2ebd4b8e99d720dfb2ebd954ee96ddbedea2d3f38b842e99c724724eeefdfd
+size 25525

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form.yaml
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form.yaml
@@ -1,0 +1,26 @@
+- heading "Signal form" [level=2]
+- text: Name*
+- textbox "Name*"
+- text: Description
+- textbox "Description"
+- text: Day of birth*
+- textbox "Day of birth*"
+- text: Arrival
+- textbox "Arrival"
+- text: Departure
+- textbox "Departure"
+- text: Class of service
+- combobox "Class of service":
+  - option "First class" [selected]
+  - option "Business"
+  - option "Economy"
+- text: Fellow passengers
+- spinbutton "Fellow passengers": "0"
+- checkbox "I confirm that I accept all and everything*"
+- text: I confirm that I accept all and everything*
+- checkbox "I confirm that I do not care about my privacy"
+- text: I confirm that I do not care about my privacy
+- button "Cancel"
+- button "Save"
+- heading "Debugging" [level=2]
+- paragraph: "Validation status: INVALID"

--- a/projects/element-ng/form/index.ts
+++ b/projects/element-ng/form/index.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 export * from './si-form-container/si-form-container.component';
+export * from './si-form-field/si-form-field.component';
+export * from './si-form-field/si-form-field.provider';
 export * from './si-form-item/si-form-item.component';
 export * from './si-form-validation-tooltip/si-form-validation-tooltip.directive';
 export * from './form-fieldset/si-form-fieldset.component';

--- a/projects/element-ng/form/si-form-field/si-form-field.component.html
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.html
@@ -1,0 +1,30 @@
+@if (!isFormCheck()) {
+  <ng-container [ngTemplateOutlet]="labelTemplate" />
+}
+<div class="form-item-content">
+  <ng-content />
+  @if (isFormCheck()) {
+    <ng-container [ngTemplateOutlet]="labelTemplate" />
+  }
+  <ng-container [ngTemplateOutlet]="feedbackTemplate" />
+</div>
+
+<ng-template #labelTemplate>
+  <label
+    [for]="controlId()"
+    [class.form-label]="!isFormCheck()"
+    [class.form-check-label]="isFormCheck()"
+    [class.required]="required()"
+    >{{ label() | translate }}</label
+  >
+</ng-template>
+
+<ng-template #feedbackTemplate>
+  <div class="invalid-feedback" [class.d-block]="errors().length" [attr.id]="errormessageId()">
+    @for (error of errors(); track $index) {
+      <div>
+        {{ error.message | translate }}
+      </div>
+    }
+  </div>
+</ng-template>

--- a/projects/element-ng/form/si-form-field/si-form-field.component.scss
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.scss
@@ -1,0 +1,23 @@
+@use 'sass:map';
+@use '@siemens/element-theme/src/styles/all-variables';
+
+:host {
+  margin-block-end: map.get(all-variables.$spacers, 5);
+}
+
+:host(:not(.form-check)) {
+  display: flex;
+  flex-direction: column;
+
+  .form-item-content {
+    flex-grow: 1;
+  }
+}
+
+.form-label:empty {
+  display: none;
+}
+
+:host(.form-check:not(.form-check-inline)) {
+  display: block;
+}

--- a/projects/element-ng/form/si-form-field/si-form-field.component.spec.ts
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { form, FormField, minLength, required } from '@angular/forms/signals';
+import { TranslatableString } from '@siemens/element-translate-ng/translate';
+import { page } from 'vitest/browser';
+
+import { SiFormFieldComponent } from './si-form-field.component';
+
+interface Model {
+  name: string;
+  birthday: string;
+  terms: boolean;
+}
+
+@Component({
+  imports: [SiFormFieldComponent, FormField],
+  template: `
+    <si-form-field [label]="label()">
+      <input type="text" class="form-control" [formField]="form.name" />
+    </si-form-field>
+    <si-form-field label="Day of birth">
+      <input type="date" class="form-control" [formField]="form.birthday" />
+    </si-form-field>
+    <si-form-field label="Terms">
+      <input type="checkbox" class="form-check-input" [formField]="form.terms" />
+    </si-form-field>
+  `
+})
+class TestHostComponent {
+  readonly label = signal<TranslatableString>('Name');
+  readonly model = signal<Model>({ name: '', birthday: '', terms: false });
+  readonly form = form(this.model, path => {
+    required(path.name, { message: 'Name is required' });
+    minLength(path.name, 3, { message: 'Min. 3 characters' });
+    required(path.birthday, { message: 'A day of birth is required' });
+    required(path.terms, { message: 'You must accept the terms' });
+  });
+}
+
+describe('SiFormFieldComponent', () => {
+  let component: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  const nameField = page.getByRole('textbox', { name: 'Name' });
+  const birthdayField = page.getByLabelText('Day of birth');
+  const termsField = page.getByRole('checkbox', { name: 'Terms' });
+
+  const blur = async (element: Element): Promise<void> => {
+    (element as HTMLElement).focus();
+    (element as HTMLElement).blur();
+    await fixture.whenStable();
+  };
+
+  beforeEach(async () => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should mark required controls as required', async () => {
+    await expect.element(nameField).toBeRequired();
+    await expect.element(termsField).toBeRequired();
+  });
+
+  it('should not mark as invalid if the field is untouched', async () => {
+    await expect.element(nameField).not.toHaveAccessibleDescription();
+    await expect.element(nameField).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('should mark the control as invalid once touched and failing validation', async () => {
+    await blur(nameField.element());
+
+    await expect.element(nameField).toHaveAttribute('aria-invalid', 'true');
+    await expect.element(nameField).toHaveAccessibleDescription(/Name is required/);
+  });
+
+  it('should clear the invalid marker once the value becomes valid', async () => {
+    await nameField.fill('Valid name');
+    await blur(nameField.element());
+
+    await expect.element(nameField).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('should clear the error description once the value becomes valid', async () => {
+    await nameField.fill('Valid name');
+    await blur(nameField.element());
+
+    await expect.element(nameField).not.toHaveAccessibleDescription();
+    await expect.element(nameField).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('should expose errors on all fields once the root form is marked as touched', async () => {
+    component.form().markAsTouched();
+    await fixture.whenStable();
+
+    await expect.element(nameField).toHaveAccessibleDescription(/Name is required/);
+    await expect.element(birthdayField).toHaveAccessibleDescription(/A day of birth is required/);
+    await expect.element(termsField).toHaveAccessibleDescription(/You must accept the terms/);
+  });
+});

--- a/projects/element-ng/form/si-form-field/si-form-field.component.ts
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { NgTemplateOutlet } from '@angular/common';
+import { Component, computed, contentChild, effect, input } from '@angular/core';
+import { FormField } from '@angular/forms/signals';
+import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
+
+/**
+ * Constructs a full form field including error messages, labels and aria-* attributes.
+ * It must be used with Angular's signal forms.
+ *
+ * @example
+ * ```html
+ * <si-form-field label="Name">
+ *   <input class="form-control" [formField]="form.name" />
+ * </si-form-field>
+ * ```
+ */
+@Component({
+  selector: 'si-form-field',
+  imports: [SiTranslatePipe, NgTemplateOutlet],
+  templateUrl: './si-form-field.component.html',
+  styleUrl: './si-form-field.component.scss',
+  host: {
+    '[class.required]': 'required()',
+    '[class.form-check]': 'isFormCheck()'
+  }
+})
+export class SiFormFieldComponent {
+  private static idCounter = 0;
+
+  /**
+   * The label to be displayed in the form field.
+   * It will be translated if a translation key is available.
+   */
+  readonly label = input.required<TranslatableString>();
+
+  private readonly formField = contentChild.required(FormField);
+
+  private readonly generatedId = `__si-form-field-${SiFormFieldComponent.idCounter++}`;
+
+  /** The id of the connected control, used for the label's `for` attribute. */
+  protected readonly controlId = computed(() => this.formField().element.id || this.generatedId);
+
+  protected readonly errormessageId = computed(() => `${this.controlId()}-errormessage`);
+
+  /** Whether the connected control is a form-check (checkbox, radio or switch). */
+  protected readonly isFormCheck = computed(() =>
+    this.formField().element.classList.contains('form-check-input')
+  );
+
+  private readonly fieldState = computed(() => this.formField().state());
+
+  protected readonly required = computed(() => this.fieldState().required());
+
+  private readonly invalid = computed(() => {
+    const state = this.fieldState();
+    return state.touched() && state.invalid();
+  });
+
+  protected readonly errors = computed(() => {
+    const state = this.fieldState();
+    if (!state.touched()) {
+      return [];
+    }
+    return state.errors().filter(error => !!error.message);
+  });
+
+  constructor() {
+    effect(() => this.syncControlId());
+    effect(() => this.syncErrorDescription());
+    effect(() => this.syncInvalidState());
+  }
+
+  private syncControlId(): void {
+    const element = this.formField().element;
+    if (!element.id) {
+      element.id = this.generatedId;
+    }
+  }
+
+  /** Associates the error messages with the projected control for assistive technologies. */
+  private syncErrorDescription(): void {
+    this.formField().element.setAttribute('aria-describedby', this.errormessageId());
+  }
+
+  /**
+   * Reflects the validation state onto the projected control via `aria-invalid`. This is needed
+   * because signal forms does not set `aria-invalid`, and the native `:user-invalid` pseudo-class
+   * ignores `markAsTouched()`. The matching `.ng-invalid`/`.ng-touched` classes that drive the
+   * styling are added by signal forms itself, see `provideSiFormFieldConfig()`.
+   */
+  private syncInvalidState(): void {
+    const element = this.formField().element;
+    if (this.invalid()) {
+      element.setAttribute('aria-invalid', 'true');
+    } else {
+      element.removeAttribute('aria-invalid');
+    }
+  }
+}

--- a/projects/element-ng/form/si-form-field/si-form-field.provider.ts
+++ b/projects/element-ng/form/si-form-field/si-form-field.provider.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Provider } from '@angular/core';
+import { provideSignalFormsConfig, SignalFormsConfig } from '@angular/forms/signals';
+import { NG_STATUS_CLASSES } from '@angular/forms/signals/compat';
+
+/**
+ * Provides the signal forms configuration required by {@link SiFormFieldComponent}.
+ *
+ * It restores the `ng-*` classes applied by the directives of {@link @angular/forms#FormsModule | FormsModule} / {@link @angular/forms#ReactiveFormsModule | ReactiveFormsModule}.
+ *
+ * @example
+ * ```ts
+ * bootstrapApplication(AppComponent, {
+ *   providers: [provideSiFormFieldConfig()]
+ * });
+ * ```
+ */
+export const provideSiFormFieldConfig = (config: SignalFormsConfig = {}): Provider[] =>
+  provideSignalFormsConfig({
+    ...config,
+    classes: {
+      ...NG_STATUS_CLASSES,
+      ...config.classes
+    }
+  });

--- a/src/app/examples/si-signal-form/si-signal-form.html
+++ b/src/app/examples/si-signal-form/si-signal-form.html
@@ -1,0 +1,78 @@
+<div class="container-fluid">
+  <div class="row gy-5">
+    <div class="col-12 col-md">
+      <h2>Signal form</h2>
+      <div class="card">
+        <div class="card-body">
+          <form [formRoot]="form">
+            <si-form-field label="Name">
+              <input type="text" class="form-control" [formField]="form.name" />
+            </si-form-field>
+
+            <si-form-field label="Description">
+              <input type="text" class="form-control" [formField]="form.description" />
+            </si-form-field>
+
+            <si-form-field label="Day of birth">
+              <input type="date" class="form-control" [formField]="form.birthday" />
+            </si-form-field>
+
+            <si-form-field label="Arrival">
+              <input type="time" class="form-control" [formField]="form.arrival" />
+            </si-form-field>
+
+            <si-form-field label="Departure">
+              <input type="time" class="form-control" [formField]="form.departure" />
+            </si-form-field>
+
+            <si-form-field label="Class of service">
+              <select class="form-select" [formField]="form.serviceClass">
+                <option value="first">First class</option>
+                <option value="business">Business</option>
+                <option value="economy">Economy</option>
+              </select>
+            </si-form-field>
+
+            <si-form-field label="Fellow passengers">
+              <input type="number" class="form-control" [formField]="form.fellowPassengers" />
+            </si-form-field>
+
+            <si-form-field label="I confirm that I accept all and everything">
+              <input type="checkbox" class="form-check-input" [formField]="form.termsAccepted" />
+            </si-form-field>
+
+            <si-form-field label="I confirm that I do not care about my privacy">
+              <input type="checkbox" class="form-check-input" [formField]="form.privacyDeclined" />
+            </si-form-field>
+
+            <div class="mt-6">
+              <button type="button" class="btn btn-secondary me-6" (click)="cancel()">
+                Cancel
+              </button>
+              <button type="submit" class="btn btn-primary">Save</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-12 col-md e2e-ignore">
+      <h2>Debugging</h2>
+      <p>Validation status: {{ form().valid() ? 'VALID' : 'INVALID' }}</p>
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">Model</th>
+            <th scope="col">Submitted</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style="white-space: pre-wrap">{{ model() | json }}</td>
+            <td style="white-space: pre-wrap">{{ (submitted() | json) ?? 'undefined' }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/src/app/examples/si-signal-form/si-signal-form.ts
+++ b/src/app/examples/si-signal-form/si-signal-form.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { JsonPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import {
+  form,
+  FormField,
+  FormRoot,
+  min,
+  minLength,
+  pattern,
+  required
+} from '@angular/forms/signals';
+import { provideSiFormFieldConfig, SiFormFieldComponent } from '@siemens/element-ng/form';
+
+export interface TravelRequest {
+  name: string;
+  description: string;
+  birthday: string;
+  arrival: string;
+  departure: string;
+  serviceClass: string;
+  fellowPassengers: number;
+  termsAccepted: boolean;
+  privacyDeclined: boolean;
+}
+
+const emptyRequest: TravelRequest = {
+  name: '',
+  description: '',
+  birthday: '',
+  arrival: '',
+  departure: '',
+  serviceClass: 'first',
+  fellowPassengers: 0,
+  termsAccepted: false,
+  privacyDeclined: false
+};
+
+@Component({
+  selector: 'app-sample',
+  imports: [JsonPipe, FormField, FormRoot, SiFormFieldComponent],
+  templateUrl: './si-signal-form.html',
+  providers: [provideSiFormFieldConfig()],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'p-5' }
+})
+export class SampleComponent {
+  protected readonly model = signal<TravelRequest>({ ...emptyRequest });
+
+  protected readonly submitted = signal<TravelRequest | undefined>(undefined);
+
+  protected readonly form = form(
+    this.model,
+    path => {
+      required(path.name, { message: 'Name required' });
+      minLength(path.name, 3, { message: 'Minimum 3 characters' });
+      pattern(path.name, /^[A-Z].*/, {
+        message: 'Name must start with an uppercase letter'
+      });
+      required(path.birthday, { message: 'Day of birth required' });
+      min(path.fellowPassengers, 2, { message: 'Minimum 2' });
+      required(path.termsAccepted, {
+        message: 'Accept terms before joining'
+      });
+    },
+    {
+      submission: {
+        action: async () => {
+          this.submitted.set(this.model());
+          return undefined;
+        }
+      }
+    }
+  );
+
+  protected cancel(): void {
+    this.model.set({ ...emptyRequest });
+    this.submitted.set(undefined);
+  }
+}


### PR DESCRIPTION
Introduces a new component called `si-form-field` which is built around Angular's signal forms.
This initial version only supports native browser inputs. Currently missing:
- integration of the error resolution mechanism
- label in a separate column
- fieldset combination with fieldset
- documentation

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2272/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2272/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2272/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2272/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2272/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2272/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2272/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2272/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2272/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2272/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->




