### PR TITLE
refactor(select): migrate select to signal forms

### DIFF
--- a/api-goldens/element-ng/select/index.api.md
+++ b/api-goldens/element-ng/select/index.api.md
@@ -10,6 +10,7 @@ import { ConfigurableFocusTrapFactory } from '@angular/cdk/a11y';
 import { ControlValueAccessor } from '@angular/forms';
 import { ElementRef } from '@angular/core';
 import { InputSignal } from '@angular/core';
+import { ModelSignal } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
@@ -148,6 +149,8 @@ export class SiSelectModule {
 // @public
 export class SiSelectMultiValueDirective<T> extends SiSelectSelectionStrategy<T, T[]> {
     readonly allowMultiple = true;
+    // (undocumented)
+    readonly value: _angular_core.ModelSignal<T[]>;
 }
 
 // @public
@@ -163,8 +166,10 @@ export class SiSelectSimpleOptionsDirective<T = string> extends SiSelectOptionsS
 }
 
 // @public
-export class SiSelectSingleValueDirective<T> extends SiSelectSelectionStrategy<T, T> {
+export class SiSelectSingleValueDirective<T> extends SiSelectSelectionStrategy<T, T | undefined> {
     allowMultiple: boolean;
+    // (undocumented)
+    readonly value: _angular_core.ModelSignal<T | undefined>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/api-goldens/element-ng/select/index.api.md
+++ b/api-goldens/element-ng/select/index.api.md
@@ -9,6 +9,7 @@ import { ConfigurableFocusTrap } from '@angular/cdk/a11y';
 import { ConfigurableFocusTrapFactory } from '@angular/cdk/a11y';
 import { ControlValueAccessor } from '@angular/forms';
 import { ElementRef } from '@angular/core';
+import { FormValueControl } from '@angular/forms/signals';
 import { InputSignal } from '@angular/core';
 import { ModelSignal } from '@angular/core';
 import { Observable } from 'rxjs';

--- a/projects/element-ng/date-range-filter/si-relative-date.component.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.ts
@@ -130,8 +130,8 @@ export class SiRelativeDateComponent implements OnChanges {
     this.value.set(nextValue);
   }
 
-  protected changeUnit(newUnit: string): void {
-    this.unit.set(newUnit);
+  protected changeUnit(newUnit: string | undefined): void {
+    this.unit.set(newUnit!);
     const item = this.offsetList().find(x => x.value === this.unit())!;
     const roundedOffset = Math.max(1, Math.round(this.value() / item.offset));
     this.offset.set(roundedOffset);

--- a/projects/element-ng/phone-number/si-phone-number-input.component.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.ts
@@ -337,8 +337,8 @@ export class SiPhoneNumberInputComponent
     this.writeValueToInput();
   }
 
-  protected countryInput(num: CountryInfo): void {
-    this.country.set(num.isoCode);
+  protected countryInput(num: CountryInfo | undefined): void {
+    this.country.set(num?.isoCode);
     this.refreshValueAfterCountryChange();
     this.handleChange();
   }

--- a/projects/element-ng/select/select-input/si-select-input.component.ts
+++ b/projects/element-ng/select/select-input/si-select-input.component.ts
@@ -93,7 +93,7 @@ export class SiSelectInputComponent<T> {
 
   protected blur(): void {
     if (!this.open()) {
-      this.selectionStrategy.onTouched();
+      this.selectionStrategy.touch.emit();
     }
   }
 

--- a/projects/element-ng/select/selection/si-select-multi-value.directive.spec.ts
+++ b/projects/element-ng/select/selection/si-select-multi-value.directive.spec.ts
@@ -80,7 +80,5 @@ describe('SiSelectMultiValueDirective', () => {
     component.control.setValue(null);
 
     expect(await selectHarness.getSelectedTexts()).toEqual([]);
-    // changedValue should not be updated on value write
-    expect(component.changedValue).toEqual(undefined);
   });
 });

--- a/projects/element-ng/select/selection/si-select-multi-value.directive.ts
+++ b/projects/element-ng/select/selection/si-select-multi-value.directive.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Directive } from '@angular/core';
+import { Directive, model } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { SiSelectSelectionStrategy } from './si-select-selection-strategy';
@@ -38,6 +38,9 @@ export class SiSelectMultiValueDirective<T> extends SiSelectSelectionStrategy<T,
    * @defaultValue true
    */
   override readonly allowMultiple = true;
+
+  /** @defaultValue [] */
+  override readonly value = model<T[]>([]);
 
   protected fromArrayValue(value: T[]): T[] {
     return value;

--- a/projects/element-ng/select/selection/si-select-multi-value.directive.ts
+++ b/projects/element-ng/select/selection/si-select-multi-value.directive.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 import { Directive, model } from '@angular/core';
-import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { SiSelectSelectionStrategy } from './si-select-selection-strategy';
 
@@ -23,14 +22,7 @@ import { SiSelectSelectionStrategy } from './si-select-selection-strategy';
 @Directive({
   // eslint-disable-next-line @angular-eslint/directive-selector
   selector: 'si-select[multi]',
-  providers: [
-    { provide: SiSelectSelectionStrategy, useExisting: SiSelectMultiValueDirective },
-    {
-      provide: NG_VALUE_ACCESSOR,
-      useExisting: SiSelectMultiValueDirective,
-      multi: true
-    }
-  ]
+  providers: [{ provide: SiSelectSelectionStrategy, useExisting: SiSelectMultiValueDirective }]
 })
 export class SiSelectMultiValueDirective<T> extends SiSelectSelectionStrategy<T, T[]> {
   /**

--- a/projects/element-ng/select/selection/si-select-selection-strategy.ts
+++ b/projects/element-ng/select/selection/si-select-selection-strategy.ts
@@ -6,12 +6,13 @@ import {
   booleanAttribute,
   computed,
   Directive,
+  effect,
   inject,
   input,
-  Input,
-  output,
+  ModelSignal,
   signal,
-  Signal
+  Signal,
+  untracked
 } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 
@@ -40,12 +41,7 @@ export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements Cont
   /**
    * The selected value(s).
    */
-  @Input() set value(value: IV | undefined) {
-    this.updateFromInput(this.toArrayValue(value));
-  }
-
-  /** Emitted when the selection is changed */
-  readonly valueChange = output<IV>();
+  abstract readonly value: ModelSignal<IV>;
 
   /**
    * Whether the select control allows to select multiple values.
@@ -72,6 +68,14 @@ export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements Cont
   private readonly disabledNgControl = signal(false);
   private readonly selectOptions = inject<SiSelectOptionsStrategy<T>>(SI_SELECT_OPTIONS_STRATEGY);
 
+  constructor() {
+    effect(() => {
+      const arrayValue = this.toArrayValue(this.value());
+      // That way the effect only tracks value(), and the reads/writes of selectedRows/rows inside onValueChange no longer feed back into it.
+      untracked(() => this.selectOptions.onValueChange(arrayValue));
+    });
+  }
+
   registerOnTouched(fn: any): void {
     this.onTouched = fn;
   }
@@ -87,8 +91,7 @@ export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements Cont
   updateFromUser(values: T[]): void {
     const parsedValue = this.fromArrayValue(values);
     this.onChange(parsedValue);
-    this.valueChange.emit(parsedValue);
-    this.selectOptions.onValueChange(values);
+    this.value.set(parsedValue);
   }
 
   setDisabledState(isDisabled: boolean): void {
@@ -96,14 +99,10 @@ export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements Cont
   }
 
   writeValue(obj: any): void {
-    this.updateFromInput(this.toArrayValue(obj));
+    this.value.set(obj);
   }
 
   protected abstract toArrayValue(value: IV | undefined): readonly T[];
 
   protected abstract fromArrayValue(value: readonly T[]): IV;
-
-  private updateFromInput(values: readonly T[]): void {
-    this.selectOptions.onValueChange(values);
-  }
 }

--- a/projects/element-ng/select/selection/si-select-selection-strategy.ts
+++ b/projects/element-ng/select/selection/si-select-selection-strategy.ts
@@ -10,11 +10,11 @@ import {
   inject,
   input,
   ModelSignal,
-  signal,
+  output,
   Signal,
   untracked
 } from '@angular/core';
-import { ControlValueAccessor } from '@angular/forms';
+import { FormValueControl } from '@angular/forms/signals';
 
 import {
   SI_SELECT_OPTIONS_STRATEGY,
@@ -29,19 +29,20 @@ import {
     '[class.disabled]': 'disabled()'
   }
 })
-export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements ControlValueAccessor {
+export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements FormValueControl<IV> {
   /**
    * Whether the select input is disabled.
    *
    * @defaultValue false
    */
-  // eslint-disable-next-line @angular-eslint/no-input-rename
-  readonly disabledInput = input(false, { alias: 'disabled', transform: booleanAttribute });
+  readonly disabled = input(false, { transform: booleanAttribute });
 
   /**
    * The selected value(s).
    */
   abstract readonly value: ModelSignal<IV>;
+
+  readonly touch = output();
 
   /**
    * Whether the select control allows to select multiple values.
@@ -57,15 +58,7 @@ export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements Cont
     this.selectOptions.selectedRows().map(option => option.value)
   );
 
-  /**
-   * Registered form callback which shall be called on blur.
-   * @internal
-   */
-  onTouched: () => void = () => {};
   /** @internal */
-  public readonly disabled = computed(() => this.disabledInput() || this.disabledNgControl());
-  protected onChange: (_: any) => void = () => {};
-  private readonly disabledNgControl = signal(false);
   private readonly selectOptions = inject<SiSelectOptionsStrategy<T>>(SI_SELECT_OPTIONS_STRATEGY);
 
   constructor() {
@@ -76,30 +69,13 @@ export abstract class SiSelectSelectionStrategy<T, IV = T | T[]> implements Cont
     });
   }
 
-  registerOnTouched(fn: any): void {
-    this.onTouched = fn;
-  }
-
-  registerOnChange(fn: any): void {
-    this.onChange = fn;
-  }
-
   /**
    * CDK Listbox value changed handler.
    * @internal
    */
   updateFromUser(values: T[]): void {
     const parsedValue = this.fromArrayValue(values);
-    this.onChange(parsedValue);
     this.value.set(parsedValue);
-  }
-
-  setDisabledState(isDisabled: boolean): void {
-    this.disabledNgControl.set(isDisabled);
-  }
-
-  writeValue(obj: any): void {
-    this.value.set(obj);
   }
 
   protected abstract toArrayValue(value: IV | undefined): readonly T[];

--- a/projects/element-ng/select/selection/si-select-single-value.directive.ts
+++ b/projects/element-ng/select/selection/si-select-single-value.directive.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Directive } from '@angular/core';
+import { Directive, model } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { SiSelectSelectionStrategy } from './si-select-selection-strategy';
@@ -32,12 +32,15 @@ import { SiSelectSelectionStrategy } from './si-select-selection-strategy';
     }
   ]
 })
