### PR TITLE
refactor(dropdown): remove fix `.dropdown-item` height

### DIFF
--- a/projects/element-ng/content-action-bar/si-content-action-bar.component.scss
+++ b/projects/element-ng/content-action-bar/si-content-action-bar.component.scss
@@ -1,5 +1,6 @@
+@use 'sass:map';
 @use '@siemens/element-theme/src/styles/variables/semantic-tokens';
-@use '@siemens/element-theme/src/styles/bootstrap/variables' as bootstrap-variables;
+@use '@siemens/element-theme/src/styles/variables/spacers';
 
 div > [si-content-action-bar-toggle] {
   // The siAutoCollapsableList directive reserves space for the overflow toggle by reading its
@@ -10,7 +11,7 @@ div > [si-content-action-bar-toggle] {
   // items and preventing resize-triggered expand/collapse from reaching a stable state.
   // The fixed inline-size guarantees a deterministic clientWidth at all times so the reserved
   // space matches the toggle's actual footprint the moment it becomes visible.
-  inline-size: calc(1.25rem + 2 * bootstrap-variables.$dropdown-item-padding-y);
+  inline-size: calc(1.25rem + 2 * map.get(spacers.$spacers, 4));
   justify-content: center;
   border-radius: semantic-tokens.$element-button-radius;
 }

--- a/projects/element-theme/src/styles/bootstrap/_dropdowns.scss
+++ b/projects/element-theme/src/styles/bootstrap/_dropdowns.scss
@@ -90,7 +90,7 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  block-size: calc(1lh + 2 * bootstrap-variables.$dropdown-item-padding-y);
+  min-block-size: calc(1lh + 2 * bootstrap-variables.$dropdown-item-padding-y);
   inline-size: 100%;
   padding-block: bootstrap-variables.$dropdown-item-padding-y;
   padding-inline: bootstrap-variables.$dropdown-item-padding-x;

--- a/projects/element-theme/src/styles/bootstrap/_variables.scss
+++ b/projects/element-theme/src/styles/bootstrap/_variables.scss
@@ -451,7 +451,7 @@ $dropdown-divider-margin-y: 4px !default;
 $dropdown-box-shadow: elevation.$element-elevation-2 !default;
 $dropdown-link-color: semantic-tokens.$element-text-primary !default;
 $dropdown-link-disabled-color: semantic-tokens.$element-text-disabled !default;
-$dropdown-item-padding-y: map.get(spacers.$spacers, 4);
+$dropdown-item-padding-y: map.get(spacers.$spacers, 3);
 $dropdown-item-padding-x: map.get(spacers.$spacers, 5);
 $dropdown-header-color: semantic-tokens.$element-text-primary !default;
 


### PR DESCRIPTION
The `dropdown-item` had previously a fixed height, to force shrink dropdown-items as the content was always oversized.
This change reduces the padding and drops the fixed height.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2277/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2277/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2277/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2277/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2277/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2277/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2277/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2277/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2277/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2277/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


