### PR TITLE
fixup(form): support help button in si-form-field

### DIFF
--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8f1ed41806e6a5e9a8d6ae078a88e8f27b0397fec72b4f3d35dab50754360fa
-size 39157
+oid sha256:6a73f705868e1e394b2d258a6d0442ac6acd7653a60cf71ba58e0431bbbf31c5
+size 40698

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c974f0025b28e4166754113b3efe31fcf3bb580d8fb008e3c8cc2d6bc9513759
-size 38451
+oid sha256:3a2c979362cb04fb7c2b16d85893cbc2955a825b4d75f5f80b0f64696954df5e
+size 40011

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated.yaml
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated.yaml
@@ -1,11 +1,13 @@
 - heading "Signal form" [level=2]
 - group "Role*":
   - text: ""
+  - button "More information about the role"
   - radio "Engineer"
   - text: Engineer
   - radio "Installer"
   - text: Installer Role required
 - text: Name*
+- button "More information about the name"
 - textbox "Name*" [invalid]
 - text: Minimum 3 characters Name must start with an uppercase letter Description
 - textbox "Description"
@@ -24,10 +26,21 @@
 - spinbutton "Fellow passengers" [invalid]: "0"
 - text: Minimum 2
 - checkbox "I confirm that I accept all and everything*" [invalid]
-- text: I confirm that I accept all and everything* Accept terms before joining
+- text: I confirm that I accept all and everything*
+- button "More information about the terms"
+- text: Accept terms before joining
 - checkbox "I confirm that I do not care about my privacy"
 - text: I confirm that I do not care about my privacy
 - button "Cancel"
 - button "Save"
 - heading "Debugging" [level=2]
 - paragraph: "Validation status: INVALID"
+- table:
+  - rowgroup:
+    - row "Model Submitted":
+      - columnheader "Model"
+      - columnheader "Submitted"
+  - rowgroup:
+    - 'row "{ \"name\": \"a\", \"description\": \"\", \"birthday\": \"\", \"arrival\": \"\", \"departure\": \"\", \"serviceClass\": \"first\", \"role\": \"\", \"fellowPassengers\": 0, \"termsAccepted\": false, \"privacyDeclined\": false } undefined"':
+      - 'cell "{ \"name\": \"a\", \"description\": \"\", \"birthday\": \"\", \"arrival\": \"\", \"departure\": \"\", \"serviceClass\": \"first\", \"role\": \"\", \"fellowPassengers\": 0, \"termsAccepted\": false, \"privacyDeclined\": false }"'
+      - cell "undefined"

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38bc8bb7295c44e532502808021b7ee291abd8927b6c326b39c418fcef76e273
-size 28972
+oid sha256:baaed6df9f626d31c2131929366e1e23031d4f4da4fee3292e380d30756987ef
+size 30520

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bfc1d62a2ccb8ed8420cddaccc303cf68b642865e7be5ed6cbcdb181be298b67
-size 28132
+oid sha256:73ee962261a725f874174341078f204a405c4d3256c375c93b0478a640fc71f1
+size 29644

--- a/projects/element-ng/form/si-form-field/si-form-field.component.html
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.html
@@ -12,13 +12,16 @@
 </div>
 
 <ng-template #labelTemplate>
-  <label
-    [for]="controlId()"
+  <div
+    class="d-flex gap-2"
     [class.form-label]="!isFormCheck()"
     [class.form-check-label]="isFormCheck()"
-    [class.required]="required() && !isPartOfRadioGroup()"
-    >{{ label() | translate }}</label
   >
+    <label [for]="controlId()" [class.required]="required() && !isPartOfRadioGroup()">{{
+      label() | translate
+    }}</label>
+    <ng-content select="[si-help-button]" />
+  </div>
 </ng-template>
 
 <ng-template #feedbackTemplate>

--- a/projects/element-ng/form/si-form-field/si-form-field.component.ts
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.ts
@@ -27,6 +27,14 @@ import { SiFormValidationErrorService } from '../si-form-validation-error.servic
  * ```html
  * <si-form-field label="Name">
  *   <input class="form-control" [formField]="form.name" />
+ *
+ *   <!-- Optional help button -->
+ *   <button
+ *     si-help-button
+ *     type="button"
+ *     siHelpTitle="Help for name"
+ *     siHelpContent="The context help description"
+ *   >More information about the name</button>
  * </si-form-field>
  * ```
  */

--- a/src/app/examples/si-signal-form/si-signal-form.html
+++ b/src/app/examples/si-signal-form/si-signal-form.html
@@ -22,10 +22,24 @@
                   [formField]="form.role"
                 />
               </si-form-field>
+              <button
+                si-help-button
+                type="button"
+                siHelpTitle="More information"
+                siHelpContent="A role must be selected."
+                >More information about the role</button
+              >
             </si-form-fieldset>
 
             <si-form-field label="Name">
               <input type="text" class="form-control" [formField]="form.name" />
+              <button
+                si-help-button
+                type="button"
+                siHelpTitle="More information"
+                siHelpContent="Full name must start with an uppercase letter and be at least 3 characters long."
+                >More information about the name</button
+              >
             </si-form-field>
 
             <si-form-field label="Description">
@@ -58,6 +72,13 @@
 
             <si-form-field label="I confirm that I accept all and everything">
               <input type="checkbox" class="form-check-input" [formField]="form.termsAccepted" />
+              <button
+                si-help-button
+                type="button"
+                siHelpTitle="More information"
+                siHelpContent="Acceptance of terms and conditions is required to join."
+                >More information about the terms</button
+              >
             </si-form-field>
 
             <si-form-field label="I confirm that I do not care about my privacy">

--- a/src/app/examples/si-signal-form/si-signal-form.ts
+++ b/src/app/examples/si-signal-form/si-signal-form.ts
@@ -20,6 +20,7 @@ import {
 } from '@siemens/element-ng/form';
 
 export type Role = 'engineer' | 'installer';
+import { SiHelpButtonComponent } from '@siemens/element-ng/help-button';
 
 export interface TravelRequest {
   name: string;
@@ -49,7 +50,14 @@ const emptyRequest: TravelRequest = {
 
 @Component({
   selector: 'app-sample',
-  imports: [JsonPipe, FormField, FormRoot, SiFormFieldComponent, SiFormFieldsetComponent],
+  imports: [
+    JsonPipe,
+    FormField,
+    FormRoot,
+    SiFormFieldComponent,
+    SiFormFieldsetComponent,
+    SiHelpButtonComponent
+  ],
   templateUrl: './si-signal-form.html',
   providers: [provideSiFormFieldConfig()],
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
Add a projection slot for a button with the `si-help-button` directive in
`si-form-field`, so contextual help can be shown next to the label. This
matches the existing behavior of `si-form-item` and `si-form-fieldset`.

The si-signal-form example is updated to demonstrate the help button on the
name field and the terms checkbox.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2300/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2300/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2300/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2300/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2300/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2300/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2300/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2300/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2300/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2300/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

