### PR TITLE
refactor(maps): remove deprecated constant

### DIFF
--- a/projects/maps-ng/src/components/si-map/models/constants.ts
+++ b/projects/maps-ng/src/components/si-map/models/constants.ts
@@ -17,8 +17,6 @@ export const DEFAULT_FEATURE_CLICK_ZOOM = 15;
 export const DEFAULT_CLUSTER_CLICK_ZOOM = 15;
 export const DEFAULT_GLOBAL_ZOOM = 5;
 export const DEFAULT_CLUSTER_DISTANCE = 40;
-/** @deprecated will be removed in favour of individual inputs. */
-export const DEFAULT_FIT_PADDING = [20, 20, 20, 20];
 
 /** Updates the amount of buildings to be shown in a cluster tooltip after hovering over it */
 export const TOOLTIP_FEATURES_TO_DISPLAY = 4;


### PR DESCRIPTION
BREAKING CHANGE: Removed constant `DEFAULT_FIT_PADDING` without any replacement.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2326/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2326/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2326/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2326/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2326/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2326/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2326/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2326/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2326/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2326/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
