### PR TITLE
refactor(list-item): use grid-template-areas for content layout

### DIFF
--- a/projects/element-theme/src/styles/components/_list-item.scss
+++ b/projects/element-theme/src/styles/components/_list-item.scss
@@ -14,6 +14,12 @@ ol:has(.list-item) {
 .list-item {
   display: grid;
   grid-template-columns: 1fr auto;
+  grid-template-areas:
+    'timestamp timestamp'
+    'title action'
+    'description description'
+    'metadata metadata'
+    'quick-actions quick-actions';
   padding-block: map.get(variables.$spacers, 4);
   padding-inline: map.get(variables.$spacers, 6);
 
@@ -28,12 +34,13 @@ ol:has(.list-item) {
   }
 
   .list-item-timestamp {
+    grid-area: timestamp;
     color: variables.$element-text-secondary;
     margin-block-end: 0;
   }
 
   .list-item-title {
-    grid-column: 1;
+    grid-area: title;
     padding-block: map.get(variables.$spacers, 4);
     margin-block-end: 0;
 
@@ -67,15 +74,17 @@ ol:has(.list-item) {
   }
 
   .list-item-primary-action {
-    grid-column: 2;
+    grid-area: action;
     align-self: center;
   }
 
   .list-item-description {
+    grid-area: description;
     margin-block-end: map.get(variables.$spacers, 4);
   }
 
   .list-item-metadata {
+    grid-area: metadata;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -100,6 +109,7 @@ ol:has(.list-item) {
   }
 
   .list-item-quick-actions {
+    grid-area: quick-actions;
     display: flex;
     gap: map.get(variables.$spacers, 4);
   }


### PR DESCRIPTION
## Description

Position `.list-item` content using named CSS grid areas instead of manual `grid-column` placement.

The layout now declares an explicit `grid-template-areas` map on `.list-item` and assigns each child (`timestamp`, `title`, `action`, `description`, `metadata`, `quick-actions`) to its named area. This makes the grid structure explicit and easier to maintain, replacing the positional `grid-column: 1` / `grid-column: 2` rules.

No visual change is intended; empty rows collapse since the auto-sized rows have no content and there is no grid gap.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2286/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2286/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2286/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2286/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2286/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2286/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2286/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2286/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2286/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2286/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
