### PR TITLE
refactor(form): pass form validation tooltip errors via input binding instead of DI token

### DIFF
--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.component.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.component.ts
@@ -2,14 +2,10 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiFormError } from '../si-form-item/si-form-item.component';
-
-export const SI_FORM_VALIDATION_TOOLTIP_DATA = new InjectionToken<Signal<SiFormError[]>>(
-  'SiFormValidationTooltipData'
-);
 
 @Component({
   selector: 'si-form-validation-tooltip',
@@ -25,5 +21,10 @@ export const SI_FORM_VALIDATION_TOOLTIP_DATA = new InjectionToken<Signal<SiFormE
   }
 })
 export class SiFormValidationTooltipComponent {
-  protected errors = inject(SI_FORM_VALIDATION_TOOLTIP_DATA);
+  /**
+   * The validation errors to display.
+   *
+   * @defaultValue []
+   */
+  readonly errors = input<SiFormError[]>([]);
 }

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
@@ -2,16 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  Directive,
-  DoCheck,
-  ElementRef,
-  inject,
-  Injector,
-  input,
-  OnDestroy,
-  signal
-} from '@angular/core';
+import { Directive, DoCheck, ElementRef, inject, input, OnDestroy, signal } from '@angular/core';
 import { NgControl, ValidationErrors } from '@angular/forms';
 import { SiTooltipService, TooltipRef } from '@siemens/element-ng/tooltip';
 
@@ -19,10 +10,7 @@ import { SiFormContainerComponent } from '../si-form-container/si-form-container
 import { SiFormError } from '../si-form-item/si-form-item.component';
 import { SiFormValidationErrorMapper } from '../si-form-validation-error.model';
 import { SiFormValidationErrorService } from '../si-form-validation-error.service';
-import {
-  SI_FORM_VALIDATION_TOOLTIP_DATA,
-  SiFormValidationTooltipComponent
-} from './si-form-validation-tooltip.component';
+import { SiFormValidationTooltipComponent } from './si-form-validation-tooltip.component';
 
 /**
  * Directive to show a tooltip with validation errors of a form control.
@@ -100,12 +88,8 @@ export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
       placement: 'auto',
       element: this.elementRef,
       describedBy: this.describedBy,
-      injector: Injector.create({
-        providers: [{ provide: SI_FORM_VALIDATION_TOOLTIP_DATA, useValue: this.errors }]
-      }),
       tooltip: () => SiFormValidationTooltipComponent,
-      // Not actually used, but errors in the context triggers a resize if the errors changes.
-      tooltipContext: () => this.errors()
+      tooltipContext: () => ({ errors: this.errors() })
     });
   }
 

--- a/projects/element-ng/tooltip/si-tooltip.component.html
+++ b/projects/element-ng/tooltip/si-tooltip.component.html
@@ -18,7 +18,10 @@
         [ngTemplateOutletContext]="config.tooltipContext()"
       />
     } @else if (tooltipComponent()) {
-      <ng-container [ngComponentOutlet]="tooltipComponent()!" />
+      <ng-container
+        [ngComponentOutlet]="tooltipComponent()!"
+        [ngComponentOutletInputs]="tooltipComponentInputs()"
+      />
     }
   </div>
 </div>

--- a/projects/element-ng/tooltip/si-tooltip.component.ts
+++ b/projects/element-ng/tooltip/si-tooltip.component.ts
@@ -84,6 +84,10 @@ export class TooltipComponent {
       : null;
   });
 
+  protected readonly tooltipComponentInputs = computed(
+    () => this.config.tooltipContext() as Record<string, unknown> | undefined
+  );
+
   /** @internal */
   updateTooltipPosition(change: ConnectedOverlayPositionChange, anchor?: ElementRef): void {
     this.lastPositionChange = change;


### PR DESCRIPTION
Expose validation errors on `SiFormValidationTooltipComponent` as a regular `errors` input and supply them through the tooltip's `tooltipContext`, instead of providing a `SI_FORM_VALIDATION_TOOLTIP_DATA` injection token.

To support this, `TooltipComponent` now forwards `tooltipContext` to the rendered component via `ngComponentOutletInputs`.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2338/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2338/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2338/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2338/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2338/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2338/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2338/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2338/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2338/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2338/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
