### PR TITLE
refactor(typeahead): drop HostListener in favour for component host b…

### DIFF
--- a/projects/element-ng/typeahead/si-typeahead.component.ts
+++ b/projects/element-ng/typeahead/si-typeahead.component.ts
@@ -9,7 +9,6 @@ import {
   Component,
   computed,
   ElementRef,
-  HostListener,
   inject,
   viewChild
 } from '@angular/core';
@@ -40,7 +39,7 @@ import { TypeaheadMatch } from './si-typeahead.model';
   templateUrl: './si-typeahead.component.html',
   styleUrl: './si-typeahead.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  host: { class: 'w-100' }
+  host: { class: 'w-100', '(mousedown)': '$event.preventDefault()' }
 })
 export class SiTypeaheadComponent implements AfterViewInit {
   protected parent = inject(SiTypeaheadDirective);
@@ -60,11 +59,6 @@ export class SiTypeaheadComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
     this.setHeight(this.typeaheadElement());
-  }
-
-  @HostListener('mousedown', ['$event'])
-  protected onMouseDown(event: Event): void {
-    event.preventDefault();
   }
 
   /*

--- a/projects/element-ng/typeahead/si-typeahead.directive.ts
+++ b/projects/element-ng/typeahead/si-typeahead.directive.ts
@@ -17,7 +17,6 @@ import {
   Directive,
   effect,
   ElementRef,
-  HostListener,
   inject,
   Injector,
   input,
@@ -50,7 +49,11 @@ import { SiTypeaheadSorting } from './si-typeahead.sorting';
 @Directive({
   selector: '[siTypeahead]',
   host: {
-    class: 'si-typeahead'
+    class: 'si-typeahead',
+    '(focusout)': 'onBlur()',
+    '(focusin)': 'onInput($event)',
+    '(input)': 'onInput($event)',
+    '(keydown.escape)': 'onKeydownEscape()'
   },
   hostDirectives: [SiAutocompleteDirective],
   exportAs: 'si-typeahead'
@@ -434,15 +437,12 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
   }
 
   // Clear the current input timeout (if set) and remove the component when the focus of the host is lost.
-  @HostListener('focusout')
   protected onBlur(): void {
     this.clearTimer();
     this.canBeOpen.set(false);
   }
 
   // Start the input timeout to display the typeahead when the host is focussed or a value is inputted into it.
-  @HostListener('focusin', ['$event'])
-  @HostListener('input', ['$event'])
   protected onInput(event: Event): void {
     const target = event.target as HTMLInputElement;
     if (!target) {
@@ -460,7 +460,6 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
     }, this.typeaheadWaitMs());
   }
 
-  @HostListener('keydown.escape')
   protected onKeydownEscape(): void {
     if (this.typeaheadCloseOnEsc()) {
       this.clearTimer();


### PR DESCRIPTION
…indings

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2302/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2302/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2302/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2302/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2302/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2302/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2302/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2302/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2302/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2302/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
