### PR TITLE
refactor(phone-number): make selected country computed

### DIFF
--- a/projects/element-ng/phone-number/si-phone-number-input.component.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.ts
@@ -191,17 +191,6 @@ export class SiPhoneNumberInputComponent
   readonly errormessageId = input(`${this.id()}-errormessage`);
 
   protected readonly phoneInput = viewChild.required<ElementRef<HTMLInputElement>>('phoneInput');
-  protected readonly selectedCountry = signal<CountryInfo | undefined>(undefined);
-  protected readonly placeholder = computed(() => {
-    const selectedCountry = this.selectedCountry();
-    if (!selectedCountry) {
-      return '';
-    }
-
-    return this.phoneUtil
-      .format(this.phoneUtil.getExampleNumber(selectedCountry.isoCode), PhoneNumberFormat.NATIONAL)
-      .replace(/^0/, '');
-  });
   protected readonly countryFocused = signal(false);
   protected open = false;
   protected overlayWidth = 0;
@@ -224,6 +213,40 @@ export class SiPhoneNumberInputComponent
       })
       .sort((a, b) => a.value.name.localeCompare(b.value.name));
   });
+  protected readonly selectedCountry = computed(() => {
+    const currentCountry = this.country();
+    if (!currentCountry) {
+      return undefined;
+    }
+
+    const selectedCountry = this.countryList().find(
+      country => country.value.isoCode === currentCountry
+    )?.value;
+    if (selectedCountry) {
+      return selectedCountry;
+    }
+
+    const countryCode = this.phoneUtil.getCountryCodeForRegion(currentCountry);
+    if (!countryCode) {
+      return undefined;
+    }
+
+    return {
+      isoCode: currentCountry,
+      countryCode,
+      name: this.getCountryName(currentCountry)
+    };
+  });
+  protected readonly placeholder = computed(() => {
+    const selectedCountry = this.selectedCountry();
+    if (!selectedCountry) {
+      return '';
+    }
+
+    return this.phoneUtil
+      .format(this.phoneUtil.getExampleNumber(selectedCountry.isoCode), PhoneNumberFormat.NATIONAL)
+      .replace(/^0/, '');
+  });
   protected readonly icons = addIcons({ elementDown2 });
   private readonly allowedCountries = computed(
     () => this.supportedCountries() ?? this.phoneUtil.getSupportedRegions()
@@ -243,7 +266,7 @@ export class SiPhoneNumberInputComponent
 
   ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.country) {
-      this.writeCountry();
+      this.refreshValueAfterCountryChange();
     }
   }
 
@@ -259,7 +282,6 @@ export class SiPhoneNumberInputComponent
       this.writeTextToInput(value);
       this.country.set(this.defaultCountry() ?? this.country());
     }
-    this.writeCountry();
     this.changeDetectorRef.markForCheck();
   }
 
@@ -309,21 +331,11 @@ export class SiPhoneNumberInputComponent
 
     if (phoneNumber) {
       const regionCode = this.getRegionCode();
-      let countryInfo = this.countryList().find(
-        country => regionCode === country.value.isoCode
-      )?.value;
-      if (!countryInfo && regionCode) {
-        countryInfo = {
-          name: this.getCountryName(regionCode),
-          countryCode: phoneNumber.getCountryCode()!,
-          isoCode: regionCode
-        };
-      }
-      if (countryInfo && this.selectedCountry()?.isoCode !== countryInfo.isoCode) {
-        this.selectedCountry.set(countryInfo);
+      if (regionCode && this.country() !== regionCode) {
+        this.country.set(regionCode);
       }
     } else if (rawNumber.trim().startsWith('+')) {
-      this.selectedCountry.set(undefined);
+      this.country.set(undefined);
     }
 
     this.handleChange();
@@ -336,7 +348,7 @@ export class SiPhoneNumberInputComponent
   }
 
   protected countryInput(num: CountryInfo): void {
-    this.selectedCountry.set(num);
+    this.country.set(num.isoCode);
     this.refreshValueAfterCountryChange();
     this.handleChange();
   }
@@ -351,26 +363,6 @@ export class SiPhoneNumberInputComponent
   protected overlayDetach(): void {
     this.open = false;
     this.phoneInput().nativeElement.focus();
-  }
-
-  private writeCountry(): void {
-    const currentCountry = this.country()!;
-    this.selectedCountry.set(
-      this.countryList().find(country => country.value.isoCode === currentCountry)?.value
-    );
-    if (!this.selectedCountry()) {
-      const countryCode = this.phoneUtil.getCountryCodeForRegion(
-        currentCountry ?? this.defaultCountry() ?? 'XX'
-      );
-      if (countryCode) {
-        this.selectedCountry.set({
-          isoCode: currentCountry,
-          countryCode,
-          name: this.getCountryName(currentCountry)
-        });
-      }
-    }
-    this.refreshValueAfterCountryChange();
   }
 
   private getCountryName(countryCode: string): string {
@@ -440,11 +432,6 @@ export class SiPhoneNumberInputComponent
   }
 
   private handleChange(): void {
-    const selectedCountry = this.selectedCountry();
-    if (selectedCountry && this.country() !== selectedCountry.isoCode) {
-      this.country.set(selectedCountry.isoCode);
-    }
-
     if (this.phoneNumber()) {
       this.onChange(this.formatPhoneNumber(PhoneNumberFormat.INTERNATIONAL)!);
     } else {


### PR DESCRIPTION
This changes phone-number-input so selectedCountry is derived from country instead of being writable state.\n\nThe component now writes directly to country and keeps the selected country view in sync through computed state.\n\n- selectedCountry is computed from country\n- country writes now drive selection updates directly\n- existing tests pass<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2305/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2305/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2305/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2305/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2305/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2305/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2305/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2305/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2305/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2305/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

