### PR TITLE
refactor(dashboards): deprecate widgetCatalog in favor of signal based widgetList

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -252,7 +252,9 @@ export class SiWidgetCatalogComponent extends SiWidgetEditorBase implements OnIn
     readonly closed: _angular_core.OutputEmitterRef<Omit<WidgetConfig, "id">[] | undefined>;
     readonly multiSelect: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly searchPlaceholder: _angular_core.InputSignal<_siemens_element_translate_ng_translate.TranslatableString>;
+    // @deprecated
     widgetCatalog: Widget[];
+    readonly widgetList: _angular_core.WritableSignal<Widget[]>;
 }
 
 // @public

--- a/projects/dashboards-demo/src/app/components/widget-catalog/custom-widget-catalog.component.ts
+++ b/projects/dashboards-demo/src/app/components/widget-catalog/custom-widget-catalog.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, output } from '@angular/core';
+import { Component, output, signal } from '@angular/core';
 import { SiWidgetCatalogComponent, Widget, WidgetConfig } from '@siemens/dashboards-ng';
 import { SiCircleStatusComponent } from '@siemens/element-ng/circle-status';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
@@ -18,7 +18,7 @@ import { HELLO_DESCRIPTOR } from '../../widgets/hello-widget/widget-descriptors'
 export class CustomWidgetCatalogComponent extends SiWidgetCatalogComponent {
   override readonly closed = output<Omit<WidgetConfig, 'id'>[] | undefined>();
 
-  override widgetCatalog: Widget[] = [];
+  override readonly widgetList = signal<Widget[]>([]);
 
   myDescriptor = HELLO_DESCRIPTOR;
 

--- a/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.ts
+++ b/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.ts
@@ -296,7 +296,7 @@ export class SiFlexibleDashboardComponent implements OnInit, OnChanges, OnDestro
         })
       ]
     });
