### PR TITLE
refactor(tooltip): pass tooltip data via input bindings instead of DI token

### DIFF
--- a/projects/element-ng/tooltip/si-tooltip.component.html
+++ b/projects/element-ng/tooltip/si-tooltip.component.html
@@ -1,7 +1,7 @@
 <div
   class="tooltip show position-relative"
   role="tooltip"
-  [id]="config.id"
+  [id]="id()"
   [class]="tooltipPositionClass()"
 >
   <div
@@ -15,7 +15,7 @@
     } @else if (tooltipTemplate()) {
       <ng-template
         [ngTemplateOutlet]="tooltipTemplate()"
-        [ngTemplateOutletContext]="config.tooltipContext()"
+        [ngTemplateOutletContext]="tooltipContext()"
       />
     } @else if (tooltipComponent()) {
       <ng-container [ngComponentOutlet]="tooltipComponent()!" />

--- a/projects/element-ng/tooltip/si-tooltip.component.ts
+++ b/projects/element-ng/tooltip/si-tooltip.component.ts
@@ -11,13 +11,14 @@ import {
   computed,
   ElementRef,
   inject,
+  input,
   signal,
   TemplateRef
 } from '@angular/core';
 import { calculateOverlayArrowPosition, OverlayArrowPosition } from '@siemens/element-ng/common';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
-import { SI_TOOLTIP_CONFIG } from './si-tooltip.model';
+import { SiTooltipContent } from './si-tooltip.model';
 
 @Component({
   selector: 'si-tooltip',
@@ -30,10 +31,15 @@ import { SI_TOOLTIP_CONFIG } from './si-tooltip.model';
   }
 })
 export class TooltipComponent {
+  readonly id = input<string>();
+
+  readonly tooltip = input<SiTooltipContent>();
+
+  readonly tooltipContext = input<unknown>();
+
   protected readonly tooltipPositionClass = signal('');
   protected readonly arrowPos = signal<OverlayArrowPosition | undefined>(undefined);
 
-  protected readonly config = inject(SI_TOOLTIP_CONFIG);
   private readonly elementRef = inject(ElementRef);
   private readonly overlayRef = inject(OverlayRef);
 
@@ -43,8 +49,8 @@ export class TooltipComponent {
   constructor() {
     let isFirstRun = true;
     afterRenderEffect(() => {
-      this.config.tooltip();
-      this.config.tooltipContext();
+      this.tooltip();
+      this.tooltipContext();
       if (isFirstRun) {
         isFirstRun = false;
         return;
@@ -57,7 +63,7 @@ export class TooltipComponent {
   }
 
   protected readonly tooltipText = computed<string | null>(() => {
-    const tooltip = this.config.tooltip();
+    const tooltip = this.tooltip();
     if (typeof tooltip === 'string') {
       return tooltip;
     }
@@ -71,12 +77,12 @@ export class TooltipComponent {
   });
 
   protected readonly tooltipTemplate = computed<TemplateRef<any> | null>(() => {
-    const tooltip = this.config.tooltip();
+    const tooltip = this.tooltip();
     return tooltip instanceof TemplateRef ? tooltip : null;
   });
 
   protected readonly tooltipComponent = computed(() => {
-    const tooltip = this.config.tooltip();
+    const tooltip = this.tooltip();
     return !(tooltip instanceof TemplateRef) &&
       !(tooltip instanceof ElementRef) &&
       typeof tooltip !== 'string'

--- a/projects/element-ng/tooltip/si-tooltip.model.ts
+++ b/projects/element-ng/tooltip/si-tooltip.model.ts
@@ -2,16 +2,8 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ElementRef, InjectionToken, TemplateRef, Type } from '@angular/core';
+import { ElementRef, TemplateRef, Type } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 export type SiTooltipContent =
   TranslatableString | TemplateRef<any> | Type<any> | ElementRef<Element> | null | undefined;
-
-export interface SiTooltipConfig {
-  id?: string;
-  tooltip: () => SiTooltipContent;
-  tooltipContext: () => unknown;
-}
-
-export const SI_TOOLTIP_CONFIG = new InjectionToken<SiTooltipConfig>('SiTooltipConfig');

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -5,13 +5,21 @@
 import { Overlay, OverlayRef, ScrollStrategy } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { isPlatformBrowser } from '@angular/common';
-import { ComponentRef, ElementRef, inject, Injectable, Injector, PLATFORM_ID } from '@angular/core';
+import {
+  ComponentRef,
+  ElementRef,
+  inject,
+  Injectable,
+  Injector,
+  inputBinding,
+  PLATFORM_ID
+} from '@angular/core';
 import { getOverlay, getPositionStrategy, positions } from '@siemens/element-ng/common';
 import { fromEvent, Subject, Subscription, timer } from 'rxjs';
 import { delayWhen, filter, takeUntil } from 'rxjs/operators';
 
 import { TooltipComponent } from './si-tooltip.component';
-import { SI_TOOLTIP_CONFIG, SiTooltipContent } from './si-tooltip.model';
+import { SiTooltipContent } from './si-tooltip.model';
 
 /** @internal */
 interface TooltipRef {
@@ -156,7 +164,11 @@ class BrowserTooltipRef {
       providers: [{ provide: OverlayRef, useValue: overlayRef }]
     });
 
-    const toolTipPortal = new ComponentPortal(TooltipComponent, undefined, injector);
+    const toolTipPortal = new ComponentPortal(TooltipComponent, undefined, injector, undefined, [
+      inputBinding('id', () => this.config.describedBy),
+      inputBinding('tooltip', this.config.tooltip),
+      inputBinding('tooltipContext', this.config.tooltipContext)
+    ]);
     const tooltipRef: ComponentRef<TooltipComponent> = overlayRef.attach(toolTipPortal);
 
     const positionStrategy = getPositionStrategy(overlayRef);
@@ -208,23 +220,8 @@ export class SiTooltipService {
       return new NoopTooltipRef();
     }
 
-    const injector = Injector.create({
-      parent: config.injector,
-      providers: [
-        {
-          provide: SI_TOOLTIP_CONFIG,
-          useValue: {
-            id: config.describedBy,
-            tooltip: config.tooltip,
-            tooltipContext: config.tooltipContext
-          }
-        }
-      ]
-    });
-
     return new BrowserTooltipRef({
       ...config,
-      injector,
       overlay: this.overlay
     });
   }


### PR DESCRIPTION
Bind `id`, `tooltip`, and `tooltipContext` directly onto `TooltipComponent` inputs using `inputBinding()` when creating the `ComponentPortal`, instead of providing a `SI_TOOLTIP_CONFIG` injection token. This removes the extra injector indirection and lets the component consume its data through regular signal inputs.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2336/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2336/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2336/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2336/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2336/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2336/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2336/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2336/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2336/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2336/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
