### PR TITLE
ci(release): tag npm publish command by channel

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -78,7 +78,8 @@ export default {
       '@semantic-release/exec',
       {
         verifyConditionsCmd: 'pnpm publish --recursive --no-git-checks --dry-run',
-        publishCmd: 'pnpm publish --recursive --no-git-checks'
+        publishCmd:
+          'pnpm publish --recursive --no-git-checks ${nextRelease.channel ? "--tag " + nextRelease.channel : ""}'
       }
     ],
     ...(skipCommits


### PR DESCRIPTION
Adds `--tag ${nextRelease.channel}` to the `pnpm publish` command so releases from versioned branches are published to the correct npm dist-tag instead of always defaulting to `latest`.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2349/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2349/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2349/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2349/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2349/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2349/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2349/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2349/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2349/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2349/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

