### PR TITLE
feat(split): configure sizes per part via size and unit

### DIFF
--- a/api-goldens/element-ng/split/index.api.md
+++ b/api-goldens/element-ng/split/index.api.md
@@ -38,7 +38,6 @@ export class SiSplitComponent {
     constructor();
     readonly gutterSize: _angular_core.InputSignal<number>;
     readonly orientation: _angular_core.InputSignal<SplitOrientation>;
-    readonly sizes: _angular_core.InputSignal<number[]>;
     // (undocumented)
     readonly sizesChange: _angular_core.OutputEmitterRef<number[]>;
     readonly stateId: _angular_core.InputSignal<string | undefined>;
@@ -70,15 +69,19 @@ export class SiSplitPartComponent {
     readonly scale: _angular_core.InputSignal<Scale>;
     readonly showCollapseButton: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly showHeader: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly size: _angular_core.InputSignalWithTransform<number | undefined, unknown>;
+    readonly size: _angular_core.InputSignalWithTransform<number, string | number>;
     // (undocumented)
     readonly stateChange: _angular_core.OutputEmitterRef<PartState>;
     readonly stateId: _angular_core.InputSignal<string | undefined>;
     toggleCollapse(): void;
+    readonly unit: _angular_core.InputSignal<SplitUnit>;
 }
 
 // @public (undocumented)
 export type SplitOrientation = 'horizontal' | 'vertical';
+
+// @public (undocumented)
+export type SplitUnit = 'px' | 'fr';
 
 // (No @packageDocumentation comment for this package)
 

--- a/projects/element-ng/list-details/si-list-details.component.html
+++ b/projects/element-ng/list-details/si-list-details.component.html
@@ -3,11 +3,12 @@
     class="w-100 flex-grow-1"
     orientation="horizontal"
     [stateId]="stateId()"
-    [sizes]="splitSizes()"
     (sizesChange)="onSplitSizesChange($event)"
   >
     <si-split-part
       scale="none"
+      unit="fr"
+      [size]="splitSizes()[0]"
       [showCollapseButton]="false"
       [showHeader]="false"
       [minSize]="minListSize()"
@@ -17,6 +18,8 @@
     </si-split-part>
     <si-split-part
       scale="auto"
+      unit="fr"
+      [size]="splitSizes()[1]"
       [showCollapseButton]="false"
       [showHeader]="false"
       [minSize]="minDetailsSize()"

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.html
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.html
@@ -5,11 +5,12 @@
       class="w-100 flex-grow-1"
       orientation="horizontal"
       [stateId]="stateId()"
-      [sizes]="splitSizes"
       (sizesChange)="onSplitSizesChange($event)"
     >
       <si-split-part
         scale="none"
+        unit="fr"
+        [size]="splitSizes[0]"
         [showCollapseButton]="false"
         [showHeader]="false"
         [minSize]="minMainSize()"
@@ -19,6 +20,8 @@
       </si-split-part>
       <si-split-part
         scale="auto"
+        unit="fr"
+        [size]="splitSizes[1]"
         [showCollapseButton]="false"
         [showHeader]="false"
         [minSize]="minDetailSize()"

--- a/projects/element-ng/schematics/ng-update/index.spec.ts
+++ b/projects/element-ng/schematics/ng-update/index.spec.ts
@@ -89,6 +89,57 @@ export const appConfig: ApplicationConfig = {
     expect(modifiedContent).toContain('providers: [provideZonelessChangeDetection()]');
   });
 
