### PR TITLE
fixup(form): resolve message-less signal-form errors in si-form-field

### DIFF
--- a/api-goldens/element-ng/form/index.api.md
+++ b/api-goldens/element-ng/form/index.api.md
@@ -9,7 +9,6 @@ import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
 import * as _angular_core from '@angular/core';
 import * as _angular_forms from '@angular/forms';
-import * as _angular_forms_signals from '@angular/forms/signals';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { FormGroup } from '@angular/forms';

--- a/api-goldens/element-ng/formly-legacy/index.api.md
+++ b/api-goldens/element-ng/formly-legacy/index.api.md
@@ -7,7 +7,6 @@
 import { AbstractControl } from '@angular/forms';
 import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
-import * as _angular_forms_signals from '@angular/forms/signals';
 import { ConfigOption } from '@ngx-formly/core';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';

--- a/projects/element-ng/form/si-form-field/si-form-field.component.html
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.html
@@ -23,7 +23,7 @@
   <div class="invalid-feedback" [class.d-block]="errors().length" [attr.id]="errormessageId()">
     @for (error of errors(); track $index) {
       <div>
-        {{ error.message | translate }}
+        {{ error.message ?? error.key | translate: error.params }}
       </div>
     }
   </div>

--- a/projects/element-ng/form/si-form-field/si-form-field.component.spec.ts
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.spec.ts
@@ -4,44 +4,50 @@
  */
 import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { form, FormField, minLength, required } from '@angular/forms/signals';
+import { form, FormField, min, minLength, required, validate } from '@angular/forms/signals';
+import { provideTranslateService, TranslateService } from '@ngx-translate/core';
+import {
+  provideMissingTranslationHandlerForElement,
+  provideNgxTranslateForElement
+} from '@siemens/element-translate-ng/ngx-translate';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 import { page } from 'vitest/browser';
 
+import { provideFormValidationErrorMapper } from '../si-form-validation-error.provider';
 import { SiFormFieldComponent } from './si-form-field.component';
 
-interface Model {
-  name: string;
-  birthday: string;
-  terms: boolean;
-}
-
-@Component({
-  imports: [SiFormFieldComponent, FormField],
-  template: `
-    <si-form-field [label]="label()">
-      <input type="text" class="form-control" [formField]="form.name" />
-    </si-form-field>
-    <si-form-field label="Day of birth">
-      <input type="date" class="form-control" [formField]="form.birthday" />
-    </si-form-field>
-    <si-form-field label="Terms">
-      <input type="checkbox" class="form-check-input" [formField]="form.terms" />
-    </si-form-field>
-  `
-})
-class TestHostComponent {
-  readonly label = signal<TranslatableString>('Name');
-  readonly model = signal<Model>({ name: '', birthday: '', terms: false });
-  readonly form = form(this.model, path => {
-    required(path.name, { message: 'Name is required' });
-    minLength(path.name, 3, { message: 'Min. 3 characters' });
-    required(path.birthday, { message: 'A day of birth is required' });
-    required(path.terms, { message: 'You must accept the terms' });
-  });
-}
-
 describe('SiFormFieldComponent', () => {
+  interface Model {
+    name: string;
+    birthday: string;
+    terms: boolean;
+  }
+
+  @Component({
+    imports: [SiFormFieldComponent, FormField],
+    template: `
+      <si-form-field [label]="label()">
+        <input type="text" class="form-control" [formField]="form.name" />
+      </si-form-field>
+      <si-form-field label="Day of birth">
+        <input type="date" class="form-control" [formField]="form.birthday" />
+      </si-form-field>
+      <si-form-field label="Terms">
+        <input type="checkbox" class="form-check-input" [formField]="form.terms" />
+      </si-form-field>
+    `
+  })
+  class TestHostComponent {
+    readonly label = signal<TranslatableString>('Name');
+    readonly model = signal<Model>({ name: '', birthday: '', terms: false });
+    readonly form = form(this.model, path => {
+      required(path.name, { message: 'Name is required' });
+      minLength(path.name, 3, { message: 'NAME.MIN_LENGTH' });
+      required(path.birthday, { message: 'A day of birth is required' });
+      required(path.terms, { message: 'You must accept the terms' });
+    });
+  }
+
   let component: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
 
@@ -56,6 +62,19 @@ describe('SiFormFieldComponent', () => {
   };
 
   beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideNgxTranslateForElement(),
+        provideTranslateService({
+          missingTranslationHandler: provideMissingTranslationHandlerForElement()
+        })
+      ]
+    });
+
+    const translate = TestBed.inject(TranslateService);
+    translate.setTranslation('en', { NAME: { MIN_LENGTH: 'Min. {{minLength}} characters' } });
+    translate.use('en');
+
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
     await fixture.whenStable();
