### PR TITLE
docs(localization): improve translation key override example

### DIFF
--- a/docs/fundamentals/localization.md
+++ b/docs/fundamentals/localization.md
@@ -165,7 +165,7 @@ The overriding of text keys is available for every framework except `@angular/lo
 Overrides are declared like this:
 
 ```ts
-import { provideSiTranslatableOverrides } from '@siemens/element-translate-ng/translate';
+import { provideSiTranslatableOverrides } from '@siemens/element-ng/translate';
 
 @NgModule({
   providers: [

--- a/docs/fundamentals/localization.md
+++ b/docs/fundamentals/localization.md
@@ -170,7 +170,7 @@ import { provideSiTranslatableOverrides } from '@siemens/element-ng/translate';
 @NgModule({
   providers: [
     provideSiTranslatableOverrides({
-      'SI-TOAST.CLOSE': 'MY-CUSTOM-CLOSE'
+      'SI_TOAST.CLOSE': 'MY_CUSTOM_CLOSE'
     })
   ]
 })


### PR DESCRIPTION
A different import path is needed and the example key name is invalid.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2294/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2294/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2294/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2294/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2294/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2294/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2294/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2294/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2294/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2294/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
