### PR TITLE
chore(element-ng): remove explicit OnPush

### DIFF
--- a/projects/element-ng/about/si-about.component.ts
+++ b/projects/element-ng/about/si-about.component.ts
@@ -4,15 +4,7 @@
  */
 import { NgTemplateOutlet } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  input,
-  OnInit,
-  signal
-} from '@angular/core';
+import { Component, computed, inject, input, OnInit, signal } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { elementDocument } from '@siemens/element-icons';
 import { SiCollapsiblePanelComponent } from '@siemens/element-ng/accordion';
@@ -34,8 +26,7 @@ import { ApiInfo, LicenseInfo } from './si-about-data.model';
     SiTranslatePipe
   ],
   templateUrl: './si-about.component.html',
-  styleUrl: './si-about.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-about.component.scss'
 })
 export class SiAboutComponent implements OnInit {
   private http = inject(HttpClient);

--- a/projects/element-ng/accordion/si-accordion.component.spec.ts
+++ b/projects/element-ng/accordion/si-accordion.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiAccordionComponent } from './si-accordion.component';
@@ -16,8 +16,7 @@ import { SiCollapsiblePanelComponent } from './si-collapsible-panel.component';
       <si-collapsible-panel heading="two"><div>content</div></si-collapsible-panel>
       <si-collapsible-panel heading="three"><div>content</div></si-collapsible-panel>
     </si-accordion>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostComponent {
   readonly component = viewChild.required(SiAccordionComponent);

--- a/projects/element-ng/accordion/si-accordion.component.ts
+++ b/projects/element-ng/accordion/si-accordion.component.ts
@@ -5,7 +5,6 @@
 import {
   AfterContentInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChildren,
@@ -29,7 +28,6 @@ const PANEL_MIN_HEIGHT = 100;
   template: '<div><ng-content /></div>',
   styleUrl: './si-accordion.component.scss',
   providers: [SiAccordionService],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.full-height]': 'fullHeight()',
     '[class.hcollapsed]': 'collapsed()'

--- a/projects/element-ng/accordion/si-collapsible-panel.component.spec.ts
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -20,8 +20,7 @@ import { SiCollapsiblePanelComponent } from './index';
       >
       <div style="height: 100px;">This is the content</div>
     </si-collapsible-panel>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostComponent {
   heading!: string;

--- a/projects/element-ng/accordion/si-collapsible-panel.component.ts
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -33,7 +32,6 @@ let controlIdCounter = 1;
   imports: [SiIconComponent, SiTranslatePipe, SiTooltipDirective],
   templateUrl: './si-collapsible-panel.component.html',
   styleUrl: './si-collapsible-panel.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class]': 'colorVariant()',
     '[class.opened]': 'opened()',

--- a/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { elementCancel } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiLoadingButtonComponent } from '@siemens/element-ng/loading-spinner';
@@ -16,8 +16,7 @@ import { AlertDialogResult } from '../si-action-dialog.types';
 @Component({
   selector: 'si-alert-dialog',
   imports: [AsyncPipe, SiIconComponent, SiTranslatePipe, SiLoadingButtonComponent],
-  templateUrl: './si-alert-dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-alert-dialog.component.html'
 })
 export class SiAlertDialogComponent {
   readonly titleId = input<string>();

--- a/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiLoadingButtonComponent } from '@siemens/element-ng/loading-spinner';
 import { ModalRef } from '@siemens/element-ng/modal';
@@ -15,8 +15,7 @@ import { ConfirmationDialogResult } from '../si-action-dialog.types';
 @Component({
   selector: 'si-confirmation-dialog',
   imports: [AsyncPipe, SiIconComponent, SiTranslatePipe, SiLoadingButtonComponent],
-  templateUrl: './si-confirmation-dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-confirmation-dialog.component.html'
 })
 export class SiConfirmationDialogComponent {
   readonly titleId = input<string>();

--- a/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { elementCancel } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiLoadingButtonComponent } from '@siemens/element-ng/loading-spinner';
@@ -16,8 +16,7 @@ import { DeleteConfirmationDialogResult } from '../si-action-dialog.types';
 @Component({
   selector: 'si-delete-confirmation-dialog',
   imports: [AsyncPipe, SiIconComponent, SiTranslatePipe, SiLoadingButtonComponent],
-  templateUrl: './si-delete-confirmation-dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-delete-confirmation-dialog.component.html'
 })
 export class SiDeleteConfirmationDialogComponent {
   readonly titleId = input<string>();

--- a/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { AsyncPipe } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { booleanAttribute, Component, inject, input } from '@angular/core';
 import { elementCancel } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiLoadingButtonComponent } from '@siemens/element-ng/loading-spinner';
@@ -16,8 +16,7 @@ import { EditDiscardDialogResult } from '../si-action-dialog.types';
 @Component({
   selector: 'si-edit-discard-dialog',
   imports: [AsyncPipe, SiIconComponent, SiTranslatePipe, SiLoadingButtonComponent],
-  templateUrl: './si-edit-discard-dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-edit-discard-dialog.component.html'
 })
 export class SiEditDiscardDialogComponent {
   readonly titleId = input<string>();

--- a/projects/element-ng/application-header/launchpad/si-launchpad-app.component.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-app.component.ts
@@ -2,15 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  HostListener,
-  inject,
-  input,
-  model
-} from '@angular/core';
+import { booleanAttribute, Component, HostListener, inject, input, model } from '@angular/core';
 import { elementExport, elementFavorites, elementFavoritesFilled } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -23,7 +15,6 @@ import { SiApplicationHeaderComponent } from '../si-application-header.component
   imports: [SiIconComponent, SiTranslatePipe],
   templateUrl: './si-launchpad-app.component.html',
   styleUrl: './si-launchpad-app.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'focus-inside',
     '[class.active]': 'active()',

--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
@@ -3,15 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { A11yModule } from '@angular/cdk/a11y';
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  input,
-  output
-} from '@angular/core';
+import { booleanAttribute, Component, computed, inject, input, output } from '@angular/core';
 import { ActivatedRoute, RouterLink, RouterLinkActive } from '@angular/router';
 import { elementCancel, elementDown2 } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
@@ -39,8 +31,7 @@ export interface FavoriteChangeEvent {
     RouterLink
   ],
   templateUrl: './si-launchpad-factory.component.html',
