### PR TITLE
refactor(maps): remove deprecated input

### DIFF
--- a/projects/maps-ng/src/components/si-map/si-map.component.html
+++ b/projects/maps-ng/src/components/si-map/si-map.component.html
@@ -1,5 +1,5 @@
 <div #map class="map"></div>
 <ng-content select="si-map-tooltip">
-  <si-map-tooltip [moreText]="moreText()" />
+  <si-map-tooltip />
 </ng-content>
 <si-map-popover #popover />

--- a/projects/maps-ng/src/components/si-map/si-map.component.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.ts
@@ -255,19 +255,6 @@ export class SiMapComponent implements AfterViewInit, OnChanges, OnDestroy, Afte
    */
   readonly fitGeoJsonPadding = input<number[]>([20, 20, 20, 20]);
   /**
-   * Cutoff text for tooltips, when cluster combines more than 4 features
-   *
-   * @deprecated Use `SiMapTooltipComponent` instead to set the `moreText` input e.g. `<si-map ...><si-map-tooltip [moreText]="'KEY_MORE'" /></si-map>`.
-   *
-   * @defaultValue
-   * ```
-   * t(() => $localize`:@@SI_MAPS.TOOLTIP_MORE_TEXT:and {{length}} more...`)
-   * ```
-   */
-  readonly moreText = input(
-    t(() => $localize`:@@SI_MAPS.TOOLTIP_MORE_TEXT:and {{length}} more...`)
-  );
-  /**
    * Show multiple worlds, including points that cross the 180th meridian.
    *
    * @defaultValue true


### PR DESCRIPTION
BREAKING CHANGE: Removed input `SiMapComponent.moreText`. Use `SiMapTooltipComponent.moreText` instead.

Example:
```html
<si-map ...><si-map-tooltip [moreText]="'KEY_MORE'" /></si-map>
```

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2329/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2329/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2329/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2329/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2329/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2329/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2329/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2329/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2329/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2329/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
