### PR TITLE
refactor(element-theme): remove deprecated typography styles

### DIFF
--- a/projects/element-ng/chat-messages/si-attachment-list.component.html
+++ b/projects/element-ng/chat-messages/si-attachment-list.component.html
@@ -17,7 +17,7 @@
           />
           <div class="attachment-info flex-grow-1 min-width-0">
             <span
-              class="attachment-name me-4 text-truncate si-body-2 d-block"
+              class="attachment-name me-4 text-truncate si-body d-block"
               [title]="attachment.name"
             >
               {{ attachment.name }}
@@ -32,7 +32,7 @@
           />
           <div class="attachment-info flex-grow-1 min-width-0">
             <span
-              class="attachment-name me-4 text-truncate si-body-2 d-block"
+              class="attachment-name me-4 text-truncate si-body d-block"
               [title]="attachment.name"
             >
               {{ attachment.name }}

--- a/projects/element-ng/chat-messages/si-chat-input.component.html
+++ b/projects/element-ng/chat-messages/si-chat-input.component.html
@@ -15,7 +15,7 @@
     />
   }
 
-  <div class="si-body-2">
+  <div class="si-body">
     <label class="form-label d-none" [for]="id">{{ label() | translate }}</label>
     <textarea
       #textInput

--- a/projects/element-ng/chat-messages/si-chat-message.component.html
+++ b/projects/element-ng/chat-messages/si-chat-message.component.html
@@ -1,5 +1,5 @@
 <!--- Flex-row if alignment start, flex-row-reverse if alignment end, flex-column if mobile -->
-<div class="d-flex si-body-2 chat-message-container" [class.start]="alignment() === 'start'">
+<div class="d-flex si-body chat-message-container" [class.start]="alignment() === 'start'">
   <div class="avatar-wrapper flex-shrink-0" [class.end]="alignment() === 'end'">
     <ng-content select="si-icon,si-avatar,img" />
   </div>

--- a/projects/element-theme/src/styles/bootstrap/_type.scss
+++ b/projects/element-theme/src/styles/bootstrap/_type.scss
@@ -112,9 +112,7 @@ h1,
   );
 }
 