@@ -76,6 +95,13 @@ describe('SiFormFieldComponent', () => {
 
     await expect.element(nameField).toHaveAttribute('aria-invalid', 'true');
     await expect.element(nameField).toHaveAccessibleDescription(/Name is required/);
+  });
+
+  it('should interpolate translation parameters into the translated message', async () => {
+    await nameField.fill('ab');
+    await blur(nameField.element());
+
+    await expect.element(nameField).toHaveAccessibleDescription(/Min\. 3 characters/);
   });
 
   it('should clear the invalid marker once the value becomes valid', async () => {
@@ -100,5 +126,130 @@ describe('SiFormFieldComponent', () => {
     await expect.element(nameField).toHaveAccessibleDescription(/Name is required/);
     await expect.element(birthdayField).toHaveAccessibleDescription(/A day of birth is required/);
     await expect.element(termsField).toHaveAccessibleDescription(/You must accept the terms/);
+  });
+});
+
+describe('SiFormFieldComponent validation error resolution', () => {
+  interface Model {
+    name: string;
+    age: number;
+    address: { city: string };
+  }
+
+  @Component({
+    imports: [SiFormFieldComponent, FormField],
+    template: `
+      <si-form-field label="Name">
+        <input type="text" class="form-control" [formField]="form.name" />
+      </si-form-field>
+      <si-form-field label="Age">
+        <input type="number" class="form-control" [formField]="form.age" />
+      </si-form-field>
+      <si-form-field label="City">
+        <input type="text" class="form-control" [formField]="form.address.city" />
+      </si-form-field>
+    `
+  })
+  class TestHostComponent {
+    readonly model = signal<Model>({ name: '', age: 0, address: { city: '' } });
+    // No `message` is provided on the validators, so the errors are resolved via the validation
+    // error service. An explicit form name makes the generated field names deterministic:
+    // the field name is `<parent name>.<key>`, rooted at the form name.
+    readonly form = form(
+      this.model,
+      path => {
+        required(path.name);
+        min(path.age, 18);
+        required(path.address.city);
+        validate(path.name, ({ value }) =>
+          value() === 'reserved' ? { kind: 'reserved' } : undefined
+        );
+      },
+      { name: 'profile' }
+    );
+  }
+
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  const nameField = page.getByRole('textbox', { name: 'Name' });
+  const ageField = page.getByRole('spinbutton', { name: 'Age' });
+  const cityField = page.getByRole('textbox', { name: 'City' });
+
+  describe('with a global error mapper', () => {
+    beforeEach(async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideFormValidationErrorMapper({
+            required: 'A name is required',
+            reserved: 'This value is reserved'
+          })
+        ]
+      });
+      fixture = TestBed.createComponent(TestHostComponent);
+      await fixture.whenStable();
+    });
+
+    it('should only resolve message-less errors once the fields are touched', async () => {
+      await expect.element(nameField).not.toHaveAccessibleDescription();
+      await expect.element(ageField).not.toHaveAccessibleDescription();
+
+      fixture.componentInstance.form().markAsTouched();
+      await fixture.whenStable();
+
+      // Resolved via the provided error mapper ...
+      await expect.element(nameField).toHaveAccessibleDescription(/A name is required/);
+      // ... and via the default mapper with interpolated params.
+      await expect.element(ageField).toHaveAccessibleDescription(/Min\. 18/);
+    });
+
+    it('should resolve custom validation error kinds via the provided error mapper', async () => {
+      await nameField.fill('reserved');
+      fixture.componentInstance.form().markAsTouched();
+      await fixture.whenStable();
+
+      await expect.element(nameField).toHaveAccessibleDescription(/This value is reserved/);
+    });
+  });
+
+  describe('with control-specific keys', () => {
+    beforeEach(async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideFormValidationErrorMapper({
+            required: 'Generic required',
+            'profile.name.required': 'Name is mandatory'
+          })
+        ]
+      });
+      fixture = TestBed.createComponent(TestHostComponent);
+      await fixture.whenStable();
+    });
+
+    it('should derive the field name from its path in the form', () => {
+      const model = fixture.componentInstance.form;
+
+      expect(model.name().name()).toBe('profile.name');
+      expect(model.address.city().name()).toBe('profile.address.city');
+    });
+
+    it('should prefer the control-specific mapper key over the generic one', async () => {
+      fixture.componentInstance.form().markAsTouched();
+      await fixture.whenStable();
+
+      // The name field matches the control-specific key ...
+      await expect.element(nameField).toHaveAccessibleDescription(/Name is mandatory/);
+      // ... while the city field falls back to the generic key.
+      await expect.element(cityField).toHaveAccessibleDescription(/Generic required/);
+    });
+
+    it('should fall back to the raw error key when no mapper resolves the kind', async () => {
+      // The `reserved` kind is covered neither by the provided mapper nor by the defaults, so the
+      // template renders the raw key instead of an empty message.
+      await nameField.fill('reserved');
+      fixture.componentInstance.form().markAsTouched();
+      await fixture.whenStable();
+
+      await expect.element(nameField).toHaveAccessibleDescription(/reserved/);
+    });
   });
 });

