### PR TITLE
refactor(resize-observer): remove deprecated method

### DIFF
--- a/api-goldens/element-ng/resize-observer/index.api.md
+++ b/api-goldens/element-ng/resize-observer/index.api.md
@@ -37,8 +37,6 @@ export interface ElementDimensions {
 // @public
 export class ResizeObserverService {
     constructor();
-    // @deprecated
-    _checkAll(): void;
     observe(element: Element, throttle: number, emitInitial?: boolean, emitImmediate?: boolean): Observable<ElementDimensions>;
 }
 

--- a/projects/element-ng/resize-observer/resize-observer.service.ts
+++ b/projects/element-ng/resize-observer/resize-observer.service.ts
@@ -195,25 +195,4 @@ export class ResizeObserverService {
       });
     });
   }
-
-  /**
-   * check size on all observed elements. Only use in testing!
-   * @deprecated Will be removed in major version 50! For testing purposes use the resize observer mock:
-   *
-   * ```ts
-   * beforeEach(() => mockResizeObserver());
-   * afterEach(() => restoreResizeObserver());
-   * it('should trigger resize', () => {
-   *   // For all observed elements
-   *   MockResizeObserver.triggerResize({});
-   *   // For specific HTML element
-   *   MockResizeObserver.triggerResize({ target: myElement });
-   * });
-   * ```
-
-   */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  _checkAll(): void {
-    this.listeners.forEach(entry => this.handleElement(entry.element));
-  }
 }


### PR DESCRIPTION
BREAKING CHANGE: Removed method `ResizeObserverService._checkAll`. For testing purposes use the resize observer mock:

 ```ts
  beforeEach(() => mockResizeObserver());
  afterEach(() => restoreResizeObserver());
  it('should trigger resize', () => {
      // For all observed elements
      MockResizeObserver.triggerResize({});
      // For specific HTML element
      MockResizeObserver.triggerResize({ target: myElement });
 });
```

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2313/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2313/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2313/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2313/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2313/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2313/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2313/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2313/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2313/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2313/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
