### PR TITLE
refactor(phone-number): make input value the source of truth

### DIFF
--- a/projects/element-ng/phone-number/si-phone-number-input.component.html
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.html
@@ -15,7 +15,7 @@
     [disabled]="disabled()"
     [class.readonly]="readonly()"
     [attr.aria-labelledby]="id() + '-aria-label ' + id() + '-value'"
-    [attr.aria-expanded]="open"
+    [attr.aria-expanded]="open()"
     [options]="countryList()"
     [value]="selectedCountry()"
     [tabindex]="disabled() ? '-1' : '0'"
@@ -45,7 +45,7 @@
       cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
       [cdkConnectedOverlayHasBackdrop]="true"
       [cdkConnectedOverlayOrigin]="trigger"
-      [cdkConnectedOverlayOpen]="open"
+      [cdkConnectedOverlayOpen]="open()"
       [cdkConnectedOverlayFlexibleDimensions]="true"
       [cdkConnectedOverlayOffsetX]="-1"
       [cdkConnectedOverlayMinWidth]="overlayWidth"
@@ -69,12 +69,13 @@
     #phoneInput
     type="tel"
     class="ms-4 border-0 p-0 focus-none shadow-none flex-grow-1 phone-number"
+    [value]="phoneInputValue()"
     [attr.aria-label]="phoneNumberAriaLabel() | translate"
     [attr.aria-describedby]="errormessageId()"
     [placeholder]="placeholder()"
     [disabled]="disabled()"
     [readonly]="readonly()"
-    (input)="input()"
+    (input)="input($event)"
     (blur)="blur()"
   />
 </div>

--- a/projects/element-ng/phone-number/si-phone-number-input.component.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.ts
@@ -6,8 +6,6 @@ import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
 import { LowerCasePipe } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   computed,
   ElementRef,
@@ -72,7 +70,6 @@ import { CountryInfo, PhoneDetails } from './si-phone-number-input.models';
       useExisting: SiPhoneNumberInputComponent
     }
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'role': 'group',
     '[attr.aria-labelledby]': 'labelledby()',
@@ -90,7 +87,6 @@ export class SiPhoneNumberInputComponent
   private phoneUtil = PhoneNumberUtil.getInstance();
   private translate = injectSiTranslateService();
   private locale = inject(LOCALE_ID).toString();
-  private changeDetectorRef = inject(ChangeDetectorRef);
   private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
   /**
@@ -192,9 +188,10 @@ export class SiPhoneNumberInputComponent
 
   protected readonly phoneInput = viewChild.required<ElementRef<HTMLInputElement>>('phoneInput');
   protected readonly countryFocused = signal(false);
-  protected open = false;
+  protected readonly open = signal(false);
   protected overlayWidth = 0;
   protected readonly disabled = computed(() => this.disabledInput() || this.disabledNgControl());
+  protected readonly phoneInputValue = signal('');
   protected readonly countryList = computed(() => {
     const countries = this.allowedCountries() ?? this.phoneUtil.getSupportedRegions();
     return countries
@@ -253,14 +250,7 @@ export class SiPhoneNumberInputComponent
   );
   private readonly disabledNgControl = signal(false);
   private isValidNumber = true;
-  private readonly phoneNumber = signal<PhoneNumber | undefined>(undefined, {
-    equal: (a, b) => {
-      if (!a || !b) {
-        return !a && !b;
-      }
-      return this.phoneUtil.isNumberMatch(a, b) === PhoneNumberUtil.MatchType.EXACT_MATCH;
-    }
-  });
+  private readonly phoneNumber = computed(() => this.parseNumber(this.phoneInputValue()));
   private onChange: (val: string) => void = () => {};
   private onTouched: () => void = () => {};
 
@@ -273,16 +263,16 @@ export class SiPhoneNumberInputComponent
   /** @internal */
   writeValue(value: string | undefined): void {
     const phoneNumber = this.parseNumber(value);
-    this.phoneNumber.set(phoneNumber);
     if (phoneNumber) {
-      this.writeValueToInput();
-      this.country.set(this.getRegionCode());
+      this.country.set(this.getRegionCode(phoneNumber));
+      this.phoneInputValue.set(
+        this.phoneUtil.format(phoneNumber, PhoneNumberFormat.NATIONAL).replace(/^0/, '')
+      );
     } else {
       // Number could not be parsed, write raw value instead to handle cases like undefined
-      this.writeTextToInput(value);
+      this.phoneInputValue.set(value ?? '');
       this.country.set(this.defaultCountry() ?? this.country());
     }
-    this.changeDetectorRef.markForCheck();
   }
 
   /** @internal */
