### PR TITLE
refactor(dashboards-ng): remove unused custom attribute

### DIFF
--- a/playwright/e2e/dashboards-demo/dashboard.spec.ts
+++ b/playwright/e2e/dashboards-demo/dashboard.spec.ts
@@ -224,13 +224,13 @@ test.describe('dashboard', () => {
     await si.visitExample(example, undefined);
     await expect(page.getByRole('heading', { name: 'Sample Dashboard' })).toBeVisible();
 
-    // Record original bounding boxes of all widgets keyed by item-id
+    // Record original bounding boxes of all widgets keyed by gs-id
     const widgets = page.locator('si-widget-host');
     const count = await widgets.count();
     const originalBoxes: Record<string, { x: number; y: number }> = {};
     for (let i = 0; i < count; i++) {
       const widget = widgets.nth(i);
-      const itemId = await widget.getAttribute('item-id');
+      const itemId = await widget.getAttribute('gs-id');
       expect(itemId).toBeTruthy();
       const box = await widget.boundingBox();
       expect(box).toBeTruthy();
@@ -278,7 +278,7 @@ test.describe('dashboard', () => {
 
     // Verify all widgets returned to their original positions
     for (const [itemId, expectedBox] of Object.entries(originalBoxes)) {
-      await expect(page.locator(`si-widget-host[item-id="${itemId}"]`)).toHaveBoundingBox(
+      await expect(page.locator(`si-widget-host[gs-id="${itemId}"]`)).toHaveBoundingBox(
         expectedBox
       );
     }

--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.html
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.html
@@ -7,7 +7,6 @@
     @for (item of widgetConfigs(); track item.id) {
       <si-widget-host
         [grid]="grid"
-        [attr.item-id]="item.id"
         [editable]="editable()"
         [widgetConfig]="item"
         [componentFactory]="widgetCatalogMap().get(item.widgetId)?.componentFactory"


### PR DESCRIPTION
Previously we used this attribute for querying widget but now it is no longer needed.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2327/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2327/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2327/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2327/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2327/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2327/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2327/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2327/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2327/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2327/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

