### PR TITLE
chore(docs): update docs-composer to support TS 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
       "optionalDependencies": {
         "@siemens-ux/design-tokens": "^0.5.0",
         "@simpl/brand": "3.3.0",
-        "@simpl/docs-composer": "11.16.10"
+        "@simpl/docs-composer": "12.0.0"
       }
     },
     "node_modules/@actions/core": {
@@ -9735,9 +9735,9 @@
       }
     },
     "node_modules/@simpl/docs-composer": {
-      "version": "11.16.10",
-      "resolved": "https://code.siemens.com/api/v4/projects/732/packages/npm/@simpl/docs-composer/-/@simpl/docs-composer-11.16.10.tgz",
-      "integrity": "sha1-xMt2CK/OkQXqoTUpYg64AeW2THU=",
+      "version": "12.0.0",
+      "resolved": "https://code.siemens.com/api/v4/projects/732/packages/npm/@simpl/docs-composer/-/@simpl/docs-composer-12.0.0.tgz",
+      "integrity": "sha1-FF3FyjnBHh0giXrpe7k49dGCe7I=",
       "optional": true,
       "dependencies": {
         "ajv": "8.17.1",
@@ -9749,8 +9749,8 @@
         "meow": "14.1.0",
         "path": "0.12.7",
         "source-map-support": "0.5.21",
-        "ts-morph": "27.0.2",
-        "typedoc": "^0.28.17",
+        "ts-morph": "28.0.0",
+        "typedoc": "^0.28.19",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -9940,9 +9940,9 @@
       "license": "MIT"
     },
     "node_modules/@ts-morph/common": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
-      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.29.0.tgz",
+      "integrity": "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24693,13 +24693,13 @@
       }
     },
     "node_modules/ts-morph": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
-      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-28.0.0.tgz",
+      "integrity": "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@ts-morph/common": "~0.28.1",
+        "@ts-morph/common": "~0.29.0",
         "code-block-writer": "^13.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
   "optionalDependencies": {
     "@siemens-ux/design-tokens": "^0.5.0",
     "@simpl/brand": "3.3.0",
-    "@simpl/docs-composer": "11.16.10"
+    "@simpl/docs-composer": "12.0.0"
   },
   "overrides": {
     "@microsoft/api-extractor": {


### PR DESCRIPTION
Seems to already works but this will work better with more TS features and Angular 22.
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2295/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2295/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2295/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2295/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2295/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2295/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2295/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2295/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2295/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2295/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