-    catalogRef.instance.widgetCatalog = this.widgetCatalog();
+    catalogRef.instance.widgetList.set(this.widgetCatalog());
   }
 
   protected onModified(event: boolean): void {

--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.spec.ts
@@ -17,8 +17,10 @@ import { page } from 'vitest/browser';
 
 import { TEST_WIDGET } from '../../../test/test-widget/test-widget';
 import { createTestingWidget, TestingModule } from '../../../test/testing.module';
-import { WidgetConfig } from '../../model/widgets.model';
+import { Widget, WidgetConfig } from '../../model/widgets.model';
 import { SiWidgetCatalogComponent } from './si-widget-catalog.component';
+
+type WidgetSetterMode = 'deprecated' | 'signal';
 
 describe('SiWidgetCatalogComponent', () => {
   let component: SiWidgetCatalogComponent;
@@ -30,6 +32,14 @@ describe('SiWidgetCatalogComponent', () => {
       .filter(
         (debugElement: DebugElement) => debugElement.nativeElement.textContent.trim() === label
       );
+  };
+
+  const setWidgets = (widgets: Widget[], mode: WidgetSetterMode): void => {
+    if (mode === 'deprecated') {
+      component.widgetCatalog = widgets;
+    } else {
+      component.widgetList.set(widgets);
+    }
   };
 
   beforeEach(async () => {
@@ -53,246 +63,256 @@ describe('SiWidgetCatalogComponent', () => {
     expect(addButtons[0].attributes.disabled).toBeDefined();
   });
 
-  describe('Add button', () => {
-    it('should be present and active if the selected widget has no widget editor component', () => {
-      component.widgetCatalog = [createTestingWidget('hello', 'helloId', 'HelloComponent')];
-      fixture.detectChanges();
+  (['deprecated', 'signal'] as const).forEach(mode => {
+    describe(`Add button (${mode})`, () => {
+      it('should be present and active if the selected widget has no widget editor component', () => {
+        setWidgets([createTestingWidget('hello', 'helloId', 'HelloComponent')], mode);
+        fixture.detectChanges();
 
-      const addButtons = buttonsByName('Add');
-      expect(addButtons).toHaveLength(1);
-      expect(addButtons[0].attributes.disabled).toBeUndefined();
+        const addButtons = buttonsByName('Add');
+        expect(addButtons).toHaveLength(1);
+        expect(addButtons[0].attributes.disabled).toBeUndefined();
+      });
+
+      it('should be invisible if the catalog component has an editor', () => {
+        setWidgets(
+          [createTestingWidget('hello', 'helloId', 'HelloComponent', 'HelloEditorComponent')],
+          mode
+        );
+        fixture.detectChanges();
+
+        const addButtons = buttonsByName('Add');
+        expect(addButtons).toHaveLength(0);
+      });
+
+      it('should be visible on the editor view', () => {
+        setWidgets(
+          [createTestingWidget('hello', 'helloId', 'HelloComponent', 'HelloEditorComponent')],
+          mode
+        );
+        component.view.set('editor');
+        fixture.detectChanges();
+        const addButtons = buttonsByName('Add');
+        expect(addButtons).toHaveLength(1);
+      });
+
+      it('should create and emit widget config from selected', async () => {
+        setWidgets([createTestingWidget('Hello', 'id-1234')], mode);
+        fixture.detectChanges();
+
+        const widgetConfigPromise = firstValueFrom(outputToObservable(component.closed));
+        buttonsByName('Add')[0].nativeElement.click();
+        fixture.detectChanges();
+        const widgetConfigs = await widgetConfigPromise;
+        expect(widgetConfigs).toHaveLength(1);
+        expect(widgetConfigs?.[0].widgetId).toBe('id-1234');
+      });
     });
 
-    it('should be invisible if the catalog component has an editor', () => {
-      component.widgetCatalog = [
-        createTestingWidget('hello', 'helloId', 'HelloComponent', 'HelloEditorComponent')
-      ];
-      fixture.detectChanges();
+    describe(`Next button (${mode})`, () => {
+      it('should be visible if the selected widget has an editor component in list view', () => {
+        setWidgets(
+          [createTestingWidget('hello', 'helloId', 'HelloComponent', 'HelloEditorComponent')],
+          mode
+        );
+        fixture.detectChanges();
 
-      const addButtons = buttonsByName('Add');
-      expect(addButtons).toHaveLength(0);
+        expect(component.view()).toBe('list');
+        const addButtons = buttonsByName('Next');
+        expect(addButtons).toHaveLength(1);
+      });
+
+      it('should be invisible false if the selected widget has no editor component', () => {
+        setWidgets([createTestingWidget('hello', 'helloId', 'HelloComponent')], mode);
+        fixture.detectChanges();
+
+        const addButtons = buttonsByName('Next');
+        expect(addButtons).toHaveLength(0);
+      });
+
+      it('should be invisible in editor view', () => {
+        setWidgets(
+          [createTestingWidget('hello', 'helloId', 'HelloComponent', 'HelloEditorComponent')],
+          mode
+        );
+        component.view.set('editor');
+        fixture.detectChanges();
+
+        expect(buttonsByName('Next')).toHaveLength(0);
+
+        component.view.set('editor-only');
+        fixture.detectChanges();
+        expect(buttonsByName('Next')).toHaveLength(0);
+
+        component.view.set('list');
+        fixture.detectChanges();
+        expect(buttonsByName('Next')).toHaveLength(1);
+      });
+
+      it('should switch to editor view and display the widget editor component', async () => {
+        setWidgets([TEST_WIDGET], mode);
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+
+        buttonsByName('Next')[0].nativeElement.click();
+        fixture.detectChanges();
+
+        // cannot use jasmine.clock here.
+        await new Promise(resolve => setTimeout(resolve, 100));
+        expect(component.view()).toBe('editor');
+        expect(
+          fixture.debugElement.query(By.css('.si-layout-fixed-height')).children[0].nativeElement
+            .tagName
+        ).toBe('SI-TEST-WIDGET-EDITOR');
+      });
+
+      it('with wrong widget editor configuration should switch to editor view should not display an editor', async () => {
+        setWidgets(
+          [createTestingWidget('hello', 'helloId', 'HelloComponent', 'Hello123Component')],
+          mode
+        );
+        fixture.detectChanges();
+
+        buttonsByName('Next')[0].nativeElement.click();
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(component.view()).toBe('editor');
+        expect(fixture.debugElement.query(By.css('.si-layout-fixed-height')).children).toHaveLength(
+          0
+        );
+      });
     });
 
-    it('should be visible on the editor view', () => {
-      component.widgetCatalog = [
-        createTestingWidget('hello', 'helloId', 'HelloComponent', 'HelloEditorComponent')
-      ];
-      component.view.set('editor');
-      fixture.detectChanges();
-      const addButtons = buttonsByName('Add');
-      expect(addButtons).toHaveLength(1);
+    describe(`Search (${mode})`, () => {
+      beforeEach(() => {
+        setWidgets(
+          [
+            createTestingWidget('eins', '1'),
+            createTestingWidget('zwei', '2', 'HelloComponent', 'HelloEditorComponent'),
+            createTestingWidget('drei', '3')
+          ],
+          mode
+        );
+        fixture.detectChanges();
+      });
+
+      it('with undefined should not filter visible widgets', () => {
+        fixture.debugElement
+          .query(By.css('si-search-bar'))
+          .triggerEventHandler('searchChange', 'some');
+        fixture.detectChanges();
+
+        expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(0);
+
+        fixture.debugElement
+          .query(By.css('si-search-bar'))
+          .triggerEventHandler('searchChange', undefined);
+        fixture.detectChanges();
+        expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(3);
+      });
+
+      it('with case-insensitive matching string should filter visible widgets', () => {
+        fixture.debugElement
+          .query(By.css('si-search-bar'))
+          .triggerEventHandler('searchChange', 'WEI');
+        fixture.detectChanges();
+
+        expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(1);
+      });
+
+      it('with empty string should not filter visible widgets', () => {
+        fixture.debugElement
+          .query(By.css('si-search-bar'))
+          .triggerEventHandler('searchChange', 'some');
+        fixture.detectChanges();
+        expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(0);
+
+        fixture.debugElement
+          .query(By.css('si-search-bar'))
+          .triggerEventHandler('searchChange', '   ');
+        fixture.detectChanges();
+        expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(3);
+      });
+
+      it('shall keep the search term and result after clicking `Next` to widget editor and `Previous` to catalog', async () => {
+        expect(buttonsByName('Next')).toHaveLength(0);
+
+        let searchInput = fixture.nativeElement.querySelector('si-search-bar input')!;
+        searchInput.value = 'zwei';
+        searchInput.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+
+        const searchBarEl = fixture.debugElement.query(By.css('si-search-bar'));
+        const searchBarComponent = searchBarEl.componentInstance as SiSearchBarComponent;
+        const debounceTime = searchBarComponent.debounceTime();
+        // cannot use jasmine.clock here.
+        await new Promise(resolve => setTimeout(resolve, debounceTime + 1)); // wait for debounce time + extra 1 ms to avoid flaky test
+        await fixture.whenStable();
+
+        expect(buttonsByName('Next')).toHaveLength(1);
+        expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(1);
+
+        const nextButton = buttonsByName('Next')[0].nativeElement;
+        expect(nextButton.innerHTML).toBe('Next');
+
+        // Navigate to next page that shows the editor of the widget and not the widget catalog.
+        // Test by verifying the search input is gone.
+        nextButton.click();
+        fixture.detectChanges();
+        searchInput = fixture.nativeElement.querySelector('si-search-bar input')!;
+        expect(searchInput).toBeNull();
+
+        // Navigate back to the widget catalog.
+        const previousButton = fixture.nativeElement.querySelectorAll(
+          'button'
+        )[1] as HTMLButtonElement;
+        expect(previousButton.innerHTML).toBe('Previous');
+        previousButton.click();
+        fixture.detectChanges();
+
+        // Verify that the search input is back and includes the value `zwei`
+        searchInput = fixture.nativeElement.querySelector('si-search-bar input')!;
+        expect(searchInput).not.toBeNull();
+        expect(searchInput.value).toBe('zwei');
+        expect(buttonsByName('Next')).toHaveLength(1);
+        expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(1);
+      });
     });
 
-    it('should create and emit widget config from selected', async () => {
-      component.widgetCatalog = [createTestingWidget('Hello', 'id-1234')];
+    it('Cancel button shall emit undefined on closed', async () => {
       fixture.detectChanges();
 
-      const widgetConfigPromise = firstValueFrom(outputToObservable(component.closed));
-      buttonsByName('Add')[0].nativeElement.click();
-      fixture.detectChanges();
-      const widgetConfigs = (await widgetConfigPromise) as Omit<WidgetConfig, 'id'>[];
-      expect(widgetConfigs).toHaveLength(1);
-      expect(widgetConfigs[0].widgetId).toBe('id-1234');
-    });
-  });
-
-  describe('Next button', () => {
-    it('should be visible if the selected widget has an editor component in list view', () => {
-      component.widgetCatalog = [
-        createTestingWidget('hello', 'helloId', 'HelloComponent', 'HelloEditorComponent')
-      ];
-      fixture.detectChanges();
-
-      expect(component.view()).toBe('list');
-      const addButtons = buttonsByName('Next');
-      expect(addButtons).toHaveLength(1);
+      const closedPromise = firstValueFrom(outputToObservable(component.closed));
+      buttonsByName('Cancel')[0].nativeElement.click();
+      const wd = await closedPromise;
+      expect(wd).toBeUndefined();
     });
 
-    it('should be invisible false if the selected widget has no editor component', () => {
-      component.widgetCatalog = [createTestingWidget('hello', 'helloId', 'HelloComponent')];
-      fixture.detectChanges();
-
-      const addButtons = buttonsByName('Next');
-      expect(addButtons).toHaveLength(0);
-    });
-
-    it('should be invisible in editor view', () => {
-      component.widgetCatalog = [
-        createTestingWidget('hello', 'helloId', 'HelloComponent', 'HelloEditorComponent')
-      ];
-      component.view.set('editor');
-      fixture.detectChanges();
-
-      expect(buttonsByName('Next')).toHaveLength(0);
-
-      component.view.set('editor-only');
-      fixture.detectChanges();
-      expect(buttonsByName('Next')).toHaveLength(0);
-
-      component.view.set('list');
-      fixture.detectChanges();
-      expect(buttonsByName('Next')).toHaveLength(1);
-    });
-
-    it('should switch to editor view and display the widget editor component', async () => {
-      component.widgetCatalog = [TEST_WIDGET];
-      fixture.changeDetectorRef.markForCheck();
+    it(`Previous button shall switch to list view (${mode})`, async () => {
+      setWidgets([TEST_WIDGET], mode);
       fixture.detectChanges();
 
       buttonsByName('Next')[0].nativeElement.click();
       fixture.detectChanges();
+      await fixture.whenStable();
 
+      expect(component.view()).toBe('editor');
       // cannot use jasmine.clock here.
       await new Promise(resolve => setTimeout(resolve, 100));
-      expect(component.view()).toBe('editor');
       expect(
         fixture.debugElement.query(By.css('.si-layout-fixed-height')).children[0].nativeElement
           .tagName
       ).toBe('SI-TEST-WIDGET-EDITOR');
+
+      buttonsByName('Previous')[0].nativeElement.click();
+      fixture.detectChanges();
+      expect(component.view()).toBe('list');
+      expect(
+        fixture.debugElement.query(By.css('.si-layout-fixed-height')).children[0].nativeElement
+          .tagName
+      ).not.toBe('SI-TEST-WIDGET-EDITOR');
     });
-
-    it('with wrong widget editor configuration should switch to editor view should not display an editor', async () => {
-      component.widgetCatalog = [
-        createTestingWidget('hello', 'helloId', 'HelloComponent', 'Hello123Component')
-      ];
-      fixture.detectChanges();
-
-      buttonsByName('Next')[0].nativeElement.click();
-      fixture.detectChanges();
-      await fixture.whenStable();
-
-      expect(component.view()).toBe('editor');
-      expect(fixture.debugElement.query(By.css('.si-layout-fixed-height')).children).toHaveLength(
-        0
-      );
-    });
-  });
-
-  describe('Search', () => {
-    beforeEach(() => {
-      component.widgetCatalog = [
-        createTestingWidget('eins', '1'),
-        createTestingWidget('zwei', '2', 'HelloComponent', 'HelloEditorComponent'),
-        createTestingWidget('drei', '3')
-      ];
-      fixture.detectChanges();
-    });
-
-    it('with undefined should not filter visible widgets', () => {
-      fixture.debugElement
-        .query(By.css('si-search-bar'))
-        .triggerEventHandler('searchChange', 'some');
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(0);
-
-      fixture.debugElement
-        .query(By.css('si-search-bar'))
-        .triggerEventHandler('searchChange', undefined);
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(3);
-    });
-
-    it('with case-insensitive matching string should filter visible widgets', () => {
-      fixture.debugElement
-        .query(By.css('si-search-bar'))
-        .triggerEventHandler('searchChange', 'WEI');
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(1);
-    });
-
-    it('with empty string should not filter visible widgets', () => {
-      fixture.debugElement
-        .query(By.css('si-search-bar'))
-        .triggerEventHandler('searchChange', 'some');
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(0);
-
-      fixture.debugElement
-        .query(By.css('si-search-bar'))
-        .triggerEventHandler('searchChange', '   ');
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(3);
-    });
-
-    it('shall keep the search term and result after clicking `Next` to widget editor and `Previous` to catalog', async () => {
-      expect(buttonsByName('Next')).toHaveLength(0);
-
-      let searchInput = fixture.nativeElement.querySelector('si-search-bar input')!;
-      searchInput.value = 'zwei';
-      searchInput.dispatchEvent(new Event('input'));
-      fixture.detectChanges();
-
-      const searchBarEl = fixture.debugElement.query(By.css('si-search-bar'));
-      const searchBarComponent = searchBarEl.componentInstance as SiSearchBarComponent;
-      const debounceTime = searchBarComponent.debounceTime();
-      // cannot use jasmine.clock here.
-      await new Promise(resolve => setTimeout(resolve, debounceTime + 1)); // wait for debounce time + extra 1 ms to avoid flaky test
-      await fixture.whenStable();
-
-      expect(buttonsByName('Next')).toHaveLength(1);
-      expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(1);
-
-      const nextButton = buttonsByName('Next')[0].nativeElement;
-      expect(nextButton.innerHTML).toBe('Next');
-
-      // Navigate to next page that shows the editor of the widget and not the widget catalog.
-      // Test by verifying the search input is gone.
-      nextButton.click();
-      fixture.detectChanges();
-      searchInput = fixture.nativeElement.querySelector('si-search-bar input')!;
-      expect(searchInput).toBeNull();
-
-      // Navigate back to the widget catalog.
-      const previousButton = fixture.nativeElement.querySelectorAll(
-        'button'
-      )[1] as HTMLButtonElement;
-      expect(previousButton.innerHTML).toBe('Previous');
-      previousButton.click();
-      fixture.detectChanges();
-
-      // Verify that the search input is back and includes the value `zwei`
-      searchInput = fixture.nativeElement.querySelector('si-search-bar input')!;
-      expect(searchInput).not.toBeNull();
-      expect(searchInput.value).toBe('zwei');
-      expect(buttonsByName('Next')).toHaveLength(1);
-      expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(1);
-    });
-  });
-
-  it('Cancel button shall emit undefined on closed', async () => {
-    fixture.detectChanges();
-
-    const closedPromise = firstValueFrom(outputToObservable(component.closed));
-    buttonsByName('Cancel')[0].nativeElement.click();
-    const wd = await closedPromise;
-    expect(wd).toBeUndefined();
-  });
-
-  it('Previous button shall switch to list view', async () => {
-    component.widgetCatalog = [TEST_WIDGET];
-    fixture.detectChanges();
-
-    buttonsByName('Next')[0].nativeElement.click();
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    expect(component.view()).toBe('editor');
-    // cannot use jasmine.clock here.
-    await new Promise(resolve => setTimeout(resolve, 100));
-    expect(
-      fixture.debugElement.query(By.css('.si-layout-fixed-height')).children[0].nativeElement
-        .tagName
-    ).toBe('SI-TEST-WIDGET-EDITOR');
-
-    buttonsByName('Previous')[0].nativeElement.click();
-    fixture.detectChanges();
-    expect(component.view()).toBe('list');
-    expect(
-      fixture.debugElement.query(By.css('.si-layout-fixed-height')).children[0].nativeElement
-        .tagName
-    ).not.toBe('SI-TEST-WIDGET-EDITOR');
   });
 
   describe('List multi selection', () => {
@@ -383,51 +403,61 @@ describe('SiWidgetCatalogComponent', () => {
           )
         ]
       });
-
-      fixture = TestBed.createComponent(SiWidgetCatalogComponent);
-      component = fixture.componentInstance;
     });
 
-    it('should display translated widget name and description', () => {
-      component.widgetCatalog = [
-        {
-          ...createTestingWidget('WIDGET.NAME_KEY', 'translatable-1'),
-          description: 'WIDGET.DESCRIPTION_KEY'
-        }
-      ];
-      fixture.detectChanges();
+    (['deprecated', 'signal'] as const).forEach(mode => {
+      beforeEach(() => {
+        fixture = TestBed.createComponent(SiWidgetCatalogComponent);
+        component = fixture.componentInstance;
+      });
 
-      const listItems = fixture.debugElement.queryAll(By.css('.list-group-item'));
-      expect(listItems).toHaveLength(1);
-      expect(listItems[0].query(By.css('.si-h5')).nativeElement).toHaveTextContent(
-        'Translated Widget Name'
-      );
-      expect(listItems[0].query(By.css('.si-body')).nativeElement).toHaveTextContent(
-        'Translated Widget Description'
-      );
-    });
+      it(`should display translated widget name and description (${mode})`, () => {
+        setWidgets(
+          [
+            {
+              ...createTestingWidget('WIDGET.NAME_KEY', 'translatable-1'),
+              description: 'WIDGET.DESCRIPTION_KEY'
+            }
+          ],
+          mode
+        );
+        fixture.detectChanges();
 
-    it('should filter widgets by translated name', () => {
-      component.widgetCatalog = [
-        {
-          ...createTestingWidget('WIDGET.NAME_KEY', 'translatable-1'),
-          description: 'WIDGET.DESCRIPTION_KEY'
-        },
-        createTestingWidget('Other Widget', 'other-1')
-      ];
-      fixture.detectChanges();
+        const listItems = fixture.debugElement.queryAll(By.css('.list-group-item'));
+        expect(listItems).toHaveLength(1);
+        expect(listItems[0].query(By.css('.si-h5')).nativeElement).toHaveTextContent(
+          'Translated Widget Name'
+        );
+        expect(listItems[0].query(By.css('.si-body')).nativeElement).toHaveTextContent(
+          'Translated Widget Description'
+        );
+      });
 
-      expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(2);
+      it(`should filter widgets by translated name (${mode})`, () => {
+        setWidgets(
+          [
+            {
+              ...createTestingWidget('WIDGET.NAME_KEY', 'translatable-1'),
+              description: 'WIDGET.DESCRIPTION_KEY'
+            },
+            createTestingWidget('Other Widget', 'other-1')
+          ],
+          mode
+        );
+        fixture.detectChanges();
 
-      fixture.debugElement
-        .query(By.css('si-search-bar'))
-        .triggerEventHandler('searchChange', 'Translated');
-      fixture.detectChanges();
+        expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(2);
 
-      expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(1);
-      expect(
-        fixture.debugElement.query(By.css('.list-group-item .si-h5')).nativeElement
-      ).toHaveTextContent('Translated Widget Name');
+        fixture.debugElement
+          .query(By.css('si-search-bar'))
+          .triggerEventHandler('searchChange', 'Translated');
+        fixture.detectChanges();
+
+        expect(fixture.debugElement.queryAll(By.css('.list-group-item'))).toHaveLength(1);
+        expect(
+          fixture.debugElement.query(By.css('.list-group-item .si-h5')).nativeElement
+        ).toHaveTextContent('Translated Widget Name');
+      });
     });
   });
 });

--- a/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
+++ b/projects/dashboards-ng/src/components/widget-catalog/si-widget-catalog.component.ts
@@ -90,8 +90,17 @@ export class SiWidgetCatalogComponent extends SiWidgetEditorBase implements OnIn
    * dashboard creates the catalog by Angular's `createComponent()` method
    * and sets the available widgets to this attribute.
    *
+   * @deprecated This property will be removed in v52. Use the signal `widgetList` instead.
    * @defaultValue [] */
   widgetCatalog: Widget[] = [];
+
+  /**
+   * Property to provide the available widgets to the catalog. The flexible
+   * dashboard creates the catalog by Angular's `createComponent()` method
+   * and sets the available widgets to this attribute.
+   *
+   * @defaultValue [] */
+  readonly widgetList = signal<Widget[]>([]);
 
   /**
    * Holds the search term from the catalog to be visible when going back
@@ -120,6 +129,12 @@ export class SiWidgetCatalogComponent extends SiWidgetEditorBase implements OnIn
   );
 
   private readonly translateService = injectSiTranslateService();
+  /**
+   * TODO: Remove this property in v52. Use the signal `widgetList` instead.
+   */
+  private get widgetCatalogList(): Widget[] {
+    return this.widgetList().length ? this.widgetList() : this.widgetCatalog;
+  }
 
   protected labelCancel = t(() => $localize`:@@DASHBOARD.WIDGET_LIBRARY.CANCEL:Cancel`);
   protected labelPrevious = t(() => $localize`:@@DASHBOARD.WIDGET_LIBRARY.PREVIOUS:Previous`);
@@ -188,20 +203,20 @@ export class SiWidgetCatalogComponent extends SiWidgetEditorBase implements OnIn
   }
 
   ngOnInit(): void {
-    this.filteredWidgetCatalog = this.widgetCatalog;
-    if (this.widgetCatalog.length > 0 && !this.multiSelect()) {
-      this.selectWidgets([this.widgetCatalog[0]]);
+    this.filteredWidgetCatalog = this.widgetCatalogList;
+    if (this.widgetCatalogList.length > 0 && !this.multiSelect()) {
+      this.selectWidgets([this.widgetCatalogList[0]]);
     }
   }
 
   protected onSearch(searchTerm?: string): void {
     if (!searchTerm || searchTerm.trim().length === 0) {
       this.searchTerm = '';
-      this.filteredWidgetCatalog = this.widgetCatalog;
+      this.filteredWidgetCatalog = this.widgetCatalogList;
     } else {
       this.searchTerm = searchTerm;
       const term = searchTerm.trim().toLowerCase();
-      this.filteredWidgetCatalog = this.widgetCatalog.filter(wd => {
+      this.filteredWidgetCatalog = this.widgetCatalogList.filter(wd => {
         const name = this.translateService.translateSync(wd.name);
         return name.toLowerCase().includes(term);
       });


### PR DESCRIPTION
DEPRECATED: `widgetCatalog` property of `SiWidgetCatalogComponent` is deprecated, use the signal based `widgetList` property instead.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2315/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2315/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2315/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2315/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2315/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2315/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2315/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2315/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2315/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2315/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

