### PR TITLE
feat(split): migrate si-split to OnPush

### DIFF
--- a/api-goldens/element-ng/split/index.api.md
+++ b/api-goldens/element-ng/split/index.api.md
@@ -4,12 +4,8 @@
 
 ```ts
 
-import { AfterContentInit } from '@angular/core';
 import * as _angular_core from '@angular/core';
-import { OnChanges } from '@angular/core';
-import { QueryList } from '@angular/core';
 import { Signal } from '@angular/core';
-import { SimpleChanges } from '@angular/core';
 import { TemplateRef } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
@@ -38,17 +34,14 @@ export interface PartState {
 export type Scale = 'none' | 'auto';
 
 // @public (undocumented)
-export class SiSplitComponent implements AfterContentInit, OnChanges {
-    // (undocumented)
-    gutterSize: number;
-    // (undocumented)
-    get orientation(): SplitOrientation;
-    set orientation(value: SplitOrientation);
-    // (undocumented)
-    sizes: number[];
+export class SiSplitComponent {
+    constructor();
+    readonly gutterSize: _angular_core.InputSignal<number>;
+    readonly orientation: _angular_core.InputSignal<SplitOrientation>;
+    readonly sizes: _angular_core.InputSignal<number[]>;
     // (undocumented)
     readonly sizesChange: _angular_core.OutputEmitterRef<number[]>;
-    stateId?: string;
+    readonly stateId: _angular_core.InputSignal<string | undefined>;
 }
 
 // @public (undocumented)
@@ -56,51 +49,31 @@ export class SiSplitModule {
 }
 
 // @public (undocumented)
-export class SiSplitPartComponent implements OnChanges {
-    // (undocumented)
-    actions: Action[];
+export class SiSplitPartComponent {
+    constructor();
+    readonly actions: _angular_core.InputSignal<Action[]>;
     // (undocumented)
     readonly collapseChanged: _angular_core.OutputEmitterRef<boolean>;
     get collapsed(): boolean;
-    // (undocumented)
-    collapseDirection: CollapseTo;
-    collapseIconClass: string;
-    collapseLabel: TranslatableString;
-    collapseOthers: boolean;
-    collapseToMinSize: boolean;
-    set expanded(value: boolean);
-    // (undocumented)
-    get expanded(): boolean;
-    // (undocumented)
-    headerTemplate?: TemplateRef<{
+    readonly collapseDirection: _angular_core.InputSignal<CollapseTo>;
+    readonly collapseIconClass: _angular_core.InputSignal<string>;
+    readonly collapseLabel: _angular_core.InputSignal<TranslatableString>;
+    readonly collapseOthers: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    readonly collapseToMinSize: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    readonly expanded: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    readonly headerTemplate: _angular_core.InputSignal<TemplateRef<{
         $implicit: SiSplitPartComponent;
-    }>;
-    heading: TranslatableString;
-    minSize: number;
-    // (undocumented)
-    static ngAcceptInputType_collapseOthers: unknown;
-    // (undocumented)
-    static ngAcceptInputType_collapseToMinSize: unknown;
-    // (undocumented)
-    static ngAcceptInputType_expanded: unknown;
-    // (undocumented)
-    static ngAcceptInputType_minSize: unknown;
-    // (undocumented)
-    static ngAcceptInputType_removeContentOnCollapse: unknown;
-    // (undocumented)
-    static ngAcceptInputType_showCollapseButton: unknown;
-    // (undocumented)
-    static ngAcceptInputType_showHeader: unknown;
-    // (undocumented)
-    static ngAcceptInputType_size: unknown;
-    removeContentOnCollapse: boolean;
-    scale: Scale;
-    showCollapseButton: boolean;
-    showHeader: boolean;
-    size?: number;
+    }> | undefined>;
+    readonly heading: _angular_core.InputSignal<TranslatableString | undefined>;
+    readonly minSize: _angular_core.InputSignalWithTransform<number, unknown>;
+    readonly removeContentOnCollapse: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    readonly scale: _angular_core.InputSignal<Scale>;
+    readonly showCollapseButton: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    readonly showHeader: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    readonly size: _angular_core.InputSignalWithTransform<number | undefined, unknown>;
     // (undocumented)
     readonly stateChange: _angular_core.OutputEmitterRef<PartState>;
-    stateId?: string;
+    readonly stateId: _angular_core.InputSignal<string | undefined>;
     toggleCollapse(): void;
 }
 

--- a/projects/element-ng/split/si-split-part.component.html
+++ b/projects/element-ng/split/si-split-part.component.html
@@ -1,11 +1,11 @@
-@if (!headerTemplate && showHeader) {
+@if (!headerTemplate() && showHeader()) {
   <div class="si-split-part-header" [class.is-collapsed]="collapsedState()">
     <div class="si-split-part-title text-truncate">
-      {{ heading | translate }}
+      {{ heading() | translate }}
     </div>
     @if (!collapsedState()) {
       <div class="si-split-part-actions">
-        @for (action of actions; track $index) {
+        @for (action of actions(); track $index) {
           <button
             type="button"
             class="si-split-button"
@@ -18,30 +18,30 @@
         }
       </div>
     }
-    @if (showCollapseButton) {
+    @if (showCollapseButton()) {
       <div class="si-split-part-collapse-button">
         <button
           type="button"
           class="si-split-button"
-          [attr.aria-label]="collapseLabel | translate"
+          [attr.aria-label]="collapseLabel() | translate"
           (click)="toggleCollapse()"
         >
-          <si-icon class="collapse-icon" [icon]="collapseIconClass" />
+          <si-icon class="collapse-icon" [icon]="collapseIconClass()" />
         </button>
       </div>
     }
   </div>
 }
 
-@if (headerTemplate) {
+@if (headerTemplate(); as headerTemplate) {
   <ng-container *ngTemplateOutlet="headerTemplate; context: headerContext" />
 }
 
 <div
   class="si-split-part-content"
-  [class.d-none]="!removeContentOnCollapse && collapsedState() && !collapseToMinSize"
+  [class.d-none]="!removeContentOnCollapse() && collapsedState() && !collapseToMinSize()"
 >
-  @if (!removeContentOnCollapse || !collapsedState()) {
+  @if (!removeContentOnCollapse() || !collapsedState()) {
     <ng-content />
   }
 </div>

--- a/projects/element-ng/split/si-split-part.component.ts
+++ b/projects/element-ng/split/si-split-part.component.ts
@@ -5,18 +5,18 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   ElementRef,
   inject,
-  Input,
+  input,
+  linkedSignal,
   numberAttribute,
-  OnChanges,
   output,
   signal,
-  SimpleChanges,
-  TemplateRef
+  TemplateRef,
+  untracked
 } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -28,22 +28,25 @@ import { Action, CollapseTo, PartState, Scale, SplitOrientation } from './si-spl
   imports: [NgTemplateOutlet, SiIconComponent, SiTranslatePipe],
   templateUrl: './si-split-part.component.html',
   styleUrl: './si-split-part.component.scss',
-  changeDetection: ChangeDetectionStrategy.Eager,
-  // Signals cannot be used directly with @HostBinding. See: https://github.com/angular/angular/issues/53888#issuecomment-1888935225
-  // Having every binding here for consistency.
   host: {
     '[class.is-collapsed]': 'collapsedState()',
-    '[class.collapse-start]': 'collapseDirection === "start"',
+    '[class.collapse-start]': 'collapseDirectionState() === "start"',
     '[style.grid-area]': '"p-" + this.index'
   }
 })
-export class SiSplitPartComponent implements OnChanges {
-  /** @defaultValue [] */
-  @Input() actions: Action[] = [];
+export class SiSplitPartComponent {
   /**
+   * Action buttons displayed in the split part header.
+   *
+   * @defaultValue []
+   */
+  readonly actions = input<Action[]>([]);
+  /**
+   * Defines which direction the split part collapses to.
+   *
    * @defaultValue 'start'
    */
-  @Input() collapseDirection: CollapseTo = 'start';
+  readonly collapseDirection = input<CollapseTo>('start');
 
   /**
    * Sets the icon class that is used in the buttons of split parts to
@@ -51,28 +54,31 @@ export class SiSplitPartComponent implements OnChanges {
    *
    * @defaultValue 'element-double-right'
    */
-  @Input() collapseIconClass = 'element-double-right';
+  readonly collapseIconClass = input('element-double-right');
 
   /**
    * Collapse only to the given min size.
    *
    * @defaultValue false
    */
-  @Input({ transform: booleanAttribute }) collapseToMinSize = false;
+  readonly collapseToMinSize = input(false, { transform: booleanAttribute });
 
-  @Input() headerTemplate?: TemplateRef<{ $implicit: SiSplitPartComponent }>;
+  /**
+   * Custom template for the split part header. The template receives the component instance as implicit context.
+   */
+  readonly headerTemplate = input<TemplateRef<{ $implicit: SiSplitPartComponent }>>();
 
   /**
    * Sets the title of the split part header.
    */
-  @Input() heading!: TranslatableString;
+  readonly heading = input<TranslatableString>();
 
   /**
    * Minimum size in px.
    *
    * @defaultValue 0
    */
-  @Input({ transform: numberAttribute }) minSize = 0;
+  readonly minSize = input(0, { transform: numberAttribute });
 
   /**
    * When a split part is collapsed, the content gets hidden but it will
@@ -82,7 +88,7 @@ export class SiSplitPartComponent implements OnChanges {
    *
    * @defaultValue false
    */
-  @Input({ transform: booleanAttribute }) removeContentOnCollapse = false;
+  readonly removeContentOnCollapse = input(false, { transform: booleanAttribute });
 
   /**
    * Defines the behavior of the split part during scaling.
@@ -90,37 +96,39 @@ export class SiSplitPartComponent implements OnChanges {
    *
    * @defaultValue 'auto'
    */
-  @Input() scale: Scale = 'auto';
+  readonly scale = input<Scale>('auto');
 
   /**
    * Defines if the collapse button of a split part is displayed. Default value is true.
    *
    * @defaultValue true
    */
-  @Input({ transform: booleanAttribute }) showCollapseButton = true;
+  readonly showCollapseButton = input(true, { transform: booleanAttribute });
 
   /**
    * Defines if the header of the split part is visible. Default is true.
    *
    * @defaultValue true
    */
-  @Input({ transform: booleanAttribute }) showHeader = true;
+  readonly showHeader = input(true, { transform: booleanAttribute });
   /**
    * Aria label for collapse button. Needed for a11y
    *
    * @defaultValue 'collapse'
    */
-  @Input() collapseLabel: TranslatableString = 'collapse';
+  readonly collapseLabel = input<TranslatableString>('collapse');
   /**
    * An optional stateId to uniquely identify a component instance.
    * Required for persistence of ui state.
    */
-  @Input() stateId?: string;
+  readonly stateId = input<string>();
 
   /**
    * Expanded size in px.
+   *
+   * @defaultValue undefined
    */
-  @Input({ transform: numberAttribute }) size?: number;
+  readonly size = input<number | undefined, unknown>(undefined, { transform: numberAttribute });
 
   /**
    * This toggles the behavior when collapsing this split part.
@@ -129,7 +137,14 @@ export class SiSplitPartComponent implements OnChanges {
    *
    * @defaultValue false
    */
-  @Input({ transform: booleanAttribute }) collapseOthers = false;
+  readonly collapseOthers = input(false, { transform: booleanAttribute });
+
+  /**
+   * Sets the initial expanded or collapsed state of the split part.
+   *
+   * @defaultValue true
+   */
+  readonly expanded = input(true, { transform: booleanAttribute });
 
   readonly collapseChanged = output<boolean>();
   readonly stateChange = output<PartState>();
@@ -137,18 +152,29 @@ export class SiSplitPartComponent implements OnChanges {
   /** @internal */
   index = 0;
   /** @internal */
-  before?: SiSplitPartComponent;
+  readonly before = signal<SiSplitPartComponent | undefined>(undefined);
   /** @internal */
-  after?: SiSplitPartComponent;
+  readonly after = signal<SiSplitPartComponent | undefined>(undefined);
 
   /** @internal */
   readonly fractionalSize = signal<number | undefined>(undefined);
 
   /** @internal */
-  readonly collapsedSize = signal(0);
+  readonly collapsedSize = computed(() => (this.collapseToMinSize() ? (this.minSize() ?? 40) : 40));
 
-  /** @internal */
-  readonly collapsedState = signal(false);
+  /**
+   * Internal, mutable collapsed state. Initialized from the {@link expanded} input but can be
+   * overwritten while toggling, cascading to sibling parts or restoring the persisted ui state.
+   * @internal
+   */
+  readonly collapsedState = linkedSignal(() => !this.expanded());
+
+  /**
+   * Internal, mutable collapse direction. Initialized from the {@link collapseDirection}
+   * input but can be overwritten while cascading collapse state to sibling parts.
+   * @internal
+   */
+  readonly collapseDirectionState = linkedSignal(() => this.collapseDirection());
 
   /**
    * Get collapsed state.
@@ -159,7 +185,7 @@ export class SiSplitPartComponent implements OnChanges {
   }
 
   /** @internal */
-  readonly expandedSize = signal<number | undefined>(undefined);
+  readonly expandedSize = linkedSignal(() => this.size());
 
   /** @internal */
   readonly actualSize = computed(() => {
@@ -177,7 +203,8 @@ export class SiSplitPartComponent implements OnChanges {
     if (!this.collapsedState()) {
       return this as SiSplitPartComponent;
     }
-    const nextExpanded: SiSplitPartComponent = this.after ? this.after.nextExpandedAfter() : this;
+    const after = this.after();
+    const nextExpanded: SiSplitPartComponent = after ? after.nextExpandedAfter() : this;
 
     return nextExpanded;
   });
@@ -188,28 +215,16 @@ export class SiSplitPartComponent implements OnChanges {
     $implicit: this
   };
 
-  /** @defaultValue true */
-  @Input({ transform: booleanAttribute }) set expanded(value: boolean) {
-    this.collapsedState.set(!value);
-    if (this.collapseOthers) {
-      this.before?.refreshCollapseToStart();
-      this.after?.refreshCollapsedToEnd();
-    }
-  }
-  get expanded(): boolean {
-    return !this.collapsedState();
-  }
-
-  ngOnChanges(changes: SimpleChanges<this>): void {
-    if (changes.collapseToMinSize && this.collapseToMinSize) {
-      this.collapsedSize.set(this.minSize ?? 40);
-    } else {
-      this.collapsedSize.set(40); // 40px is default size of the header
-    }
-
-    if (changes.size) {
-      this.expandedSize.set(this.size);
-    }
+  constructor() {
+    effect(() => {
+      this.expanded();
+      untracked(() => {
+        if (this.collapseOthers()) {
+          this.before()?.refreshCollapseToStart();
+          this.after()?.refreshCollapsedToEnd();
+        }
+      });
+    });
   }
 
   /** @internal */
@@ -229,28 +244,30 @@ export class SiSplitPartComponent implements OnChanges {
    */
   toggleCollapse(): void {
     this.collapsedState.update(v => !v);
-    if (this.collapseOthers) {
-      this.before?.refreshCollapseToStart();
-      this.after?.refreshCollapsedToEnd();
+    if (this.collapseOthers()) {
+      this.before()?.refreshCollapseToStart();
+      this.after()?.refreshCollapsedToEnd();
     }
     this.collapseChanged.emit(this.collapsedState());
-    this.stateChange.emit({ expanded: this.expanded, size: this.actualSize() });
+    this.stateChange.emit({ expanded: !this.collapsedState(), size: this.actualSize() });
     this.saveUIState();
   }
 
   private refreshCollapsedToEnd(): void {
-    if (this.before?.collapsedState() && this.before.collapseDirection === 'end') {
+    const before = this.before();
+    if (before?.collapsedState() && before.collapseDirectionState() === 'end') {
       this.collapsedState.set(true);
-      this.collapseDirection = 'end';
-      this.after?.refreshCollapsedToEnd();
+      this.collapseDirectionState.set('end');
+      this.after()?.refreshCollapsedToEnd();
     }
   }
 
   private refreshCollapseToStart(): void {
-    if (this.after?.collapsedState() && this.after.collapseDirection === 'start') {
+    const after = this.after();
+    if (after?.collapsedState() && after.collapseDirectionState() === 'start') {
       this.collapsedState.set(true);
-      this.collapseDirection = 'start';
-      this.before?.refreshCollapseToStart();
+      this.collapseDirectionState.set('start');
+      this.before()?.refreshCollapseToStart();
     }
   }
 }

--- a/projects/element-ng/split/si-split.component.html
+++ b/projects/element-ng/split/si-split.component.html
@@ -1,13 +1,13 @@
 <ng-content />
 
-@for (gutter of gutters; track $index) {
-  @if ($index < parts.length - 1) {
+@for (gutter of gutters(); track $index) {
+  @if ($index < parts().length - 1) {
     <div
       class="si-split-gutter"
       [class.d-none]="!gutter.visible()"
       [style.grid-area]="'g-' + $index"
-      [style.width.px]="orientation === 'horizontal' ? gutterSize : null"
-      [style.height.px]="orientation === 'vertical' ? gutterSize : null"
+      [style.width.px]="orientation() === 'horizontal' ? gutterSize() : null"
+      [style.height.px]="orientation() === 'vertical' ? gutterSize() : null"
       (mousedown)="resizeStart(gutter, $event)"
       (touchstart)="resizeStart(gutter, $event)"
     ></div>

--- a/projects/element-ng/split/si-split.component.spec.ts
+++ b/projects/element-ng/split/si-split.component.spec.ts
@@ -12,8 +12,8 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideSiUiState, SI_UI_STATE_SERVICE, UIStateStorage } from '@siemens/element-ng/common';
+import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
 
-import { runOnPushChangeDetection } from '../test-helpers';
 import { CollapseTo, PartState, Scale, SiSplitModule, SplitOrientation } from './index';
 import { SiSplitPartComponent } from './si-split-part.component';
 import { SiSplitComponent as TestComponent } from './si-split.component';
@@ -343,9 +343,9 @@ describe('SiSplitComponent', () => {
         expect(split).toContain('Test 2');
         expect(split).toContain('Test 3');
 
-        expect(wrapperComponent.split().sizes).toBeDefined();
-        expect(wrapperComponent.split().sizes).toEqual([20, 60, 20]);
-        expect(wrapperComponent.split().orientation).toEqual('horizontal');
+        expect(wrapperComponent.split().sizes()).toBeDefined();
+        expect(wrapperComponent.split().sizes()).toEqual([20, 60, 20]);
+        expect(wrapperComponent.split().orientation()).toEqual('horizontal');
       });
     });
 
@@ -369,9 +369,9 @@ describe('SiSplitComponent', () => {
           expect(split).toContain('Test 2');
           expect(split).toContain('Test 3');
 
-          expect(wrapperComponent.split().sizes).toBeDefined();
-          expect(wrapperComponent.split().sizes).toEqual([20, 60, 20]);
-          expect(wrapperComponent.split().orientation).toEqual('horizontal');
+          expect(wrapperComponent.split().sizes()).toBeDefined();
+          expect(wrapperComponent.split().sizes()).toEqual([20, 60, 20]);
+          expect(wrapperComponent.split().orientation()).toEqual('horizontal');
         });
 
         it('should save ui state', async () => {
@@ -412,7 +412,7 @@ describe('SiSplitComponent', () => {
           expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
           expect(wrapperComponent.measureSize2()).toBeCloseTo(200, 0);
           expect(wrapperComponent.measureSize3()).toBeCloseTo(100, 0);
-          expect(wrapperComponent.split().orientation).toEqual('horizontal');
+          expect(wrapperComponent.split().orientation()).toEqual('horizontal');
         });
       });
     });
@@ -516,7 +516,7 @@ describe('SiSplitComponent', () => {
         expect(wrapperComponent.measureSize3()).toBeCloseTo(150, 0);
 
         partElement1.querySelector<HTMLElement>('.si-split-part-collapse-button button')!.click();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(50, 0);
         expect(wrapperComponent.measureSize2()).toBeCloseTo(241, 0);

--- a/projects/element-ng/split/si-split.component.ts
+++ b/projects/element-ng/split/si-split.component.ts
@@ -3,26 +3,23 @@
  * SPDX-License-Identifier: MIT
  */
 import {
-  AfterContentInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
-  ContentChildren,
+  contentChildren,
   ElementRef,
   inject,
-  Input,
+  input,
   NgZone,
-  OnChanges,
-  QueryList,
   signal,
   Signal,
-  SimpleChanges,
   DOCUMENT,
   DestroyRef,
-  output
+  output,
+  effect,
+  untracked
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import {
   isRTL,
   SI_UI_STATE_SERVICE,
@@ -50,52 +47,91 @@ interface SplitPartState {
   selector: 'si-split',
   templateUrl: './si-split.component.html',
   styleUrl: './si-split.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  // Signals cannot be used directly with @HostBinding. See: https://github.com/angular/angular/issues/53888#issuecomment-1888935225
   host: {
-    '[class]': '_orientation()',
+    '[class]': 'orientation()',
     '[style.grid-template-rows]': 'gridTemplateRows()',
     '[style.grid-template-columns]': 'gridTemplateColumns()',
     '[style.grid-template-areas]': 'gridTemplateAreas()'
   }
 })
-export class SiSplitComponent implements AfterContentInit, OnChanges {
-  /** @defaultValue 16 */
-  @Input() gutterSize = 16;
+export class SiSplitComponent {
+  /**
+   * Size of the gutter (divider) between split parts in pixels.
+   *
+   * @defaultValue 16
+   */
+  readonly gutterSize = input(16);
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  protected readonly _orientation = signal<SplitOrientation>('horizontal');
+  /**
+   * Defines the split layout direction.
+   *
+   * @defaultValue 'horizontal'
+   */
+  readonly orientation = input<SplitOrientation>('horizontal');
 
-  get orientation(): SplitOrientation {
-    return this._orientation();
-  }
-
-  @Input() set orientation(value: SplitOrientation) {
-    this._orientation.set(value);
-  }
-
-  /** @defaultValue [] */
-  @Input() sizes: number[] = [];
+  /**
+   * Initial relative sizes of the split parts as fractional values.
+   *
+   * @defaultValue []
+   */
+  // eslint-disable-next-line @angular-eslint/prefer-signal-model
+  readonly sizes = input<number[]>([]);
 
   /**
    * An optional stateId to uniquely identify a component instance.
    * Required for persistence of ui state.
    */
-  @Input() stateId?: string;
+  readonly stateId = input<string>();
 
   readonly sizesChange = output<number[]>();
 
   @WebComponentContentChildren(SiSplitPartComponent)
-  @ContentChildren(SiSplitPartComponent)
-  protected parts!: QueryList<SiSplitPartComponent>;
-  protected gutters: Gutter[] = [];
+  protected readonly parts = contentChildren(SiSplitPartComponent);
+  protected readonly gutters = signal<Gutter[]>([]);
 
-  // eslint-disable-next-line
-  protected gridTemplateRows: Signal<string> = signal('');
-  // eslint-disable-next-line
-  protected gridTemplateColumns: Signal<string> = signal('');
-  // eslint-disable-next-line
-  protected gridTemplateAreas: Signal<string> = signal('');
+  private readonly gridTemplate = computed(() => {
+    if (!this.initialized()) {
+      return '';
+    }
+    return this.parts()
+      .map(part =>
+        part.collapsedState()
+          ? part.collapseToMinSize()
+            ? `${part.minSize()}px`
+            : 'min-content'
+          : part.actualSize()
+            ? part.scale() === 'auto'
+              ? `minmax(${part.minSize()}px, ${part.actualSize()}fr)`
+              : `minmax(${part.minSize()}px, ${part.actualSize()}px)`
+            : `minmax(${part.minSize()}px, ${
+                part.fractionalSize()! * this.fractionalSizeToExpandedSizeFactor()
+              }fr)`
+      )
+      .join(' min-content ');
+  });
+
+  protected readonly gridTemplateRows = computed(() =>
+    this.orientation() === 'vertical' ? this.gridTemplate() : '1fr'
+  );
+
+  protected readonly gridTemplateColumns = computed(() =>
+    this.orientation() === 'horizontal' ? this.gridTemplate() : '1fr'
+  );
+
+  protected readonly gridTemplateAreas = computed(() => {
+    if (!this.initialized()) {
+      return '';
+    }
+    const areaNames = this.parts()
+      .map((part, index) => [`p-${index}`, part.after() ? `g-${index}` : []])
+      .flat(2) as string[];
+
+    if (this.orientation() === 'horizontal') {
+      return `"${areaNames.join(' ')}"`;
+    } else {
+      return `"${areaNames.join('" "')}"`;
+    }
+  });
 
   private readonly elementRef = inject(ElementRef<HTMLElement>);
   private readonly ngZone = inject(NgZone);
@@ -105,93 +141,68 @@ export class SiSplitComponent implements AfterContentInit, OnChanges {
   private readonly destroyRef = inject(DestroyRef);
   // New parts won't be measured, so we need this to scale up their fractional size to the expanded size.
   // Using 10, as the sum of all fractional sizes is 1, so we need to scale them up as fr-values should be >= 1.
-  private fractionalSizeToExpandedSizeFactor = 10;
+  private readonly fractionalSizeToExpandedSizeFactor = signal(10);
+  private readonly initialized = signal(false);
 
-  ngOnChanges(changes: SimpleChanges<this>): void {
-    if (changes.sizes && !changes.sizes.firstChange && this.parts) {
-      this.sizes.forEach((size, index) => {
-        const part = this.parts.get(index);
-        if (part) {
-          part.fractionalSize.set(size);
-          part.expandedSize.set(undefined);
+  constructor() {
+    effect(() => {
+      const sizes = this.sizes();
+      untracked(() => {
+        if (!this.initialized()) {
+          return;
         }
+        sizes.forEach((size, index) => {
+          const part = this.parts()[index];
+          if (part) {
+            part.fractionalSize.set(size);
+            part.expandedSize.set(undefined);
+          }
+        });
+        this.alignRelativeSizes();
       });
-      this.alignRelativeSizes();
-    }
+    });
+
+    toObservable(this.parts)
+      .pipe(observeOn(asapScheduler), takeUntilDestroyed())
+      .subscribe(() => this.setupParts());
   }
 
-  ngAfterContentInit(): void {
-    this.parts.changes.pipe(observeOn(asapScheduler)).subscribe(() => {
-      this.changeDetectorRef.markForCheck();
-      this.gutters = [];
+  private setupParts(): void {
+    this.initialized.set(true);
+    const gutters: Gutter[] = [];
 
-      for (let index = 0; index < this.parts.length; index++) {
-        const component = this.parts.get(index)!;
-        component.index = index;
-        component.after = this.parts.get(index + 1);
-        component.before = this.parts.get(index - 1);
-        component.fractionalSize.set(this.sizes[index]);
-        component.saveUIState = () => this.saveUIState();
+    const parts = this.parts();
+    for (let index = 0; index < parts.length; index++) {
+      const component = parts[index];
+      component.index = index;
+      component.after.set(parts[index + 1]);
+      component.before.set(parts[index - 1]);
+      component.fractionalSize.set(this.sizes()[index]);
+      component.saveUIState = () => this.saveUIState();
 
-        if (component.after) {
-          this.gutters.push({
-            before: component,
-            after: this.parts.get(index + 1)!,
-            visible: computed(() => {
-              const afterPart = component.after!.nextExpandedAfter();
-              return !afterPart.collapsedState() && !component.collapsedState();
-            })
-          });
-        }
+      if (component.after()) {
+        gutters.push({
+          before: component,
+          after: parts[index + 1]!,
+          visible: computed(() => {
+            const afterPart = component.after()!.nextExpandedAfter();
+            return !afterPart.collapsedState() && !component.collapsedState();
+          })
+        });
       }
+    }
+    this.gutters.set(gutters);
 
-      this.alignRelativeSizes();
-      this.updateFractionalSizeToExpandSizeFactor();
-      this.restoreFromUIState();
-
-      const gridTemplate = computed(() =>
-        this.parts
-          .map(part =>
-            part.collapsedState()
-              ? part.collapseToMinSize
-                ? `${part.minSize}px`
-                : 'min-content'
-              : part.actualSize()
-                ? part.scale === 'auto'
-                  ? `minmax(${part.minSize}px, ${part.actualSize()}fr)`
-                  : `minmax(${part.minSize}px, ${part.actualSize()}px)`
-                : `minmax(${part.minSize}px, ${
-                    part.fractionalSize()! * this.fractionalSizeToExpandedSizeFactor
-                  }fr)`
-          )
-          .join(' min-content ')
-      );
-
-      this.gridTemplateRows = computed(() =>
-        this._orientation() === 'vertical' ? gridTemplate() : '1fr'
-      );
-      this.gridTemplateColumns = computed(() =>
-        this._orientation() === 'horizontal' ? gridTemplate() : '1fr'
-      );
-      this.gridTemplateAreas = computed(() => {
-        const areaNames = this.parts
-          .map((part, index) => [`p-${index}`, part.after ? `g-${index}` : []])
-          .flat(2) as string[];
-
-        if (this._orientation() === 'horizontal') {
-          return `"${areaNames.join(' ')}"`;
-        } else {
-          return `"${areaNames.join('" "')}"`;
-        }
-      });
-      setTimeout(() => this.refreshAllPartSizes());
-    });
-    this.parts.notifyOnChanges();
+    this.alignRelativeSizes();
+    this.updateFractionalSizeToExpandSizeFactor();
+    this.restoreFromUIState();
+    setTimeout(() => this.refreshAllPartSizes());
   }
 
   private alignRelativeSizes(): void {
-    const requestedNoSize = this.parts.filter(part => !part.size && !part.fractionalSize());
-    const requestedRelSize = this.parts.filter(part => part.fractionalSize() && !part.size);
+    const parts = this.parts();
+    const requestedNoSize = parts.filter(part => !part.size() && !part.fractionalSize());
+    const requestedRelSize = parts.filter(part => part.fractionalSize() && !part.size());
 
     if (requestedRelSize.length) {
       const totalRequestedRelSize = requestedRelSize.reduce((a, b) => a + b.fractionalSize()!, 0);
@@ -212,34 +223,36 @@ export class SiSplitComponent implements AfterContentInit, OnChanges {
     let previousScalableFractionalSum = 0;
     let previousScalableExpandedSizeSum = 0;
 
-    for (let index = 0; index < this.parts.length; index++) {
-      const component = this.parts.get(index)!;
-      if (component.scale === 'auto' && component.expandedSize() !== undefined) {
+    for (const component of this.parts()) {
+      if (component.scale() === 'auto' && component.expandedSize() !== undefined) {
         previousScalableExpandedSizeSum += component.expandedSize()!;
         previousScalableFractionalSum += component.fractionalSize()!;
       }
     }
 
-    this.fractionalSizeToExpandedSizeFactor = previousScalableFractionalSum
-      ? previousScalableExpandedSizeSum / previousScalableFractionalSum
-      : 10;
+    this.fractionalSizeToExpandedSizeFactor.set(
+      previousScalableFractionalSum
+        ? previousScalableExpandedSizeSum / previousScalableFractionalSum
+        : 10
+    );
   }
 
   private refreshAllPartSizes(): void {
-    const refParts = this.parts.filter(
+    const parts = this.parts();
+    const refParts = parts.filter(
       part =>
         !part.collapsedState() &&
-        part.scale === 'auto' &&
+        part.scale() === 'auto' &&
         (part.expandedSize() || part.fractionalSize())
     );
     const beforeFrSum = refParts.reduce((a, b) => a + (b.expandedSize() ?? b.fractionalSize()!), 0);
-    this.parts.forEach(part => part.refreshSizePx(this.orientation));
+    parts.forEach(part => part.refreshSizePx(this.orientation()));
     const afterFrSum = refParts.reduce((a, b) => a + b.expandedSize()!, 0);
     const beforeToAfterFactor = beforeFrSum > 0 ? afterFrSum / beforeFrSum : 1;
-    this.parts
+    parts
       .filter(
         part =>
-          part.collapsedState() && (part.scale === 'auto' || part.expandedSize() === undefined)
+          part.collapsedState() && (part.scale() === 'auto' || part.expandedSize() === undefined)
       )
       .forEach(part =>
         part.expandedSize.update(prev => (prev ?? part.fractionalSize()!) * beforeToAfterFactor)
@@ -255,8 +268,8 @@ export class SiSplitComponent implements AfterContentInit, OnChanges {
     let appliedDelta = 0;
     const rtl = isRTL();
     const startPosition = this.getPosition(event);
-    const minDelta = -1 * (beforeSize - gutter.before.minSize);
-    const maxDelta = afterSize - afterPart.minSize;
+    const minDelta = -1 * (beforeSize - gutter.before.minSize());
+    const maxDelta = afterSize - afterPart.minSize();
     const containerSize = this.measureContainerSize();
     event.preventDefault(); // prevents text-selection
 
@@ -271,7 +284,7 @@ export class SiSplitComponent implements AfterContentInit, OnChanges {
         .subscribe({
           next: move => {
             let delta = this.getPosition(move) - startPosition;
-            if (rtl && this.orientation === 'horizontal') {
+            if (rtl && this.orientation() === 'horizontal') {
               delta *= -1;
             }
 
@@ -291,7 +304,7 @@ export class SiSplitComponent implements AfterContentInit, OnChanges {
             appliedDelta += delta;
             gutter.before.expandedSize.set(beforeSize);
             afterPart.expandedSize.set(afterSize);
-            if (this.orientation === 'vertical') {
+            if (this.orientation() === 'vertical') {
               this.elementRef.nativeElement.style.setProperty(
                 'grid-template-rows',
                 this.gridTemplateRows()
@@ -304,7 +317,7 @@ export class SiSplitComponent implements AfterContentInit, OnChanges {
             }
             this.ngZone.run(() =>
               this.sizesChange.emit(
-                this.parts.map(part => (part.actualSize() * 100) / containerSize)
+                this.parts().map(part => (part.actualSize() * 100) / containerSize)
               )
             );
           },
@@ -315,7 +328,7 @@ export class SiSplitComponent implements AfterContentInit, OnChanges {
 
   private measureContainerSize(): number {
     const rect = this.elementRef.nativeElement.getBoundingClientRect();
-    if (this._orientation() === 'vertical') {
+    if (this.orientation() === 'vertical') {
       return rect.height;
     } else {
       return rect.width;
@@ -324,24 +337,26 @@ export class SiSplitComponent implements AfterContentInit, OnChanges {
 
   private getPosition(event: Event): number {
     const positionObject = (event as TouchEvent).touches?.[0] ?? (event as MouseEvent);
-    return this.orientation === 'horizontal'
+    return this.orientation() === 'horizontal'
       ? (positionObject.clientX ?? 0)
       : (positionObject.clientY ?? 0);
   }
 
   private saveUIState(): void {
-    if (!this.stateId || !this.uiStateService) {
+    const stateId = this.stateId();
+    if (!stateId || !this.uiStateService) {
       return;
     }
 
     const containerSize = this.measureContainerSize();
-    const state = this.parts.reduce(
+    const state = this.parts().reduce(
       (partState, part) => {
-        if (part.stateId) {
-          partState[part.stateId] = {
+        const partStateId = part.stateId();
+        if (partStateId) {
+          partState[partStateId] = {
             size: ((part.expandedSize() ?? 0) * 100) / containerSize,
-            initialSize: this.sizes[part.index],
-            expanded: part.expanded
+            initialSize: this.sizes()[part.index],
+            expanded: !part.collapsedState()
           };
         }
         return partState;
@@ -349,23 +364,24 @@ export class SiSplitComponent implements AfterContentInit, OnChanges {
       {} as Record<string, SplitPartState>
     );
 
-    this.uiStateService.save(this.stateId, state);
+    this.uiStateService.save(stateId, state);
   }
 
   private restoreFromUIState(): void {
-    if (!this.stateId || !this.uiStateService) {
+    const stateId = this.stateId();
+    if (!stateId || !this.uiStateService) {
       return;
     }
 
-    this.uiStateService.load<Record<string, SplitPartState>>(this.stateId).then(uiState => {
+    this.uiStateService.load<Record<string, SplitPartState>>(stateId).then(uiState => {
       if (!uiState) {
         return;
       }
 
-      this.parts
-        .filter(part => part.stateId)
-        .map(part => ({ part, state: uiState[part.stateId!] }))
-        .filter(({ part, state }) => this.sizes[part.index] === state?.initialSize)
+      this.parts()
+        .filter(part => part.stateId())
+        .map(part => ({ part, state: uiState[part.stateId()!] }))
+        .filter(({ part, state }) => this.sizes()[part.index] === state?.initialSize)
         .forEach(({ part, state }) => {
           part.expandedSize.set(undefined);
           part.fractionalSize.set(state?.size);


### PR DESCRIPTION
BREAKING CHANGE: si-split and si-split-part inputs were migrated to signal inputs

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2281/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2281/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2281/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2281/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2281/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2281/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2281/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2281/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2281/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2281/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



