### PR TITLE
fix(status-bar): use static text for the toggle button

### DIFF
--- a/api-goldens/element-ng/status-bar/index.api.md
+++ b/api-goldens/element-ng/status-bar/index.api.md
@@ -31,13 +31,12 @@ export class SiStatusBarComponent implements OnDestroy, OnChanges {
     readonly allOkText: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly blink: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly blinkPulse: _angular_core.InputSignal<Observable<boolean> | undefined>;
-    readonly collapseButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly compact: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly expandButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly items: _angular_core.InputSignal<StatusBarItem[]>;
     readonly muteButton: _angular_core.InputSignal<boolean | undefined>;
     readonly muteButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
     readonly muteToggle: _angular_core.OutputEmitterRef<void>;
+    readonly toggleButtonText: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
 }
 
 // @public (undocumented)

--- a/playwright/snapshots/si-page-header.spec.ts-snapshots/si-page-header--si-page-header--small.yaml
+++ b/playwright/snapshots/si-page-header.spec.ts-snapshots/si-page-header--si-page-header--small.yaml
@@ -9,7 +9,7 @@
   - button "Expand"
 - main:
   - text: /\d+ Not clickable/
-  - button "Expand"
+  - button "Toggle"
   - navigation "Breadcrumbs":
     - list:
       - listitem:

--- a/playwright/snapshots/si-status-bar.spec.ts-snapshots/si-status-bar--si-status-bar-custom--collapsed.yaml
+++ b/playwright/snapshots/si-status-bar.spec.ts-snapshots/si-status-bar--si-status-bar-custom--collapsed.yaml
@@ -1,6 +1,6 @@
 - text: /4 Emergency \d+ Trouble \d+ Caution 1 Nasty long text that won't fit 8\+/
 - button "Mute/unmute"
-- button "Expand"
+- button "Toggle"
 - button "Pause blinking"
 - button "Resume blinking"
 - button "Blink element"

--- a/playwright/snapshots/si-status-bar.spec.ts-snapshots/si-status-bar--si-status-bar-custom--open.yaml
+++ b/playwright/snapshots/si-status-bar.spec.ts-snapshots/si-status-bar--si-status-bar-custom--open.yaml
@@ -1,7 +1,7 @@
 - text: /4 Emergency \d+ Trouble \d+ Caution 1 Nasty long text that won't fit 8\+/
 - button "Mute/unmute"
 - text: /4 Emergency 0 Life safety 0 Security 0 Supervisory \d+ Trouble \d+ Caution 1 Nasty long text that won't fit \d+ Not clickable 4 More stuff 2 Coffee machines 2 Test 2 Supervisory \d+ Trouble \d+ Warnings 1 Nasty long text/
-- button "Collapse" [expanded]
+- button "Toggle" [expanded]
 - button "Pause blinking"
 - button "Resume blinking"
 - button "Blink element"

--- a/playwright/snapshots/static.spec.ts-snapshots/si-electron-titlebar--si-fixed-height-layout-side-panel.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-electron-titlebar--si-fixed-height-layout-side-panel.yaml
@@ -11,7 +11,7 @@
   - heading "Application name" [level=1]
   - button "Layout"
   - button "Help"
-  - button "Jane Smith"
+  - button "Jane Smith": JS
 - navigation:
   - button "collapse" [expanded]
   - button "Home"
@@ -28,7 +28,7 @@
   - button "Documents"
   - button "Graphics"
   - text: /4 Emergency \d+ Trouble \d+ Success/
-  - button "Expand"
+  - button "Toggle"
   - heading "Here is a title" [level=2]
   - text: A nice list of things
   - button "Toggle"

--- a/projects/element-ng/status-bar/si-status-bar.component.html
+++ b/projects/element-ng/status-bar/si-status-bar.component.html
@@ -93,7 +93,7 @@
       <button
         type="button"
         class="collapse-expand text-center p-0 focus-force"
-        [attr.aria-label]="(expanded() ? collapseButtonText() : expandButtonText()) | translate"
+        [attr.aria-label]="toggleButtonText() | translate"
         [attr.aria-expanded]="!!expanded()"
         [attr.aria-controls]="statusId"
         [class.expanded]="expanded() === 2"

--- a/projects/element-ng/status-bar/si-status-bar.component.ts
+++ b/projects/element-ng/status-bar/si-status-bar.component.ts
@@ -122,23 +122,15 @@ export class SiStatusBarComponent implements OnDestroy, OnChanges {
    */
   readonly blinkPulse = input<Observable<boolean>>();
   /**
-   * Text for the navbar expand button. Required for a11y
+   * Text for the toggle button that expands/collapses the status bar. Required for a11y.
+   * The expanded/collapsed state is communicated separately via `aria-expanded`.
    *
    * @defaultValue
    * ```
-   * t(() => $localize`:@@SI_STATUS_BAR.EXPAND:Expand`)
+   * t(() => $localize`:@@SI_STATUS_BAR.TOGGLE:Toggle`)
    * ```
    */
-  readonly expandButtonText = input(t(() => $localize`:@@SI_STATUS_BAR.EXPAND:Expand`));
-  /**
-   * Text for the navbar collapse button. Required for a11y
-   *
-   * @defaultValue
-   * ```
-   * t(() => $localize`:@@SI_STATUS_BAR.COLLAPSE:Collapse`)
-   * ```
-   */
-  readonly collapseButtonText = input(t(() => $localize`:@@SI_STATUS_BAR.COLLAPSE:Collapse`));
+  readonly toggleButtonText = input(t(() => $localize`:@@SI_STATUS_BAR.TOGGLE:Toggle`));
 
   /**
    * Emitted when the mute toggle button is clicked

--- a/projects/element-ng/translate/si-translatable-keys.interface.ts
+++ b/projects/element-ng/translate/si-translatable-keys.interface.ts
@@ -226,9 +226,8 @@ export interface SiTranslatableKeys {
   'SI_SLIDER.LABEL'?: string;
   'SI_SORT_BAR.TITLE'?: string;
   'SI_STATUS_BAR.ALL_OK'?: string;
-  'SI_STATUS_BAR.COLLAPSE'?: string;
-  'SI_STATUS_BAR.EXPAND'?: string;
   'SI_STATUS_BAR.MUTE'?: string;
+  'SI_STATUS_BAR.TOGGLE'?: string;
   'SI_THRESHOLD.ADD'?: string;
   'SI_THRESHOLD.DELETE'?: string;
   'SI_THRESHOLD.INPUT_LABEL'?: string;


### PR DESCRIPTION
The toggle button of `si-status-bar` switched its `aria-label` between an
expand and a collapse text depending on the expanded state. Since that state
is already communicated via `aria-expanded`, this duplicated the information
for screen reader users.

This replaces the separate `expandButtonText` and `collapseButtonText` inputs
with a single static `toggleButtonText` input.

Fixes #2004

BREAKING CHANGE: changed the accessibility text inputs of si-status-bar

The `expandButtonText` and `collapseButtonText` inputs were removed and
replaced by a single `toggleButtonText` input. Update usages that set these
inputs to use `toggleButtonText` instead. The associated translation keys
`SI_STATUS_BAR.EXPAND` and `SI_STATUS_BAR.COLLAPSE` were replaced by
`SI_STATUS_BAR.TOGGLE`.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2279/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2279/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2279/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2279/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2279/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2279/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2279/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2279/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2279/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2279/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



