### PR TITLE
fixup(forms): integrate `si-form-field` with `si-form-fieldset`

### DIFF
--- a/api-goldens/element-ng/form/index.api.md
+++ b/api-goldens/element-ng/form/index.api.md
@@ -9,6 +9,7 @@ import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
 import * as _angular_core from '@angular/core';
 import * as _angular_forms from '@angular/forms';
+import * as _angular_forms_signals from '@angular/forms/signals';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { FormGroup } from '@angular/forms';
@@ -52,13 +53,13 @@ export class SiFormContainerComponent<TControl extends {
 }
 
 // @public
-export class SiFormFieldComponent {
+export class SiFormFieldComponent implements SiFormFieldsetControl {
     constructor();
     readonly label: _angular_core.InputSignal<TranslatableString>;
 }
 
 // @public (undocumented)
-export class SiFormFieldsetComponent implements DoCheck {
+export class SiFormFieldsetComponent {
     readonly inline: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly label: _angular_core.InputSignal<TranslatableString>;
     readonly labelWidth: _angular_core.InputSignal<string | undefined>;
@@ -66,7 +67,7 @@ export class SiFormFieldsetComponent implements DoCheck {
 }
 
 // @public (undocumented)
-export class SiFormItemComponent implements AfterContentInit, AfterContentChecked, OnChanges, OnInit, OnDestroy {
+export class SiFormItemComponent implements AfterContentInit, AfterContentChecked, OnChanges, OnInit, OnDestroy, SiFormFieldsetControl {
     readonly disableErrorPrinting: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
     readonly formErrorMapper: _angular_core.InputSignal<SiFormValidationErrorMapper | undefined>;

--- a/api-goldens/element-ng/formly-legacy/index.api.md
+++ b/api-goldens/element-ng/formly-legacy/index.api.md
@@ -7,6 +7,7 @@
 import { AbstractControl } from '@angular/forms';
 import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
+import * as _angular_forms_signals from '@angular/forms/signals';
 import { ConfigOption } from '@ngx-formly/core';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:75d6a34801b74d3eece05e97f67d64fe8111ef59fe64e36c19428a2d89534cc5
-size 35474
+oid sha256:b8f1ed41806e6a5e9a8d6ae078a88e8f27b0397fec72b4f3d35dab50754360fa
+size 39157

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bfa55617544c6df01fe77ab2285d57464f77ed3b97e23cc5cbe6f60f574ac72e
-size 34941
+oid sha256:c974f0025b28e4166754113b3efe31fcf3bb580d8fb008e3c8cc2d6bc9513759
+size 38451

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated.yaml
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated.yaml
@@ -1,4 +1,10 @@
 - heading "Signal form" [level=2]
+- group "Role*":
+  - text: ""
+  - radio "Engineer"
+  - text: Engineer
+  - radio "Installer"
+  - text: Installer Role required
 - text: Name*
 - textbox "Name*" [invalid]
 - text: Minimum 3 characters Name must start with an uppercase letter Description

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27ce183cbb3f939a3f6e373a88fe69b40181ed0b65811796cde4338291c7223f
-size 26198
+oid sha256:38bc8bb7295c44e532502808021b7ee291abd8927b6c326b39c418fcef76e273
+size 28972

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd2ebd4b8e99d720dfb2ebd954ee96ddbedea2d3f38b842e99c724724eeefdfd
-size 25525
+oid sha256:bfc1d62a2ccb8ed8420cddaccc303cf68b642865e7be5ed6cbcdb181be298b67
+size 28132

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form.yaml
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form.yaml
@@ -1,4 +1,10 @@
 - heading "Signal form" [level=2]
+- group "Role*":
+  - text: ""
+  - radio "Engineer"
+  - text: Engineer
+  - radio "Installer"
+  - text: Installer
 - text: Name*
 - textbox "Name*"
 - text: Description

--- a/projects/element-ng/form/form-fieldset/si-form-fieldset.component.ts
+++ b/projects/element-ng/form/form-fieldset/si-form-fieldset.component.ts
@@ -7,13 +7,12 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  DoCheck,
   input,
   signal
 } from '@angular/core';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
-import { SiFormItemComponent } from '../si-form-item/si-form-item.component';
+import { SiFormFieldsetControl } from './si-form-fieldset.control';
 
 @Component({
   selector: 'si-form-fieldset',
@@ -28,7 +27,7 @@ import { SiFormItemComponent } from '../si-form-item/si-form-item.component';
     '[attr.aria-labelledby]': 'labelId'
   }
 })
-export class SiFormFieldsetComponent implements DoCheck {
+export class SiFormFieldsetComponent {
   private static labelIdCounter = 0;
 
   /** The label for the entire fieldset. */
@@ -51,26 +50,23 @@ export class SiFormFieldsetComponent implements DoCheck {
    */
   readonly inline = input(false, { transform: booleanAttribute });
 
-  private readonly formItems = signal<SiFormItemComponent[]>([]);
+  private readonly formItems = signal<SiFormFieldsetControl[]>([]);
 
   /** @internal */
   readonly hasOnlyRadios = computed(() => {
     // Check if the fieldset only contains radio buttons.
-    // We can safely assume that, if all items have the same control name and if there are at least 2 items.
+    // We can safely assume that, if all items reference the same control and if there are at least 2 items.
     const items = this.formItems();
     if (items.length > 1) {
-      const first = items[0];
-      return items.every(item => item.ngControl()?.name === first.ngControl()?.name);
+      const first = items[0].control();
+      return first != null && items.every(item => item.control() === first);
     }
 
     return false;
   });
 
-  protected readonly errors = computed(() =>
-    // All errors should be the same for radios, so we just take the first.
-    this.hasOnlyRadios() ? this.formItems()[0].errors() : []
-  );
-  protected readonly touched = signal(false);
+  protected readonly errors = computed(() => this.formItems()[0].errors());
+  protected readonly touched = computed(() => this.formItems().some(item => item.touched()));
   protected readonly isRequired = computed(
     () =>
       this.required() || (this.hasOnlyRadios() && this.formItems().every(item => item.required()))
@@ -78,17 +74,13 @@ export class SiFormFieldsetComponent implements DoCheck {
 
   protected readonly labelId = `__si-form-fieldset-label-${SiFormFieldsetComponent.labelIdCounter++}`;
 
-  ngDoCheck(): void {
-    this.touched.set(this.formItems().some(item => item.ngControl()?.touched));
-  }
-
   /** @internal */
-  registerFormItem(item: SiFormItemComponent): void {
+  registerControl(item: SiFormFieldsetControl): void {
     this.formItems.update(items => [...items, item]);
   }
 
   /** @internal */
-  unregisterFormItem(item: SiFormItemComponent): void {
+  unregisterControl(item: SiFormFieldsetControl): void {
     this.formItems.update(items => items.filter(i => i !== item));
   }
 }

--- a/projects/element-ng/form/form-fieldset/si-form-fieldset.control.ts
+++ b/projects/element-ng/form/form-fieldset/si-form-fieldset.control.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Signal } from '@angular/core';
+
+import type { SiFormError } from '../si-form-item/si-form-item.component';
+
+export interface SiFormFieldsetControl {
+  readonly control: Signal<unknown>;
+  readonly required: Signal<boolean>;
+  readonly touched: Signal<boolean>;
+  readonly errors: Signal<readonly SiFormError[]>;
+}

--- a/projects/element-ng/form/si-form-field/si-form-field.component.html
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.html
@@ -6,7 +6,9 @@
   @if (isFormCheck()) {
     <ng-container [ngTemplateOutlet]="labelTemplate" />
   }
-  <ng-container [ngTemplateOutlet]="feedbackTemplate" />
+  @if (!isPartOfRadioGroup()) {
+    <ng-container [ngTemplateOutlet]="feedbackTemplate" />
+  }
 </div>
 
 <ng-template #labelTemplate>
@@ -14,7 +16,7 @@
     [for]="controlId()"
     [class.form-label]="!isFormCheck()"
     [class.form-check-label]="isFormCheck()"
-    [class.required]="required()"
+    [class.required]="required() && !isPartOfRadioGroup()"
     >{{ label() | translate }}</label
   >
 </ng-template>

--- a/projects/element-ng/form/si-form-field/si-form-field.component.scss
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.scss
@@ -5,6 +5,10 @@
   margin-block-end: map.get(all-variables.$spacers, 5);
 }
 
+:host-context(si-form-fieldset) {
+  margin-block-end: 0;
+}
+
 :host(:not(.form-check)) {
   display: flex;
   flex-direction: column;

--- a/projects/element-ng/form/si-form-field/si-form-field.component.ts
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.ts
@@ -3,10 +3,20 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, computed, contentChild, effect, inject, input } from '@angular/core';
+import {
+  Component,
+  computed,
+  contentChild,
+  DestroyRef,
+  effect,
+  inject,
+  input
+} from '@angular/core';
 import { FormField } from '@angular/forms/signals';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
+import { SiFormFieldsetComponent } from '../form-fieldset/si-form-fieldset.component';
+import { SiFormFieldsetControl } from '../form-fieldset/si-form-fieldset.control';
 import { SiFormValidationErrorService } from '../si-form-validation-error.service';
 
 /**
@@ -26,11 +36,12 @@ import { SiFormValidationErrorService } from '../si-form-validation-error.servic
   templateUrl: './si-form-field.component.html',
   styleUrl: './si-form-field.component.scss',
   host: {
-    '[class.required]': 'required()',
-    '[class.form-check]': 'isFormCheck()'
+    '[class.required]': 'required() && !isPartOfRadioGroup()',
+    '[class.form-check]': 'isFormCheck()',
+    '[class.form-check-inline]': 'fieldset?.inline()'
   }
 })
-export class SiFormFieldComponent {
+export class SiFormFieldComponent implements SiFormFieldsetControl {
   private static idCounter = 0;
 
   /**
@@ -40,6 +51,8 @@ export class SiFormFieldComponent {
   readonly label = input.required<TranslatableString>();
 
   private readonly formField = contentChild.required(FormField);
+
+  protected readonly fieldset = inject(SiFormFieldsetComponent, { optional: true });
 
   private readonly validationErrorService = inject(SiFormValidationErrorService);
 
@@ -57,14 +70,24 @@ export class SiFormFieldComponent {
 
   private readonly fieldState = computed(() => this.formField().state());
 
-  protected readonly required = computed(() => this.fieldState().required());
+  /** @internal */
+  readonly control = computed(() => this.fieldState().fieldTree);
+
+  /** @internal */
+  readonly required = computed(() => this.fieldState().required());
 
   private readonly invalid = computed(() => {
     const state = this.fieldState();
     return state.touched() && state.invalid();
   });
 
-  protected readonly errors = computed(() => {
+  /** @internal */
+  readonly touched = computed(() => this.fieldState().touched());
+
+  protected readonly isPartOfRadioGroup = computed(() => this.fieldset?.hasOnlyRadios() ?? false);
+
+  /** @internal */
+  readonly errors = computed(() => {
     const state = this.fieldState();
     if (!state.touched()) {
       return [];
@@ -74,6 +97,11 @@ export class SiFormFieldComponent {
   });
 
   constructor() {
+    if (this.fieldset) {
+      this.fieldset.registerControl(this);
+      inject(DestroyRef).onDestroy(() => this.fieldset!.unregisterControl(this));
+    }
+
     effect(() => this.syncControlId());
     effect(() => this.syncErrorDescription());
     effect(() => this.syncInvalidState());

--- a/projects/element-ng/form/si-form-item/si-form-item.component.ts
+++ b/projects/element-ng/form/si-form-item/si-form-item.component.ts
@@ -31,6 +31,7 @@ import {
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiFormFieldsetComponent } from '../form-fieldset/si-form-fieldset.component';
+import { SiFormFieldsetControl } from '../form-fieldset/si-form-fieldset.control';
 import { SiFormContainerComponent } from '../si-form-container/si-form-container.component';
 import { SI_FORM_ITEM_CONTROL, SiFormItemControl } from '../si-form-item.control';
 import { SiFormValidationErrorMapper } from '../si-form-validation-error.model';
@@ -59,7 +60,13 @@ export interface SiFormError {
   }
 })
 export class SiFormItemComponent
-  implements AfterContentInit, AfterContentChecked, OnChanges, OnInit, OnDestroy
+  implements
+    AfterContentInit,
+    AfterContentChecked,
+    OnChanges,
+    OnInit,
+    OnDestroy,
+    SiFormFieldsetControl
 {
   /**
    * The label to be displayed in the form item.
@@ -110,6 +117,9 @@ export class SiFormItemComponent
   /** @internal */
   readonly errors = signal<SiFormError[]>([]);
 
+  /** @internal */
+  readonly touched = signal(false);
+
   protected fieldset = inject(SiFormFieldsetComponent, { optional: true });
   protected container = inject(SiFormContainerComponent, { optional: true });
 
@@ -159,6 +169,9 @@ export class SiFormItemComponent
   /** @internal */
   readonly required = computed(() => this.requiredInput() || this.hasRequiredValidator());
 
+  /** @internal */
+  readonly control = computed(() => this.ngControl()?.control);
+
   ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.formErrorMapper) {
       this.updateValidationMessages();
@@ -166,7 +179,7 @@ export class SiFormItemComponent
   }
 
   ngOnInit(): void {
-    this.fieldset?.registerFormItem(this);
+    this.fieldset?.registerControl(this);
   }
 
   ngAfterContentInit(): void {
@@ -180,10 +193,11 @@ export class SiFormItemComponent
   ngAfterContentChecked(): void {
     this.updateRequiredState();
     this.updateValidationMessages();
+    this.touched.set(!!this.ngControl()?.touched);
   }
 
   ngOnDestroy(): void {
-    this.fieldset?.unregisterFormItem(this);
+    this.fieldset?.unregisterControl(this);
   }
 
   private updateRequiredState(): void {

--- a/projects/element-ng/form/si-form.spec.ts
+++ b/projects/element-ng/form/si-form.spec.ts
@@ -13,10 +13,13 @@ import {
   ReactiveFormsModule,
   Validators
 } from '@angular/forms';
+import { form, FormField, required } from '@angular/forms/signals';
 import type { Mock } from 'vitest';
+import { page } from 'vitest/browser';
 
 import { SiFormFieldsetComponent } from './form-fieldset/si-form-fieldset.component';
 import { SiFormContainerComponent } from './si-form-container/si-form-container.component';
+import { SiFormFieldComponent } from './si-form-field/si-form-field.component';
 import { SiFormItemComponent } from './si-form-item/si-form-item.component';
 import { provideFormValidationErrorMapper } from './si-form-validation-error.provider';
 import { SiFormModule } from './si-form.module';
@@ -273,6 +276,51 @@ describe('SiForm', () => {
       fixture.detectChanges();
       expect(emailMapperSpy).toHaveBeenCalled();
       expect(await field.getErrorMessages()).toEqual(['email-true']);
+    });
+  });
+
+  describe('with fieldset containing signal form fields', () => {
+    @Component({
+      imports: [SiFormFieldsetComponent, SiFormFieldComponent, FormField],
+      template: `
+        <si-form-fieldset label="Choose">
+          <si-form-field label="Option 1">
+            <input type="radio" class="form-check-input" value="a" [formField]="form.choice" />
+          </si-form-field>
+          <si-form-field label="Option 2">
+            <input type="radio" class="form-check-input" value="b" [formField]="form.choice" />
+          </si-form-field>
+        </si-form-fieldset>
+      `,
+      changeDetection: ChangeDetectionStrategy.OnPush
+    })
+    class TestHostComponent {
+      readonly model = signal({ choice: '' });
+      readonly form = form(this.model, path => {
+        required(path.choice, { message: 'A choice is required' });
+      });
+    }
+
+    let fixture: ComponentFixture<TestHostComponent>;
+
+    const fieldset = page.getByRole('group', { name: 'Choose' });
+    const fieldsetLabel = page.getByText('Choose');
+    const errorMessage = fieldset.getByText('A choice is required');
+
+    beforeEach(async () => {
+      fixture = TestBed.createComponent(TestHostComponent);
+      await fixture.whenStable();
+    });
+
+    it('should group error messages from the form fields onto the fieldset', async () => {
+      fixture.componentInstance.form().markAsTouched();
+      await fixture.whenStable();
+
+      await expect.element(errorMessage).toBeVisible();
+    });
+
+    it('should only have a required indicator on the fieldset', async () => {
+      await expect.element(fieldsetLabel).toHaveClass('required');
     });
   });
 

--- a/src/app/examples/si-signal-form/si-signal-form.html
+++ b/src/app/examples/si-signal-form/si-signal-form.html
@@ -5,6 +5,25 @@
       <div class="card">
         <div class="card-body">
           <form [formRoot]="form">
+            <si-form-fieldset label="Role" inline>
+              <si-form-field label="Engineer">
+                <input
+                  type="radio"
+                  class="form-check-input"
+                  value="engineer"
+                  [formField]="form.role"
+                />
+              </si-form-field>
+              <si-form-field label="Installer">
+                <input
+                  type="radio"
+                  class="form-check-input"
+                  value="installer"
+                  [formField]="form.role"
+                />
+              </si-form-field>
+            </si-form-fieldset>
+
             <si-form-field label="Name">
               <input type="text" class="form-control" [formField]="form.name" />
             </si-form-field>

--- a/src/app/examples/si-signal-form/si-signal-form.ts
+++ b/src/app/examples/si-signal-form/si-signal-form.ts
@@ -13,7 +13,13 @@ import {
   pattern,
   required
 } from '@angular/forms/signals';
-import { provideSiFormFieldConfig, SiFormFieldComponent } from '@siemens/element-ng/form';
+import {
+  provideSiFormFieldConfig,
+  SiFormFieldComponent,
+  SiFormFieldsetComponent
+} from '@siemens/element-ng/form';
+
+export type Role = 'engineer' | 'installer';
 
 export interface TravelRequest {
   name: string;
@@ -22,6 +28,7 @@ export interface TravelRequest {
   arrival: string;
   departure: string;
   serviceClass: string;
+  role: Role | '';
   fellowPassengers: number;
   termsAccepted: boolean;
   privacyDeclined: boolean;
@@ -34,6 +41,7 @@ const emptyRequest: TravelRequest = {
   arrival: '',
   departure: '',
   serviceClass: 'first',
+  role: '',
   fellowPassengers: 0,
   termsAccepted: false,
   privacyDeclined: false
@@ -41,7 +49,7 @@ const emptyRequest: TravelRequest = {
 
 @Component({
   selector: 'app-sample',
-  imports: [JsonPipe, FormField, FormRoot, SiFormFieldComponent],
+  imports: [JsonPipe, FormField, FormRoot, SiFormFieldComponent, SiFormFieldsetComponent],
   templateUrl: './si-signal-form.html',
   providers: [provideSiFormFieldConfig()],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -61,6 +69,7 @@ export class SampleComponent {
         message: 'Name must start with an uppercase letter'
       });
       required(path.birthday, { message: 'Day of birth required' });
+      required(path.role, { message: 'Role required' });
       min(path.fellowPassengers, 2, { message: 'Minimum 2' });
       required(path.termsAccepted, {
         message: 'Accept terms before joining'


### PR DESCRIPTION
Introduces a new common interface implemented by `SiFormField` and `SiFormItem` which is used by `SiFormFieldset`. It decouples Angular form logic from the `SiFormFieldset`.

A fixup type was chosen, as the form item was introduced but not yet released.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2285/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2285/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2285/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2285/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2285/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2285/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2285/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2285/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2285/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2285/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->