--- a/projects/element-ng/form/si-form-field/si-form-field.component.ts
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.ts
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, computed, contentChild, effect, input } from '@angular/core';
+import { Component, computed, contentChild, effect, inject, input } from '@angular/core';
 import { FormField } from '@angular/forms/signals';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
+
+import { SiFormValidationErrorService } from '../si-form-validation-error.service';
 
 /**
  * Constructs a full form field including error messages, labels and aria-* attributes.
@@ -39,6 +41,8 @@ export class SiFormFieldComponent {
 
   private readonly formField = contentChild.required(FormField);
 
+  private readonly validationErrorService = inject(SiFormValidationErrorService);
+
   private readonly generatedId = `__si-form-field-${SiFormFieldComponent.idCounter++}`;
 
   /** The id of the connected control, used for the label's `for` attribute. */
@@ -65,7 +69,8 @@ export class SiFormFieldComponent {
     if (!state.touched()) {
       return [];
     }
-    return state.errors().filter(error => !!error.message);
+
+    return this.validationErrorService.resolveFormFieldErrors(state);
   });
 
   constructor() {

--- a/projects/element-ng/form/si-form-validation-error.service.ts
+++ b/projects/element-ng/form/si-form-validation-error.service.ts
@@ -4,6 +4,7 @@
  */
 import { inject, Injectable } from '@angular/core';
 import { ValidationErrors } from '@angular/forms';
+import type { FieldState } from '@angular/forms/signals';
 import { t } from '@siemens/element-translate-ng/translate';
 
 import { SiFormError } from './si-form-item/si-form-item.component';
@@ -107,6 +108,24 @@ export class SiFormValidationErrorService {
 
   // eslint-disable-next-line @angular-eslint/prefer-inject
   constructor(private errorMapper: SiFormValidationErrorMapper) {}
+
+  /**
+   * Resolves validation errors for Angular signal forms.
+   *
+   * If the validation error has no message associated, the resolution flow of {@link resolveErrors} is followed.
+   *
+   * @param state - the fieldState of the formfield.
+   */
+  resolveFormFieldErrors(state: FieldState<any>): SiFormError[] {
+    return state.errors().map(error => {
+      const { message, kind, ...params } = error;
+      if (!message) {
+        return this.resolveError(kind, state.name(), params);
+      } else {
+        return { message, key: kind, params };
+      }
+    });
+  }
 
   /**
    * Resolves the provided form errors to a list of {@link SiFormError}.


### PR DESCRIPTION
## What & why

Integrates the validation error resolver into the unreleased `si-form-field` (Angular signal forms). Previously `si-form-field` only surfaced errors that carried an explicit `message`, silently dropping validators without one. Now it delegates to `SiFormValidationErrorService`, so message-less validators are resolved through the configured validation error mapper.

## Changes

- `si-form-field.component.ts`: inject `SiFormValidationErrorService` and resolve errors via `resolveFormFieldErrors(state)` instead of filtering out message-less errors.
- `si-form-validation-error.service.ts`: add `resolveFormFieldErrors()`, which maps each `FieldState` error and falls back to kind-/control-name-based resolution when no `message` is present.
- `si-form-field.component.html`: pass `error.params` to the `translate` pipe so interpolated messages (e.g. `Min. 18`) render correctly.
- `si-form-field.component.spec.ts`: add coverage for global mapper resolution, default mapper param interpolation, custom validator kinds, path-based field names, and control-specific mapper keys taking precedence.

This targets an unreleased feature, so no changelog entry is added.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2291/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2291/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2291/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2291/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2291/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2291/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2291/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2291/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2291/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2291/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->