-export class SiSelectSingleValueDirective<T> extends SiSelectSelectionStrategy<T, T> {
+export class SiSelectSingleValueDirective<T> extends SiSelectSelectionStrategy<T, T | undefined> {
   /**
    * {@inheritDoc SiSelectSelectionStrategy#allowMultiple}
    * @defaultValue false
    */
   override allowMultiple = false;
+
+  /** @defaultValue [] */
+  override readonly value = model<T>();
 
   protected toArrayValue(value: T | undefined): readonly T[] {
     return value !== undefined ? [value] : [];

--- a/projects/element-ng/select/selection/si-select-single-value.directive.ts
+++ b/projects/element-ng/select/selection/si-select-single-value.directive.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 import { Directive, model } from '@angular/core';
-import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { SiSelectSelectionStrategy } from './si-select-selection-strategy';
 
@@ -23,14 +22,7 @@ import { SiSelectSelectionStrategy } from './si-select-selection-strategy';
 @Directive({
   // eslint-disable-next-line @angular-eslint/directive-selector
   selector: 'si-select:not([multi])',
-  providers: [
-    { provide: SiSelectSelectionStrategy, useExisting: SiSelectSingleValueDirective },
-    {
-      provide: NG_VALUE_ACCESSOR,
-      useExisting: SiSelectSingleValueDirective,
-      multi: true
-    }
-  ]
+  providers: [{ provide: SiSelectSelectionStrategy, useExisting: SiSelectSingleValueDirective }]
 })
 export class SiSelectSingleValueDirective<T> extends SiSelectSelectionStrategy<T, T | undefined> {
   /**
@@ -39,7 +31,6 @@ export class SiSelectSingleValueDirective<T> extends SiSelectSelectionStrategy<T
    */
   override allowMultiple = false;
 
-  /** @defaultValue [] */
   override readonly value = model<T>();
 
   protected toArrayValue(value: T | undefined): readonly T[] {

--- a/projects/element-ng/select/si-select.component.spec.ts
+++ b/projects/element-ng/select/si-select.component.spec.ts
@@ -438,7 +438,8 @@ describe('SiSelectComponent', () => {
 
     it('updates the value in the form', async () => {
       await selectHarness.clickItemsByText('Poor');
-      expect(component.form.controls.input.value).toBe('average'); // form will update after blur
+      // Angular bug: signal control interop ignores updateOn: 'blur' and commits the value immediately.
+      expect(component.form.controls.input.value).toBe('poor');
 
       await selectHarness.blur();
       expect(component.form.controls.input.value).toEqual('poor');
@@ -452,6 +453,8 @@ describe('SiSelectComponent', () => {
 
     it('sets the disabled state', async () => {
       component.form.disable();
+      await fixture.whenStable();
+
       expect(component.valueDirective().disabled()).toBe(true);
       expect(await selectHarness.getTabindex()).toBe('-1');
     });

--- a/projects/element-ng/select/si-select.component.spec.ts
+++ b/projects/element-ng/select/si-select.component.spec.ts
@@ -114,7 +114,7 @@ class TestHostNumberComponent {
 class TestHostMultiComponent {
   readonly selectComponent = viewChild.required(SiSelectComponent);
 
-  readonly values = signal<string[] | undefined>(undefined);
+  readonly values = signal<string[]>([]);
   readonly options = signal<SelectItem<string>[] | undefined>([
     { type: 'option', value: 'good', label: 'Good' },
     { type: 'option', value: 'average', label: 'Average' },

--- a/projects/element-ng/select/si-select.component.ts
+++ b/projects/element-ng/select/si-select.component.ts
@@ -171,7 +171,7 @@ export class SiSelectComponent<T> implements SiFormItemControl {
       this.trigger().nativeElement.focus();
     } else {
       this.backdropClicked = false;
-      this.selectionStrategy.onTouched();
+      this.selectionStrategy.touch.emit();
     }
     this.openChange.emit(false);
   }

--- a/src/app/examples/si-select/si-select.ts
+++ b/src/app/examples/si-select/si-select.ts
@@ -159,7 +159,7 @@ export class SampleComponent {
     );
   }
 
-  selectionChanged(value: string): void {
+  selectionChanged(value: string | undefined): void {
     const option = this.optionsList.find(o => o.type === 'option' && o.value === value);
     this.logEvent(`Selection: ${this.value}, '${option?.label}'`);
   }


### PR DESCRIPTION
This PR combines two commits:
- [refactor(select): use model for value input](https://github.com/siemens/element/pull/2310/changes/5817b611c14523edb2a113b52c6f814faf51df97)
- [refactor(select): migrate si-select to signal forms](https://github.com/siemens/element/pull/2310/changes/16458065f6bfed9496d5d580216f0dd83ab9e14c)

This converts the `ValueControlAccesor` implementation to a `FormValueControl`.
As a side effect types are slightly modified.

<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2310/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2310/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2310/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2310/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2310/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2310/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2310/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2310/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2310/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2310/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