@@ -302,7 +292,7 @@ export class SiPhoneNumberInputComponent
 
   /** @internal */
   validate(control: AbstractControl): ValidationErrors | null {
-    if (!this.phoneInput().nativeElement.value) {
+    if (!this.phoneInputValue()) {
       return null;
     }
 
@@ -324,13 +314,13 @@ export class SiPhoneNumberInputComponent
     return null;
   }
 
-  protected input(): void {
-    const rawNumber = this.phoneInput().nativeElement.value;
-    const phoneNumber = this.parseNumber(rawNumber);
-    this.phoneNumber.set(phoneNumber);
+  protected input(event: Event): void {
+    const rawNumber = (event.target as HTMLInputElement).value;
+    this.phoneInputValue.set(rawNumber);
+    const phoneNumber = this.phoneNumber();
 
     if (phoneNumber) {
-      const regionCode = this.getRegionCode();
+      const regionCode = this.getRegionCode(phoneNumber);
       if (regionCode && this.country() !== regionCode) {
         this.country.set(regionCode);
       }
@@ -355,13 +345,13 @@ export class SiPhoneNumberInputComponent
 
   protected openOverlay(): void {
     if (!this.readonly()) {
-      this.open = true;
+      this.open.set(true);
       this.overlayWidth = this.elementRef.nativeElement.getBoundingClientRect().width + 2; // 2px border
     }
   }
 
   protected overlayDetach(): void {
-    this.open = false;
+    this.open.set(false);
     this.phoneInput().nativeElement.focus();
   }
 
@@ -391,35 +381,30 @@ export class SiPhoneNumberInputComponent
    * PhoneUtil does not resolve country code early enough when the national prefix is shared among other countries (+1 and +44).
    * This Method fakes a complete number to force PhoneUtil returning a proper region code.
    */
-  private getRegionCode(): string | undefined {
-    const phoneNumber = this.phoneNumber();
-    if (phoneNumber) {
-      const regionCode = this.phoneUtil.getRegionCodeForNumber(phoneNumber);
-      if (regionCode) {
-        return regionCode;
-      }
-
-      const nationalNumber = phoneNumber.getNationalNumber() + '';
-      if (
-        // USA, CANADA, ...
-        (phoneNumber.getCountryCode() === 1 && nationalNumber.length >= 3) ||
-        // UK, ...
-        (phoneNumber.getCountryCode() === 44 && nationalNumber.length >= 4)
-      ) {
-        return this.phoneUtil.getRegionCodeForNumber(
-          this.phoneUtil.parse(
-            '+' +
-              phoneNumber.getCountryCode() +
-              nationalNumber +
-              new Array(10 - nationalNumber.length).fill(5).join('')
-          )
-        );
-      }
-
-      return this.phoneUtil.getRegionCodeForCountryCode(phoneNumber.getCountryCode()!);
+  private getRegionCode(phoneNumber: PhoneNumber): string | undefined {
+    const regionCode = this.phoneUtil.getRegionCodeForNumber(phoneNumber);
+    if (regionCode) {
+      return regionCode;
     }
 
-    return undefined;
+    const nationalNumber = phoneNumber.getNationalNumber() + '';
+    if (
+      // USA, CANADA, ...
+      (phoneNumber.getCountryCode() === 1 && nationalNumber.length >= 3) ||
+      // UK, ...
+      (phoneNumber.getCountryCode() === 44 && nationalNumber.length >= 4)
+    ) {
+      return this.phoneUtil.getRegionCodeForNumber(
+        this.phoneUtil.parse(
+          '+' +
+            phoneNumber.getCountryCode() +
+            nationalNumber +
+            new Array(10 - nationalNumber.length).fill(5).join('')
+        )
+      );
+    }
+
+    return this.phoneUtil.getRegionCodeForCountryCode(phoneNumber.getCountryCode()!);
   }
 
   private formatPhoneNumber(format: PhoneNumberFormat): string | undefined {
@@ -432,43 +417,30 @@ export class SiPhoneNumberInputComponent
   }
 
   private handleChange(): void {
-    if (this.phoneNumber()) {
-      this.onChange(this.formatPhoneNumber(PhoneNumberFormat.INTERNATIONAL)!);
-    } else {
-      this.onChange('');
-    }
+    const phoneNumber = this.formatPhoneNumber(PhoneNumberFormat.INTERNATIONAL);
+    this.onChange(phoneNumber ?? '');
 
     this.valueChange.emit({
       country: this.selectedCountry(),
-      phoneNumber: this.formatPhoneNumber(PhoneNumberFormat.INTERNATIONAL),
+      phoneNumber,
       isValid: this.isValidNumber
     });
   }
 
-  private writeTextToInput(value?: string): void {
-    this.phoneInput().nativeElement.value = value ?? '';
-  }
   /**
    * Format and update input text or clear input text if the input value is undefined.
    */
   private writeValueToInput(): void {
     if (this.phoneNumber()) {
-      this.writeTextToInput(this.formatPhoneNumber(PhoneNumberFormat.NATIONAL)!.replace(/^0/, ''));
+      this.phoneInputValue.set(
+        this.formatPhoneNumber(PhoneNumberFormat.NATIONAL)!.replace(/^0/, '')
+      );
     }
   }
 
   private refreshValueAfterCountryChange(): void {
     const selectedCountry = this.selectedCountry();
     if (selectedCountry) {
-      this.phoneNumber.update(current => {
-        if (!current) {
-          return undefined;
-        }
-        // TODO: Remove any once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75189 is merged/released
-        const phoneNumber = (current as any)?.clone();
-        phoneNumber.setCountryCode(selectedCountry.countryCode);
-        return phoneNumber;
-      });
       this.writeValueToInput();
     }
   }


### PR DESCRIPTION
This restructures the phone number input state so the text field is driven by a dedicated phoneInputValue signal, and phoneNumber is derived from that value plus the selected country context.

<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2306/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2306/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2306/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2306/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2306/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2306/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2306/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2306/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2306/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2306/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