+  it('should move literal split sizes to inline split parts', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  template: \`<si-split [sizes]="[20, 60, 20]">
+  <si-split-part>Left</si-split-part>
+  <si-split-part>Center</si-split-part>
+  <si-split-part>Right</si-split-part>
+</si-split>\`
+})
+export class SplitComponent {}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const modifiedContent = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(modifiedContent).not.toContain('[sizes]');
+    expect(modifiedContent).toContain('<si-split-part size="20" unit="fr">Left</si-split-part>');
+    expect(modifiedContent).toContain('<si-split-part size="60" unit="fr">Center</si-split-part>');
+    expect(modifiedContent).toContain('<si-split-part size="20" unit="fr">Right</si-split-part>');
+  });
+
+  it('should move expression split sizes to external split parts', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  templateUrl: './split.component.html'
+})
+export class SplitComponent {}`,
+      '/projects/app/src/split.component.html': `<si-split [sizes]="panelSizes">
+  <si-split-part>Left</si-split-part>
+  <si-split-part>Right</si-split-part>
+</si-split>`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const modifiedContent = tree.readContent('/projects/app/src/split.component.html');
+
+    expect(modifiedContent).not.toContain('[sizes]');
+    expect(modifiedContent).toContain(
+      '<si-split-part [size]="panelSizes[0]" unit="fr">Left</si-split-part>'
+    );
+    expect(modifiedContent).toContain(
+      '<si-split-part [size]="panelSizes[1]" unit="fr">Right</si-split-part>'
+    );
+  });
+
   it('should pass options to sub-migrations', async () => {
     const customPath = '/custom/path';
     const options = { path: customPath };
@@ -98,5 +149,115 @@ export const appConfig: ApplicationConfig = {
 
     // Verify the schematic ran with custom options
     // In a real scenario, you'd verify the migration respected the path option
+  });
+
+  it('should add unit="px" to a split part with a literal size but no unit (inline template)', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  template: \`<si-split>
+  <si-split-part size="300">Left</si-split-part>
+  <si-split-part size="200">Right</si-split-part>
+</si-split>\`
+})
+export class SplitComponent {}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const modifiedContent = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(modifiedContent).toContain('<si-split-part size="300" unit="px">Left</si-split-part>');
+    expect(modifiedContent).toContain('<si-split-part size="200" unit="px">Right</si-split-part>');
+  });
+
+  it('should add unit="px" to a split part with a bound size but no unit (external template)', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  templateUrl: './split.component.html'
+})
+export class SplitComponent {}`,
+      '/projects/app/src/split.component.html': `<si-split>
+  <si-split-part [size]="leftSize">Left</si-split-part>
+  <si-split-part [size]="rightSize">Right</si-split-part>
+</si-split>`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const modifiedContent = tree.readContent('/projects/app/src/split.component.html');
+
+    expect(modifiedContent).toContain(
+      '<si-split-part [size]="leftSize" unit="px">Left</si-split-part>'
+    );
+    expect(modifiedContent).toContain(
+      '<si-split-part [size]="rightSize" unit="px">Right</si-split-part>'
+    );
+  });
+
+  it('should not add unit="px" when unit is already present', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.html': `<si-split>
+  <si-split-part size="20" unit="fr">Left</si-split-part>
+  <si-split-part [size]="rightSize" [unit]="unitVal">Right</si-split-part>
+</si-split>`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const modifiedContent = tree.readContent('/projects/app/src/split.component.html');
+
+    expect(modifiedContent).toContain('<si-split-part size="20" unit="fr">Left</si-split-part>');
+    expect(modifiedContent).toContain(
+      '<si-split-part [size]="rightSize" [unit]="unitVal">Right</si-split-part>'
+    );
+  });
+
+  it('should add unit="fr" when converting [sizes] and not duplicate with unit="px"', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  templateUrl: './split.component.html'
+})
+export class SplitComponent {}`,
+      '/projects/app/src/split.component.html': `<si-split [sizes]="[30, 70]">
+  <si-split-part>Left</si-split-part>
+  <si-split-part>Right</si-split-part>
+</si-split>`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const modifiedContent = tree.readContent('/projects/app/src/split.component.html');
+
+    expect(modifiedContent).not.toContain('[sizes]');
+    expect(modifiedContent).toContain('<si-split-part size="30" unit="fr">Left</si-split-part>');
+    expect(modifiedContent).toContain('<si-split-part size="70" unit="fr">Right</si-split-part>');
+    expect(modifiedContent).not.toContain('unit="px"');
+  });
+
+  it('should add unit="px" to a self-closing split part with a size but no unit', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  templateUrl: './split.component.html'
+})
+export class SplitComponent {}`,
+      '/projects/app/src/split.component.html': `<si-split>
+  <si-split-part size="400" heading="Left" />
+  <si-split-part size="200" heading="Right" />
+</si-split>`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const modifiedContent = tree.readContent('/projects/app/src/split.component.html');
+
+    expect(modifiedContent).toContain('<si-split-part size="400" heading="Left"  unit="px"/>');
+    expect(modifiedContent).toContain('<si-split-part size="200" heading="Right"  unit="px"/>');
   });
 });

--- a/projects/element-ng/schematics/ng-update/migrate-split-sizes.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-sizes.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Rule, SchematicContext, Tree, UpdateRecorder } from '@angular-devkit/schematics';
+import { Element } from '@angular/compiler';
+import { dirname, join } from 'path/posix';
+import ts from 'typescript';
+
+import {
+  discoverSourceFiles,
+  findElement,
+  getInlineTemplates,
+  getTemplateUrl
+} from '../utils/index.js';
+
+export const splitSizesMigrationRule = (options: { path: string }): Rule => {
+  return async (tree: Tree, context: SchematicContext) => {
+    const processedTemplates = new Set<string>();
+
+    for await (const discoveredSourceFile of discoverSourceFiles(tree, context, options.path)) {
+      const { path: filePath, sourceFile } = discoveredSourceFile;
+      const recorder = tree.beginUpdate(filePath);
+
+      for (const template of getInlineTemplates(sourceFile)) {
+        const templateText = sourceFile.text.substring(
+          template.getStart() + 1,
+          template.getEnd() - 1
+        );
+        migrateSplitSizes(templateText, template.getStart() + 1, recorder);
+        migrateMissingSplitUnit(templateText, template.getStart() + 1, recorder);
+      }
+      tree.commitUpdate(recorder);
+
+      for (const templateUrl of getTemplateUrl(sourceFile)) {
+        const templatePath = join(dirname(filePath), templateUrl);
+        if (processedTemplates.has(templatePath) || !tree.exists(templatePath)) {
+          continue;
+        }
+
+        processedTemplates.add(templatePath);
+        const templateContent = tree.read(templatePath)!.toString('utf-8');
+        const templateRecorder = tree.beginUpdate(templatePath);
+        migrateSplitSizes(templateContent, 0, templateRecorder);
+        migrateMissingSplitUnit(templateContent, 0, templateRecorder);
+        tree.commitUpdate(templateRecorder);
+      }
+    }
+
+    return tree;
+  };
+};
+
+const migrateSplitSizes = (template: string, offset: number, recorder: UpdateRecorder): void => {
+  findElement(template, element => element.name === 'si-split').forEach(split => {
+    const sizes = split.attrs.find(attribute => attribute.name === '[sizes]');
+    if (!sizes) {
+      return;
+    }
+
+    const parts = split.children.filter(
+      (child): child is Element => child instanceof Element && child.name === 'si-split-part'
+    );
+    const literalSizes = getNumericArrayLiteral(sizes.value);
+
+    parts.forEach((part, index) => {
+      if (part.attrs.some(attribute => attribute.name === 'size' || attribute.name === '[size]')) {
+        return;
+      }
+
+      const sizeAttribute = literalSizes
+        ? ` size="${literalSizes[index]}" unit="fr"`
+        : ` [size]="${getIndexedSizeExpression(sizes.value, index)}" unit="fr"`;
+      const startTag = part.startSourceSpan.toString();
+      const insertOffset = part.startSourceSpan.end.offset - (startTag.endsWith('/>') ? 2 : 1);
+      recorder.insertLeft(insertOffset + offset, sizeAttribute);
+    });
+
+    const precedingCharacter = template[sizes.sourceSpan.start.offset - 1];
+    const removeOffset = sizes.sourceSpan.start.offset - (precedingCharacter === ' ' ? 1 : 0);
+    const removeLength = sizes.sourceSpan.end.offset - removeOffset;
+    recorder.remove(removeOffset + offset, removeLength);
+  });
+};
+
+const getNumericArrayLiteral = (value: string): string[] | undefined => {
+  const sourceFile = ts.createSourceFile(
+    'sizes.ts',
+    `const sizes = ${value};`,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const declaration = sourceFile.statements[0];
+
+  if (!declaration || !ts.isVariableStatement(declaration)) {
+    return undefined;
+  }
+
+  const initializer = declaration.declarationList.declarations[0]?.initializer;
+  if (!initializer || !ts.isArrayLiteralExpression(initializer)) {
+    return undefined;
+  }
+
+  const sizes = initializer.elements.map(element => {
+    if (ts.isNumericLiteral(element)) {
+      return element.text;
+    }
+
+    if (
+      ts.isPrefixUnaryExpression(element) &&
+      element.operator === ts.SyntaxKind.MinusToken &&
+      ts.isNumericLiteral(element.operand)
+    ) {
+      return `-${element.operand.text}`;
+    }
+
+    return undefined;
+  });
+
+  return sizes.every((size): size is string => size !== undefined) ? sizes : undefined;
+};
+
+const getIndexedSizeExpression = (expression: string, index: number): string => {
+  const isPropertyAccess = /^[A-Za-z_$][\w$]*(?:\??\.[A-Za-z_$][\w$]*)*$/.test(expression);
+  return `${isPropertyAccess ? expression : `(${expression})`}[${index}]`;
+};
+
+/**
+ * Adds `unit="px"` to every `si-split-part` that already carries an explicit
+ * `size` / `[size]` attribute but no `unit` / `[unit]` attribute. Parts that
+ * lack a size attribute are handled by {@link migrateSplitSizes} instead.
+ */
+const migrateMissingSplitUnit = (
+  template: string,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  findElement(template, element => element.name === 'si-split-part').forEach(part => {
+    const hasSize = part.attrs.some(a => a.name === 'size' || a.name === '[size]');
+    const hasUnit = part.attrs.some(a => a.name === 'unit' || a.name === '[unit]');
+
+    if (!hasSize || hasUnit) {
+      return;
+    }
+
+    const startTag = part.startSourceSpan.toString();
+    const insertOffset = part.startSourceSpan.end.offset - (startTag.endsWith('/>') ? 2 : 1);
+    recorder.insertLeft(insertOffset + offset, ' unit="px"');
+  });
+};

--- a/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
@@ -9,6 +9,7 @@ import { ElementMigrationData, getElementMigrationData } from '../migrations/dat
 import { elementMigrationRule } from '../migrations/element-migration/element-migration.js';
 import { iconPathMigrationRule } from '../migrations/icon-path-migration/index.js';
 import { missingTranslateMigrationRule } from '../migrations/ngx-translate/index.js';
+import { splitSizesMigrationRule } from './migrate-split-sizes.js';
 
 export const migrateToV51 = (): Rule => {
   return (tree: Tree, context: SchematicContext) => {
@@ -18,7 +19,8 @@ export const migrateToV51 = (): Rule => {
     return chain([
       elementMigrationRule(options, migrationData),
       missingTranslateMigrationRule(options),
-      iconPathMigrationRule(options)
+      iconPathMigrationRule(options),
+      splitSizesMigrationRule(options)
     ])(tree, context);
   };
 };

--- a/projects/element-ng/split/si-split-part.component.ts
+++ b/projects/element-ng/split/si-split-part.component.ts
@@ -22,7 +22,14 @@ import { elementDoubleRight } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
-import { Action, CollapseTo, PartState, Scale, SplitOrientation } from './si-split.interfaces';
+import {
+  Action,
+  CollapseTo,
+  PartState,
+  Scale,
+  SplitOrientation,
+  SplitUnit
+} from './si-split.interfaces';
 
 @Component({
   selector: 'si-split-part',
@@ -129,11 +136,14 @@ export class SiSplitPartComponent {
   readonly stateId = input<string>();
 
   /**
-   * Expanded size in px.
-   *
-   * @defaultValue undefined
+   * Expanded size.
    */
-  readonly size = input<number | undefined, unknown>(undefined, { transform: numberAttribute });
+  readonly size = input.required<number, number | string>({ transform: numberAttribute });
+
+  /**
+   * Unit for the configured {@link size}.
+   */
+  readonly unit = input.required<SplitUnit>();
 
   /**
    * This toggles the behavior when collapsing this split part.
@@ -162,7 +172,7 @@ export class SiSplitPartComponent {
   readonly after = signal<SiSplitPartComponent | undefined>(undefined);
 
   /** @internal */
-  readonly fractionalSize = signal<number | undefined>(undefined);
+  readonly fractionalSize = linkedSignal(() => (this.unit() === 'fr' ? this.size() : undefined));
 
   /** @internal */
   readonly collapsedSize = computed(() => (this.collapseToMinSize() ? (this.minSize() ?? 40) : 40));
@@ -190,7 +200,10 @@ export class SiSplitPartComponent {
   }
 
   /** @internal */
-  readonly expandedSize = linkedSignal(() => this.size());
+  readonly expandedSize = linkedSignal({
+    source: () => ({ size: this.size(), unit: this.unit() }),
+    computation: source => (source.unit === 'fr' ? undefined : source.size)
+  });
 
   /** @internal */
   readonly actualSize = computed(() => {

--- a/projects/element-ng/split/si-split.component.spec.ts
+++ b/projects/element-ng/split/si-split.component.spec.ts
@@ -7,7 +7,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideSiUiState, SI_UI_STATE_SERVICE, UIStateStorage } from '@siemens/element-ng/common';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
 
-import { CollapseTo, PartState, Scale, SiSplitModule, SplitOrientation } from './index';
+import { CollapseTo, PartState, Scale, SiSplitModule, SplitOrientation, SplitUnit } from './index';
 import { SiSplitPartComponent } from './si-split-part.component';
 import { SiSplitComponent as TestComponent } from './si-split.component';
 
@@ -35,7 +35,6 @@ class SynchronousMockStore implements UIStateStorage {
         style="width: 100%; height: 100%;"
         stateId="split-test"
         [orientation]="orientation()"
-        [sizes]="sizes()"
         [gutterSize]="gutterSize()"
       >
         <si-split-part
@@ -52,6 +51,8 @@ class SynchronousMockStore implements UIStateStorage {
           [collapseToMinSize]="collapseToMinSize1()"
           [minSize]="minSize1()"
           [scale]="scale1()"
+          [size]="size1()"
+          [unit]="unit1()"
           (collapseChanged)="collapseChanged1($event)"
           (stateChange)="stateChange1($event)"
         >
@@ -71,31 +72,37 @@ class SynchronousMockStore implements UIStateStorage {
           [collapseToMinSize]="false"
           [minSize]="0"
           [scale]="scale2()"
+          [size]="size2()"
+          [unit]="unit2()"
           [collapseOthers]="collapseOthers2()"
           (collapseChanged)="collapseChanged2($event)"
           (stateChange)="stateChange2($event)"
         >
           Test 2
         </si-split-part>
-        <si-split-part
-          #splitPart3
-          collapseLabel="collapse"
-          collapseIconClass="element-command-arrow"
-          heading="part 3"
-          removeContentOnCollapse="false"
-          stateId="three"
-          showCollapseButton="true"
-          showHeader="true"
-          [actions]="[]"
-          [collapseDirection]="collapseDirection3()"
-          [collapseToMinSize]="false"
-          [minSize]="minSize3()"
-          [scale]="scale3()"
-          (collapseChanged)="collapseChanged3($event)"
-          (stateChange)="stateChange3($event)"
-        >
-          Test 3
-        </si-split-part>
+        @if (showPart3()) {
+          <si-split-part
+            #splitPart3
+            collapseLabel="collapse"
+            collapseIconClass="element-command-arrow"
+            heading="part 3"
+            removeContentOnCollapse="false"
+            stateId="three"
+            showCollapseButton="true"
+            showHeader="true"
+            [actions]="[]"
+            [collapseDirection]="collapseDirection3()"
+            [collapseToMinSize]="false"
+            [minSize]="minSize3()"
+            [scale]="scale3()"
+            [size]="size3()"
+            [unit]="unit3()"
+            (collapseChanged)="collapseChanged3($event)"
+            (stateChange)="stateChange3($event)"
+          >
+            Test 3
+          </si-split-part>
+        }
       </si-split>
     </div>
   `
