### PR TITLE
chore(dashboards-demo): add rootDir to resolve TypeScript path mapping errors

### DIFF
--- a/projects/dashboards-demo/tsconfig.app.json
+++ b/projects/dashboards-demo/tsconfig.app.json
@@ -4,6 +4,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/app",
+    "rootDir": "../..",
     "types": ["@siemens/element-translate-ng/localize-types", "node"]
   },
   "files": ["src/main.ts"],


### PR DESCRIPTION
Set rootDir to '../..' in tsconfig.app.json to allow imports from @siemens/element-ng/* and other library packages via path mappings without triggering 'not under rootDir' TypeScript errors.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2319/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2319/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2319/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2319/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2319/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2319/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2319/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2319/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2319/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2319/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
