### PR TITLE
refactor(datepicker): remove deprecated input

### DIFF
--- a/api-goldens/element-ng/datepicker/index.api.md
+++ b/api-goldens/element-ng/datepicker/index.api.md
@@ -328,8 +328,6 @@ export class SiDateInputDirective implements ControlValueAccessor, OnChanges, Va
 export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
     constructor();
     readonly calendarWeekLabel: _angular_core.InputSignal<TranslatableString>;
-    // @deprecated
-    readonly calenderWeekLabel: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly config: _angular_core.ModelSignal<DatepickerConfig>;
     readonly date: _angular_core.ModelSignal<Date | undefined>;
     readonly dateRange: _angular_core.ModelSignal<DateRange | undefined>;

--- a/projects/element-ng/datepicker/si-datepicker.component.html
+++ b/projects/element-ng/datepicker/si-datepicker.component.html
@@ -49,7 +49,7 @@
           [maxDate]="config().maxDate"
           [minMonth]="minMonth()"
           [weekStartDay]="weekStartDay"
-          [calendarWeekLabel]="derivedWeekLabel()"
+          [calendarWeekLabel]="calendarWeekLabel()"
           [previousLabel]="previousLabel() | translate"
           [nextLabel]="nextLabel() | translate"
           [todayLabel]="config().todayText"

--- a/projects/element-ng/datepicker/si-datepicker.component.ts
+++ b/projects/element-ng/datepicker/si-datepicker.component.ts
@@ -136,16 +136,6 @@ export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
   /**
    * Aria label for week number column
    *
-   * @deprecated Use `calendarWeekLabel` instead.
-   * @defaultValue
-   * ```
-   * t(() => $localize`:@@SI_DATEPICKER.CALENDAR_WEEK_LABEL:Calendar week`)
-   * ```
-   */
-  readonly calenderWeekLabel = input<TranslatableString>();
-  /**
-   * Aria label for week number column
-   *
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_DATEPICKER.CALENDAR_WEEK_LABEL:Calendar week`)
@@ -153,9 +143,6 @@ export class SiDatepickerComponent implements OnInit, OnChanges, AfterViewInit {
    */
   readonly calendarWeekLabel = input<TranslatableString>(
     t(() => $localize`:@@SI_DATEPICKER.CALENDAR_WEEK_LABEL:Calendar week`)
-  );
-  protected readonly derivedWeekLabel = computed(
-    () => this.calenderWeekLabel() ?? this.calendarWeekLabel()
   );
   /**
    * Enable/disable 12H mode in timepicker. Defaults to locale


### PR DESCRIPTION
BREAKING CHAGNE: Removed deprecated input `SiDatepickerComponent.calenderWeekLabel`, use `SiDatepickerComponent.calendarWeekLabel` instead.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2308/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2308/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2308/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2308/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2308/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2308/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2308/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2308/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2308/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2308/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