-.si-h1-bold,
-// @deprecated Will be removed in a future major version, use `.si-h1-bold` instead.
-.si-h1-black {
+.si-h1-bold {
   @include typography.si-font(
     typography.$si-font-size-h1-bold,
     typography.$si-line-height-h1-bold,
@@ -142,9 +140,7 @@ h3,
   );
 }
 
-.si-h4-bold,
-// @deprecated Will be removed in a future major version, use `.si-h4-bold` instead.
-.si-title-1-bold {
+.si-h4-bold {
   @include typography.si-font(
     typography.$si-font-size-h4-bold,
     typography.$si-line-height-h4-bold,
@@ -154,9 +150,7 @@ h3,
 
 h4,
 .h4,
-.si-h4,
-// @deprecated Will be removed in a future major version, use `.si-h4` instead.
-.si-title-1 {
+.si-h4 {
   @include typography.si-font(
     typography.$si-font-size-h4,
     typography.$si-line-height-h4,
@@ -164,9 +158,7 @@ h4,
   );
 }
 
-.si-h5-bold,
-// @deprecated Will be removed in a future major version, use `.si-h5-bold` instead.
-.si-title-2-bold {
+.si-h5-bold {
   @include typography.si-font(
     typography.$si-font-size-h5-bold,
     typography.$si-line-height-h5-bold,
@@ -178,9 +170,7 @@ h5,
 h6,
 .h5,
 .h6,
-.si-h5,
-// @deprecated Will be removed in a future major version, use `.si-h5` instead.
-.si-title-2 {
+.si-h5 {
   @include typography.si-font(
     typography.$si-font-size-h5,
     typography.$si-line-height-h5,
@@ -188,9 +178,7 @@ h6,
   );
 }
 
-.si-body-lg,
-// @deprecated Will be removed in a future major version, use `.si-body-lg` instead.
-.si-body-1 {
+.si-body-lg {
   @include typography.si-font(
     typography.$si-font-size-body-lg,
     typography.$si-line-height-body-lg,
@@ -198,9 +186,7 @@ h6,
   );
 }
 
-.si-body,
-// @deprecated Will be removed in a future major version, use `.si-body` instead.
-.si-body-2 {
+.si-body {
   @include typography.si-font(
     typography.$si-font-size-body,
     typography.$si-line-height-body,
@@ -217,9 +203,7 @@ h6,
 }
 
 .si-display-xl,
-.display-1,
-// @deprecated Will be removed in a future major version, use `.si-display-xl` instead.
-.si-display-1 {
+.display-1 {
   @include typography.si-font(
     typography.$si-font-size-display-xl,
     typography.$si-line-height-display-xl,
@@ -228,9 +212,7 @@ h6,
 }
 
 .si-display-lg,
-.display-2,
-// @deprecated Will be removed in a future major version, use `.si-display-lg` instead.
-.si-display-2 {
+.display-2 {
   @include typography.si-font(
     typography.$si-font-size-display-lg,
     typography.$si-line-height-display-lg,
@@ -239,9 +221,7 @@ h6,
 }
 
 .si-display-bold,
-.display-3,
-// @deprecated Will be removed in a future major version, use `.si-display-bold` instead.
-.si-display-3 {
+.display-3 {
   @include typography.si-font(
     typography.$si-font-size-display-bold,
     typography.$si-line-height-display-bold,
@@ -250,9 +230,7 @@ h6,
 }
 
 .si-display,
-.display-4,
-// @deprecated Will be removed in a future major version, use `.si-display` instead.
-.si-display-4 {
+.display-4 {
   @include typography.si-font(
     typography.$si-font-size-display,
     typography.$si-line-height-display,

--- a/src/app/examples/si-notification-item/si-notification-item-popover.html
+++ b/src/app/examples/si-notification-item/si-notification-item-popover.html
@@ -69,7 +69,7 @@
     <si-header-dropdown>
       <div class="d-flex flex-column notification-dropdown">
         <div class="dropdown-header d-flex justify-content-between align-items-center px-6 py-4">
-          <span class="si-title-2">Notifications</span>
+          <span class="si-h5">Notifications</span>
           <button type="button" class="btn btn-tertiary" (click)="logEvent('Dismiss all')"
             >Dismiss all</button
           >
@@ -112,7 +112,7 @@
           </si-notification-item>
         </div>
         <div class="dropdown-divider"></div>
-        <a class="si-title-2 px-6 pt-4 pb-2" href="#">Show all</a>
+        <a class="si-h5 px-6 pt-4 pb-2" href="#">Show all</a>
       </div>
     </si-header-dropdown>
   </ng-template>
@@ -120,7 +120,7 @@
   <ng-template #account>
     <si-header-dropdown>
       <div class="mx-5">
-        <div class="si-title-2">John Doe</div>
+        <div class="si-h5">John Doe</div>
         <div>john.doe&#64;siemens.com</div>
         <div class="d-flex align-items-center text-secondary mt-2">
           Siemens AG

--- a/src/app/examples/si-notification-item/si-notification-item-side-panel.html
+++ b/src/app/examples/si-notification-item/si-notification-item-side-panel.html
@@ -68,7 +68,7 @@
   <ng-template #account>
     <si-header-dropdown>
       <div class="mx-5">
-        <div class="si-title-2">John Doe</div>
+        <div class="si-h5">John Doe</div>
         <div>john.doe&#64;siemens.com</div>
         <div class="d-flex align-items-center text-secondary mt-2">
           Siemens AG


### PR DESCRIPTION
BREAKING CHANGE: All `.si-*` typography utility classes were adapted to match the new typography system. Replace the following matches with their new counterparts:

- Instead of `.si-h1-black`, use `.si-h1-bold` instead.
- Instead of `.si-title-1-bold`, use `.si-h4-bold` instead.
- Instead of `.si-title-1`, use `.si-h4` instead.
- Instead of `.si-title-2-bold`, use `.si-h5-bold` instead.
- Instead of `.si-title-2`, use `.si-h5` instead.
- Instead of `.si-body-1`, use `.si-body-lg` instead.
- Instead of `.si-body-2`, use `.si-body` instead.
- Instead of `.si-display-1`, use `.si-display-xl` instead.
- Instead of `.si-display-2`, use `.si-display-lg` instead.
- Instead of `.si-display-3`, use `.si-display-bold` instead.
- Instead of `.si-display-4`, use `.si-display` instead.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2331/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2331/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2331/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2331/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2331/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2331/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2331/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2331/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2331/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2331/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


