### PR TITLE
refactor(phone-number): make placeholder computed

### DIFF
--- a/projects/element-ng/phone-number/si-phone-number-input.component.html
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.html
@@ -71,7 +71,7 @@
     class="ms-4 border-0 p-0 focus-none shadow-none flex-grow-1 phone-number"
     [attr.aria-label]="phoneNumberAriaLabel() | translate"
     [attr.aria-describedby]="errormessageId()"
-    [placeholder]="placeholder"
+    [placeholder]="placeholder()"
     [disabled]="disabled()"
     [readonly]="readonly()"
     (input)="input()"

--- a/projects/element-ng/phone-number/si-phone-number-input.component.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.ts
@@ -192,7 +192,16 @@ export class SiPhoneNumberInputComponent
 
   protected readonly phoneInput = viewChild.required<ElementRef<HTMLInputElement>>('phoneInput');
   protected readonly selectedCountry = signal<CountryInfo | undefined>(undefined);
-  protected placeholder = '';
+  protected readonly placeholder = computed(() => {
+    const selectedCountry = this.selectedCountry();
+    if (!selectedCountry) {
+      return '';
+    }
+
+    return this.phoneUtil
+      .format(this.phoneUtil.getExampleNumber(selectedCountry.isoCode), PhoneNumberFormat.NATIONAL)
+      .replace(/^0/, '');
+  });
   protected readonly countryFocused = signal(false);
   protected open = false;
   protected overlayWidth = 0;
@@ -328,7 +337,6 @@ export class SiPhoneNumberInputComponent
 
   protected countryInput(num: CountryInfo): void {
     this.selectedCountry.set(num);
-    this.updatePlaceholder();
     this.refreshValueAfterCountryChange();
     this.handleChange();
   }
@@ -362,7 +370,6 @@ export class SiPhoneNumberInputComponent
         });
       }
     }
-    this.updatePlaceholder();
     this.refreshValueAfterCountryChange();
   }
 
@@ -373,18 +380,6 @@ export class SiPhoneNumberInputComponent
         type: 'region'
       }).of(countryCode.toUpperCase()) ?? ''
     );
-  }
-
-  private updatePlaceholder(): void {
-    const selectedCountry = this.selectedCountry();
-    if (selectedCountry) {
-      this.placeholder = this.phoneUtil
-        .format(
-          this.phoneUtil.getExampleNumber(selectedCountry.isoCode),
-          PhoneNumberFormat.NATIONAL
-        )
-        .replace(/^0/, '');
-    }
   }
 
   private parseNumber(rawNumber: string | undefined): PhoneNumber | undefined {


### PR DESCRIPTION
## Summary
- make the phone-number-input placeholder a computed signal derived from the selected country
- bind the template to `placeholder()`

## Verification
- `npm run lib:test -- --include=**/phone-number/si-phone-number-input.component.spec.ts --no-watch`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2304/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2304/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2304/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2304/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2304/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2304/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2304/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2304/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2304/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2304/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