@@ -107,19 +114,25 @@ class WrapperComponent {
   readonly containerHeight = signal(532);
   readonly splitElement = viewChild.required(TestComponent, { read: ElementRef });
   readonly orientation = signal<SplitOrientation>('horizontal');
-  readonly sizes = signal<number[]>([]);
   readonly gutterSize = signal(16);
   readonly splitPart1 = viewChild.required('splitPart1', { read: ElementRef });
   readonly collapseToMinSize1 = signal(false);
   readonly minSize1 = signal(0);
   readonly scale1 = signal<Scale>('auto');
+  readonly size1 = signal(0);
+  readonly unit1 = signal<SplitUnit>('px');
   readonly splitPart2 = viewChild.required('splitPart2', { read: ElementRef });
   readonly collapseDirection2 = signal<CollapseTo>('start');
   readonly scale2 = signal<Scale>('auto');
+  readonly size2 = signal(0);
+  readonly unit2 = signal<SplitUnit>('px');
   readonly splitPart3 = viewChild.required('splitPart3', { read: ElementRef });
   readonly collapseDirection3 = signal<CollapseTo>('start');
   readonly minSize3 = signal(0);
   readonly scale3 = signal<Scale>('auto');
+  readonly size3 = signal(0);
+  readonly unit3 = signal<SplitUnit>('px');
+  readonly showPart3 = signal(true);
   readonly collapseOthers2 = signal(true);
   collapseChanged1 = (event: boolean): void => {};
   stateChange1 = (event: PartState): void => {};
@@ -138,6 +151,15 @@ class WrapperComponent {
 
   measureSize3(): number {
     return this.measureSize(this.splitPart3());
+  }
+
+  setSizes(sizes: [number, number, number], unit: SplitUnit = 'fr'): void {
+    this.size1.set(sizes[0]);
+    this.size2.set(sizes[1]);
+    this.size3.set(sizes[2]);
+    this.unit1.set(unit);
+    this.unit2.set(unit);
+    this.unit3.set(unit);
   }
 
   private measureSize(element: ElementRef<HTMLElement>): number {
@@ -323,7 +345,7 @@ describe('SiSplitComponent', () => {
         fixture = TestBed.createComponent(WrapperComponent);
         wrapperComponent = fixture.componentInstance;
         element = fixture.nativeElement;
-        wrapperComponent.sizes.set([20, 60, 20]);
+        wrapperComponent.setSizes([20, 60, 20], 'fr');
         await fixture.whenStable();
       });
 
@@ -335,8 +357,9 @@ describe('SiSplitComponent', () => {
         expect(split).toContain('Test 2');
         expect(split).toContain('Test 3');
 
-        expect(wrapperComponent.split().sizes()).toBeDefined();
-        expect(wrapperComponent.split().sizes()).toEqual([20, 60, 20]);
+        expect(wrapperComponent.size1()).toEqual(20);
+        expect(wrapperComponent.size2()).toEqual(60);
+        expect(wrapperComponent.size3()).toEqual(20);
         expect(wrapperComponent.split().orientation()).toEqual('horizontal');
       });
     });
@@ -349,7 +372,7 @@ describe('SiSplitComponent', () => {
           fixture = TestBed.createComponent(WrapperComponent);
           wrapperComponent = fixture.componentInstance;
           element = fixture.nativeElement;
-          wrapperComponent.sizes.set([20, 60, 20]);
+          wrapperComponent.setSizes([20, 60, 20], 'fr');
           await fixture.whenStable();
         });
 
@@ -361,8 +384,9 @@ describe('SiSplitComponent', () => {
           expect(split).toContain('Test 2');
           expect(split).toContain('Test 3');
 
-          expect(wrapperComponent.split().sizes()).toBeDefined();
-          expect(wrapperComponent.split().sizes()).toEqual([20, 60, 20]);
+          expect(wrapperComponent.unit1()).toEqual('fr');
+          expect(wrapperComponent.unit2()).toEqual('fr');
+          expect(wrapperComponent.unit3()).toEqual('fr');
           expect(wrapperComponent.split().orientation()).toEqual('horizontal');
         });
 
@@ -384,14 +408,14 @@ describe('SiSplitComponent', () => {
         beforeEach(() => {
           const store = TestBed.inject(SI_UI_STATE_SERVICE);
           store.save('split-test', {
-            one: { initialSize: 20, size: 40, expanded: true },
-            two: { initialSize: 60, size: 40, expanded: true },
-            three: { initialSize: 20, size: 20, expanded: true }
+            one: { initialSize: 20, initialUnit: 'fr', size: 40, expanded: true },
+            two: { initialSize: 60, initialUnit: 'fr', size: 40, expanded: true },
+            three: { initialSize: 20, initialUnit: 'fr', size: 20, expanded: true }
           });
 
           fixture = TestBed.createComponent(WrapperComponent);
           wrapperComponent = fixture.componentInstance;
-          wrapperComponent.sizes.set([20, 60, 20]);
+          wrapperComponent.setSizes([20, 60, 20], 'fr');
           // We need this here to run checks after async tasks completed.
           fixture.autoDetectChanges();
           element = fixture.nativeElement;
@@ -412,9 +436,10 @@ describe('SiSplitComponent', () => {
 
   describe('independent of ui state service', () => {
     setup();
-    beforeEach(() => {
+    beforeEach(async () => {
       fixture = TestBed.createComponent(WrapperComponent);
       wrapperComponent = fixture.componentInstance;
+      await fixture.whenStable();
       component = wrapperComponent.splitElement();
       element = component.nativeElement;
       partComponent1 = wrapperComponent.splitPart1();
@@ -429,7 +454,7 @@ describe('SiSplitComponent', () => {
 
     describe('in horizontal orientation', () => {
       it('should display with set sizes and gutter size', async () => {
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         await fixture.whenStable();
@@ -439,8 +464,28 @@ describe('SiSplitComponent', () => {
         expect(wrapperComponent.measureSize3()).toBeCloseTo(150, 0);
       });
 
+      it('should preserve fractional sizes when a part is removed and re-added', async () => {
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
+        wrapperComponent.gutterSize.set(32);
+        wrapperComponent.containerWidth.set(564);
+        await fixture.whenStable();
+        await new Promise(resolve => setTimeout(resolve));
+
+        wrapperComponent.showPart3.set(false);
+        await fixture.whenStable();
+        await new Promise(resolve => setTimeout(resolve));
+
+        wrapperComponent.showPart3.set(true);
+        await fixture.whenStable();
+        await new Promise(resolve => setTimeout(resolve));
+
+        expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
+        expect(wrapperComponent.measureSize2()).toBeCloseTo(150, 0);
+        expect(wrapperComponent.measureSize3()).toBeCloseTo(150, 0);
+      });
+
       it('should display with set sizes and gutter size while respecting min size after resize', async () => {
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         wrapperComponent.minSize3.set(175);
@@ -458,11 +503,10 @@ describe('SiSplitComponent', () => {
         expect(wrapperComponent.measureSize3()).toBeCloseTo(300, 0);
       });
 
-      it('should display with set sizes and gutter size while keeping size with scale none after resize', async () => {
-        wrapperComponent.sizes.set([40, 30, 30]);
+      it('should keep px sizes after resize', async () => {
+        wrapperComponent.setSizes([200, 150, 150], 'px');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
-        wrapperComponent.scale3.set('none');
         await fixture.whenStable();
         await new Promise(resolve => setTimeout(resolve));
 
@@ -472,13 +516,29 @@ describe('SiSplitComponent', () => {
 
         wrapperComponent.containerWidth.set(1064);
         await fixture.whenStable();
-        expect(wrapperComponent.measureSize1()).toBeCloseTo(486, 0);
-        expect(wrapperComponent.measureSize2()).toBeCloseTo(364, 0);
+        expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
+        expect(wrapperComponent.measureSize2()).toBeCloseTo(150, 0);
         expect(wrapperComponent.measureSize3()).toBeCloseTo(150, 0);
       });
 
+      it('should use px for configured px sizes and fr for configured fr sizes', async () => {
+        wrapperComponent.size1.set(200);
+        wrapperComponent.unit1.set('px');
+        wrapperComponent.size2.set(1);
+        wrapperComponent.unit2.set('fr');
+        wrapperComponent.size3.set(3);
+        wrapperComponent.unit3.set('fr');
+        wrapperComponent.gutterSize.set(32);
+        wrapperComponent.containerWidth.set(664);
+        await fixture.whenStable();
+
+        expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
+        expect(wrapperComponent.measureSize2()).toBeCloseTo(100, 0);
+        expect(wrapperComponent.measureSize3()).toBeCloseTo(300, 0);
+      });
+
       it('should collapse part on click if enabled', async () => {
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         await fixture.whenStable();
@@ -496,7 +556,7 @@ describe('SiSplitComponent', () => {
       });
 
       it('should collapse part to min size on click if set', async () => {
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         wrapperComponent.collapseToMinSize1.set(true);
@@ -516,7 +576,7 @@ describe('SiSplitComponent', () => {
       });
 
       it('should switch to vertical orientation', async () => {
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         wrapperComponent.containerHeight.set(564);
@@ -535,7 +595,7 @@ describe('SiSplitComponent', () => {
       });
 
       it('should display with set sizes and gutter size and resize on drag', async () => {
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         await fixture.whenStable();
@@ -552,7 +612,7 @@ describe('SiSplitComponent', () => {
       });
 
       it('should display with set sizes and gutter size and not resize on incorrect drag', async () => {
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         await fixture.whenStable();
@@ -578,7 +638,7 @@ describe('SiSplitComponent', () => {
       });
 
       it('should display with set sizes and gutter size and resize to min size on drag', async () => {
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([200, 150, 150], 'px');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         wrapperComponent.minSize3.set(100);
@@ -601,7 +661,7 @@ describe('SiSplitComponent', () => {
 
       if ('TouchEvent' in window) {
         it('should display with set sizes and gutter size and resize on touch drag', async () => {
-          wrapperComponent.sizes.set([40, 30, 30]);
+          wrapperComponent.setSizes([40, 30, 30], 'fr');
           wrapperComponent.containerWidth.set(564);
           wrapperComponent.gutterSize.set(32);
           await fixture.whenStable();
@@ -619,14 +679,14 @@ describe('SiSplitComponent', () => {
       }
 
       it('should display with set sizes and gutter size after changes', async () => {
-        wrapperComponent.sizes.set([20, 60, 20]);
+        wrapperComponent.setSizes([20, 60, 20], 'fr');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(100, 0);
         expect(wrapperComponent.measureSize2()).toBeCloseTo(300, 0);
         expect(wrapperComponent.measureSize3()).toBeCloseTo(100, 0);
 
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         await fixture.whenStable();
@@ -638,7 +698,7 @@ describe('SiSplitComponent', () => {
 
       it('should collapse all to the same side on click', async () => {
         wrapperComponent.orientation.set('horizontal');
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         wrapperComponent.collapseDirection2.set('end');
@@ -659,7 +719,7 @@ describe('SiSplitComponent', () => {
 
       it('should only collapse split part if collapseOthers2 is false', async () => {
         wrapperComponent.orientation.set('horizontal');
-        wrapperComponent.sizes.set([40, 20, 40]);
+        wrapperComponent.setSizes([40, 20, 40], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         wrapperComponent.collapseDirection2.set('end');
@@ -683,7 +743,7 @@ describe('SiSplitComponent', () => {
     describe('in vertical orientation', () => {
       it('should display with set sizes and gutter size', async () => {
         wrapperComponent.orientation.set('vertical');
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
@@ -693,7 +753,7 @@ describe('SiSplitComponent', () => {
 
       it('should switch to horizontal orientation', async () => {
         wrapperComponent.orientation.set('vertical');
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
@@ -710,7 +770,7 @@ describe('SiSplitComponent', () => {
 
       it('should display with set sizes and gutter size and resize on drag', async () => {
         wrapperComponent.orientation.set('vertical');
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
@@ -727,7 +787,7 @@ describe('SiSplitComponent', () => {
       if ('TouchEvent' in window) {
         it('should display with set sizes and gutter size and resize on touch drag', async () => {
           wrapperComponent.orientation.set('vertical');
-          wrapperComponent.sizes.set([40, 30, 30]);
+          wrapperComponent.setSizes([40, 30, 30], 'fr');
           await fixture.whenStable();
 
           expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
@@ -744,7 +804,7 @@ describe('SiSplitComponent', () => {
 
       it('should display with set sizes and gutter size and resize to min size on drag', async () => {
         wrapperComponent.orientation.set('vertical');
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([200, 150, 150], 'px');
         wrapperComponent.minSize1.set(100);
         wrapperComponent.scale1.set('none');
         wrapperComponent.scale2.set('auto');
@@ -765,7 +825,7 @@ describe('SiSplitComponent', () => {
 
       it('should display with set sizes and gutter size after changes with scale none', async () => {
         wrapperComponent.orientation.set('vertical');
-        wrapperComponent.sizes.set([20, 60, 20]);
+        wrapperComponent.setSizes([100, 300, 100], 'px');
         wrapperComponent.scale1.set('none');
         wrapperComponent.scale2.set('none');
         wrapperComponent.scale3.set('none');
@@ -775,7 +835,7 @@ describe('SiSplitComponent', () => {
         expect(wrapperComponent.measureSize2()).toBeCloseTo(300, 0);
         expect(wrapperComponent.measureSize3()).toBeCloseTo(100, 0);
 
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([200, 150, 150], 'px');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
@@ -785,7 +845,7 @@ describe('SiSplitComponent', () => {
 
       it('should collapse all to the same side on click', async () => {
         wrapperComponent.orientation.set('vertical');
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
@@ -802,7 +862,7 @@ describe('SiSplitComponent', () => {
 
       it('should switch to horizontal orientation after collapsed part on click', async () => {
         wrapperComponent.orientation.set('vertical');
-        wrapperComponent.sizes.set([40, 30, 30]);
+        wrapperComponent.setSizes([40, 30, 30], 'fr');
         wrapperComponent.collapseDirection3.set('end');
         await fixture.whenStable();
 

--- a/projects/element-ng/split/si-split.component.ts
+++ b/projects/element-ng/split/si-split.component.ts
@@ -15,9 +15,7 @@ import {
   Signal,
   DOCUMENT,
   DestroyRef,
-  output,
-  effect,
-  untracked
+  output
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import {
@@ -29,7 +27,7 @@ import { asapScheduler, fromEvent, merge } from 'rxjs';
 import { observeOn, takeUntil } from 'rxjs/operators';
 
 import { SiSplitPartComponent } from './si-split-part.component';
-import { SplitOrientation } from './si-split.interfaces';
+import { SplitOrientation, SplitUnit } from './si-split.interfaces';
 
 interface Gutter {
   before: SiSplitPartComponent;
@@ -40,6 +38,7 @@ interface Gutter {
 interface SplitPartState {
   size: number;
   initialSize: number;
+  initialUnit: SplitUnit;
   expanded: boolean;
 }
 
@@ -70,14 +69,6 @@ export class SiSplitComponent {
   readonly orientation = input<SplitOrientation>('horizontal');
 
   /**
-   * Initial relative sizes of the split parts as fractional values.
-   *
-   * @defaultValue []
-   */
-  // eslint-disable-next-line @angular-eslint/prefer-signal-model
-  readonly sizes = input<number[]>([]);
-
-  /**
    * An optional stateId to uniquely identify a component instance.
    * Required for persistence of ui state.
    */
@@ -99,12 +90,12 @@ export class SiSplitComponent {
           ? part.collapseToMinSize()
             ? `${part.minSize()}px`
             : 'min-content'
-          : part.actualSize()
-            ? part.scale() === 'auto'
-              ? `minmax(${part.minSize()}px, ${part.actualSize()}fr)`
-              : `minmax(${part.minSize()}px, ${part.actualSize()}px)`
+          : part.unit() === 'px'
+            ? `minmax(${part.minSize()}px, ${part.expandedSize() ?? part.size()}px)`
             : `minmax(${part.minSize()}px, ${
-                part.fractionalSize()! * this.fractionalSizeToExpandedSizeFactor()
+                part.expandedSize() === undefined
+                  ? part.fractionalSize()! * this.fractionalSizeToExpandedSizeFactor()
+                  : part.fractionalSize()!
               }fr)`
       )
       .join(' min-content ');
@@ -139,29 +130,22 @@ export class SiSplitComponent {
   private readonly document = inject(DOCUMENT);
   private readonly uiStateService = inject(SI_UI_STATE_SERVICE, { optional: true });
   private readonly destroyRef = inject(DestroyRef);
-  // New parts won't be measured, so we need this to scale up their fractional size to the expanded size.
-  // Using 10, as the sum of all fractional sizes is 1, so we need to scale them up as fr-values should be >= 1.
-  private readonly fractionalSizeToExpandedSizeFactor = signal(10);
+  // Existing fr parts are measured in pixels after layout or dragging, so their fr weights become
+  // pixel-derived. A newly added fr part has not been measured yet and still has its configured
+  // weight. This factor converts that configured weight into the same scale until it is measured.
+  // It is the ratio of measured expanded sizes to configured weights of visible measured fr parts.
+  private readonly fractionalSizeToExpandedSizeFactor = computed(() => {
+    const measuredParts = this.parts().filter(
+      part => !part.collapsedState() && part.unit() === 'fr' && part.expandedSize() !== undefined
+    );
+    const configuredSizeSum = measuredParts.reduce((sum, part) => sum + part.size(), 0);
+    const expandedSizeSum = measuredParts.reduce((sum, part) => sum + part.expandedSize()!, 0);
+
+    return configuredSizeSum ? expandedSizeSum / configuredSizeSum : 1;
+  });
   private readonly initialized = signal(false);
 
   constructor() {
-    effect(() => {
-      const sizes = this.sizes();
-      untracked(() => {
-        if (!this.initialized()) {
-          return;
-        }
-        sizes.forEach((size, index) => {
-          const part = this.parts()[index];
-          if (part) {
-            part.fractionalSize.set(size);
-            part.expandedSize.set(undefined);
-          }
-        });
-        this.alignRelativeSizes();
-      });
-    });
-
     toObservable(this.parts)
       .pipe(observeOn(asapScheduler), takeUntilDestroyed())
       .subscribe(() => this.setupParts());
@@ -177,7 +161,6 @@ export class SiSplitComponent {
       component.index = index;
       component.after.set(parts[index + 1]);
       component.before.set(parts[index - 1]);
-      component.fractionalSize.set(this.sizes()[index]);
       component.saveUIState = () => this.saveUIState();
 
       if (component.after()) {
@@ -193,70 +176,17 @@ export class SiSplitComponent {
     }
     this.gutters.set(gutters);
 
-    this.alignRelativeSizes();
-    this.updateFractionalSizeToExpandSizeFactor();
     this.restoreFromUIState();
     setTimeout(() => this.refreshAllPartSizes());
   }
 
-  private alignRelativeSizes(): void {
-    const parts = this.parts();
-    const requestedNoSize = parts.filter(part => !part.size() && !part.fractionalSize());
-    const requestedRelSize = parts.filter(part => part.fractionalSize() && !part.size());
-
-    if (requestedRelSize.length) {
-      const totalRequestedRelSize = requestedRelSize.reduce((a, b) => a + b.fractionalSize()!, 0);
-      const averageRelSize = totalRequestedRelSize / requestedRelSize.length;
-      const totalAssignedRelSize = totalRequestedRelSize + requestedNoSize.length * averageRelSize;
-      requestedNoSize.forEach(part =>
-        part.fractionalSize.set(averageRelSize / totalAssignedRelSize)
-      );
-      requestedRelSize.forEach(part =>
-        part.fractionalSize.set(part.fractionalSize()! / totalAssignedRelSize)
-      );
-    } else {
-      requestedNoSize.forEach(part => part.fractionalSize.set(1 / requestedNoSize.length));
-    }
-  }
-
-  private updateFractionalSizeToExpandSizeFactor(): void {
-    let previousScalableFractionalSum = 0;
-    let previousScalableExpandedSizeSum = 0;
-
-    for (const component of this.parts()) {
-      if (component.scale() === 'auto' && component.expandedSize() !== undefined) {
-        previousScalableExpandedSizeSum += component.expandedSize()!;
-        previousScalableFractionalSum += component.fractionalSize()!;
-      }
-    }
-
-    this.fractionalSizeToExpandedSizeFactor.set(
-      previousScalableFractionalSum
-        ? previousScalableExpandedSizeSum / previousScalableFractionalSum
-        : 10
-    );
-  }
-
   private refreshAllPartSizes(): void {
-    const parts = this.parts();
-    const refParts = parts.filter(
-      part =>
-        !part.collapsedState() &&
-        part.scale() === 'auto' &&
-        (part.expandedSize() || part.fractionalSize())
-    );
-    const beforeFrSum = refParts.reduce((a, b) => a + (b.expandedSize() ?? b.fractionalSize()!), 0);
-    parts.forEach(part => part.refreshSizePx(this.orientation()));
-    const afterFrSum = refParts.reduce((a, b) => a + b.expandedSize()!, 0);
-    const beforeToAfterFactor = beforeFrSum > 0 ? afterFrSum / beforeFrSum : 1;
-    parts
-      .filter(
-        part =>
-          part.collapsedState() && (part.scale() === 'auto' || part.expandedSize() === undefined)
-      )
-      .forEach(part =>
-        part.expandedSize.update(prev => (prev ?? part.fractionalSize()!) * beforeToAfterFactor)
-      );
+    this.parts().forEach(part => {
+      part.refreshSizePx(this.orientation());
+      if (!part.collapsedState() && part.unit() === 'fr') {
+        part.fractionalSize.set(part.expandedSize()!);
+      }
+    });
   }
 
   protected resizeStart(gutter: Gutter, event: Event): void {
@@ -304,6 +234,12 @@ export class SiSplitComponent {
             appliedDelta += delta;
             gutter.before.expandedSize.set(beforeSize);
             afterPart.expandedSize.set(afterSize);
+            if (gutter.before.unit() === 'fr') {
+              gutter.before.fractionalSize.set(beforeSize);
+            }
+            if (afterPart.unit() === 'fr') {
+              afterPart.fractionalSize.set(afterSize);
+            }
             if (this.orientation() === 'vertical') {
               this.elementRef.nativeElement.style.setProperty(
                 'grid-template-rows',
@@ -348,14 +284,15 @@ export class SiSplitComponent {
       return;
     }
 
-    const containerSize = this.measureContainerSize();
     const state = this.parts().reduce(
       (partState, part) => {
         const partStateId = part.stateId();
         if (partStateId) {
+          const unit = part.unit();
           partState[partStateId] = {
-            size: ((part.expandedSize() ?? 0) * 100) / containerSize,
-            initialSize: this.sizes()[part.index],
+            size: unit === 'px' ? part.expandedSize()! : part.fractionalSize()!,
+            initialSize: part.size(),
+            initialUnit: unit,
             expanded: !part.collapsedState()
           };
         }
@@ -381,11 +318,19 @@ export class SiSplitComponent {
       this.parts()
         .filter(part => part.stateId())
         .map(part => ({ part, state: uiState[part.stateId()!] }))
-        .filter(({ part, state }) => this.sizes()[part.index] === state?.initialSize)
+        .filter(
+          (item): item is { part: SiSplitPartComponent; state: SplitPartState } =>
+            !!item.state &&
+            item.state.initialSize === item.part.size() &&
+            item.state.initialUnit === item.part.unit()
+        )
         .forEach(({ part, state }) => {
-          part.expandedSize.set(undefined);
-          part.fractionalSize.set(state?.size);
-          part.collapsedState.set(!(state?.expanded ?? true));
+          if (part.unit() === 'px') {
+            part.expandedSize.set(state.size);
+          } else {
+            part.fractionalSize.set(state.size);
+          }
+          part.collapsedState.set(!state.expanded);
         });
       setTimeout(() => this.refreshAllPartSizes());
     });

--- a/projects/element-ng/split/si-split.interfaces.ts
+++ b/projects/element-ng/split/si-split.interfaces.ts
@@ -5,6 +5,7 @@
 /** */
 type CollapseTo = 'start' | 'end';
 type SplitOrientation = 'horizontal' | 'vertical';
+type SplitUnit = 'px' | 'fr';
 
 type Scale = 'none' | 'auto';
 
@@ -19,4 +20,4 @@ interface PartState {
   size?: number;
 }
 
-export type { Action, CollapseTo, PartState, Scale, SplitOrientation };
+export type { Action, CollapseTo, PartState, Scale, SplitOrientation, SplitUnit };

--- a/src/app/examples/si-split/si-split-auto.html
+++ b/src/app/examples/si-split/si-split-auto.html
@@ -4,25 +4,39 @@
       Toggle details
     </button>
   </div>
-  <si-split class="si-layout-fixed-height" [orientation]="orientation" [sizes]="[20, 60, 20]">
+  <si-split class="si-layout-fixed-height" [orientation]="orientation">
     <si-split-part
       heading="Filters"
       collapseDirection="start"
       class="bg-base-1"
+      size="20"
+      unit="fr"
       [actions]="[{ iconClass: 'element-edit', click: logEvent, tooltip: 'edit' }]"
       [minSize]="100"
     >
       <p class="p-4 text-secondary">Split Part #1</p>
     </si-split-part>
 
-    <si-split-part heading="Employees" collapseDirection="start" class="bg-base-1">
+    <si-split-part
+      heading="Employees"
+      collapseDirection="start"
+      class="bg-base-1"
+      size="60"
+      unit="fr"
+    >
       <div class="si-layout-fixed-height justify-content-center bg-secondary">
         <p class="text-center text-inverse">Split Part with resizable content!</p>
       </div>
     </si-split-part>
 
     @if (showDetails) {
-      <si-split-part heading="Details" collapseDirection="end" class="bg-base-1">
+      <si-split-part
+        heading="Details"
+        collapseDirection="end"
+        class="bg-base-1"
+        size="20"
+        unit="fr"
+      >
         <p class="p-4 text-secondary">Split Part #3</p>
       </si-split-part>
     }

--- a/src/app/examples/si-split/si-split-hide-collapse.html
+++ b/src/app/examples/si-split/si-split-hide-collapse.html
@@ -1,15 +1,23 @@
-<si-split orientation="horizontal" style="height: 300px" [sizes]="[20, 60]">
+<si-split orientation="horizontal" style="height: 300px">
   <si-split-part
     heading="Filters"
     collapseDirection="start"
     class="bg-base-1"
+    size="20"
+    unit="fr"
     [actions]="[{ iconClass: 'element-edit', click: logEvent, tooltip: 'edit' }]"
     [minSize]="150"
   >
     <p class="p-4 text-secondary">Split Part #1</p>
   </si-split-part>
 
-  <si-split-part heading="Details" class="bg-base-1" [showCollapseButton]="false">
+  <si-split-part
+    heading="Details"
+    class="bg-base-1"
+    size="60"
+    unit="fr"
+    [showCollapseButton]="false"
+  >
     <p class="p-4 text-secondary">Split Part #2</p>
   </si-split-part>
 </si-split>

--- a/src/app/examples/si-split/si-split-hide-header.html
+++ b/src/app/examples/si-split/si-split-hide-header.html
@@ -1,8 +1,10 @@
-<si-split orientation="horizontal" style="height: 500px" [sizes]="[30, 70]">
+<si-split orientation="horizontal" style="height: 500px">
   <si-split-part
     heading="Filters"
     collapseDirection="start"
     class="bg-base-1"
+    size="30"
+    unit="fr"
     [actions]="[{ iconClass: 'element-edit', click: logEvent, tooltip: 'edit' }]"
     [minSize]="150"
   >
@@ -11,14 +13,18 @@
 
   <si-split-part
     heading="Details"
+    size="70"
+    unit="fr"
     [showCollapseButton]="false"
     [actions]="[{ iconClass: 'element-edit', click: logEvent, tooltip: 'edit' }]"
   >
-    <si-split orientation="vertical" [sizes]="[60, 40]">
+    <si-split orientation="vertical">
       <si-split-part
         heading="Upper"
         collapseDirection="start"
         class="bg-base-1"
+        size="60"
+        unit="fr"
         [showHeader]="false"
       >
         <p class="p-4 text-secondary">Split Part #2</p>
@@ -27,6 +33,8 @@
         heading="Lower"
         collapseDirection="start"
         class="bg-base-1"
+        size="40"
+        unit="fr"
         [showHeader]="false"
       >
         <p class="p-4 text-secondary">Split Part #3</p>

--- a/src/app/examples/si-split/si-split-icons.html
+++ b/src/app/examples/si-split/si-split-icons.html
@@ -1,9 +1,11 @@
-<si-split orientation="horizontal" style="height: 300px" [sizes]="[20, 60, 20]">
+<si-split orientation="horizontal" style="height: 300px">
   <si-split-part
     heading="Filters"
     collapseDirection="start"
     class="bg-base-1"
     collapseIconClass="element-login"
+    size="20"
+    unit="fr"
     [actions]="[{ iconClass: 'element-edit', click: logEvent, tooltip: 'edit' }]"
     [minSize]="150"
   >
@@ -15,6 +17,8 @@
     collapseDirection="start"
     class="bg-base-1"
     collapseIconClass="element-fan"
+    size="60"
+    unit="fr"
   >
     <p class="p-4 text-secondary">Split Part #2</p>
   </si-split-part>
@@ -24,6 +28,8 @@
     collapseDirection="end"
     class="bg-base-1"
     collapseIconClass="element-air"
+    size="20"
+    unit="fr"
   >
     <p class="p-4 text-secondary">Split Part #3</p>
   </si-split-part>

--- a/src/app/examples/si-split/si-split-mixed.html
+++ b/src/app/examples/si-split/si-split-mixed.html
@@ -1,15 +1,12 @@
-<si-split
-  orientation="horizontal"
-  stateId="split-mixed"
-  style="height: 300px"
-  [sizes]="[20, 60, 20]"
->
+<si-split orientation="horizontal" stateId="split-mixed" style="height: 300px">
   <si-split-part
     heading="Filters"
     stateId="filters"
     collapseDirection="start"
     scale="none"
     class="bg-base-1"
+    size="20"
+    unit="fr"
     [actions]="[
       { iconClass: 'element-edit', click: logEvent, tooltip: 'edit' },
       { iconClass: 'element-delete', click: logEvent, tooltip: 'delete' }
@@ -24,19 +21,30 @@
     stateId="employees"
     scale="auto"
     class="bg-base-1"
+    size="60"
+    unit="fr"
     [showCollapseButton]="false"
   >
-    <si-split orientation="vertical" stateId="vertical-split" [sizes]="[40, 60]">
+    <si-split orientation="vertical" stateId="vertical-split">
       <si-split-part
         scale="none"
         stateId="middle-top"
         class="bg-base-1"
+        size="40"
+        unit="fr"
         [showHeader]="false"
         (stateChange)="logEvent(format('middle', $event))"
       >
         <p class="p-4 text-secondary">Split Part #2.1</p>
       </si-split-part>
-      <si-split-part scale="auto" stateId="middle-bottom" class="bg-base-1" [showHeader]="false">
+      <si-split-part
+        scale="auto"
+        stateId="middle-bottom"
+        class="bg-base-1"
+        size="60"
+        unit="fr"
+        [showHeader]="false"
+      >
         <p class="p-4 text-secondary">Split Part #2.2</p>
       </si-split-part>
     </si-split>
@@ -48,6 +56,8 @@
     collapseDirection="end"
     scale="none"
     class="bg-base-1"
+    size="20"
+    unit="fr"
     (stateChange)="logEvent(format('right', $event))"
   >
     <p class="p-4 text-secondary">Split Part #3</p>

--- a/src/app/examples/si-split/si-split-nested.html
+++ b/src/app/examples/si-split/si-split-nested.html
@@ -1,8 +1,10 @@
-<si-split orientation="horizontal" style="height: 500px" [sizes]="[30, 70]">
+<si-split orientation="horizontal" style="height: 500px">
   <si-split-part
     heading="Outer Left"
     collapseDirection="start"
     class="bg-base-1"
+    size="30"
+    unit="fr"
     [actions]="[
       { iconClass: 'element-edit', click: logEvent, tooltip: 'edit' },
       { iconClass: 'element-delete', click: logEvent, tooltip: 'delete' }
@@ -12,17 +14,31 @@
     <p class="p-4 text-secondary">Split Part #1</p>
   </si-split-part>
 
-  <si-split-part heading="Outer Right" collapseDirection="end" class="bg-base-1">
-    <si-split orientation="vertical" [sizes]="[60, 40]">
+  <si-split-part
+    heading="Outer Right"
+    collapseDirection="end"
+    class="bg-base-1"
+    size="70"
+    unit="fr"
+  >
+    <si-split orientation="vertical">
       <si-split-part
         heading="Inner Top"
         collapseDirection="start"
         class="bg-base-1"
+        size="60"
+        unit="fr"
         [actions]="[{ iconClass: 'element-edit', click: logEvent, tooltip: 'Edit' }]"
       >
         <p class="p-4 text-secondary">Split Part #2</p>
       </si-split-part>
-      <si-split-part heading="Inner Bottom" collapseDirection="end" class="bg-base-1">
+      <si-split-part
+        heading="Inner Bottom"
+        collapseDirection="end"
+        class="bg-base-1"
+        size="40"
+        unit="fr"
+      >
         <p class="p-4 text-secondary">Split Part #3</p>
       </si-split-part>
     </si-split>

--- a/src/app/examples/si-split/si-split-vertical.html
+++ b/src/app/examples/si-split/si-split-vertical.html
@@ -1,19 +1,27 @@
-<si-split orientation="vertical" style="height: 500px" [sizes]="[20, 60, 20]">
+<si-split orientation="vertical" style="height: 500px">
   <si-split-part
     heading="Filters"
     collapseDirection="start"
     class="bg-base-1"
+    size="20"
+    unit="fr"
     [actions]="[{ iconClass: 'element-edit', click: logEvent, tooltip: 'edit' }]"
     [minSize]="250"
   >
     <p class="p-4 text-secondary">Split Part #1</p>
   </si-split-part>
 
-  <si-split-part heading="Employees" collapseDirection="start" class="bg-base-1">
+  <si-split-part
+    heading="Employees"
+    collapseDirection="start"
+    class="bg-base-1"
+    size="60"
+    unit="fr"
+  >
     <p class="p-4 text-secondary">Split Part #2</p>
   </si-split-part>
 
-  <si-split-part heading="Details" collapseDirection="end" class="bg-base-1">
+  <si-split-part heading="Details" collapseDirection="end" class="bg-base-1" size="20" unit="fr">
     <p class="p-4 text-secondary">Split Part #3</p>
   </si-split-part>
 </si-split>


### PR DESCRIPTION
BREAKING CHANGE: The relative sizes of split parts are now configured on
each `si-split-part` via the required `size` and `unit`
input (`'px' | 'fr'`), instead of the `sizes` array on
`si-split`.

The `sizes` input on `SiSplitComponent` has been removed and
`SiSplitPartComponent.size` is now required.
The `unit` input on `SiSplitPartComponent` is now required.

- Remove `SiSplitComponent.sizes` input.
- Add `SiSplitPartComponent.unit` input (`'px' | 'fr'`).
- Make `SiSplitPartComponent.size` required.

Migration: move the relative sizes from `[sizes]` on `si-split` onto the
`size`/`unit` inputs of each `si-split-part`.

Before:

```html
<si-split [sizes]="[20, 60, 20]">
  <si-split-part>Left</si-split-part>
  <si-split-part>Center</si-split-part>
  <si-split-part>Right</si-split-part>
</si-split>
```
After:
```html
<si-split>
  <si-split-part size="20" unit="fr">Left</si-split-part>
  <si-split-part size="60" unit="fr">Center</si-split-part>
  <si-split-part size="20" unit="fr">Right</si-split-part>
</si-split>
```
Fixed pixel sizes are now expressed directly on the part:

```html
<si-split>
  <si-split-part size="200" unit="px">Fixed 200px</si-split-part>
  <si-split-part size="1" unit="fr">Remaining space</si-split-part>
</si-split>
```

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2323/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2323/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2323/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2323/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2323/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2323/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2323/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2323/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2323/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2323/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->