-  styleUrl: './si-launchpad-factory.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-launchpad-factory.component.scss'
 })
 export class SiLaunchpadFactoryComponent {
   /**

--- a/projects/element-ng/application-header/si-account-details.component.ts
+++ b/projects/element-ng/application-header/si-account-details.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
@@ -25,8 +25,7 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
         </div>
       }
     </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 export class SiAccountDetailsComponent {
   /** The user's full name. */

--- a/projects/element-ng/application-header/si-application-header.component.spec.ts
+++ b/projects/element-ng/application-header/si-application-header.component.spec.ts
@@ -5,7 +5,7 @@
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, Injectable } from '@angular/core';
+import { Component, Injectable } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   SiHeaderDropdownComponent,
@@ -90,8 +90,7 @@ describe('SiApplicationHeaderComponent', () => {
             <si-header-dropdown-item>DItem 2</si-header-dropdown-item>
           </si-header-dropdown>
         </ng-template>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {}
 
@@ -211,8 +210,7 @@ describe('SiApplicationHeaderComponent', () => {
             </si-header-collapsible-actions>
           </si-header-actions>
         </si-application-header>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {
       bade1?: number | boolean;
@@ -289,8 +287,7 @@ describe('SiApplicationHeaderComponent', () => {
             <si-header-collapsible-actions />
           </si-header-actions>
         </si-application-header>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {}
 
@@ -349,8 +346,7 @@ describe('SiApplicationHeaderComponent', () => {
             </si-header-collapsible-actions>
           </si-header-actions>
         </si-application-header>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {}
 
@@ -400,8 +396,7 @@ describe('SiApplicationHeaderComponent', () => {
             </si-header-collapsible-actions>
           </si-header-actions>
         </si-application-header>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {}
 
@@ -439,8 +434,7 @@ describe('SiApplicationHeaderComponent', () => {
         <ng-template #launchpad>
           <si-launchpad-factory [apps]="[]" />
         </ng-template>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {}
 

--- a/projects/element-ng/application-header/si-application-header.component.ts
+++ b/projects/element-ng/application-header/si-application-header.component.ts
@@ -6,7 +6,6 @@ import { A11yModule, CdkTrapFocus } from '@angular/cdk/a11y';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   effect,
   ElementRef,
@@ -38,8 +37,7 @@ import { map, switchMap } from 'rxjs/operators';
   imports: [SiTranslatePipe, A11yModule, NgTemplateOutlet, SiIconComponent],
   templateUrl: './si-application-header.component.html',
   styleUrl: './si-application-header.component.scss',
-  providers: [{ provide: SI_HEADER_WITH_DROPDOWNS, useExisting: SiApplicationHeaderComponent }],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  providers: [{ provide: SI_HEADER_WITH_DROPDOWNS, useExisting: SiApplicationHeaderComponent }]
 })
 export class SiApplicationHeaderComponent implements HeaderWithDropdowns, OnDestroy {
   private static idCounter = 0;

--- a/projects/element-ng/application-header/si-header-account-item.component.ts
+++ b/projects/element-ng/application-header/si-header-account-item.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { SiAvatarComponent } from '@siemens/element-ng/avatar';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTooltipService } from '@siemens/element-ng/tooltip';
@@ -17,7 +17,6 @@ import { SiHeaderActionIconItemBase } from './si-header-action-item-icon-base.di
   templateUrl: './si-header-account-item.component.html',
   styleUrl: './si-header-account-item.component.scss',
   providers: [SiTooltipService],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'header-item focus-inside px-4 py-0',
     '[class.dropdown-toggle]': '!!dropdownTrigger'

--- a/projects/element-ng/application-header/si-header-action-item.component.ts
+++ b/projects/element-ng/application-header/si-header-action-item.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ElementRef, input, viewChild } from '@angular/core';
+import { Component, ElementRef, input, viewChild } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTooltipService } from '@siemens/element-ng/tooltip';
 
@@ -15,7 +15,6 @@ import { SiHeaderActionIconItemBase } from './si-header-action-item-icon-base.di
   imports: [SiIconComponent],
   templateUrl: './si-header-action-item.component.html',
   providers: [SiTooltipService],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'header-item focus-inside',
     '[class.dropdown-toggle]': '!!dropdownTrigger'

--- a/projects/element-ng/application-header/si-header-collapsible-actions.component.ts
+++ b/projects/element-ng/application-header/si-header-collapsible-actions.component.ts
@@ -3,16 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { A11yModule, CdkTrapFocus } from '@angular/cdk/a11y';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  inject,
-  input,
-  OnDestroy,
-  signal,
-  viewChild
-} from '@angular/core';
+import { Component, ElementRef, inject, input, OnDestroy, signal, viewChild } from '@angular/core';
 import { elementOptionsVertical } from '@siemens/element-icons';
 import { SI_HEADER_DROPDOWN_OPTIONS } from '@siemens/element-ng/header-dropdown';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
@@ -29,7 +20,6 @@ import { SiApplicationHeaderComponent } from './si-application-header.component'
   providers: [
     { provide: SI_HEADER_DROPDOWN_OPTIONS, useValue: { disableRootFocusTrapForInlineMode: true } }
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'd-contents' }
 })
 export class SiHeaderCollapsibleActionsComponent implements OnDestroy {

--- a/projects/element-ng/application-header/si-header-navigation-item.component.ts
+++ b/projects/element-ng/application-header/si-header-navigation-item.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { elementDown2 } from '@siemens/element-icons';
 import {
   SI_HEADER_DROPDOWN_OPTIONS,
@@ -26,7 +26,6 @@ import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
   providers: [
     { provide: SI_HEADER_DROPDOWN_OPTIONS, useValue: { disableRootFocusTrapForInlineMode: true } }
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'header-item focus-inside',
     '[class.dropdown-toggle]': '!!dropdownTrigger'

--- a/projects/element-ng/application-header/si-header-navigation.component.ts
+++ b/projects/element-ng/application-header/si-header-navigation.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject, OnDestroy } from '@angular/core';
+import { Component, inject, OnDestroy } from '@angular/core';
 import { elementThumbnails } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
@@ -13,7 +13,6 @@ import { SiApplicationHeaderComponent } from './si-application-header.component'
   selector: 'si-header-navigation',
   imports: [SiTranslatePipe, SiIconComponent],
   templateUrl: './si-header-navigation.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'header-navigation', role: 'navigation' }
 })
 export class SiHeaderNavigationComponent implements OnDestroy {

--- a/projects/element-ng/application-header/si-header-selection-item.component.ts
+++ b/projects/element-ng/application-header/si-header-selection-item.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 
 import { SiHeaderActionItemBase } from './si-header-action-item.base';
@@ -12,7 +12,6 @@ import { SiHeaderActionItemBase } from './si-header-action-item.base';
   selector: 'button[si-header-selection-item]',
   imports: [SiIconComponent],
   templateUrl: './si-header-selection-item.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'header-item header-selection-item focus-inside dropdown-toggle',
     '[class.show]': 'open()'

--- a/projects/element-ng/autocomplete/si-autocomplete.directive.spec.ts
+++ b/projects/element-ng/autocomplete/si-autocomplete.directive.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { DOWN_ARROW, ENTER, UP_ARROW } from '@angular/cdk/keycodes';
-import { ChangeDetectionStrategy, Component, ErrorHandler, signal } from '@angular/core';
+import { Component, ErrorHandler, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -29,8 +29,7 @@ import { SiAutocompleteDirective } from './si-autocomplete.directive';
         }
       </div>
     }
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostComponent {
   readonly showList = signal(false);

--- a/projects/element-ng/avatar/si-avatar.component.ts
+++ b/projects/element-ng/avatar/si-avatar.component.ts
@@ -2,15 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  effect,
-  inject,
-  input,
-  numberAttribute
-} from '@angular/core';
+import { Component, computed, effect, inject, input, numberAttribute } from '@angular/core';
 import { EntityStatusType } from '@siemens/element-ng/common';
 import { SiIconComponent, STATUS_ICON_CONFIG } from '@siemens/element-ng/icon';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -24,7 +16,6 @@ export type AvatarSize = 'tiny' | 'xsmall' | 'small' | 'regular' | 'large' | 'xl
   imports: [SiIconComponent],
   templateUrl: './si-avatar.component.html',
   styleUrl: './si-avatar.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class]': 'size()'
   },

--- a/projects/element-ng/badge/si-badge.component.ts
+++ b/projects/element-ng/badge/si-badge.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { type StatusType } from '@siemens/element-ng/common';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 
@@ -27,7 +27,6 @@ export type BadgeType =
     }
     <span class="text-truncate"><ng-content /></span>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     role: 'status',
     class: 'badge',

--- a/projects/element-ng/breadcrumb-router/si-breadcrumb-router.component.spec.ts
+++ b/projects/element-ng/breadcrumb-router/si-breadcrumb-router.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ElementRef, viewChild } from '@angular/core';
+import { Component, ElementRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router, RouterOutlet, Routes } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
@@ -22,14 +22,13 @@ import { SiBreadcrumbDefaultResolverService } from './si-breadcrumb-default-reso
   template: `
     <si-breadcrumb-router />
     <router-outlet />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class WrapperComponent {
   readonly breadcrumbResolver = viewChild.required(TestComponent, { read: ElementRef });
 }
 
-@Component({ template: '', changeDetection: ChangeDetectionStrategy.OnPush })
+@Component({ template: '' })
 class TestSubComponent {}
 
 describe('SiBreadcrumbRouterComponent', () => {

--- a/projects/element-ng/card/si-action-card.component.ts
+++ b/projects/element-ng/card/si-action-card.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, model } from '@angular/core';
+import { booleanAttribute, Component, input, model } from '@angular/core';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiCardBaseDirective } from './si-card-base.directive';
@@ -25,7 +25,6 @@ import { SiCardHeaderComponent } from './si-card-header.component';
   imports: [SiCardHeaderComponent, SiTranslatePipe],
   templateUrl: './si-action-card.component.html',
   styleUrl: './si-card.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'action-card',
     '[attr.aria-pressed]': 'selectable() ? (selected() ? "true" : "false") : undefined',

--- a/projects/element-ng/card/si-action-card.spec.ts
+++ b/projects/element-ng/card/si-action-card.spec.ts
@@ -5,7 +5,7 @@
 
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 
@@ -24,8 +24,7 @@ import { SiActionCardHarness } from './testing/si-action-card.harnes';
         >Action card</button
       >
     </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class WrapperComponent {
   heading = 'Test';

--- a/projects/element-ng/card/si-card-header.component.ts
+++ b/projects/element-ng/card/si-card-header.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
 import {
   ContentActionBarMainItem,
@@ -23,7 +23,6 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
   imports: [SiContentActionBarComponent, SiTranslatePipe],
   templateUrl: './si-card-header.component.html',
   styleUrl: './si-card-header.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'card-header d-flex justify-content-between'
   }

--- a/projects/element-ng/card/si-card.component.ts
+++ b/projects/element-ng/card/si-card.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
 import { ContentActionBarMainItem, ViewType } from '@siemens/element-ng/content-action-bar';
 import { MenuItem } from '@siemens/element-ng/menu';
@@ -15,8 +15,7 @@ import { SiCardHeaderComponent } from './si-card-header.component';
   selector: 'si-card',
   imports: [SiCardHeaderComponent, SiTranslatePipe],
   templateUrl: './si-card.component.html',
-  styleUrl: './si-card.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-card.component.scss'
 })
 export class SiCardComponent extends SiCardBaseDirective {
   /**

--- a/projects/element-ng/carousel/si-carousel.component.spec.ts
+++ b/projects/element-ng/carousel/si-carousel.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { page, userEvent } from '@vitest/browser/context';
 
@@ -26,8 +26,7 @@ import { SiCarouselComponent } from './si-carousel.component';
         <div siCarouselItem class="carousel-item">{{ item }}</div>
       }
     </si-carousel>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestCarouselComponent {
   readonly carousel = viewChild.required(SiCarouselComponent);

--- a/projects/element-ng/carousel/si-carousel.component.ts
+++ b/projects/element-ng/carousel/si-carousel.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -94,7 +93,6 @@ const SCROLL_STALL_THRESHOLD = 0.25;
   imports: [SiTranslatePipe, SiResizeObserverDirective, SiIconComponent],
   templateUrl: './si-carousel.component.html',
   styleUrl: './si-carousel.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[attr.role]': 'ariaRole()',
     '[attr.aria-roledescription]': 'translatedCarouselRoleDescription()',

--- a/projects/element-ng/chat-messages/si-ai-message.component.ts
+++ b/projects/element-ng/chat-messages/si-ai-message.component.ts
@@ -10,8 +10,7 @@ import {
   input,
   viewChild,
   ElementRef,
-  signal,
-  ChangeDetectionStrategy
+  signal
 } from '@angular/core';
 import { elementOptionsVertical } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
@@ -54,8 +53,7 @@ import { SiChatMessageComponent } from './si-chat-message.component';
     SiTranslatePipe
   ],
   templateUrl: './si-ai-message.component.html',
-  styleUrl: './si-ai-message.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-ai-message.component.scss'
 })
 export class SiAiMessageComponent {
   protected readonly formattedContent = viewChild<ElementRef<HTMLDivElement>>('formattedContent');

--- a/projects/element-ng/chat-messages/si-ai-welcome-screen.component.ts
+++ b/projects/element-ng/chat-messages/si-ai-welcome-screen.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input, model, output } from '@angular/core';
+import { Component, input, model, output } from '@angular/core';
 import { SiActionCardComponent } from '@siemens/element-ng/card';
 import { SiSummaryChipComponent } from '@siemens/element-ng/summary-chip';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -38,7 +38,6 @@ export interface PromptSuggestion {
   imports: [SiActionCardComponent, SiSummaryChipComponent],
   templateUrl: './si-ai-welcome-screen.component.html',
   styleUrl: './si-ai-welcome-screen.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'd-block'
   }

--- a/projects/element-ng/chat-messages/si-attachment-list.component.ts
+++ b/projects/element-ng/chat-messages/si-attachment-list.component.ts
@@ -2,15 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  inject,
-  input,
-  output,
-  TemplateRef
-} from '@angular/core';
+import { booleanAttribute, Component, inject, input, output, TemplateRef } from '@angular/core';
 import { elementStateClose, elementDocument } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiModalService } from '@siemens/element-ng/modal';
@@ -58,8 +50,7 @@ export interface Attachment {
   selector: 'si-attachment-list',
   imports: [SiIconComponent, SiTranslatePipe],
   templateUrl: './si-attachment-list.component.html',
-  styleUrl: './si-attachment-list.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-attachment-list.component.scss'
 })
 export class SiAttachmentListComponent {
   protected modalService = inject(SiModalService);

--- a/projects/element-ng/chat-messages/si-chat-container.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-chat-container.component.spec.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  DebugElement,
-  inputBinding,
-  signal,
-  WritableSignal
-} from '@angular/core';
+import { Component, DebugElement, inputBinding, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -21,15 +14,13 @@ import { SiChatContainerComponent } from './si-chat-container.component';
     <si-chat-container colorVariant="base-0" noAutoScroll="false">
       <div class="test-message">Test message</div>
     </si-chat-container>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostComponent {}
 
 @Component({
   imports: [SiChatContainerComponent],
-  template: `<si-chat-container noAutoScroll />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<si-chat-container noAutoScroll />`
 })
 class NoAutoScrollHostComponent {}
 

--- a/projects/element-ng/chat-messages/si-chat-container.component.ts
+++ b/projects/element-ng/chat-messages/si-chat-container.component.ts
@@ -12,8 +12,7 @@ import {
   OnDestroy,
   PLATFORM_ID,
   viewChild,
-  inject,
-  ChangeDetectionStrategy
+  inject
 } from '@angular/core';
 
 /**
@@ -40,7 +39,6 @@ import {
   selector: 'si-chat-container',
   templateUrl: './si-chat-container.component.html',
   styleUrl: './si-chat-container.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'd-flex si-layout-inner flex-grow-1 flex-column h-100 w-100',
     '[class]': 'colorVariant()'

--- a/projects/element-ng/chat-messages/si-chat-input.component.ts
+++ b/projects/element-ng/chat-messages/si-chat-input.component.ts
@@ -6,7 +6,6 @@ import { CdkMenuTrigger } from '@angular/cdk/menu';
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -90,8 +89,7 @@ export interface ChatInputAttachment extends Attachment {
     SiFileUploadDirective
   ],
   templateUrl: './si-chat-input.component.html',
-  styleUrl: './si-chat-input.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-chat-input.component.scss'
 })
 export class SiChatInputComponent implements AfterViewInit {
   private static idCounter = 0;

--- a/projects/element-ng/chat-messages/si-chat-message.component.ts
+++ b/projects/element-ng/chat-messages/si-chat-message.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { SiResponsiveContainerDirective } from '@siemens/element-ng/resize-observer';
 
 /**
@@ -40,7 +40,6 @@ import { SiResponsiveContainerDirective } from '@siemens/element-ng/resize-obser
   selector: 'si-chat-message',
   templateUrl: './si-chat-message.component.html',
   styleUrl: './si-chat-message.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'd-block'
   },

--- a/projects/element-ng/chat-messages/si-user-message.component.ts
+++ b/projects/element-ng/chat-messages/si-user-message.component.ts
@@ -3,16 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkMenuTrigger } from '@angular/cdk/menu';
-import {
-  Component,
-  effect,
-  input,
-  viewChild,
-  ElementRef,
-  computed,
-  signal,
-  ChangeDetectionStrategy
-} from '@angular/core';
+import { Component, effect, input, viewChild, ElementRef, computed, signal } from '@angular/core';
 import { elementOptionsVertical } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { MenuItem, SiMenuFactoryComponent } from '@siemens/element-ng/menu';
@@ -57,8 +48,7 @@ import { SiChatMessageComponent } from './si-chat-message.component';
     SiTranslatePipe
   ],
   templateUrl: './si-user-message.component.html',
-  styleUrl: './si-user-message.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-user-message.component.scss'
 })
 export class SiUserMessageComponent {
   protected readonly formattedContent = viewChild<ElementRef<HTMLDivElement>>('formattedContent');

--- a/projects/element-ng/circle-status/si-circle-status.component.ts
+++ b/projects/element-ng/circle-status/si-circle-status.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -26,8 +25,7 @@ import { Observable, Subscription } from 'rxjs';
   selector: 'si-circle-status',
   imports: [SiIconComponent, SiTranslatePipe],
   templateUrl: './si-circle-status.component.html',
-  styleUrl: './si-circle-status.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-circle-status.component.scss'
 })
 export class SiCircleStatusComponent implements OnChanges, OnDestroy {
   private readonly statusIcons = inject(STATUS_ICON_CONFIG);

--- a/projects/element-ng/color-picker/si-color-picker.component.spec.ts
+++ b/projects/element-ng/color-picker/si-color-picker.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ComponentRef, viewChild } from '@angular/core';
+import { Component, ComponentRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -10,8 +10,7 @@ import { SiColorPickerComponent as TestComponent } from './index';
 
 @Component({
   imports: [ReactiveFormsModule, TestComponent],
-  template: `<si-color-picker [formControl]="colorPickerControl" />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<si-color-picker [formControl]="colorPickerControl" />`
 })
 class FormHostComponent {
   readonly colorPickerComp = viewChild.required(TestComponent);

--- a/projects/element-ng/color-picker/si-color-picker.component.ts
+++ b/projects/element-ng/color-picker/si-color-picker.component.ts
@@ -5,7 +5,6 @@
 import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -54,8 +53,7 @@ const defaultDataColors: string[] = [
       useExisting: SiColorPickerComponent,
       multi: true
     }
-  ],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  ]
 })
 export class SiColorPickerComponent implements ControlValueAccessor {
   // eslint-disable-next-line defaultValue/tsdoc-defaultValue-annotation

--- a/projects/element-ng/column-selection-dialog/column-selection-editor/si-column-selection-editor.component.ts
+++ b/projects/element-ng/column-selection-dialog/column-selection-editor/si-column-selection-editor.component.ts
@@ -5,7 +5,6 @@
 import { CdkDragHandle } from '@angular/cdk/drag-drop';
 import { CdkOption } from '@angular/cdk/listbox';
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   HostListener,
@@ -28,7 +27,6 @@ import { Column } from '../si-column-selection-dialog.types';
       cursor: text;
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'd-block my-4 mx-1 rounded-2 elevation-1'
   }

--- a/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.ts
+++ b/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.ts
@@ -14,7 +14,6 @@ import { CdkListbox, CdkOption } from '@angular/cdk/listbox';
 import { CdkScrollableModule } from '@angular/cdk/scrolling';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   inject,
@@ -58,8 +57,7 @@ const dragConfig = {
   ],
   templateUrl: './si-column-selection-dialog.component.html',
   styleUrl: './si-column-selection-dialog.component.scss',
-  providers: [{ provide: CDK_DRAG_CONFIG, useValue: dragConfig }],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  providers: [{ provide: CDK_DRAG_CONFIG, useValue: dragConfig }]
 })
 export class SiColumnSelectionDialogComponent implements OnInit {
   readonly titleId = input<string>();

--- a/projects/element-ng/connection-strength/si-connection-strength.component.ts
+++ b/projects/element-ng/connection-strength/si-connection-strength.component.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  input
-} from '@angular/core';
+import { booleanAttribute, Component, computed, input } from '@angular/core';
 
 export type ConnectionStrength = 'none' | 'low' | 'medium' | 'strong';
 
@@ -17,8 +11,7 @@ const CONNECTION_STRENGTH_MAP = { 'none': 0, 'low': 1, 'medium': 2, 'strong': 3 
 @Component({
   selector: 'si-connection-strength',
   templateUrl: './si-connection-strength.component.html',
-  styleUrl: './si-connection-strength.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-connection-strength.component.scss'
 })
 export class SiConnectionStrengthComponent {
   /**

--- a/projects/element-ng/content-action-bar/si-content-action-bar-toggle.component.ts
+++ b/projects/element-ng/content-action-bar/si-content-action-bar-toggle.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 
 @Component({
@@ -11,7 +11,6 @@ import { SiIconComponent } from '@siemens/element-ng/icon';
   imports: [SiIconComponent],
   templateUrl: './si-content-action-bar-toggle.component.html',
   styleUrl: '../menu/si-menu-item.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'dropdown-item flex-grow-0 focus-inside' }
 })
 export class SiContentActionBarToggleComponent {

--- a/projects/element-ng/copyright-notice/si-copyright-notice.component.ts
+++ b/projects/element-ng/copyright-notice/si-copyright-notice.component.ts
@@ -2,15 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 
 import { CopyrightDetails, SI_COPYRIGHT_DETAILS } from './si-copyright-notice';
 
 @Component({
   selector: 'si-copyright-notice',
   templateUrl: './si-copyright-notice.component.html',
-  styleUrl: './si-copyright-notice.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-copyright-notice.component.scss'
 })
 export class SiCopyrightNoticeComponent {
   private globalCopyrightInfo: CopyrightDetails | null = inject(SI_COPYRIGHT_DETAILS, {

--- a/projects/element-ng/dashboard/si-dashboard.component.spec.ts
+++ b/projects/element-ng/dashboard/si-dashboard.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, signal, viewChild, viewChildren } from '@angular/core';
+import { Component, signal, viewChild, viewChildren } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ElementDimensions, ResizeObserverService } from '@siemens/element-ng/resize-observer';
@@ -37,8 +37,7 @@ import { SiDashboardCardComponent, SiDashboardComponent } from './index';
         }
       </ng-container>
     </si-dashboard>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class WrapperComponent {
   readonly dashboard = viewChild.required(SiDashboardComponent);

--- a/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-body.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-body.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, Directive, input } from '@angular/core';
+import { Component, computed, Directive, input } from '@angular/core';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiWidgetBaseDirective } from '../si-widget-base.directive';
@@ -67,7 +67,6 @@ export class SiWeatherRangeDefDirective {
   ],
   templateUrl: './si-weather-widget-body.component.html',
   styleUrl: './si-weather-widget-body.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: { '[class]': 'layoutClass()' }
 })
 export class SiWeatherWidgetBodyComponent extends SiWidgetBaseDirective<SiWeatherWidgetData> {

--- a/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-forecast.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-forecast.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
@@ -22,8 +22,7 @@ type ForecastLayout = 'vertical' | 'horizontal';
   selector: 'si-weather-widget-forecast',
   imports: [SiIconComponent, SiTranslatePipe, SiWeatherWidgetIllustrationComponent],
   templateUrl: './si-weather-widget-forecast.component.html',
-  styleUrl: './si-weather-widget-forecast.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-weather-widget-forecast.component.scss'
 })
 export class SiWeatherWidgetForecastComponent {
   readonly forecast = input.required<SiWeatherWidgetForecast>();

--- a/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-illustration.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-illustration.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
@@ -44,7 +44,6 @@ type IllustrationSize = 'sm' | 'md' | 'lg';
     }
   `,
   styleUrl: './si-weather-widget-illustration.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.si-weather-widget-illustration-sm]': "size() === 'sm'",
     '[class.si-weather-widget-illustration-md]': "size() === 'md'",

--- a/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-skeleton.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-skeleton.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 /**
  * Skeleton loading state for the `<si-weather-widget-body>`. Not exported from
@@ -22,7 +22,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
       </div>
     </div>
   `,
-  styleUrl: './si-weather-widget-skeleton.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-weather-widget-skeleton.component.scss'
 })
 export class SiWeatherWidgetSkeletonComponent {}

--- a/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget.component.ts
+++ b/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget.component.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  input
-} from '@angular/core';
+import { booleanAttribute, Component, computed, input } from '@angular/core';
 import { SiCardComponent } from '@siemens/element-ng/card';
 import { AccentLineType } from '@siemens/element-ng/common';
 import { ContentActionBarMainItem } from '@siemens/element-ng/content-action-bar';
@@ -44,7 +38,6 @@ import { SiWeatherWidgetData, SiWeatherWidgetLayout } from './si-weather-widget.
   selector: 'si-weather-widget',
   imports: [SiCardComponent, SiWeatherWidgetBodyComponent],
   templateUrl: './si-weather-widget.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'si-weather-widget' }
 })
 export class SiWeatherWidgetComponent {

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
@@ -9,7 +9,6 @@ import { OverlayModule } from '@angular/cdk/overlay';
 import { DatePipe, NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -75,7 +74,6 @@ export class PresetMatchFilterPipe implements PipeTransform {
   ],
   templateUrl: './si-date-range-filter.component.html',
   styleUrl: './si-date-range-filter.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.mobile]': 'smallScreen'
   }

--- a/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { t } from '@siemens/element-translate-ng/translate';
 
@@ -18,8 +18,7 @@ const ONE_DAY = ONE_MINUTE * 60 * 24;
     [unitLabel]="unitLabel"
     [valueLabel]="valueLabel"
     [(value)]="value"
-  /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  /> `
 })
 class TestHostComponent {
   readonly value = signal(0);

--- a/projects/element-ng/date-range-filter/si-relative-date.component.ts
+++ b/projects/element-ng/date-range-filter/si-relative-date.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   input,
@@ -37,8 +36,7 @@ interface OffsetOption extends SelectOption<string> {
     SiSelectSimpleOptionsDirective
   ],
   templateUrl: './si-relative-date.component.html',
-  styleUrl: './si-relative-date.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-relative-date.component.scss'
 })
 export class SiRelativeDateComponent implements OnChanges {
   /** @defaultValue 0 */

--- a/projects/element-ng/datepicker/components/si-calendar-body.component.ts
+++ b/projects/element-ng/datepicker/components/si-calendar-body.component.ts
@@ -5,7 +5,6 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   input,
@@ -142,7 +141,6 @@ class RangeSelectionStrategy extends SelectionStrategy {
   selector: '[si-calendar-body]',
   imports: [A11yModule, SiCalendarDateCellDirective],
   templateUrl: './si-calendar-body.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'si-calendar-body'
   },

--- a/projects/element-ng/datepicker/components/si-calendar-direction-button.component.ts
+++ b/projects/element-ng/datepicker/components/si-calendar-direction-button.component.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  input,
-  output
-} from '@angular/core';
+import { booleanAttribute, Component, computed, input, output } from '@angular/core';
 import { elementLeft2, elementRight2 } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 
@@ -18,8 +11,7 @@ export type Direction = 'left' | 'right';
 @Component({
   selector: 'si-calendar-direction-button',
   imports: [SiIconComponent],
-  templateUrl: './si-calendar-direction-button.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-calendar-direction-button.component.html'
 })
 export class SiCalendarDirectionButtonComponent {
   readonly ariaLabel = input.required<string>();

--- a/projects/element-ng/datepicker/components/si-day-selection.component.ts
+++ b/projects/element-ng/datepicker/components/si-day-selection.component.ts
@@ -5,7 +5,6 @@
 import { DatePipe } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -48,7 +47,6 @@ import { SiInitialFocusComponent } from './si-initial-focus.component';
   selector: 'si-day-selection',
   imports: [DatePipe, SiCalendarBodyComponent, SiCalendarDirectionButtonComponent, SiTranslatePipe],
   templateUrl: './si-day-selection.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'd-flex flex-column gap-6'
   }

--- a/projects/element-ng/datepicker/components/si-initial-focus.component.ts
+++ b/projects/element-ng/datepicker/components/si-initial-focus.component.ts
@@ -5,7 +5,6 @@
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   input,
   model,
@@ -20,8 +19,7 @@ import { Cell, SiCalendarBodyComponent } from './si-calendar-body.component';
  * Helper directive to set the initial focus to the calendar body cell.
  */
 @Component({
-  template: '',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: ''
 })
 export class SiInitialFocusComponent implements AfterViewInit {
   /** The cell which has the mouse hover. */

--- a/projects/element-ng/datepicker/components/si-month-selection.component.ts
+++ b/projects/element-ng/datepicker/components/si-month-selection.component.ts
@@ -4,7 +4,6 @@
  */
 import { DatePipe } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   HostListener,
@@ -38,7 +37,6 @@ import { SiInitialFocusComponent } from './si-initial-focus.component';
   selector: 'si-month-selection',
   imports: [SiCalendarDirectionButtonComponent, SiCalendarBodyComponent, DatePipe],
   templateUrl: './si-month-selection.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'd-flex flex-column gap-6'
   }

--- a/projects/element-ng/datepicker/components/si-year-selection.component.ts
+++ b/projects/element-ng/datepicker/components/si-year-selection.component.ts
@@ -4,7 +4,6 @@
  */
 import { DatePipe } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   HostListener,
@@ -37,7 +36,6 @@ import { SiInitialFocusComponent } from './si-initial-focus.component';
   selector: 'si-year-selection',
   imports: [SiCalendarDirectionButtonComponent, SiCalendarBodyComponent, DatePipe],
   templateUrl: './si-year-selection.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'd-flex flex-column gap-6'
   }

--- a/projects/element-ng/datepicker/si-calendar-button.component.spec.ts
+++ b/projects/element-ng/datepicker/si-calendar-button.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DatepickerInputConfig, SiDatepickerDirective } from '@siemens/element-ng/datepicker';
@@ -23,8 +23,7 @@ import { CalendarTestHelper, enterValue } from './testing/test-helper';
         [readonly]="readonly()"
       />
     </si-calendar-button>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class WrapperComponent {
   readonly config = signal<DatepickerInputConfig>({});

--- a/projects/element-ng/datepicker/si-calendar-button.component.ts
+++ b/projects/element-ng/datepicker/si-calendar-button.component.ts
@@ -5,7 +5,6 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
 import {
   AfterContentInit,
-  ChangeDetectionStrategy,
   Component,
   contentChild,
   DestroyRef,
@@ -59,7 +58,6 @@ import { SiDatepickerDirective } from './si-datepicker.directive';
       </button>
     </div>`,
   styleUrl: './si-calendar-button.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'd-inline-block position-relative form-control-wrapper'
   }

--- a/projects/element-ng/datepicker/si-date-input.directive.spec.ts
+++ b/projects/element-ng/datepicker/si-date-input.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ElementRef, signal, viewChild } from '@angular/core';
+import { Component, ElementRef, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl } from '@angular/forms';
 
@@ -24,8 +24,7 @@ import { dispatchEvents, enterValue } from './testing/test-helper';
     [siDatepickerConfig]="config()"
     [ngModel]="date"
     (ngModelChange)="onModelChange($event)"
-  />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  />`
 })
 class WrapperComponent {
   readonly siDateInput = viewChild.required<ElementRef>('siDateInput');

--- a/projects/element-ng/datepicker/si-date-range.component.spec.ts
+++ b/projects/element-ng/datepicker/si-date-range.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
@@ -32,8 +32,7 @@ const endInput = (element: HTMLElement): HTMLInputElement =>
     [autoClose]="autoClose()"
     [formControl]="dateRange"
     (siDatepickerRangeChange)="rangeChanged($event)"
-  />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  />`
 })
 class WrapperComponent {
   dateRange = new FormControl<DateRange | null>(null);
@@ -234,8 +233,7 @@ describe('SiDateRangeComponent', () => {
   imports: [SiDatepickerModule, FormsModule, ReactiveFormsModule, TestComponent],
   template: `<form [formGroup]="form">
     <si-date-range formControlName="dateRange" [siDatepickerConfig]="config()" />
-  </form>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  </form>`
 })
 class FormWrapperComponent {
   form = new FormGroup({

--- a/projects/element-ng/datepicker/si-datepicker-overlay.component.ts
+++ b/projects/element-ng/datepicker/si-datepicker-overlay.component.ts
@@ -10,7 +10,6 @@ import {
 } from '@angular/cdk/a11y';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -84,7 +83,6 @@ import { DatepickerConfig, DateRange } from './si-datepicker.model';
     }
   `,
   styleUrl: './si-datepicker-overlay.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'mt-md-1 d-flex elevation-2 rounded-2 overflow-auto align-items-stretch',
     '[class.flex-wrap]': 'isMobile()',

--- a/projects/element-ng/datepicker/si-datepicker-overlay.directive.spec.ts
+++ b/projects/element-ng/datepicker/si-datepicker-overlay.directive.spec.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ComponentRef,
-  HostListener,
-  inject,
-  signal
-} from '@angular/core';
+import { Component, ComponentRef, HostListener, inject, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
@@ -22,7 +15,6 @@ import { generateKeyEvent } from './testing/test-helper';
 @Component({
   imports: [FormsModule, SiDateInputDirective],
   template: `<input siDateInput type="text" class="form-control" [(ngModel)]="inputText" />`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     {
       directive: SiDatepickerOverlayDirective,

--- a/projects/element-ng/datepicker/si-datepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-datepicker.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { userEvent } from 'vitest/browser';
 
@@ -23,8 +23,7 @@ import { CalendarTestHelper, enterValue, generateKeyEvent } from './testing/test
     [date]="date()"
     (dateChange)="date.set($event); changedDate = $event"
     (dateRangeChange)="rangeChanged($event)"
-  />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  />`
 })
 class TestHostComponent {
   readonly datePicker = viewChild.required(SiDatepickerComponent);

--- a/projects/element-ng/datepicker/si-datepicker.directive.spec.ts
+++ b/projects/element-ng/datepicker/si-datepicker.directive.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, ElementRef, signal, viewChild } from '@angular/core';
+import { Component, ElementRef, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl } from '@angular/forms';
 import type { Mock } from 'vitest';
@@ -36,8 +36,7 @@ export type Spied<T> = {
     [ngModelOptions]="{ standalone: true }"
     [ngModel]="date()"
     (ngModelChange)="date.set($event)"
-  />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  />`
 })
 class WrapperComponent {
   readonly siDatePicker = viewChild.required<ElementRef>('siDatePicker');

--- a/projects/element-ng/datepicker/si-timepicker.component.spec.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -22,8 +22,7 @@ import { SiTimepickerComponent as TestComponent } from './index';
       [showMeridian]="showMeridian()"
       (inputCompleted)="onInputCompleted()"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class WrapperComponent {
   readonly picker = viewChild.required<TestComponent>(TestComponent);

--- a/projects/element-ng/datepicker/si-timepicker.component.ts
+++ b/projects/element-ng/datepicker/si-timepicker.component.ts
@@ -13,7 +13,6 @@ import {
 } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
@@ -87,7 +86,6 @@ const dateWithTime = (base: Date, time: Date): Date =>
       useExisting: SiTimepickerComponent
     }
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     role: 'group',
     class: 'form-custom-control',

--- a/projects/element-ng/empty-state/si-empty-state.component.ts
+++ b/projects/element-ng/empty-state/si-empty-state.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
@@ -10,8 +10,7 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
   selector: 'si-empty-state',
   imports: [SiIconComponent, SiTranslatePipe],
   templateUrl: './si-empty-state.component.html',
-  styleUrl: './si-empty-state.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-empty-state.component.scss'
 })
 export class SiEmptyStateComponent {
   /**

--- a/projects/element-ng/file-uploader/si-file-dropzone.component.ts
+++ b/projects/element-ng/file-uploader/si-file-dropzone.component.ts
@@ -2,15 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  input,
-  output,
-  viewChild
-} from '@angular/core';
+import { booleanAttribute, Component, computed, input, output, viewChild } from '@angular/core';
 import { elementUpload } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
@@ -22,8 +14,7 @@ import { UploadFile } from './si-file-uploader.model';
   selector: 'si-file-dropzone',
   imports: [SiIconComponent, SiTranslatePipe, SiFileUploadDirective],
   templateUrl: './si-file-dropzone.component.html',
-  styleUrl: './si-file-dropzone.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-file-dropzone.component.scss'
 })
 export class SiFileDropzoneComponent {
   /**

--- a/projects/element-ng/filtered-search/si-filtered-search-input.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search-input.component.ts
@@ -2,16 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  ElementRef,
-  input,
-  model,
-  output,
-  viewChild
-} from '@angular/core';
+import { Component, computed, ElementRef, input, model, output, viewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SiTypeaheadDirective, TypeaheadOption } from '@siemens/element-ng/typeahead';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -24,7 +15,6 @@ import { InternalCriterionDefinition } from './si-filtered-search-helper';
   imports: [FormsModule, SiTypeaheadDirective, SiTranslatePipe],
   templateUrl: './si-filtered-search-input.component.html',
   styleUrl: './si-filtered-search-input.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'w-100'
   }

--- a/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search-value.component.ts
@@ -5,7 +5,6 @@
 import { CdkMonitorFocus, FocusOrigin } from '@angular/cdk/a11y';
 import {
   afterNextRender,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -47,8 +46,7 @@ import { SiFilteredSearchTypeaheadComponent } from './values/typeahead/si-filter
     SiIconComponent
   ],
   templateUrl: './si-filtered-search-value.component.html',
-  styleUrl: './si-filtered-search-value.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-filtered-search-value.component.scss'
 })
 export class SiFilteredSearchValueComponent implements OnInit {
   private readonly injector = inject(Injector);

--- a/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.spec.ts
@@ -4,14 +4,7 @@
  */
 import { HarnessLoader, parallel, TestKey } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  inject,
-  signal,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectorRef, Component, inject, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CriterionDefinition } from '@siemens/element-ng/filtered-search';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
@@ -56,8 +49,7 @@ import { SiFilteredSearchHarness } from './testing/si-filtered-search.harness';
     (doSearch)="doSearch($event)"
     (searchCriteriaChange)="searchCriteriaChange($event)"
     (interceptDisplayedCriteria)="showCriteria($event)"
-  />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  />`
 })
 class TestHostComponent {
   readonly filteredSearch = viewChild.required(SiFilteredSearchComponent);

--- a/projects/element-ng/filtered-search/values/date-value/si-filtered-search-date-value.component.ts
+++ b/projects/element-ng/filtered-search/values/date-value/si-filtered-search-date-value.component.ts
@@ -4,7 +4,6 @@
  */
 import { DatePipe } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -33,8 +32,7 @@ import { SiFilteredSearchValueBase } from '../si-filtered-search-value.base';
   styleUrl: './si-filtered-search-date-value.component.scss',
   providers: [
     { provide: SiFilteredSearchValueBase, useExisting: SiFilteredSearchDateValueComponent }
-  ],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  ]
 })
 export class SiFilteredSearchDateValueComponent extends SiFilteredSearchValueBase {
   private locale = inject(LOCALE_ID).toString();

--- a/projects/element-ng/filtered-search/values/free-text/si-filtered-search-free-text.component.ts
+++ b/projects/element-ng/filtered-search/values/free-text/si-filtered-search-free-text.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, ElementRef, viewChild } from '@angular/core';
+import { Component, computed, ElementRef, viewChild } from '@angular/core';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiFilteredSearchValueBase } from '../si-filtered-search-value.base';
@@ -14,8 +14,7 @@ import { SiFilteredSearchValueBase } from '../si-filtered-search-value.base';
   styleUrl: './si-filtered-search-free-text.component.scss',
   providers: [
     { provide: SiFilteredSearchValueBase, useExisting: SiFilteredSearchFreeTextComponent }
-  ],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  ]
 })
 export class SiFilteredSearchFreeTextComponent extends SiFilteredSearchValueBase {
   protected readonly valueInput = viewChild<ElementRef<HTMLInputElement>>('freeTextInput');

--- a/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.ts
+++ b/projects/element-ng/filtered-search/values/multi-select/si-filtered-search-multi-select.component.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -31,8 +30,7 @@ import { SiFilteredSearchValueBase } from '../si-filtered-search-value.base';
   styleUrl: './si-filtered-search-multi-select.component.scss',
   providers: [
     { provide: SiFilteredSearchValueBase, useExisting: SiFilteredSearchMultiSelectComponent }
-  ],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  ]
 })
 export class SiFilteredSearchMultiSelectComponent
   extends SiFilteredSearchOptionValueBase

--- a/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
+++ b/projects/element-ng/filtered-search/values/typeahead/si-filtered-search-typeahead.component.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -29,8 +28,7 @@ import { SiFilteredSearchValueBase } from '../si-filtered-search-value.base';
   styleUrl: './si-filtered-search-typeahead.component.scss',
   providers: [
     { provide: SiFilteredSearchValueBase, useExisting: SiFilteredSearchTypeaheadComponent }
-  ],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  ]
 })
 export class SiFilteredSearchTypeaheadComponent
   extends SiFilteredSearchOptionValueBase

--- a/projects/element-ng/form/form-fieldset/si-form-fieldset.component.ts
+++ b/projects/element-ng/form/form-fieldset/si-form-fieldset.component.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  input,
-  signal
-} from '@angular/core';
+import { booleanAttribute, Component, computed, input, signal } from '@angular/core';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiFormFieldsetControl } from './si-form-fieldset.control';
@@ -19,7 +12,6 @@ import { SiFormFieldsetControl } from './si-form-fieldset.control';
   imports: [SiTranslatePipe],
   templateUrl: './si-form-fieldset.component.html',
   styleUrl: '../si-form.shared.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     role: 'group',
     class: 'si-form-input',

--- a/projects/element-ng/form/si-form-container/si-form-container.component.spec.ts
+++ b/projects/element-ng/form/si-form-container/si-form-container.component.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  inject,
-  viewChild
-} from '@angular/core';
+import { ChangeDetectorRef, Component, inject, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import {
@@ -31,8 +25,7 @@ interface TestForm {
       [form]="form"
       [errorCodeTranslateKeyMap]="customErrorMapper"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 export class TestHostComponent {
   cdRef = inject(ChangeDetectorRef);
@@ -53,8 +46,7 @@ export class TestHostComponent {
         <div si-form-container-content style="block-size: 10px"></div>
       </si-form-container>
     </si-form-container>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostWithNestingComponent {
   form = new FormGroup({});

--- a/projects/element-ng/form/si-form-item/si-form-item.component.spec.ts
+++ b/projects/element-ng/form/si-form-item/si-form-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
@@ -14,8 +14,7 @@ import { SiFormItemComponent } from './si-form-item.component';
     <si-form-item [label]="label()!">
       <input type="text" id="name" class="form-control" />
     </si-form-item>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 export class TestHostComponent {
   readonly formItem = viewChild.required(SiFormItemComponent);

--- a/projects/element-ng/form/si-form-item/si-form-item.component.ts
+++ b/projects/element-ng/form/si-form-item/si-form-item.component.ts
@@ -7,7 +7,6 @@ import {
   AfterContentChecked,
   AfterContentInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChild,
@@ -50,7 +49,6 @@ export interface SiFormError {
   imports: [SiTranslatePipe, NgTemplateOutlet],
   templateUrl: './si-form-item.component.html',
   styleUrl: '../si-form.shared.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.required]': 'required()',
     '[style.--si-form-label-width]': 'labelWidthCssVar()',

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts
@@ -4,7 +4,7 @@
  */
 import { Overlay } from '@angular/cdk/overlay';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 
@@ -14,8 +14,7 @@ import { SiFormValidationTooltipDirective } from './si-form-validation-tooltip.d
 describe('SiFormValidationTooltipDirective', () => {
   @Component({
     imports: [SiFormValidationTooltipDirective, ReactiveFormsModule],
-    template: `<input siFormValidationTooltip required [formControl]="control" />`,
-    changeDetection: ChangeDetectionStrategy.OnPush
+    template: `<input siFormValidationTooltip required [formControl]="control" />`
   })
   class TestHostComponent {
     control = new FormControl('');

--- a/projects/element-ng/form/si-form.spec.ts
+++ b/projects/element-ng/form/si-form.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   FormControl,
@@ -73,8 +73,7 @@ describe('SiForm', () => {
             </si-form-item>
           </form>
         </si-form-container>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {
       form = new FormGroup({
@@ -160,8 +159,7 @@ describe('SiForm', () => {
             <input formControlName="input" />
           </si-form-item>
         </form>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {
       form = new FormGroup({
@@ -210,8 +208,7 @@ describe('SiForm', () => {
             <input name="value" [required]="required()" [(ngModel)]="value" />
           </si-form-item>
         </form>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {
       readonly value = signal('');
@@ -246,8 +243,7 @@ describe('SiForm', () => {
         <si-form-item label="Input">
           <input type="text" id="email" class="form-control" [formControl]="email" />
         </si-form-item>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {
       readonly email = new FormControl('email', [Validators.email]);
@@ -291,8 +287,7 @@ describe('SiForm', () => {
             <input type="radio" class="form-check-input" value="b" [formField]="form.choice" />
           </si-form-field>
         </si-form-fieldset>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {
       readonly model = signal({ choice: '' });
@@ -331,8 +326,7 @@ describe('SiForm', () => {
         <si-form-item label="Normal">
           <input type="checkbox" class="form-check-input" [formControl]="normal" />
         </si-form-item>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class TestHostComponent {
       normal = new FormControl(true);

--- a/projects/element-ng/formly/fields/button/si-formly-button.component.spec.ts
+++ b/projects/element-ng/formly/fields/button/si-formly-button.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -24,8 +24,7 @@ import { SiFormlyButtonComponent } from './si-formly-button.component';
     [fields]="fields()"
     [model]="model()"
     [options]="options()"
-  /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  /> `
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/fields/date-range/si-formly-date-range.component.spec.ts
+++ b/projects/element-ng/formly/fields/date-range/si-formly-date-range.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -14,8 +14,7 @@ import { SiFormlyDateRangeComponent } from './si-formly-date-range.component';
 @Component({
   selector: 'si-formly-test',
   imports: [FormlyModule],
-  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/fields/datetime/si-formly-datetime.component.spec.ts
+++ b/projects/element-ng/formly/fields/datetime/si-formly-datetime.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -13,8 +13,7 @@ import { SiFormlyDateTimeComponent } from './si-formly-datetime.component';
 @Component({
   selector: 'si-formly-test',
   imports: [ReactiveFormsModule, FormlyModule],
-  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" />`
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/fields/email/si-formly-email.component.spec.ts
+++ b/projects/element-ng/formly/fields/email/si-formly-email.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -13,8 +13,7 @@ import { SiFormlyEmailComponent } from './si-formly-email.component';
 @Component({
   selector: 'si-formly-test',
   imports: [FormlyModule],
-  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/fields/ip-input/si-formly-ip-input.component.spec.ts
+++ b/projects/element-ng/formly/fields/ip-input/si-formly-ip-input.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -13,8 +13,7 @@ import { SiFormlyIpInputComponent } from './si-formly-ip-input.component';
 @Component({
   selector: 'si-formly-test',
   imports: [FormlyModule],
-  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" />`
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/fields/number/si-formly-number.component.spec.ts
+++ b/projects/element-ng/formly/fields/number/si-formly-number.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -14,8 +14,7 @@ import { SiFormlyNumberComponent } from './si-formly-number.component';
 @Component({
   selector: 'si-formly-test',
   imports: [FormlyModule],
-  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/fields/number/si-formly-number.component.ts
+++ b/projects/element-ng/formly/fields/number/si-formly-number.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FieldType, FieldTypeConfig, FormlyModule } from '@ngx-formly/core';
 import { SiNumberInputComponent } from '@siemens/element-ng/number-input';
@@ -12,7 +12,6 @@ import { SiValidationErrorIdPipe } from '../../utils';
 @Component({
   selector: 'si-formly-number',
   imports: [ReactiveFormsModule, FormlyModule, SiNumberInputComponent, SiValidationErrorIdPipe],
-  templateUrl: './si-formly-number.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-formly-number.component.html'
 })
 export class SiFormlyNumberComponent extends FieldType<FieldTypeConfig> {}

--- a/projects/element-ng/formly/fields/password/si-formly-password.component.ts
+++ b/projects/element-ng/formly/fields/password/si-formly-password.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FieldType, FieldTypeConfig, FormlyModule } from '@ngx-formly/core';
 import {
@@ -22,8 +22,7 @@ import { SiValidationErrorIdPipe } from '../../utils';
     SiPasswordStrengthDirective,
     SiValidationErrorIdPipe
   ],
-  templateUrl: './si-formly-password.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-formly-password.component.html'
 })
 export class SiFormlyPasswordComponent extends FieldType<FieldTypeConfig> {
   /*

--- a/projects/element-ng/formly/fields/select/si-formly-select.component.spec.ts
+++ b/projects/element-ng/formly/fields/select/si-formly-select.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -17,8 +17,7 @@ import { SiFormlySelectComponent } from './si-formly-select.component';
 @Component({
   selector: 'si-formly-test',
   imports: [FormlyModule],
-  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/fields/text/si-formly-text-display.component.spec.ts
+++ b/projects/element-ng/formly/fields/text/si-formly-text-display.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -18,8 +18,7 @@ import { SiFormlyTextDisplayComponent } from './si-formly-text-display.component
 @Component({
   selector: 'si-formly-test',
   imports: [FormlyModule],
-  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.spec.ts
+++ b/projects/element-ng/formly/fields/textarea/si-formly-textarea.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -13,8 +13,7 @@ import { SiFormlyTextareaComponent } from './si-formly-textarea.component';
 @Component({
   selector: 'si-formly-test',
   imports: [FormlyModule],
-  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/fields/time/si-formly-time.component.spec.ts
+++ b/projects/element-ng/formly/fields/time/si-formly-time.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -14,8 +14,7 @@ import { SiFormlyTimeComponent } from './si-formly-time.component';
 @Component({
   selector: 'si-formly-test',
   imports: [FormlyModule],
-  template: ` <formly-form [form]="form" [fields]="fields()" [model]="model()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: ` <formly-form [form]="form" [fields]="fields()" [model]="model()" /> `
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -21,8 +21,7 @@ import { SiFormlyComponent } from '../../si-formly.component';
       [model]="model()"
       [form]="form"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.ts
+++ b/projects/element-ng/formly/structural/si-formly-accordion/si-formly-accordion.component.ts
@@ -2,15 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { AfterViewInit, ChangeDetectionStrategy, Component } from '@angular/core';
+import { AfterViewInit, Component } from '@angular/core';
 import { FieldType, FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
 import { SiAccordionComponent, SiCollapsiblePanelComponent } from '@siemens/element-ng/accordion';
 
 @Component({
   selector: 'si-formly-accordion',
   imports: [SiCollapsiblePanelComponent, FormlyModule, SiAccordionComponent],
-  templateUrl: './si-formly-accordion.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-formly-accordion.component.html'
 })
 export class SiFormlyAccordionComponent extends FieldType implements AfterViewInit {
   protected panelToggle(toggle: boolean, fieldGroup: FormlyFieldConfig): void {

--- a/projects/element-ng/formly/structural/si-formly-array/si-formly-array.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-array/si-formly-array.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -21,8 +21,7 @@ import { SiFormlyArrayComponent } from './si-formly-array.component';
 
 @Component({
   imports: [FormlyModule],
-  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `
 })
 class WrapperComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/structural/si-formly-array/si-formly-array.component.ts
+++ b/projects/element-ng/formly/structural/si-formly-array/si-formly-array.component.ts
@@ -2,14 +2,13 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { FieldArrayType, FormlyModule } from '@ngx-formly/core';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-formly-array',
   imports: [FormlyModule, SiTranslatePipe],
-  templateUrl: './si-formly-array.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-formly-array.component.html'
 })
 export class SiFormlyArrayComponent extends FieldArrayType {}

--- a/projects/element-ng/formly/structural/si-formly-object-grid/si-formly-object-grid.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-object-grid/si-formly-object-grid.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -13,8 +13,7 @@ import { SiFormlyObjectGridComponent } from './si-formly-object-grid.component';
 @Component({
   selector: 'si-formly-test',
   imports: [FormlyModule],
-  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/structural/si-formly-object-grid/si-formly-object-grid.component.ts
+++ b/projects/element-ng/formly/structural/si-formly-object-grid/si-formly-object-grid.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FieldType, FormlyModule } from '@ngx-formly/core';
 import { SiFormContainerComponent } from '@siemens/element-ng/form';
 
@@ -11,8 +11,7 @@ import { GridColumnConfig, GridRow, ToGridRowConfig } from './si-formly-object-g
 @Component({
   selector: 'si-formly-object-grid',
   imports: [FormlyModule, SiFormContainerComponent],
-  templateUrl: './si-formly-object-grid.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-formly-object-grid.component.html'
 })
 export class SiFormlyObjectGridComponent extends FieldType implements OnInit {
   protected rows: GridRow[] = [];

--- a/projects/element-ng/formly/structural/si-formly-object-plain/si-formly-object-plain.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-object-plain/si-formly-object-plain.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -24,8 +24,7 @@ import { SiFormlyObjectPlainComponent as TestComponent } from './si-formly-objec
 
 @Component({
   imports: [FormlyModule],
-  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<formly-form [form]="form" [fields]="fields()" [model]="model()" /> `
 })
 class WrapperComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/structural/si-formly-object-plain/si-formly-object-plain.component.ts
+++ b/projects/element-ng/formly/structural/si-formly-object-plain/si-formly-object-plain.component.ts
@@ -2,13 +2,12 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { FieldType, FormlyModule } from '@ngx-formly/core';
 
 @Component({
   selector: 'si-formly-object-plain',
   imports: [FormlyModule],
-  templateUrl: './si-formly-object-plain.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-formly-object-plain.component.html'
 })
 export class SiFormlyObjectPlainComponent extends FieldType {}

--- a/projects/element-ng/formly/structural/si-formly-object/si-formly-object.component.ts
+++ b/projects/element-ng/formly/structural/si-formly-object/si-formly-object.component.ts
@@ -2,13 +2,12 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { FieldType, FormlyModule } from '@ngx-formly/core';
 
 @Component({
   selector: 'si-formly-object',
   imports: [FormlyModule],
-  templateUrl: './si-formly-object.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-formly-object.component.html'
 })
 export class SiFormlyObjectComponent extends FieldType {}

--- a/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.spec.ts
+++ b/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormRecord } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -18,8 +18,7 @@ import { SiFormlyObjectTabsetComponent } from './si-formly-object-tabset.compone
     [fields]="fields()"
     [model]="model()"
     [options]="options()"
-  /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  /> `
 })
 class FormlyTestComponent {
   readonly form = new FormRecord({});

--- a/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.ts
+++ b/projects/element-ng/formly/structural/si-formly-tabset/si-formly-object-tabset.component.ts
@@ -2,15 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { FieldType, FormlyModule } from '@ngx-formly/core';
 import { SiTabComponent, SiTabsetComponent } from '@siemens/element-ng/tabs';
 
 @Component({
   selector: 'si-formly-object-tabset',
   imports: [SiTabsetComponent, SiTabComponent, FormlyModule],
-  templateUrl: './si-formly-object-tabset.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-formly-object-tabset.component.html'
 })
 export class SiFormlyObjectTabsetComponent extends FieldType {
   protected tabIndexChange(isActive: boolean, selectedTab: number): void {

--- a/projects/element-ng/formly/wrapper/si-formly-fieldset.component.ts
+++ b/projects/element-ng/formly/wrapper/si-formly-fieldset.component.ts
@@ -2,15 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { FieldWrapper, FormlyModule } from '@ngx-formly/core';
 import { SiFormFieldsetComponent } from '@siemens/element-ng/form';
 
 @Component({
   selector: 'si-formly-fieldset',
   imports: [FormlyModule, SiFormFieldsetComponent],
-  templateUrl: './si-formly-fieldset.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-formly-fieldset.component.html'
 })
 export class SiFormlyFieldsetComponent extends FieldWrapper {
   protected get label(): string | undefined {

--- a/projects/element-ng/formly/wrapper/si-formly-horizontal-wrapper.component.ts
+++ b/projects/element-ng/formly/wrapper/si-formly-horizontal-wrapper.component.ts
@@ -2,13 +2,12 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { FieldWrapper, FormlyModule } from '@ngx-formly/core';
 
 @Component({
   selector: 'si-formly-horizontal-wrapper',
   imports: [FormlyModule],
-  templateUrl: './si-formly-horizontal-wrapper.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-formly-horizontal-wrapper.component.html'
 })
 export class SiFormlyHorizontalWrapperComponent extends FieldWrapper {}

--- a/projects/element-ng/formly/wrapper/si-formly-icon-wrapper.component.ts
+++ b/projects/element-ng/formly/wrapper/si-formly-icon-wrapper.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { FieldWrapper } from '@ngx-formly/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTooltipDirective } from '@siemens/element-ng/tooltip';
@@ -12,7 +12,6 @@ import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
   selector: 'si-formly-icon-wrapper',
   imports: [SiIconComponent, SiTooltipDirective, SiTranslatePipe],
   templateUrl: './si-formly-icon-wrapper.component.html',
-  styleUrl: './si-formly-icon-wrapper.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-formly-icon-wrapper.component.scss'
 })
 export class SiFormlyIconWrapperComponent extends FieldWrapper {}

--- a/projects/element-ng/header-dropdown/si-header-dropdown-item.component.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown-item.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { elementDown2, elementOk, elementRecordFilled } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 
@@ -17,7 +17,6 @@ import { SI_HEADER_WITH_DROPDOWNS } from './si-header.model';
   imports: [SiIconComponent],
   templateUrl: './si-header-dropdown-item.component.html',
   styleUrl: './si-header-dropdown-item.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'dropdown-item focus-inside',
     '[attr.aria-pressed]': 'checked() ? "true" : null',

--- a/projects/element-ng/header-dropdown/si-header-dropdown.component.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { A11yModule, CdkTrapFocus } from '@angular/cdk/a11y';
-import { ChangeDetectionStrategy, Component, inject, viewChild, DOCUMENT } from '@angular/core';
+import { Component, inject, viewChild, DOCUMENT } from '@angular/core';
 
 import { SiHeaderDropdownTriggerDirective } from './si-header-dropdown-trigger.directive';
 import { SI_HEADER_DROPDOWN_OPTIONS } from './si-header.model';
@@ -17,7 +17,6 @@ import { SI_HEADER_DROPDOWN_OPTIONS } from './si-header.model';
   imports: [A11yModule],
   templateUrl: './si-header-dropdown.component.html',
   styles: ':host.sub-menu {min-inline-size: 200px}',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'dropdown-menu position-static',
     '[attr.role]': "trigger.isOverlay ? 'dialog' : 'group'",

--- a/projects/element-ng/header-dropdown/si-header-dropdown.directive.spec.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown.directive.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiHeaderDropdownItemComponent } from './si-header-dropdown-item.component';
@@ -39,8 +39,7 @@ import { SiHeaderDropdownTriggerHarness } from './testing/si-header-dropdown-tri
       </si-header-dropdown>
     </ng-template>
   `,
-  providers: [{ provide: SI_HEADER_WITH_DROPDOWNS, useExisting: TestHostComponent }],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  providers: [{ provide: SI_HEADER_WITH_DROPDOWNS, useExisting: TestHostComponent }]
 })
 class TestHostComponent implements HeaderWithDropdowns {
   readonly inlineDropdown = signal(false);

--- a/projects/element-ng/icon/si-icon-legacy.component.ts
+++ b/projects/element-ng/icon/si-icon-legacy.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 /**
@@ -45,8 +45,7 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
   selector: 'si-icon-legacy',
   imports: [SiTranslatePipe],
   templateUrl: './si-icon-legacy.component.html',
-  styles: ':host, span { line-height: 1; }',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styles: ':host, span { line-height: 1; }'
 })
 export class SiIconLegacyComponent {
   /** Icon token, see {@link https://element.siemens.io/icons/element} */

--- a/projects/element-ng/icon/si-icon.component.spec.ts
+++ b/projects/element-ng/icon/si-icon.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SiThemeService } from '@siemens/element-ng/theme';
@@ -26,8 +26,7 @@ describe('SiSvgIconComponent', () => {
 
     @Component({
       imports: [SiIconComponent],
-      template: ` <si-icon [icon]="icon()" />`,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      template: ` <si-icon [icon]="icon()" />`
     })
     class TestHostComponent {
       readonly icon = signal<string>('element-user');
@@ -112,8 +111,7 @@ describe('SiSvgIconComponent', () => {
     @Component({
       selector: 'si-icon-1-test',
       imports: [SiIconComponent],
-      template: `<si-icon [icon]="icons.elementSvg" />`,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      template: `<si-icon [icon]="icons.elementSvg" />`
     })
     class IconTest1Component {
       readonly icons = addIcons({
@@ -124,8 +122,7 @@ describe('SiSvgIconComponent', () => {
     @Component({
       selector: 'si-icon-2-test',
       imports: [SiIconComponent],
-      template: `<si-icon [icon]="icons.elementSvg" />`,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      template: `<si-icon [icon]="icons.elementSvg" />`
     })
     class IconTest2Component {
       icons = addIcons({
@@ -141,8 +138,7 @@ describe('SiSvgIconComponent', () => {
         }
         @if (show2()) {
           <si-icon-2-test />
-        }`,
-      changeDetection: ChangeDetectionStrategy.OnPush
+        }`
     })
     class TestHostComponent {
       readonly show1 = signal(false);

--- a/projects/element-ng/icon/si-icon.component.ts
+++ b/projects/element-ng/icon/si-icon.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 
 import { IconService } from './si-icons';
 
@@ -19,7 +19,6 @@ import { IconService } from './si-icons';
   selector: 'si-icon',
   template: ` <div aria-hidden="true" [class]="svgIcon() ? 'svg-element-icon' : fontIcon()"></div>`,
   styleUrl: './si-icon.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[attr.data-icon]': 'icon()',
     '[style.--svg-element-icon]': 'svgIcon()'

--- a/projects/element-ng/icon/si-status-icon.component.ts
+++ b/projects/element-ng/icon/si-status-icon.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 import { EntityStatusType } from '@siemens/element-ng/common';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
@@ -20,7 +20,6 @@ import { STATUS_ICON_CONFIG } from './status-icon';
       <span class="visually-hidden">{{ iconValue.ariaLabel | translate }}</span>
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'icon-stack' }
 })
 export class SiStatusIconComponent {

--- a/projects/element-ng/info-page/si-info-page.component.ts
+++ b/projects/element-ng/info-page/si-info-page.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { Link, SiLinkDirective } from '@siemens/element-ng/link';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -17,8 +17,7 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
   selector: 'si-info-page',
   imports: [SiLinkDirective, SiIconComponent, SiTranslatePipe],
   templateUrl: './si-info-page.component.html',
-  styleUrl: './si-info-page.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-info-page.component.scss'
 })
 export class SiInfoPageComponent {
   /**

--- a/projects/element-ng/ip-input/si-ip4-input.directive.spec.ts
+++ b/projects/element-ng/ip-input/si-ip4-input.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, DebugElement, signal, viewChild } from '@angular/core';
+import { Component, DebugElement, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -19,8 +19,7 @@ import { SiIp4InputDirective } from './si-ip4-input.directive';
     [cidr]="cidr()"
     [ngModel]="address()"
     (ngModelChange)="address.set($event)"
-  />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  />`
 })
 class WrapperComponent {
   readonly validation = viewChild.required<NgControl>('validation');

--- a/projects/element-ng/ip-input/si-ip6-input.directive.spec.ts
+++ b/projects/element-ng/ip-input/si-ip6-input.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, DebugElement, signal, viewChild } from '@angular/core';
+import { Component, DebugElement, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -19,8 +19,7 @@ import { SiIp6InputDirective } from './si-ip6-input.directive';
     [cidr]="cidr()"
     [ngModel]="address()"
     (ngModelChange)="address.set($event)"
-  />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  />`
 })
 class WrapperComponent {
   readonly validation = viewChild.required<NgControl>('validation');

--- a/projects/element-ng/landing-page/change-password/si-change-password.component.ts
+++ b/projects/element-ng/landing-page/change-password/si-change-password.component.ts
@@ -11,8 +11,7 @@ import {
   TemplateRef,
   OnDestroy,
   inject,
-  DestroyRef,
-  ChangeDetectionStrategy
+  DestroyRef
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -58,8 +57,7 @@ import { ChangePassword } from '../si-landing-page.model';
     SiPasswordStrengthComponent,
     SiPasswordStrengthDirective
   ],
-  templateUrl: './si-change-password.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-change-password.component.html'
 })
 export class SiChangePasswordComponent implements OnInit, OnDestroy {
   private static idCounter = 0;

--- a/projects/element-ng/landing-page/explicit-legal-acknowledge/si-explicit-legal-acknowledge.component.ts
+++ b/projects/element-ng/landing-page/explicit-legal-acknowledge/si-explicit-legal-acknowledge.component.ts
@@ -2,15 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  Component,
-  inject,
-  input,
-  OnInit,
-  output,
-  OnDestroy,
-  ChangeDetectionStrategy
-} from '@angular/core';
+import { Component, inject, input, OnInit, output, OnDestroy } from '@angular/core';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiLandingPageComponent } from '../si-landing-page.component';
@@ -44,8 +36,7 @@ import { SiLandingPageComponent } from '../si-landing-page.component';
 @Component({
   selector: 'si-explicit-legal-acknowledge',
   imports: [SiTranslatePipe],
-  templateUrl: './si-explicit-legal-acknowledge.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-explicit-legal-acknowledge.component.html'
 })
 export class SiExplicitLegalAcknowledgeComponent implements OnInit, OnDestroy {
   /**

--- a/projects/element-ng/landing-page/login-basic/si-login-basic.component.ts
+++ b/projects/element-ng/landing-page/login-basic/si-login-basic.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   DestroyRef,
@@ -53,7 +52,6 @@ import { UsernamePassword, UsernameValidationPayload } from '../si-landing-page.
   ],
   templateUrl: './si-login-basic.component.html',
   styleUrl: './si-login-basic.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'animate.enter': 'component-enter'
   }

--- a/projects/element-ng/landing-page/login-single-sign-on/si-login-single-sign-on.component.ts
+++ b/projects/element-ng/landing-page/login-single-sign-on/si-login-single-sign-on.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
 /**
@@ -23,8 +23,7 @@ import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 @Component({
   selector: 'si-login-single-sign-on',
   imports: [SiTranslatePipe],
-  templateUrl: './si-login-single-sign-on.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-login-single-sign-on.component.html'
 })
 export class SiLoginSingleSignOnComponent {
   /**

--- a/projects/element-ng/landing-page/si-landing-page.component.ts
+++ b/projects/element-ng/landing-page/si-landing-page.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input, TemplateRef, signal } from '@angular/core';
+import { Component, input, TemplateRef, signal } from '@angular/core';
 import { CopyrightDetails, SiCopyrightNoticeComponent } from '@siemens/element-ng/copyright-notice';
 import { SiInlineNotificationComponent } from '@siemens/element-ng/inline-notification';
 import {
@@ -61,8 +61,7 @@ import { LandingPageWarning } from './si-landing-page.model';
     NgTemplateOutlet
   ],
   templateUrl: './si-landing-page.component.html',
-  styleUrl: './si-landing-page.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-landing-page.component.scss'
 })
 export class SiLandingPageComponent {
   /**

--- a/projects/element-ng/language-switcher/si-language-switcher.component.spec.ts
+++ b/projects/element-ng/language-switcher/si-language-switcher.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideTranslateService, TranslateService } from '@ngx-translate/core';
 import {
@@ -18,8 +18,7 @@ import { IsoLanguageValue, SiLanguageSwitcherComponent } from './index';
     [translationKey]="translationKey"
     [languageSwitcherLabel]="languageSwitcherLabel"
     [availableLanguages]="availableLanguages"
-  />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  />`
 })
 class TestHostComponent {
   availableLanguages: string[] | IsoLanguageValue[] = [

--- a/projects/element-ng/link/si-link.directive.spec.ts
+++ b/projects/element-ng/link/si-link.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
 import {
@@ -24,8 +24,7 @@ import { SI_LINK_DEFAULT_NAVIGATION_EXTRA, SiLinkDirective } from './si-link.dir
     (activeChange)="activeChange($event)"
   >
     Testli
-  </a>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  </a>`
 })
 class TestHostComponent {
   readonly link = signal<Link | undefined>({});
@@ -35,8 +34,7 @@ class TestHostComponent {
 
 @Component({
   selector: 'si-empty',
-  template: `empty`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `empty`
 })
 class SiEmptyComponent {}
 

--- a/projects/element-ng/list-details/si-details-pane-body/si-details-pane-body.component.ts
+++ b/projects/element-ng/list-details/si-details-pane-body/si-details-pane-body.component.ts
@@ -2,13 +2,12 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'si-details-pane-body',
   imports: [],
   templateUrl: './si-details-pane-body.component.html',
-  styleUrl: './si-details-pane-body.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-details-pane-body.component.scss'
 })
 export class SiDetailsPaneBodyComponent {}

--- a/projects/element-ng/list-details/si-details-pane-footer/si-details-pane-footer.component.ts
+++ b/projects/element-ng/list-details/si-details-pane-footer/si-details-pane-footer.component.ts
@@ -2,13 +2,12 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'si-details-pane-footer',
   imports: [],
   templateUrl: './si-details-pane-footer.component.html',
-  styleUrl: './si-details-pane-footer.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-details-pane-footer.component.scss'
 })
 export class SiDetailsPaneFooterComponent {}

--- a/projects/element-ng/list-details/si-details-pane-header/si-details-pane-header.component.ts
+++ b/projects/element-ng/list-details/si-details-pane-header/si-details-pane-header.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   inject,
@@ -26,7 +25,6 @@ import { SiListDetailsComponent } from '../si-list-details.component';
   imports: [SiTranslatePipe, SiIconComponent],
   templateUrl: './si-details-pane-header.component.html',
   styleUrl: './si-details-pane-header.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'nav nav-tabs' // To allow nav-link styling.
   }

--- a/projects/element-ng/list-details/si-details-pane/si-details-pane.component.ts
+++ b/projects/element-ng/list-details/si-details-pane/si-details-pane.component.ts
@@ -2,15 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  contentChild,
-  DestroyRef,
-  effect,
-  inject
-} from '@angular/core';
+import { Component, computed, contentChild, DestroyRef, effect, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterOutlet } from '@angular/router';
 import { Subscription } from 'rxjs';
@@ -22,7 +14,6 @@ import { SiListDetailsComponent } from '../si-list-details.component';
   imports: [],
   templateUrl: './si-details-pane.component.html',
   styleUrl: './si-details-pane.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.expanded]': 'parent.hasLargeSize()',
     '[class.details-active]': 'parent.detailsActive() && !parent.hasLargeSize()',

--- a/projects/element-ng/list-details/si-list-details.component.spec.ts
+++ b/projects/element-ng/list-details/si-list-details.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, DebugElement, signal, viewChild } from '@angular/core';
+import { Component, DebugElement, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter, RouterOutlet } from '@angular/router';
@@ -56,8 +56,7 @@ import { SiListPaneComponent } from './si-list-pane/si-list-pane.component';
         </si-details-pane-footer>
       </si-details-pane>
     </si-list-details>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class WrapperComponent {
   readonly listDetails = viewChild.required(SiListDetailsComponent);
@@ -371,15 +370,13 @@ describe('ListDetailsComponent', () => {
       template: `
         <si-details-pane-header>Header</si-details-pane-header>
         <si-details-pane-body>Body</si-details-pane-body>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class DetailsComponent {}
 
     @Component({
       selector: 'si-empty',
-      template: 'EMPTY',
-      changeDetection: ChangeDetectionStrategy.OnPush
+      template: 'EMPTY'
     })
     class EmptyComponent {}
 
@@ -392,8 +389,7 @@ describe('ListDetailsComponent', () => {
             <router-outlet />
           </si-details-pane>
         </si-list-details>
-      `,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      `
     })
     class ListComponent {}
 

--- a/projects/element-ng/list-details/si-list-details.component.ts
+++ b/projects/element-ng/list-details/si-list-details.component.ts
@@ -5,7 +5,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -33,7 +32,6 @@ import { BehaviorSubject, Subject, Subscription } from 'rxjs';
   imports: [NgTemplateOutlet, SiSplitComponent, SiSplitPartComponent],
   templateUrl: './si-list-details.component.html',
   styleUrl: './si-list-details.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'si-layout-inner list-details-layout d-flex flex-column',
     '[class.animations-disabled]': 'animationsGloballyDisabled',

--- a/projects/element-ng/list-details/si-list-pane-body/si-list-pane-body.component.ts
+++ b/projects/element-ng/list-details/si-list-pane-body/si-list-pane-body.component.ts
@@ -2,12 +2,11 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'si-list-pane-body',
   templateUrl: './si-list-pane-body.component.html',
-  styleUrl: './si-list-pane-body.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-list-pane-body.component.scss'
 })
 export class SiListPaneBodyComponent {}

--- a/projects/element-ng/list-details/si-list-pane-header/si-list-pane-header.component.ts
+++ b/projects/element-ng/list-details/si-list-pane-header/si-list-pane-header.component.ts
@@ -2,12 +2,11 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'si-list-pane-header',
   templateUrl: './si-list-pane-header.component.html',
-  styleUrl: './si-list-pane-header.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-list-pane-header.component.scss'
 })
 export class SiListPaneHeaderComponent {}

--- a/projects/element-ng/list-details/si-list-pane/si-list-pane.component.ts
+++ b/projects/element-ng/list-details/si-list-pane/si-list-pane.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ElementRef, inject } from '@angular/core';
+import { Component, ElementRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { SiListDetailsComponent } from '../si-list-details.component';
@@ -11,7 +11,6 @@ import { SiListDetailsComponent } from '../si-list-details.component';
   selector: 'si-list-pane',
   templateUrl: './si-list-pane.component.html',
   styleUrl: './si-list-pane.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.expanded]': 'parent.hasLargeSize()',
     '[class.details-active]': 'parent.detailsActive() && !parent.hasLargeSize()',

--- a/projects/element-ng/loading-spinner/si-loading-button.component.ts
+++ b/projects/element-ng/loading-spinner/si-loading-button.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { booleanAttribute, ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { booleanAttribute, Component, input } from '@angular/core';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiLoadingSpinnerComponent } from './si-loading-spinner.component';
@@ -12,7 +12,6 @@ import { SiLoadingSpinnerComponent } from './si-loading-spinner.component';
   imports: [SiLoadingSpinnerComponent, SiTranslatePipe],
   templateUrl: './si-loading-button.component.html',
   styleUrl: './si-loading-button.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.pe-none]': 'disabled()'
   }

--- a/projects/element-ng/loading-spinner/si-loading-spinner.component.ts
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, input } from '@angular/core';
+import { Component, inject, InjectionToken, input } from '@angular/core';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
 export const LOADING_SPINNER_BLOCKING = new InjectionToken<boolean>('isBlockingSpinner');
@@ -13,7 +13,6 @@ export const LOADING_SPINNER_OVERLAY = new InjectionToken<boolean>('isSpinnerOve
   imports: [SiTranslatePipe],
   templateUrl: './si-loading-spinner.component.html',
   styleUrl: './si-loading-spinner.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'animate.leave': 'spinner-leave'
   }

--- a/projects/element-ng/loading-spinner/si-loading-spinner.directive.spec.ts
+++ b/projects/element-ng/loading-spinner/si-loading-spinner.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiLoadingSpinnerModule } from './si-loading-spinner.module';
@@ -19,8 +19,7 @@ import { SiLoadingSpinnerModule } from './si-loading-spinner.module';
       et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
       sanctus est Lorem ipsum dolor sit amet.
     </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 export class TestHostComponent {
   readonly loading = signal(true);

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, DebugElement, signal, viewChild } from '@angular/core';
+import { Component, DebugElement, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Subject } from 'rxjs';
@@ -37,8 +37,7 @@ import { SiMainDetailContainerComponent } from './si-main-detail-container.compo
       <span slot="detailActions">detail-action</span>
       <span slot="details">details</span>
     </si-main-detail-container>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class WrapperComponent {
   readonly mainDetail = viewChild.required(SiMainDetailContainerComponent);

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
@@ -5,7 +5,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -43,7 +42,6 @@ import { timer } from 'rxjs';
   ],
   templateUrl: './si-main-detail-container.component.html',
   styleUrl: './si-main-detail-container.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'si-layout-inner',
     '[class.animate]': 'animate()',

--- a/projects/element-ng/menu/si-menu-item-checkbox.component.ts
+++ b/projects/element-ng/menu/si-menu-item-checkbox.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CDK_MENU, CdkMenuItemCheckbox, CdkMenuTrigger } from '@angular/cdk/menu';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { elementOk } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 
@@ -14,7 +14,6 @@ import { SiMenuItemBase } from './si-menu-item-base.directive';
   imports: [SiIconComponent],
   templateUrl: './si-menu-item-checkbox.component.html',
   styleUrl: './si-menu-item.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     {
       directive: CdkMenuItemCheckbox,

--- a/projects/element-ng/menu/si-menu-item-radio.component.ts
+++ b/projects/element-ng/menu/si-menu-item-radio.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkMenuItemRadio, CdkMenuTrigger } from '@angular/cdk/menu';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { elementRecordFilled } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 
@@ -14,7 +14,6 @@ import { SiMenuItemBase } from './si-menu-item-base.directive';
   imports: [SiIconComponent],
   templateUrl: './si-menu-item-radio.component.html',
   styleUrl: './si-menu-item.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     {
       directive: CdkMenuItemRadio,

--- a/projects/element-ng/menu/si-menu-item.component.ts
+++ b/projects/element-ng/menu/si-menu-item.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { elementRight2 } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 
@@ -14,7 +14,6 @@ import { SiMenuItemBase } from './si-menu-item-base.directive';
   imports: [SiIconComponent],
   templateUrl: './si-menu-item.component.html',
   styleUrl: './si-menu-item.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     {
       directive: CdkMenuItem,

--- a/projects/element-ng/modal/si-modal-service.spec.ts
+++ b/projects/element-ng/modal/si-modal-service.spec.ts
@@ -2,21 +2,13 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ApplicationRef,
-  ChangeDetectionStrategy,
-  Component,
-  input,
-  TemplateRef,
-  viewChild
-} from '@angular/core';
+import { ApplicationRef, Component, input, TemplateRef, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiModalService } from './si-modal.service';
 
 @Component({
-  template: '<div>test component-{{inputProp()}}</div>',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: '<div>test component-{{inputProp()}}</div>'
 })
 class DialogComponent {
   readonly inputProp = input<string>();
@@ -27,8 +19,7 @@ class DialogComponent {
     <ng-template #ref>
       <div>test template</div>
     </ng-template>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class DialogTemplateComponent {
   readonly templateRef = viewChild.required<TemplateRef<any>>('ref');

--- a/projects/element-ng/modal/si-modal.component.ts
+++ b/projects/element-ng/modal/si-modal.component.ts
@@ -5,7 +5,6 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   inject,
@@ -21,7 +20,6 @@ import { ModalRef } from './modalref';
   selector: 'si-modal',
   imports: [A11yModule],
   templateUrl: './si-modal.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[style.--element-animations-enabled]': 'modalRef.data.animated === false ? 0 : null',
     '(mousedown)': 'clickStarted($event)',

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-divider.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-divider.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 /**
  * @experimental
@@ -11,7 +11,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 @Component({
   selector: 'si-navbar-vertical-next-divider',
   template: '',
-  styleUrl: './si-navbar-vertical-next-divider.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-navbar-vertical-next-divider.component.scss'
 })
 export class SiNavbarVerticalNextDividerComponent {}

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-footer-items.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-footer-items.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 /**
  * Content slot for footer items inside `si-navbar-vertical-next`.
@@ -13,7 +13,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 @Component({
   selector: 'si-navbar-vertical-next-footer-items',
   template: '<ng-content />',
-  styleUrl: './si-navbar-vertical-next-footer-items.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-navbar-vertical-next-footer-items.component.scss'
 })
 export class SiNavbarVerticalNextFooterItemsComponent {}

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group-trigger.directive.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group-trigger.directive.ts
@@ -9,7 +9,6 @@ import {
 } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import {
-  ChangeDetectionStrategy,
   Component,
   ComponentRef,
   computed,
@@ -40,7 +39,6 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
 @Component({
   selector: 'si-navbar-flyout-anchor',
   template: '',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: { '[attr.aria-owns]': 'groupId()' }
 })
 class SiNavbarFlyoutAnchorComponent {

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkTrapFocus } from '@angular/cdk/a11y';
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLinkActive } from '@angular/router';
 
@@ -29,7 +29,6 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
     </div>
   }`,
   styleUrl: './si-navbar-vertical-next-group.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     role: 'group',
     '[id]': 'groupTrigger.groupId',

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-header.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-header.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { SiNavbarVerticalNextDividerComponent } from './si-navbar-vertical-next-divider.component';
 import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
@@ -21,7 +21,6 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
     }
   `,
   styleUrl: './si-navbar-vertical-next-header.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.collapsed]': 'navbar.collapsed()',
     'animate.enter': 'component-enter'

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiNavbarVerticalNextItemComponent } from './si-navbar-vertical-next-item.component';
@@ -18,8 +18,7 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
     [icon]="icon()"
   >
     Test Item
-  </a>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  </a>`
 })
 class TestHostComponent {
   readonly badge = signal<string | number | undefined>(undefined);
@@ -37,8 +36,7 @@ class TestHostComponent {
     [hideBadgeWhenCollapsed]="hideBadgeWhenCollapsed()"
   >
     Test Item
-  </a>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  </a>`
 })
 class TestHostWithBadgeVisibilityComponent {
   readonly badge = signal<string | number | undefined>(undefined);

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
@@ -5,7 +5,6 @@
 import { DomPortal } from '@angular/cdk/portal';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -29,7 +28,6 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
   imports: [SiIconComponent],
   templateUrl: './si-navbar-vertical-next-item.component.html',
   styleUrl: './si-navbar-vertical-next-item.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.focus-inside]': '!chipMode() || !!parent',
     '[class.navbar-vertical-item]': '!isChip()',

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-items.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-items.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 /**
  * Content slot for navbar items inside `si-navbar-vertical-next`.
@@ -12,7 +12,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 @Component({
   selector: 'si-navbar-vertical-next-items',
   template: '<ng-content />',
-  styleUrl: './si-navbar-vertical-next-items.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-navbar-vertical-next-items.component.scss'
 })
 export class SiNavbarVerticalNextItemsComponent {}

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-search.component.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  inject,
-  input,
-  output,
-  viewChild
-} from '@angular/core';
+import { Component, inject, input, output, viewChild } from '@angular/core';
 import { elementSearch } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiSearchBarComponent } from '@siemens/element-ng/search-bar';
@@ -22,8 +15,7 @@ import { SI_NAVBAR_VERTICAL_NEXT } from './si-navbar-vertical-next.provider';
   selector: 'si-navbar-vertical-next-search',
   imports: [SiIconComponent, SiSearchBarComponent, SiTranslatePipe],
   templateUrl: './si-navbar-vertical-next-search.component.html',
-  styleUrl: './si-navbar-vertical-next-search.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-navbar-vertical-next-search.component.scss'
 })
 export class SiNavbarVerticalNextSearchComponent {
   protected readonly icons = addIcons({ elementSearch });

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.component.ts
@@ -7,7 +7,6 @@ import { PortalModule } from '@angular/cdk/portal';
 import {
   afterNextRender,
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChildren,
@@ -51,7 +50,6 @@ interface UIState {
   templateUrl: './si-navbar-vertical-next.component.html',
   styleUrl: './si-navbar-vertical-next.component.scss',
   providers: [{ provide: SI_NAVBAR_VERTICAL_NEXT, useExisting: SiNavbarVerticalNextComponent }],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'si-layout-inner ready',
     '[class.nav-collapsed]': 'collapsed()',

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
@@ -5,7 +5,7 @@
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, Injectable, signal } from '@angular/core';
+import { Component, Injectable, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router, RouterLink, RouterLinkActive } from '@angular/router';
 import {
@@ -49,7 +49,7 @@ class BreakpointObserverMock implements Partial<BreakpointObserver> {
   }
 }
 
-@Component({ template: '', changeDetection: ChangeDetectionStrategy.OnPush })
+@Component({ template: '' })
 class EmptyComponent {}
 
 @Component({
@@ -155,8 +155,7 @@ class EmptyComponent {}
           sub-item2
         </a>
       </si-navbar-vertical-next-group>
-    </ng-template>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+    </ng-template>`
 })
 class TestHostComponent {
   readonly textOnly = signal(true);

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.spec.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiNavbarVerticalItemComponent } from './si-navbar-vertical-item.component';
@@ -11,8 +11,7 @@ import { SI_NAVBAR_VERTICAL } from './si-navbar-vertical.provider';
 
 @Component({
   imports: [SiNavbarVerticalItemComponent],
-  template: `<a class="navbar-vertical-item" [si-navbar-vertical-item]="item()"> Test Item </a>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<a class="navbar-vertical-item" [si-navbar-vertical-item]="item()"> Test Item </a>`
 })
 class TestHostComponent {
   readonly item = signal<NavbarVerticalItemLink>({
@@ -24,8 +23,7 @@ class TestHostComponent {
 
 @Component({
   imports: [SiNavbarVerticalItemComponent],
-  template: `<a class="navbar-vertical-item" [si-navbar-vertical-item]="item()"> Test Item </a> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<a class="navbar-vertical-item" [si-navbar-vertical-item]="item()"> Test Item </a> `
 })
 class TestHostWithBadgeVisibilityComponent {
   readonly item = signal<NavbarVerticalItemLink>({

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical-item.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, inject, input, OnInit } from '@angular/core';
+import { Component, computed, inject, input, OnInit } from '@angular/core';
 import { RouterLinkActive } from '@angular/router';
 import { elementDown2 } from '@siemens/element-icons';
 import { MenuItem } from '@siemens/element-ng/common';
@@ -30,7 +30,6 @@ type NavbarVerticalItemInteractive =
   imports: [SiIconComponent],
   templateUrl: './si-navbar-vertical-item.component.html',
   styleUrl: './si-navbar-vertical-item.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'class': 'focus-inside',
     '[class.dropdown-item]': 'this.parent?.group?.flyout()',

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical.spec.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical.spec.ts
@@ -5,7 +5,7 @@
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, Injectable, signal } from '@angular/core';
+import { Component, Injectable, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
 import {
@@ -42,7 +42,7 @@ class BreakpointObserverMock implements Partial<BreakpointObserver> {
   }
 }
 
-@Component({ template: '', changeDetection: ChangeDetectionStrategy.OnPush })
+@Component({ template: '' })
 class EmptyComponent {}
 
 @Component({
@@ -56,8 +56,7 @@ class EmptyComponent {}
     [searchDebounceTime]="0"
     (searchEvent)="searchEvent($event)"
     (itemsChange)="itemsChange($event)"
-  />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  />`
 })
 class TestHostComponent {
   readonly items = signal<(MenuItem | NavbarVerticalItem)[]>([

--- a/projects/element-ng/navbar/si-navbar-item/si-navbar-item.component.spec.ts
+++ b/projects/element-ng/navbar/si-navbar-item/si-navbar-item.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ElementRef, signal, viewChild } from '@angular/core';
+import { Component, ElementRef, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MenuItem } from '@siemens/element-ng/common';
 import { SiNavbarPrimaryComponent } from '@siemens/element-ng/navbar';
@@ -13,8 +13,7 @@ import { SiNavbarItemComponent } from './si-navbar-item.component';
 
 @Component({
   imports: [SiNavbarItemComponent],
-  template: ` <si-navbar-item #testComponent [item]="item" [quickAction]="quickAction" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: ` <si-navbar-item #testComponent [item]="item" [quickAction]="quickAction" /> `
 })
 class WrapperComponent {
   item!: MenuItem;

--- a/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.spec.ts
+++ b/projects/element-ng/navbar/si-navbar-primary/si-navbar-primary.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideLocationMocks } from '@angular/common/testing';
-import { ChangeDetectionStrategy, Component, HostBinding, viewChild } from '@angular/core';
+import { Component, HostBinding, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { SiApplicationHeaderHarness } from '@siemens/element-ng/application-header/testing/si-application-header.harness';
@@ -23,8 +23,7 @@ const categorizedAppItems: AppItemCategory[] = [
 
 @Component({
   imports: [SiNavbarPrimaryComponent],
-  template: ` <si-navbar-primary [appItems]="appItems" [appCategoryItems]="categorizedAppItems" />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: ` <si-navbar-primary [appItems]="appItems" [appCategoryItems]="categorizedAppItems" />`
 })
 export class TestHostComponent {
   readonly component = viewChild.required(TestComponent);

--- a/projects/element-ng/number-input/si-number-input.component.spec.ts
+++ b/projects/element-ng/number-input/si-number-input.component.spec.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 import {
-  ChangeDetectionStrategy,
   Component,
   inject,
   inputBinding,
@@ -27,8 +26,7 @@ import { SiNumberInputComponent } from './si-number-input.component';
       [min]="min()"
       [max]="max()"
     />
-  </form>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  </form>`
 })
 class FormHostComponent {
   readonly required = signal(false);
@@ -40,8 +38,7 @@ class FormHostComponent {
 
 @Component({
   imports: [SiNumberInputComponent],
-  template: ` <si-number-input min="some text" max="100" />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: ` <si-number-input min="some text" max="100" />`
 })
 class AttributeComponent {
   readonly siNumberInput = viewChild.required(SiNumberInputComponent);

--- a/projects/element-ng/number-input/si-number-input.component.ts
+++ b/projects/element-ng/number-input/si-number-input.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -55,7 +54,6 @@ import { Subscription, timer } from 'rxjs';
       useExisting: SiNumberInputComponent
     }
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.show-step-buttons]': 'showButtons()',
     '[class.disabled]': 'disabled()',

--- a/projects/element-ng/pagination/si-pagination.component.ts
+++ b/projects/element-ng/pagination/si-pagination.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, input, model } from '@angular/core';
+import { Component, computed, input, model } from '@angular/core';
 import { elementLeft3, elementRight3 } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
@@ -10,8 +10,7 @@ import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 @Component({
   selector: 'si-pagination',
   imports: [SiIconComponent, SiTranslatePipe],
-  templateUrl: './si-pagination.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-pagination.component.html'
 })
 export class SiPaginationComponent {
   private static maxItems = 7;

--- a/projects/element-ng/password-strength/si-password-strength.component.spec.ts
+++ b/projects/element-ng/password-strength/si-password-strength.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ElementRef, viewChild } from '@angular/core';
+import { Component, ElementRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
@@ -36,8 +36,7 @@ const passwordStrengthValue: PasswordPolicy = {
         (passwordStrengthChanged)="passwordStrengthChangedFunc($event)"
       />
     </si-password-strength>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class WrapperComponent {
   readonly passwordStrength = viewChild.required<TestComponent, ElementRef<TestComponent>>(

--- a/projects/element-ng/password-strength/si-password-strength.component.ts
+++ b/projects/element-ng/password-strength/si-password-strength.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   contentChild,
   contentChildren,
@@ -25,7 +24,6 @@ import { SiPasswordStrengthDirective } from './si-password-strength.directive';
     </si-password-toggle>
   `,
   styleUrl: './si-password-strength.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.bad]': 'bad()',
     '[class.weak]': 'weak()',

--- a/projects/element-ng/password-toggle/si-password-toggle.component.spec.ts
+++ b/projects/element-ng/password-toggle/si-password-toggle.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   FormControl,
@@ -27,8 +27,7 @@ const rgbToHex = (rgb: string): string => {
     <si-password-toggle #toggle [showVisibilityIcon]="showVisibilityIcon()">
       <input [attr.type]="toggle.inputType" />
     </si-password-toggle>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostComponent {
   readonly showVisibilityIcon = input(true);
@@ -42,8 +41,7 @@ class TestHostComponent {
         <input class="form-control" formControlName="input" />
       </si-password-toggle>
     </form>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class FormHostComponent {
   readonly form = new FormGroup({

--- a/projects/element-ng/phone-number/si-phone-number-input.component.spec.ts
+++ b/projects/element-ng/phone-number/si-phone-number-input.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -29,8 +29,7 @@ import { SiSelectFilterListHarness } from '../select/testing/si-select-filter-li
         (valueChange)="valueChange($event)"
       />
     </form>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class WrapperComponent {
   readonly country = signal('DE');

--- a/projects/element-ng/photo-upload/si-image-cropper-style.component.ts
+++ b/projects/element-ng/photo-upload/si-image-cropper-style.component.ts
@@ -2,12 +2,11 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'si-image-cropper-style',
   template: '<ng-content />',
-  styleUrl: './si-image-cropper-style.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-image-cropper-style.component.scss'
 })
 export class SiImageCropperStyleComponent {}

--- a/projects/element-ng/photo-upload/si-photo-upload.component.ts
+++ b/projects/element-ng/photo-upload/si-photo-upload.component.ts
@@ -5,7 +5,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -51,7 +50,6 @@ import { SiImageCropperStyleComponent } from './si-image-cropper-style.component
   ],
   templateUrl: './si-photo-upload.component.html',
   styleUrl: './si-photo-upload.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     {
       directive: SiAvatarBackgroundColorDirective,

--- a/projects/element-ng/pills-input/si-pills-input.component.spec.ts
+++ b/projects/element-ng/pills-input/si-pills-input.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { userEvent } from 'vitest/browser';
@@ -15,8 +15,7 @@ import { SiPillsInputModule } from './si-pills-input.module';
     <si-pills-input [readonly]="readonly()" [(ngModel)]="value" />
     <si-pills-input class="csv" siPillsInputCsv [(ngModel)]="csvValue" />
     <si-pills-input class="email" siPillsInputEmail [(ngModel)]="emailValue" />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostComponent {
   readonly value = signal<string[]>([]);

--- a/projects/element-ng/pills-input/si-pills-input.component.ts
+++ b/projects/element-ng/pills-input/si-pills-input.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -41,7 +40,6 @@ import {
       useExisting: SiPillsInputComponent
     }
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'form-control',
     role: 'listbox',

--- a/projects/element-ng/popover-legacy/si-popover.directive.spec.ts
+++ b/projects/element-ng/popover-legacy/si-popover.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { page, userEvent } from 'vitest/browser';
 
@@ -14,8 +14,7 @@ import { SiPopoverLegacyDirective } from './si-popover-legacy.directive';
     <button type="button" siPopoverLegacy="test popover content" [triggers]="triggers()">
       Test
     </button>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 export class TestHostComponent {
   readonly triggers = signal('click');

--- a/projects/element-ng/popover/si-popover.directive.spec.ts
+++ b/projects/element-ng/popover/si-popover.directive.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { page, userEvent } from 'vitest/browser';
 
@@ -17,8 +17,7 @@ const generateKeyEvent = (key: string): KeyboardEvent => {
 
 @Component({
   imports: [SiPopoverDirective],
-  template: `<button type="button" siPopover="test popover content">Test</button>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<button type="button" siPopover="test popover content">Test</button>`
 })
 export class HostComponent {
   readonly popoverOverlay = viewChild(SiPopoverDirective);
@@ -37,8 +36,7 @@ export class HostComponent {
         <button type="button" id="button-1">Button 1</button>
       </div>
     </ng-template>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 export class CustomTemplateHostComponent {}
 
@@ -190,8 +188,7 @@ describe('with scrollStrategy', () => {
     imports: [SiPopoverDirective],
     template: `<button type="button" siPopover="test" [siPopoverScrollStrategy]="scrollStrategy()">
       Test
-    </button>`,
-    changeDetection: ChangeDetectionStrategy.OnPush
+    </button>`
   })
   class ScrollStrategyHostComponent {
     readonly scrollStrategy = signal<ScrollStrategy | undefined>(undefined);

--- a/projects/element-ng/progressbar/si-progressbar.component.ts
+++ b/projects/element-ng/progressbar/si-progressbar.component.ts
@@ -2,15 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-progressbar',
   imports: [SiTranslatePipe],
   templateUrl: './si-progressbar.component.html',
-  styleUrl: './si-progressbar.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-progressbar.component.scss'
 })
 export class SiProgressbarComponent {
   /**

--- a/projects/element-ng/resize-observer/resize-observer.service.spec.ts
+++ b/projects/element-ng/resize-observer/resize-observer.service.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ElementRef, viewChild } from '@angular/core';
+import { Component, ElementRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subscription } from 'rxjs';
 import { Mock } from 'vitest';
@@ -11,8 +11,7 @@ import { page } from 'vitest/browser';
 import { ElementDimensions, ResizeObserverService } from './resize-observer.service';
 
 @Component({
-  template: `<div #theDiv class="w-100 vh-100">Testli</div>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<div #theDiv class="w-100 vh-100">Testli</div>`
 })
 class TestHostComponent {
   readonly theDiv = viewChild.required<ElementRef>('theDiv');

--- a/projects/element-ng/resize-observer/si-responsive-container.directive.spec.ts
+++ b/projects/element-ng/resize-observer/si-responsive-container.directive.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { page } from 'vitest/browser';
 
@@ -19,8 +19,7 @@ import { SiResponsiveContainerDirective } from './index';
     >
       Testli
     </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostComponent {
   readonly width = signal(100);

--- a/projects/element-ng/search-bar/si-search-bar.component.spec.ts
+++ b/projects/element-ng/search-bar/si-search-bar.component.spec.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  inputBinding,
-  outputBinding,
-  signal,
-  viewChild
-} from '@angular/core';
+import { Component, inputBinding, outputBinding, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { userEvent } from 'vitest/browser';
@@ -33,8 +26,7 @@ describe('SiSearchBarComponent', () => {
         [formControl]="search"
         [debounceTime]="debounceTime()"
         [prohibitedCharacters]="prohibitedCharacters()"
-      />`,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      />`
     })
     class TestComponent {
       readonly placeholder = signal('Placeholder');

--- a/projects/element-ng/search-bar/si-search-bar.component.ts
+++ b/projects/element-ng/search-bar/si-search-bar.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -39,7 +38,6 @@ import { debounceTime } from 'rxjs/operators';
       multi: true
     }
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.readonly]': 'readonly()'
   }

--- a/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
+++ b/projects/element-ng/select/options/si-select-lazy-options.directive.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Observable, of } from 'rxjs';
@@ -24,8 +24,7 @@ describe('SelectLazyOptionsDirective', () => {
       ReactiveFormsModule,
       SiSelectMultiValueDirective
     ],
-    template: `<si-select multi hasFilter [optionSource]="optionSource" [formControl]="control" />`,
-    changeDetection: ChangeDetectionStrategy.OnPush
+    template: `<si-select multi hasFilter [optionSource]="optionSource" [formControl]="control" />`
   })
   class TestHostComponent {
     readonly optionSource: SelectOptionSource<string> = {

--- a/projects/element-ng/select/select-input/si-select-input.component.ts
+++ b/projects/element-ng/select/select-input/si-select-input.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -30,7 +29,6 @@ import { SelectOption } from '../si-select.types';
   imports: [SiAutoCollapsableListModule, SiIconComponent, SiSelectOptionComponent, SiTranslatePipe],
   templateUrl: './si-select-input.component.html',
   styleUrl: './si-select-input.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     // In readonly mode, the select needs to be announced as a textbox.
     // Otherwise, screen-reader won't announce the readonly state.

--- a/projects/element-ng/select/select-list/si-select-list-has-filter.component.ts
+++ b/projects/element-ng/select/select-list/si-select-list-has-filter.component.ts
@@ -4,7 +4,6 @@
  */
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -40,7 +39,6 @@ import { SiSelectListBase } from './si-select-list.base';
   ],
   templateUrl: './si-select-list-has-filter.component.html',
   styleUrl: './si-select-list-has-filter.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'pt-0',
     '[attr.id]': 'id()'

--- a/projects/element-ng/select/select-list/si-select-list.component.ts
+++ b/projects/element-ng/select/select-list/si-select-list.component.ts
@@ -4,7 +4,7 @@
  */
 import { CdkListbox, CdkOption, ListboxValueChangeEvent } from '@angular/cdk/listbox';
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ElementRef, OnInit, viewChild } from '@angular/core';
+import { Component, ElementRef, OnInit, viewChild } from '@angular/core';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiSelectOptionRowComponent } from '../select-option/si-select-option-row.component';
@@ -23,8 +23,7 @@ import { SiSelectListBase } from './si-select-list.base';
     SiSelectGroupTemplateDirective,
     SiSelectOptionRowComponent
   ],
-  templateUrl: './si-select-list.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-select-list.component.html'
 })
 export class SiSelectListComponent<T> extends SiSelectListBase<T> implements OnInit {
   private readonly listbox = viewChild.required<CdkListbox, ElementRef<HTMLUListElement>>(

--- a/projects/element-ng/select/select-option/si-select-option-row.component.ts
+++ b/projects/element-ng/select/select-option/si-select-option-row.component.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  input,
-  TemplateRef
-} from '@angular/core';
+import { booleanAttribute, Component, input, TemplateRef } from '@angular/core';
 import { elementOk } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 
@@ -20,7 +14,6 @@ import { SelectOption } from '../si-select.types';
   imports: [SiIconComponent, SiSelectOptionComponent],
   templateUrl: './si-select-option-row.component.html',
   styleUrl: './si-select-option-row.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'dropdown-item focus-none pe-4 gap-4',
     '[class.disabled]': '!!this.option().disabled',

--- a/projects/element-ng/select/select-option/si-select-option.component.ts
+++ b/projects/element-ng/select/select-option/si-select-option.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input, TemplateRef } from '@angular/core';
+import { Component, input, TemplateRef } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
@@ -14,7 +14,6 @@ import { SelectOption } from '../si-select.types';
   selector: 'si-select-option',
   imports: [NgTemplateOutlet, SiIconComponent, SiTranslatePipe, SiSelectOptionTemplateDirective],
   templateUrl: './si-select-option.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'd-flex align-items-center overflow-hidden'
   }

--- a/projects/element-ng/select/selection/si-select-multi-value.directive.spec.ts
+++ b/projects/element-ng/select/selection/si-select-multi-value.directive.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { provideTranslateService } from '@ngx-translate/core';
@@ -21,8 +21,7 @@ import { SiSelectHarness } from '../testing/si-select.harness';
       [formControl]="control"
       (valueChange)="valueChange($event)"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestComponent {
   options: SelectItem<string>[] = [

--- a/projects/element-ng/select/si-custom-select.directive.spec.ts
+++ b/projects/element-ng/select/si-custom-select.directive.spec.ts
@@ -3,14 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { OverlayContainer } from '@angular/cdk/overlay';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  inject,
-  inputBinding,
-  signal,
-  twoWayBinding
-} from '@angular/core';
+import { Component, inject, inputBinding, signal, twoWayBinding } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { SI_FORM_ITEM_CONTROL } from '@siemens/element-ng/form';
@@ -33,7 +26,6 @@ import { SiSelectDropdownDirective } from './si-select-dropdown.directive';
       }
     </ng-template>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     {
       directive: SiCustomSelectDirective,
@@ -54,8 +46,7 @@ class SiTestSelectComponent {
 
 @Component({
   imports: [SiTestSelectComponent, ReactiveFormsModule],
-  template: `<si-test-select [formControl]="control" />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<si-test-select [formControl]="control" />`
 })
 class FormHostComponent {
   readonly control = new FormControl<string | undefined>(undefined);
@@ -111,7 +102,6 @@ describe('SiCustomSelectDirective', () => {
           <si-select-combobox>{{ select.value() ?? 'Pick...' }}</si-select-combobox>
           <ng-template si-select-dropdown contentType="tree" />
         `,
-        changeDetection: ChangeDetectionStrategy.OnPush,
         hostDirectives: [SiCustomSelectDirective]
       })
       class TreeSelectComponent {

--- a/projects/element-ng/select/si-select-combobox-value.component.ts
+++ b/projects/element-ng/select/si-select-combobox-value.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 
 /**
@@ -45,7 +45,6 @@ import { SiIconComponent } from '@siemens/element-ng/icon';
     <ng-content />
   `,
   styleUrl: './si-select-combobox-value.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'text-nowrap'
   }

--- a/projects/element-ng/select/si-select-combobox.component.ts
+++ b/projects/element-ng/select/si-select-combobox.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { elementDown2 } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 
@@ -34,7 +34,6 @@ import { SiCustomSelectDirective } from './si-custom-select.directive';
     </div>
   `,
   styleUrl: './si-select-combobox.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'select focus-none dropdown-toggle d-flex align-items-center w-100',
     '[attr.id]': 'customSelect.comboboxLabelId()',

--- a/projects/element-ng/select/si-select.component.spec.ts
+++ b/projects/element-ng/select/si-select.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader, TestKey } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -31,8 +31,7 @@ const OPTIONS_LIST_NEXT: SelectOption<number>[] = [
     <form [formGroup]="form">
       <si-select #select formControlName="input" [options]="options" />
     </form>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class FormHostComponent {
   readonly form = new FormGroup({
@@ -54,8 +53,7 @@ class FormHostComponent {
       [hasFilter]="hasFilter()"
       [(value)]="value"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostComponent {
   readonly selectComponent = viewChild.required(SiSelectComponent);
@@ -79,8 +77,7 @@ class TestHostComponent {
       [hasFilter]="hasFilter()"
       [(value)]="value"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostNumberComponent {
   readonly selectComponent = viewChild.required(SiSelectComponent);
@@ -108,8 +105,7 @@ class TestHostNumberComponent {
       [(value)]="values"
       (valueChange)="selectionChanged($event)"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostMultiComponent {
   readonly selectComponent = viewChild.required(SiSelectComponent);
@@ -147,8 +143,7 @@ class TestHostMultiComponent {
         </button>
       </ng-template>
     </si-select>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostCustomActionComponent {
   readonly options = signal<SelectOption<string>[] | undefined>(OPTIONS_LIST);

--- a/projects/element-ng/select/si-select.component.ts
+++ b/projects/element-ng/select/si-select.component.ts
@@ -5,7 +5,6 @@
 import { CdkOverlayOrigin, OverlayModule } from '@angular/cdk/overlay';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChild,
@@ -40,7 +39,6 @@ import { SelectGroup, SelectItem, SelectOption } from './si-select.types';
   templateUrl: './si-select.component.html',
   styleUrl: './si-select.component.scss',
   providers: [{ provide: SI_FORM_ITEM_CONTROL, useExisting: SiSelectComponent }],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'dropdown',
     '[class.readonly]': 'readonly()',

--- a/projects/element-ng/shadow-root/si-shadow-root.directive.spec.ts
+++ b/projects/element-ng/shadow-root/si-shadow-root.directive.spec.ts
@@ -3,13 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  input,
-  signal,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, input, signal, ViewEncapsulation } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiShadowRootDirective } from './si-shadow-root.directive';
@@ -31,7 +25,6 @@ describe('ShadowRootDirective', () => {
         color: #fff;
       }
     `,
-    changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.ShadowDom,
     hostDirectives: [SiShadowRootDirective]
   })
@@ -49,8 +42,7 @@ describe('ShadowRootDirective', () => {
       .test-style {
         color: #000 !important;
       }
-    `,
-    changeDetection: ChangeDetectionStrategy.OnPush
+    `
   })
   class TestHostComponent {
     readonly open = signal(false);

--- a/projects/element-ng/side-panel/si-side-panel-action.component.ts
+++ b/projects/element-ng/side-panel/si-side-panel-action.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { booleanAttribute, ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { booleanAttribute, Component, input } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 
 /**
@@ -48,7 +48,6 @@ import { SiIconComponent } from '@siemens/element-ng/icon';
     }
   `,
   styleUrl: './si-side-panel-action.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'focus-inside'
   }

--- a/projects/element-ng/side-panel/si-side-panel-actions.component.ts
+++ b/projects/element-ng/side-panel/si-side-panel-actions.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 /**
  * Creates an actions container for the side-panel.
@@ -30,7 +30,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 @Component({
   selector: 'si-side-panel-actions',
   template: '<ng-content />',
-  styleUrl: './si-side-panel-actions.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-side-panel-actions.component.scss'
 })
 export class SiSidePanelActionsComponent {}

--- a/projects/element-ng/side-panel/si-side-panel-content.component.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiSidePanelModule } from './si-side-panel.module';
@@ -17,8 +17,7 @@ import { SidePanelDisplayMode, SidePanelNavigateConfig } from './side-panel.mode
       [displayMode]="displayMode()"
       [navigateConfig]="navigateConfig"
     />
-  </si-side-panel>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  </si-side-panel>`
 })
 class TestHostComponent {
   readonly displayMode = signal<SidePanelDisplayMode | undefined>(undefined);

--- a/projects/element-ng/side-panel/si-side-panel-service.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel-service.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkPortal, PortalModule } from '@angular/cdk/portal';
-import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SiSidePanelService } from './si-side-panel.service';
@@ -14,8 +14,7 @@ import { SiSidePanelService } from './si-side-panel.service';
   template: `<ng-template #helpPanel cdkPortal>
       <h3>Help Panel</h3>
     </ng-template>
-    <div>Test Mock Component</div>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+    <div>Test Mock Component</div>`
 })
 class MockComponent {
   readonly helpPanel = viewChild.required<CdkPortal, CdkPortal>('helpPanel', { read: CdkPortal });

--- a/projects/element-ng/side-panel/si-side-panel.component.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkPortal, PortalModule } from '@angular/cdk/portal';
-import { ChangeDetectionStrategy, Component, signal, SimpleChange, viewChild } from '@angular/core';
+import { Component, signal, SimpleChange, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 
@@ -27,8 +27,7 @@ import { SidePanelMode } from './side-panel.model';
       <si-side-panel-content heading="side-panel">
         <div class="dynamic-content">Different content</div>
       </si-side-panel-content>
-    </ng-template> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+    </ng-template> `
 })
 class TestHostComponent {
   readonly sidePanel = viewChild.required(SiSidePanelComponent);

--- a/projects/element-ng/skip-links/si-skip-links.component.ts
+++ b/projects/element-ng/skip-links/si-skip-links.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
 import { SiSkipLinkTargetDirective } from './si-skip-link-target.directive';
@@ -11,8 +11,7 @@ import { SiSkipLinkTargetDirective } from './si-skip-link-target.directive';
   selector: 'si-skip-links',
   imports: [SiTranslatePipe],
   templateUrl: './si-skip-links.component.html',
-  styleUrl: './si-skip-links.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-skip-links.component.scss'
 })
 export class SiSkipLinksComponent {
   /** @defaultValue [] */

--- a/projects/element-ng/skip-links/si-skip-links.spec.ts
+++ b/projects/element-ng/skip-links/si-skip-links.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiSkipLinkTargetDirective } from './si-skip-link-target.directive';
@@ -12,8 +12,7 @@ import { SiSkipLinkTargetDirective } from './si-skip-link-target.directive';
   template: `
     <button siSkipLinkTarget="T1" type="button">Target 1</button>
     <button siSkipLinkTarget="T2" type="button">Target 2</button>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostComponent {}
 

--- a/projects/element-ng/slider/si-slider.component.spec.ts
+++ b/projects/element-ng/slider/si-slider.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
@@ -22,8 +22,7 @@ import { SiSliderComponent } from './si-slider.component';
       display: block;
       width: 300px;
     }
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class HostComponent {
   readonly value = signal<number | undefined>(10);
@@ -37,8 +36,7 @@ class HostComponent {
   imports: [FormsModule, ReactiveFormsModule, SiSliderComponent],
   template: `<form [formGroup]="form">
     <si-slider formControlName="slider" />
-  </form>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  </form>`
 })
 class FormHostComponent {
   readonly form: FormGroup;

--- a/projects/element-ng/slider/si-slider.component.ts
+++ b/projects/element-ng/slider/si-slider.component.ts
@@ -4,7 +4,6 @@
  */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -42,7 +41,6 @@ import { Subscription, timer } from 'rxjs';
       useExisting: SiSliderComponent
     }
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     role: 'group',
     '[class.disabled]': 'disabled()',

--- a/projects/element-ng/split/si-split.component.spec.ts
+++ b/projects/element-ng/split/si-split.component.spec.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  Injectable,
-  signal,
-  viewChild
-} from '@angular/core';
+import { Component, ElementRef, Injectable, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideSiUiState, SI_UI_STATE_SERVICE, UIStateStorage } from '@siemens/element-ng/common';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
@@ -105,8 +98,7 @@ class SynchronousMockStore implements UIStateStorage {
         </si-split-part>
       </si-split>
     </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class WrapperComponent {
   readonly split = viewChild.required(TestComponent);

--- a/projects/element-ng/status-bar/si-status-bar.component.ts
+++ b/projects/element-ng/status-bar/si-status-bar.component.ts
@@ -6,7 +6,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   inject,
@@ -64,8 +63,7 @@ let idCounter = 1;
     SiTranslatePipe
   ],
   templateUrl: './si-status-bar.component.html',
-  styleUrl: './si-status-bar.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-status-bar.component.scss'
 })
 export class SiStatusBarComponent implements OnDestroy, OnChanges {
   private static readonly minNumberOfItems = 2;

--- a/projects/element-ng/status-counter/si-status-counter.component.ts
+++ b/projects/element-ng/status-counter/si-status-counter.component.ts
@@ -2,22 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  input,
-  numberAttribute
-} from '@angular/core';
+import { booleanAttribute, Component, computed, input, numberAttribute } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 
 @Component({
   selector: 'si-status-counter, si-icon-status',
   imports: [SiIconComponent],
   templateUrl: './si-status-counter.component.html',
-  styleUrl: './si-status-counter.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-status-counter.component.scss'
 })
 export class SiStatusCounterComponent {
   /** Icon to display. */

--- a/projects/element-ng/status-toggle/si-status-toggle.component.spec.ts
+++ b/projects/element-ng/status-toggle/si-status-toggle.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -11,8 +11,7 @@ import { StatusToggleItem } from './status-toggle.model';
 
 @Component({
   imports: [SiStatusToggleComponent],
-  template: `<si-status-toggle #toggle [items]="items" [disabled]="disabled" [(value)]="value" />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<si-status-toggle #toggle [items]="items" [disabled]="disabled" [(value)]="value" />`
 })
 class HostComponent {
   disabled = false;
@@ -27,8 +26,7 @@ class HostComponent {
 
 @Component({
   imports: [SiStatusToggleComponent, ReactiveFormsModule],
-  template: `<si-status-toggle #toggle [items]="items" [formControl]="formControl" />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<si-status-toggle #toggle [items]="items" [formControl]="formControl" />`
 })
 class FormHostComponent {
   readonly formControl = new FormControl('A');

--- a/projects/element-ng/status-toggle/si-status-toggle.component.ts
+++ b/projects/element-ng/status-toggle/si-status-toggle.component.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -37,8 +36,7 @@ import { StatusToggleItem } from './status-toggle.model';
       useExisting: forwardRef(() => SiStatusToggleComponent),
       multi: true
     }
-  ],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  ]
 })
 export class SiStatusToggleComponent implements ControlValueAccessor, OnInit, OnDestroy, OnChanges {
   /** List of status items. */

--- a/projects/element-ng/summary-chip/si-summary-chip.component.ts
+++ b/projects/element-ng/summary-chip/si-summary-chip.component.ts
@@ -2,15 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  input,
-  model
-} from '@angular/core';
+import { booleanAttribute, Component, computed, inject, input, model } from '@angular/core';
 import { ExtendedStatusType } from '@siemens/element-ng/common';
 import { SiIconComponent, STATUS_ICON_CONFIG } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -19,8 +11,7 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
   selector: 'si-summary-chip',
   imports: [SiIconComponent, SiTranslatePipe],
   templateUrl: './si-summary-chip.component.html',
-  styleUrl: './si-summary-chip.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-summary-chip.component.scss'
 })
 export class SiSummaryChipComponent {
   private readonly statusIcons = inject(STATUS_ICON_CONFIG);

--- a/projects/element-ng/summary-widget/si-summary-widget.component.ts
+++ b/projects/element-ng/summary-widget/si-summary-widget.component.ts
@@ -2,14 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  input,
-  model
-} from '@angular/core';
+import { booleanAttribute, Component, computed, input, model } from '@angular/core';
 import { ExtendedStatusType, STATUS_ICON } from '@siemens/element-ng/common';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
@@ -18,8 +11,7 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
   selector: 'si-summary-widget',
   imports: [SiIconComponent, SiTranslatePipe],
   templateUrl: './si-summary-widget.component.html',
-  styleUrl: './si-summary-widget.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-summary-widget.component.scss'
 })
 export class SiSummaryWidgetComponent {
   /** Status. Alternatively, use {@link icon} and {@link color}. */

--- a/projects/element-ng/system-banner/system-banner.component.ts
+++ b/projects/element-ng/system-banner/system-banner.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { ExtendedStatusType } from '@siemens/element-ng/common';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
@@ -15,7 +15,6 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
   imports: [SiTranslatePipe],
   templateUrl: './system-banner.component.html',
   styleUrl: './system-banner.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class]': 'bannerClass()'
   }

--- a/projects/element-ng/tabs-legacy/si-tab/si-tab-legacy.component.ts
+++ b/projects/element-ng/tabs-legacy/si-tab/si-tab-legacy.component.ts
@@ -5,7 +5,6 @@
 /* eslint-disable @angular-eslint/prefer-output-emitter-ref */
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   HostBinding,
@@ -26,7 +25,6 @@ import { SiTabsetLegacyComponent } from '../si-tabset/index';
 @Component({
   selector: 'si-tab-legacy',
   template: '<ng-content />',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     role: 'tabpanel'
   }

--- a/projects/element-ng/tabs-legacy/si-tabset/si-tabset-legacy.component.ts
+++ b/projects/element-ng/tabs-legacy/si-tabset/si-tabset-legacy.component.ts
@@ -6,7 +6,6 @@
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
@@ -56,8 +55,7 @@ const SCROLL_INCREMENT = 55;
   selector: 'si-tabset-legacy',
   imports: [SiIconComponent, SiResizeObserverDirective, SiTranslatePipe],
   templateUrl: './si-tabset-legacy.component.html',
-  styleUrl: './si-tabset-legacy.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-tabset-legacy.component.scss'
 })
 export class SiTabsetLegacyComponent implements AfterViewInit, OnDestroy {
   /**

--- a/projects/element-ng/tabs/si-tab-badge.component.ts
+++ b/projects/element-ng/tabs/si-tab-badge.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
@@ -10,7 +10,6 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
   imports: [SiTranslatePipe],
   templateUrl: './si-tab-badge.component.html',
   styleUrl: './si-tab-badge.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'class': 'd-contents'
   }

--- a/projects/element-ng/tabs/si-tab-link.component.ts
+++ b/projects/element-ng/tabs/si-tab-link.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { SiIconComponent } from '@siemens/element-ng/icon';
@@ -32,7 +32,6 @@ import { SiTabBaseDirective } from './si-tab-base.directive';
   templateUrl: './si-tab.component.html',
   styleUrl: './si-tab.component.scss',
   providers: [SiTooltipService, { provide: SiTabBaseDirective, useExisting: SiTabLinkComponent }],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     {
       directive: RouterLinkActive

--- a/projects/element-ng/tabs/si-tab-portal.component.ts
+++ b/projects/element-ng/tabs/si-tab-portal.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkPortalOutlet } from '@angular/cdk/portal';
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 
 import { SiTabsetComponent } from './si-tabset.component';
 
@@ -32,8 +32,7 @@ import { SiTabsetComponent } from './si-tabset.component';
 @Component({
   selector: 'si-tab-portal',
   imports: [CdkPortalOutlet],
-  template: ` <ng-template [cdkPortalOutlet]="tabset().contentPortal()" /> `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: ` <ng-template [cdkPortalOutlet]="tabset().contentPortal()" /> `
 })
 export class SiTabPortalComponent {
   /**

--- a/projects/element-ng/tabs/si-tab.component.ts
+++ b/projects/element-ng/tabs/si-tab.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input, model, OnDestroy } from '@angular/core';
+import { Component, input, model, OnDestroy } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTooltipService } from '@siemens/element-ng/tooltip';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
@@ -28,7 +28,6 @@ import { SiTabBaseDirective } from './si-tab-base.directive';
   templateUrl: './si-tab.component.html',
   styleUrl: './si-tab.component.scss',
   providers: [SiTooltipService, { provide: SiTabBaseDirective, useExisting: SiTabComponent }],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '(click)': 'selectTabByUser()',
     '(keydown.enter)': 'selectTabByUser()'

--- a/projects/element-ng/tabs/si-tabset.component.spec.ts
+++ b/projects/element-ng/tabs/si-tabset.component.spec.ts
@@ -32,8 +32,7 @@ interface TabData {
 
 @Component({
   selector: 'si-tab-route',
-  template: `Content by routing`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `Content by routing`
 })
 class SiTabRouteComponent {}
 
@@ -106,8 +105,7 @@ class TestComponent {
         </si-tabset>
       }
     </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestRoutingComponent {
   readonly tabButtonMaxWidth = signal<number | undefined>(undefined);
@@ -477,8 +475,7 @@ describe('SiTabset with portal content', () => {
 
         <si-tab-portal [tabset]="tabset" />
       </div>
-    `,
-    changeDetection: ChangeDetectionStrategy.OnPush
+    `
   })
   class TestPortalContentComponent {
     readonly tabs = signal<
@@ -605,8 +602,7 @@ describe('SiTabset with custom tooltip', () => {
       <si-tabset>
         <si-tab heading="Tab 1" icon="element-options" [siTooltip]="tooltip()" />
       </si-tabset>
-    `,
-    changeDetection: ChangeDetectionStrategy.OnPush
+    `
   })
   class TooltipHostComponent {
     readonly tooltip = signal('Custom tooltip');

--- a/projects/element-ng/tabs/si-tabset.component.ts
+++ b/projects/element-ng/tabs/si-tabset.component.ts
@@ -8,7 +8,6 @@ import { DomPortal } from '@angular/cdk/portal';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChildren,
@@ -54,8 +53,7 @@ import { SI_TABSET } from './si-tabs-tokens';
       provide: SI_TABSET,
       useExisting: SiTabsetComponent
     }
-  ],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  ]
 })
 export class SiTabsetComponent {
   /**

--- a/projects/element-ng/threshold/si-threshold.component.spec.ts
+++ b/projects/element-ng/threshold/si-threshold.component.spec.ts
@@ -4,7 +4,7 @@
  */
 import { HarnessLoader, parallel } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SelectOption } from '@siemens/element-ng/select';
 import { SiSelectHarness } from '@siemens/element-ng/select/testing';
@@ -33,8 +33,7 @@ import { SiThresholdComponent, ThresholdStep } from './index';
       (validChange)="valid.set($event)"
       (thresholdStepsChange)="thresholdStepsChange($event)"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class TestHostComponent {
   readonly options = signal<SelectOption<string>[]>(undefined!);

--- a/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification-drawer/si-toast-notification-drawer.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { areAnimationsDisabled } from '@siemens/element-ng/common';
 
 import { SiToastNotificationComponent } from '../si-toast-notification/si-toast-notification.component';
@@ -13,7 +13,6 @@ import { SI_TOAST_TOKEN } from '../si-toast-token.model';
   imports: [SiToastNotificationComponent],
   templateUrl: './si-toast-notification-drawer.component.html',
   styleUrl: './si-toast-notification-drawer.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'aria-live': 'polite',
     '[class.animations-disabled]': 'animationsDisabled'

--- a/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification/si-toast-notification.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { STATUS_ICON } from '@siemens/element-ng/common';
 import { Subject } from 'rxjs';
@@ -13,8 +13,7 @@ import { SiToastNotificationComponent } from './si-toast-notification.component'
 
 @Component({
   imports: [SiToastNotificationComponent],
-  template: `<si-toast-notification [toast]="toast()" />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<si-toast-notification [toast]="toast()" />`
 })
 class TestHostComponent {
   readonly siToastComponent = viewChild.required(SiToastNotificationComponent);

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -3,14 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  inject,
-  signal,
-  viewChild
-} from '@angular/core';
+import { Component, ElementRef, inject, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { page } from 'vitest/browser';
 
@@ -43,8 +36,7 @@ describe('SiTooltipDirective', () => {
       imports: [SiTooltipModule],
       template: `<button type="button" [siTooltip]="tooltipText()" [isDisabled]="isDisabled()">
         Test
-      </button>`,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      </button>`
     })
     class TestHostComponent {
       readonly isDisabled = signal(false);
@@ -185,8 +177,7 @@ describe('SiTooltipDirective', () => {
       template: `<button type="button" [siTooltip]="template" [tooltipContext]="tooltipContext()">
           Test
         </button>
-        <ng-template #template let-tooltip="tooltip">Template content {{ tooltip }}</ng-template>`,
-      changeDetection: ChangeDetectionStrategy.OnPush
+        <ng-template #template let-tooltip="tooltip">Template content {{ tooltip }}</ng-template>`
     })
     class TestHostComponent {
       readonly tooltipContext = signal<Record<string, unknown>>({});
@@ -232,8 +223,7 @@ describe('SiTooltipDirective', () => {
     @Component({
       template: `<button #anchor type="button">Test</button>
         <div #content>{{ contentText() }}</div>`,
-      providers: [SiTooltipService],
-      changeDetection: ChangeDetectionStrategy.OnPush
+      providers: [SiTooltipService]
     })
     class TestHostComponent {
       readonly contentText = signal('node tooltip');
@@ -299,8 +289,7 @@ describe('SiTooltipDirective', () => {
       imports: [SiTooltipModule],
       template: `<button type="button" siTooltip="test" [tooltipScrollStrategy]="scrollStrategy()"
         >Test</button
-      >`,
-      changeDetection: ChangeDetectionStrategy.OnPush
+      >`
     })
     class TestHostComponent {
       readonly scrollStrategy = signal<ScrollStrategy | undefined>(undefined);

--- a/projects/element-ng/tour/si-tour-highlight.component.ts
+++ b/projects/element-ng/tour/si-tour-highlight.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, ElementRef, inject, signal } from '@angular/core';
+import { Component, ElementRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { SI_TOUR_TOKEN } from './si-tour-token.model';
@@ -10,8 +10,7 @@ import { SI_TOUR_TOKEN } from './si-tour-token.model';
 @Component({
   selector: 'si-tour-highlight',
   templateUrl: './si-tour-highlight.component.html',
-  styleUrl: './si-tour-highlight.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrl: './si-tour-highlight.component.scss'
 })
 export class SiTourHighlightComponent {
   private tourToken = inject(SI_TOUR_TOKEN);

--- a/projects/element-ng/tour/si-tour.component.ts
+++ b/projects/element-ng/tour/si-tour.component.ts
@@ -4,7 +4,6 @@
  */
 import { A11yModule, CdkTrapFocus } from '@angular/cdk/a11y';
 import {
-  ChangeDetectionStrategy,
   Component,
   DOCUMENT,
   ElementRef,
@@ -31,7 +30,6 @@ import { PositionChange, SI_TOUR_TOKEN, TourAction, TourStepInternal } from './s
   imports: [A11yModule, SiIconComponent, SiTranslatePipe],
   templateUrl: './si-tour.component.html',
   styleUrl: './si-tour.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[attr.data-step-id]': 'step()?.step?.id'
   }

--- a/projects/element-ng/tour/si-tour.service.spec.ts
+++ b/projects/element-ng/tour/si-tour.service.spec.ts
@@ -2,14 +2,13 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiTourService } from './si-tour.service';
 
 @Component({
-  template: `<div class="h-10">Test</div>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `<div class="h-10">Test</div>`
 })
 class TestHostComponent {
   readonly tourService = inject(SiTourService);

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { CdkDragDrop, CdkDropList, DragDropModule } from '@angular/cdk/drag-drop';
-import { ChangeDetectionStrategy, Component, DebugElement, signal, viewChild } from '@angular/core';
+import { Component, DebugElement, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -40,8 +40,7 @@ import { SiTreeViewItemDirective } from './si-tree-view-item.directive';
         <si-tree-view-item cdkDrag />
       </ng-template>
     </si-tree-view>
-  </div>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  </div>`
 })
 class WrapperComponent {
   readonly treeOneList = viewChild.required('treeOne', { read: CdkDropList });

--- a/projects/element-ng/tree-view/si-tree-view.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MenuItem } from '@siemens/element-ng/menu';
@@ -43,8 +43,7 @@ import { LoadChildrenEventArgs, MenuItemsProvider, TreeItem } from './si-tree-vi
     [deleteChildrenOnCollapse]="deleteChildrenOnCollapse()"
     [expandCollapseAll]="expandCollapseAll()"
     (loadChildren)="loadChildren($event)"
-  />`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  />`
 })
 class WrapperComponent {
   readonly treeViewComponent = viewChild.required(SiTreeViewComponent);

--- a/projects/element-ng/typeahead/si-typeahead.component.ts
+++ b/projects/element-ng/typeahead/si-typeahead.component.ts
@@ -3,15 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { NgTemplateOutlet } from '@angular/common';
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  ElementRef,
-  inject,
-  viewChild
-} from '@angular/core';
+import { AfterViewInit, Component, computed, ElementRef, inject, viewChild } from '@angular/core';
 import {
   SiAutocompleteDirective,
   SiAutocompleteListboxDirective,
@@ -38,7 +30,6 @@ import { TypeaheadMatch } from './si-typeahead.model';
   ],
   templateUrl: './si-typeahead.component.html',
   styleUrl: './si-typeahead.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'w-100', '(mousedown)': '$event.preventDefault()' }
 })
 export class SiTypeaheadComponent implements AfterViewInit {

--- a/projects/element-ng/typeahead/si-typeahead.directive.spec.ts
+++ b/projects/element-ng/typeahead/si-typeahead.directive.spec.ts
@@ -5,7 +5,7 @@
 import { DOWN_ARROW, ENTER } from '@angular/cdk/keycodes';
 import { HarnessLoader, TestKey } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ChangeDetectionStrategy, Component, signal, TemplateRef, viewChild } from '@angular/core';
+import { Component, signal, TemplateRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
@@ -52,8 +52,7 @@ const testItems = ['test', 'item'];
       (ngModelChange)="onModelChange($event)"
       (typeaheadOnCreateOption)="onCreateOption($event)"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 class WrapperComponent {
   readonly items = signal<Typeahead>(testItems);

--- a/projects/element-ng/wizard/si-wizard-step.component.ts
+++ b/projects/element-ng/wizard/si-wizard-step.component.ts
@@ -2,20 +2,12 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  input,
-  output,
-  signal
-} from '@angular/core';
+import { booleanAttribute, Component, input, output, signal } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
   selector: 'si-wizard-step',
-  templateUrl: './si-wizard-step.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  templateUrl: './si-wizard-step.component.html'
 })
 export class SiWizardStepComponent {
   /** @defaultValue '' */

--- a/projects/element-ng/wizard/si-wizard.component.ts
+++ b/projects/element-ng/wizard/si-wizard.component.ts
@@ -5,7 +5,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChildren,
@@ -59,7 +58,6 @@ interface StepMetadata {
   imports: [SiIconComponent, SiResizeObserverDirective, SiTranslatePipe, NgTemplateOutlet],
   templateUrl: './si-wizard.component.html',
   styleUrl: './si-wizard.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'py-6 px-8 d-flex flex-column',
     '[class.vertical]': 'verticalLayout()',


### PR DESCRIPTION
no need to mark OnPush explicitly as it is by default now.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2332/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2332/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2332/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2332/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2332/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2332/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2332/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2332/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2332/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2332/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
