### PR TITLE
feat(theme): consumer defined root font size

### DIFF
--- a/projects/element-theme/src/styles/_root-font-size.scss
+++ b/projects/element-theme/src/styles/_root-font-size.scss
@@ -1,0 +1,29 @@
+$element-root-font-size: initial !default;
+
+html {
+  // defines the default with low specificity, i.e. easy overridable with :root
+  --element-root-font-size: #{$element-root-font-size};
+}
+
+:root {
+  font-size: var(--element-root-font-size);
+}
+
+// pre-defined root font size helper classes that can be applied to <html> tag
+
+// use browser-defined root font size
+.rfs-none {
+  --element-root-font-size: initial;
+}
+
+.rfs-16 {
+  --element-root-font-size: 16px;
+}
+
+.rfs-20 {
+  --element-root-font-size: 20px;
+}
+
+.rfs-24 {
+  --element-root-font-size: 24px;
+}

--- a/projects/element-theme/src/styles/bootstrap/_reboot.scss
+++ b/projects/element-theme/src/styles/bootstrap/_reboot.scss
@@ -26,10 +26,6 @@
 // null by default, thus nothing is generated.
 
 :root {
-  @if variables.$font-size-root != null {
-    font-size: var(--#{variables.$variable-prefix}root-font-size);
-  }
-
   @if variables.$enable-smooth-scroll {
     @media (prefers-reduced-motion: no-preference) {
       scroll-behavior: smooth;

--- a/projects/element-theme/src/styles/bootstrap/_root.scss
+++ b/projects/element-theme/src/styles/bootstrap/_root.scss
@@ -8,11 +8,6 @@
   // See https://github.com/sass/sass/issues/2383#issuecomment-336349172
   --#{variables.$variable-prefix}font-sans-serif: #{meta.inspect(variables.$font-family-sans-serif)};
   --#{variables.$variable-prefix}font-monospace: #{meta.inspect(variables.$font-family-monospace)};
-
-  // Root and body
-  @if variables.$font-size-root != null {
-    --#{variables.$variable-prefix}root-font-size: #{variables.$font-size-root};
-  }
   --#{variables.$variable-prefix}body-font-family: #{meta.inspect(variables.$font-family-base)};
   --#{variables.$variable-prefix}body-font-size: #{variables.$font-size-base};
   --#{variables.$variable-prefix}body-font-weight: #{variables.$font-weight-base};

--- a/projects/element-theme/src/styles/bootstrap/_variables.scss
+++ b/projects/element-theme/src/styles/bootstrap/_variables.scss
@@ -160,9 +160,7 @@ $font-family-monospace:
 $font-family-base: $font-family-sans-serif !default;
 $font-family-code: $font-family-monospace !default;
 
-// $font-size-root effects the value of `rem`, which is used for as well font sizes, paddings and margins
 // $font-size-base effects the font size of the body text
-$font-size-root: null !default;
 $font-size-base: typography.$si-font-size-body !default;
 $font-size-lg: typography.$si-font-size-body-lg !default;
 $font-size-sm: typography.$si-font-size-caption !default;

--- a/projects/element-theme/src/theme.scss
+++ b/projects/element-theme/src/theme.scss
@@ -1,8 +1,15 @@
 $element-theme-default: null !default;
 $element-themes: null !default;
 
+// Defines the default root font size. Change to 'none' at some point.
+$element-root-font-size: 16px !default;
+
 $_theme-default: 'element';
 $_themes: () !default;
+
+@use 'styles/root-font-size' with (
+  $element-root-font-size: $element-root-font-size
+);
 
 // Load Bootstrap
 @use 'styles/bootstrap';
@@ -41,11 +48,4 @@ $_themes: () !default;
 html,
 body {
   block-size: 100%;
-}
-
-// Define what 1rem actually means. Everything here assumes 16px.
-// When the whole thing is properly done, carefully mixing (r)em and px values,
-// this can be removed to allow the user's setting.
-html {
-  font-size: 16px;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -20,11 +20,9 @@
 @use '@simpl/brand/dist/element-theme-siemens-brand-dark' as brand-dark;
 
 @use '@siemens/element-theme/src/theme' with (
+  // $element-root-font-size: initial,
   $element-theme-default: 'siemens-brand',
-  $element-themes: (
-    'siemens-brand',
-    'element'
-  )
+  $element-themes: ('siemens-brand', 'element')
 );
 
 @use '@siemens/element-icons/dist/style/siemens-element-icons';


### PR DESCRIPTION
NOTE: The default root font size is now configurable when loading the Element theme. When loading the theme, the default value can be passed as `$element-root-font-size`. Set to `none` to use the browser default. The default value if nothing is provided is still at `16px` so nothing will break and projects can opt-in once ready.  It is recommended to set this to `initial` as soon as possible. Starting with Element v52, `initial` will be the default.

```scss
@use '@siemens/element-theme/src/theme' with (
  $element-root-font-size: initial
);
```

Furthermore, a series of helper classes are provided that can be applied to the `<html>` tag to change the root font size:
- `rfs-none`: use the browser default, regardless of the configured default
- `rfs-16`: use 16px
- `rfs-20`: use 20px
- `rfs-24`: use 24px

Any other value can be used by setting the CSS variable at the `<html>` tag or using a `:root {}` CSS block: `--element-root-font-size`.

Closes #2166

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2284/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2284/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2284/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2284/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2284/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2284/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2284/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2284/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2284/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2284/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->





