### PR TITLE
feat(navbar-vertical-next): add label input to navbar items instead of using ng-content

### DIFF
--- a/api-goldens/element-ng/navbar-vertical-next/index.api.md
+++ b/api-goldens/element-ng/navbar-vertical-next/index.api.md
@@ -72,6 +72,7 @@ export class SiNavbarVerticalNextItemComponent implements OnInit {
     readonly group: SiNavbarVerticalNextGroupTriggerDirective | null;
     readonly hideBadgeWhenCollapsed: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly icon: _angular_core.InputSignal<string | undefined>;
+    readonly label: _angular_core.InputSignal<string | undefined>;
 }
 
 // @public

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -151,6 +151,7 @@ export const templateConfig = defineConfig({
           'innerHtml',
           'innerHTML',
           'innerText',
+          'label',
           'outerHTML',
           'title',
           'si-tab'

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.html
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.html
@@ -2,9 +2,7 @@
 @if (icon) {
   <si-icon [class]="isChip() ? 'icon' : 'icon-lg'" [icon]="icon" />
 }
-<div class="item-title text-truncate si-h5">
-  <ng-content />
-</div>
+<div class="item-title text-truncate si-h5">{{ label() }}</div>
 @if (!isChip() && !navbar.textOnly() && formattedBadge()) {
   @let badgeColor = this.badgeColor();
   <span

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-item.component.ts
@@ -61,6 +61,12 @@ export class SiNavbarVerticalNextItemComponent implements OnInit {
   /** Override the active state. Useful for action items. */
   readonly activeOverride = input<boolean>();
 
+  /**
+   * Text label of this item.
+   * Consumed by the chip button to mirror the active item's label when collapsed.
+   */
+  readonly label = input<string | undefined>();
+
   protected readonly navbar = inject(SI_NAVBAR_VERTICAL_NEXT);
   protected readonly parent = inject(SiNavbarVerticalNextItemComponent, {
     skipSelf: true,

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next.spec.ts
@@ -76,9 +76,9 @@ class EmptyComponent {}
           <button
             type="button"
             si-navbar-vertical-next-item
+            label="item-1"
             [siNavbarVerticalNextGroupTriggerFor]="flyoutGroup"
           >
-            item-1
           </button>
         </si-navbar-vertical-next-items>
       }
@@ -88,9 +88,9 @@ class EmptyComponent {}
           <button
             type="button"
             si-navbar-vertical-next-item
+            label="item1"
             [siNavbarVerticalNextGroupTriggerFor]="navigationGroup"
           >
-            item1
           </button>
         </si-navbar-vertical-next-items>
       }
@@ -101,14 +101,15 @@ class EmptyComponent {}
             type="button"
             si-navbar-vertical-next-item
             stateId="item1"
+            label="item1"
             [siNavbarVerticalNextGroupTriggerFor]="stateGroupOne"
           >
-            item1
           </button>
           <button
             type="button"
             si-navbar-vertical-next-item
             stateId="item2"
+            label="item2"
             [siNavbarVerticalNextGroupTriggerFor]="stateGroupTwo"
           >
             item2
@@ -119,8 +120,12 @@ class EmptyComponent {}
 
     <ng-template #flyoutGroup>
       <si-navbar-vertical-next-group>
-        <a si-navbar-vertical-next-item routerLink="item-1/sub-item-1" routerLinkActive>
-          sub-item1
+        <a
+          si-navbar-vertical-next-item
+          label="sub-item1"
+          routerLink="item-1/sub-item-1"
+          routerLinkActive
+        >
         </a>
       </si-navbar-vertical-next-group>
     </ng-template>
@@ -131,28 +136,40 @@ class EmptyComponent {}
           si-navbar-vertical-next-item
           routerLink="item-1/sub-item-1"
           routerLinkActive
+          label="sub-item1"
           [routerLinkActiveOptions]="{ exact: true }"
         >
-          sub-item1
         </a>
-        <a si-navbar-vertical-next-item routerLink="item-1/sub-item-2" routerLinkActive>
-          sub-item2
+        <a
+          si-navbar-vertical-next-item
+          label="sub-item2"
+          routerLink="item-1/sub-item-2"
+          routerLinkActive
+        >
         </a>
       </si-navbar-vertical-next-group>
     </ng-template>
 
     <ng-template #stateGroupOne>
       <si-navbar-vertical-next-group>
-        <a si-navbar-vertical-next-item routerLink="item-1/sub-item-1" routerLinkActive>
-          sub-item1
+        <a
+          si-navbar-vertical-next-item
+          label="sub-item1"
+          routerLink="item-1/sub-item-1"
+          routerLinkActive
+        >
         </a>
       </si-navbar-vertical-next-group>
     </ng-template>
 
     <ng-template #stateGroupTwo>
       <si-navbar-vertical-next-group>
-        <a si-navbar-vertical-next-item routerLink="item-1/sub-item-2" routerLinkActive>
-          sub-item2
+        <a
+          si-navbar-vertical-next-item
+          label="sub-item2"
+          routerLink="item-1/sub-item-2"
+          routerLinkActive
+        >
         </a>
       </si-navbar-vertical-next-group>
     </ng-template>`

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-badges.html
@@ -20,10 +20,9 @@
         routerLinkActive
         icon="element-home"
         badge="Text"
+        label="Home"
         [hideBadgeWhenCollapsed]="true"
-      >
-        Home
-      </a>
+      ></a>
       <si-navbar-vertical-next-header>Badge Examples</si-navbar-vertical-next-header>
       <a
         si-navbar-vertical-next-item
@@ -32,28 +31,25 @@
         icon="element-info"
         badge="Info"
         badgeColor="info-emphasis"
-      >
-        Text badge
-      </a>
+        label="Text badge"
+      ></a>
       <button
         type="button"
         si-navbar-vertical-next-item
         icon="element-user-group"
         badgeColor="critical-emphasis"
         stateId="group-with-badges"
+        label="Group with badges"
         [badge]="6"
         [siNavbarVerticalNextGroupTriggerFor]="groupWithBadges"
-      >
-        Group with badges
-      </button>
+      ></button>
       <button
         type="button"
         si-navbar-vertical-next-item
         icon="element-special-object"
+        label="Group item"
         [siNavbarVerticalNextGroupTriggerFor]="groupItem"
-      >
-        Group item
-      </button>
+      ></button>
       <si-navbar-vertical-next-divider />
       <a
         si-navbar-vertical-next-item
@@ -61,20 +57,18 @@
         routerLinkActive
         icon="element-checked"
         badgeColor="success"
+        label="Subtle badge"
         [badge]="5"
-      >
-        Subtle badge
-      </a>
+      ></a>
       <a
         si-navbar-vertical-next-item
         routerLink="danger"
         routerLinkActive
         icon="element-warning"
         badgeColor="danger-emphasis"
+        label="Danger emphasis badge"
         [badge]="100"
-      >
-        Danger emphasis badge
-      </a>
+      ></a>
     </si-navbar-vertical-next-items>
     <si-navbar-vertical-next-footer-items>
       <a
@@ -82,9 +76,8 @@
         routerLink="configuration"
         routerLinkActive
         icon="element-parameter"
-      >
-        Configuration
-      </a>
+        label="Configuration"
+      ></a>
     </si-navbar-vertical-next-footer-items>
 
     <div class="si-layout-main-padding">
@@ -120,35 +113,32 @@
       routerLink="sub-badge-1"
       routerLinkActive
       badgeColor="critical-emphasis"
+      label="Sub item critical"
       [badge]="1"
-    >
-      Sub item critical
-    </a>
+    ></a>
     <a
       si-navbar-vertical-next-item
       routerLink="sub-badge-2"
       routerLinkActive
       badgeColor="info"
+      label="Sub item info"
       [badge]="2"
-    >
-      Sub item info
-    </a>
+    ></a>
     <a
       si-navbar-vertical-next-item
       routerLink="sub-badge-3"
       routerLinkActive
       badgeColor="warning"
+      label="Sub item warning"
       [badge]="3"
-    >
-      Sub item warning
-    </a>
+    ></a>
   </si-navbar-vertical-next-group>
 </ng-template>
 
 <ng-template #groupItem>
   <si-navbar-vertical-next-group routerLinkActive>
-    <a si-navbar-vertical-next-item routerLink="sub-badge-4" routerLinkActive> Sub item </a>
-    <a si-navbar-vertical-next-item routerLink="sub-badge-5" routerLinkActive> Sub item </a>
-    <a si-navbar-vertical-next-item routerLink="sub-badge-6" routerLinkActive> Sub item </a>
+    <a si-navbar-vertical-next-item routerLink="sub-badge-4" routerLinkActive label="Sub item"></a>
+    <a si-navbar-vertical-next-item routerLink="sub-badge-5" routerLinkActive label="Sub item"></a>
+    <a si-navbar-vertical-next-item routerLink="sub-badge-6" routerLinkActive label="Sub item"></a>
   </si-navbar-vertical-next-group>
 </ng-template>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-routing.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-routing.html
@@ -13,9 +13,13 @@
   >
     <si-navbar-vertical-next-search placeholder="Search..." />
     <si-navbar-vertical-next-items>
-      <a si-navbar-vertical-next-item routerLink="home" routerLinkActive icon="element-home">
-        Home
-      </a>
+      <a
+        si-navbar-vertical-next-item
+        routerLink="home"
+        routerLinkActive
+        icon="element-home"
+        label="Home"
+      ></a>
       <a
         si-navbar-vertical-next-item
         routerLink="coverage"
@@ -23,16 +27,23 @@
         icon="element-diagnostic"
         badge="Text"
         badgeColor="danger-emphasis"
-      >
-        Test coverage
-      </a>
+        label="Test coverage"
+      ></a>
       <si-navbar-vertical-next-header>Modules</si-navbar-vertical-next-header>
-      <a si-navbar-vertical-next-item routerLink="menu-item" routerLinkActive icon="element-fire">
-        Emergencies
-      </a>
-      <a si-navbar-vertical-next-item routerLink="energy" routerLinkActive icon="element-trend">
-        Energy &amp; sustainability
-      </a>
+      <a
+        si-navbar-vertical-next-item
+        routerLink="menu-item"
+        routerLinkActive
+        icon="element-fire"
+        label="Emergencies"
+      ></a>
+      <a
+        si-navbar-vertical-next-item
+        routerLink="energy"
+        routerLinkActive
+        icon="element-trend"
+        label="Energy &amp; sustainability"
+      ></a>
     </si-navbar-vertical-next-items>
     <si-navbar-vertical-next-footer-items>
       <a
@@ -40,9 +51,8 @@
         routerLink="configuration"
         routerLinkActive
         icon="element-parameter"
-      >
-        Configuration
-      </a>
+        label="Configuration"
+      ></a>
     </si-navbar-vertical-next-footer-items>
 
     <div class="si-layout-main-padding">

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next-text.html
@@ -37,28 +37,37 @@
         type="button"
         si-navbar-vertical-next-item
         stateId="home"
+        label="Home"
         [siNavbarVerticalNextGroupTriggerFor]="home"
-      >
-        Home
-      </button>
+      ></button>
       <button
         type="button"
         si-navbar-vertical-next-item
         stateId="documentation"
+        label="Documentation"
         [siNavbarVerticalNextGroupTriggerFor]="documentation"
-      >
-        Documentation
-      </button>
+      ></button>
       <si-navbar-vertical-next-header>All the rest</si-navbar-vertical-next-header>
-      <a si-navbar-vertical-next-item routerLink="energy" routerLinkActive>
-        Energy &amp; Operations
-      </a>
-      <a si-navbar-vertical-next-item routerLink="coverage" routerLinkActive> Test Coverage </a>
+      <a
+        si-navbar-vertical-next-item
+        routerLink="energy"
+        routerLinkActive
+        label="Energy &amp; Operations"
+      ></a>
+      <a
+        si-navbar-vertical-next-item
+        routerLink="coverage"
+        routerLinkActive
+        label="Test Coverage"
+      ></a>
     </si-navbar-vertical-next-items>
     <si-navbar-vertical-next-footer-items>
-      <a si-navbar-vertical-next-item routerLink="configuration" routerLinkActive>
-        Configuration
-      </a>
+      <a
+        si-navbar-vertical-next-item
+        routerLink="configuration"
+        routerLinkActive
+        label="Configuration"
+      ></a>
     </si-navbar-vertical-next-footer-items>
     <div class="si-layout-main-padding">
       <div class="si-layout-header">
@@ -88,16 +97,16 @@
 
 <ng-template #home>
   <si-navbar-vertical-next-group routerLinkActive>
-    <a si-navbar-vertical-next-item routerLink="subItem" routerLinkActive> Sub Item </a>
-    <a si-navbar-vertical-next-item routerLink="subItem2" routerLinkActive> Sub Item 2 </a>
-    <a si-navbar-vertical-next-item routerLink="subItem3" routerLinkActive> Sub Item 3 </a>
+    <a si-navbar-vertical-next-item routerLink="subItem" routerLinkActive label="Sub Item"></a>
+    <a si-navbar-vertical-next-item routerLink="subItem2" routerLinkActive label="Sub Item 2"></a>
+    <a si-navbar-vertical-next-item routerLink="subItem3" routerLinkActive label="Sub Item 3"></a>
   </si-navbar-vertical-next-group>
 </ng-template>
 
 <ng-template #documentation>
   <si-navbar-vertical-next-group routerLinkActive>
-    <a si-navbar-vertical-next-item routerLink="subItem4" routerLinkActive> Sub Item 4 </a>
-    <a si-navbar-vertical-next-item routerLink="subItem5" routerLinkActive> Sub Item 5 </a>
-    <a si-navbar-vertical-next-item routerLink="subItem6" routerLinkActive> Sub Item 6 </a>
+    <a si-navbar-vertical-next-item routerLink="subItem4" routerLinkActive label="Sub Item 4"></a>
+    <a si-navbar-vertical-next-item routerLink="subItem5" routerLinkActive label="Sub Item 5"></a>
+    <a si-navbar-vertical-next-item routerLink="subItem6" routerLinkActive label="Sub Item 6"></a>
   </si-navbar-vertical-next-group>
 </ng-template>

--- a/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
+++ b/src/app/examples/si-navbar-vertical-next/si-navbar-vertical-next.html
@@ -14,47 +14,51 @@
   >
     <si-navbar-vertical-next-search placeholder="Search..." />
     <si-navbar-vertical-next-items>
-      <a si-navbar-vertical-next-item routerLink="home" routerLinkActive icon="element-home">
-        Home
-      </a>
+      <a
+        si-navbar-vertical-next-item
+        routerLink="home"
+        routerLinkActive
+        icon="element-home"
+        label="Home"
+      ></a>
       <si-navbar-vertical-next-header>Modules</si-navbar-vertical-next-header>
-      <a si-navbar-vertical-next-item routerLink="energy" routerLinkActive icon="element-trend">
-        Energy &amp; sustainability
-      </a>
+      <a
+        si-navbar-vertical-next-item
+        routerLink="energy"
+        routerLinkActive
+        icon="element-trend"
+        label="Energy &amp; sustainability"
+      ></a>
       <button
         type="button"
         si-navbar-vertical-next-item
         icon="element-user-group"
+        label="User management"
         [siNavbarVerticalNextGroupTriggerFor]="userManagement"
-      >
-        User management
-      </button>
+      ></button>
       <a
         si-navbar-vertical-next-item
         routerLink="coverage"
         routerLinkActive
         icon="element-diagnostic"
-      >
-        Test coverage
-      </a>
+        label="Test coverage"
+      ></a>
       <si-navbar-vertical-next-divider />
       <button
         type="button"
         si-navbar-vertical-next-item
         icon="element-document"
         stateId="documentation"
+        label="Documentation"
         [siNavbarVerticalNextGroupTriggerFor]="documentation"
-      >
-        Documentation
-      </button>
+      ></button>
       <button
         type="button"
         si-navbar-vertical-next-item
         icon="element-warning"
+        label="Action"
         (click)="logEvent('Callback for action called')"
-      >
-        Action
-      </button>
+      ></button>
     </si-navbar-vertical-next-items>
     <si-navbar-vertical-next-footer-items>
       <a
@@ -62,9 +66,8 @@
         routerLink="configuration"
         routerLinkActive
         icon="element-parameter"
-      >
-        Configuration
-      </a>
+        label="Configuration"
+      ></a>
     </si-navbar-vertical-next-footer-items>
 
     <div class="si-layout-main-padding">
@@ -95,16 +98,16 @@
 
 <ng-template #userManagement>
   <si-navbar-vertical-next-group routerLinkActive>
-    <a si-navbar-vertical-next-item routerLink="subItem" routerLinkActive> Sub item </a>
-    <a si-navbar-vertical-next-item routerLink="subItem2" routerLinkActive> Sub item 2 </a>
-    <a si-navbar-vertical-next-item routerLink="subItem3" routerLinkActive> Sub item 3 </a>
+    <a si-navbar-vertical-next-item routerLink="subItem" routerLinkActive label="Sub item"></a>
+    <a si-navbar-vertical-next-item routerLink="subItem2" routerLinkActive label="Sub item 2"></a>
+    <a si-navbar-vertical-next-item routerLink="subItem3" routerLinkActive label="Sub item 3"></a>
   </si-navbar-vertical-next-group>
 </ng-template>
 
 <ng-template #documentation>
   <si-navbar-vertical-next-group routerLinkActive>
-    <a si-navbar-vertical-next-item routerLink="subItem4" routerLinkActive> Sub item 4 </a>
-    <a si-navbar-vertical-next-item routerLink="subItem5" routerLinkActive> Sub item 5 </a>
-    <a si-navbar-vertical-next-item routerLink="subItem6" routerLinkActive> Sub item 6 </a>
+    <a si-navbar-vertical-next-item routerLink="subItem4" routerLinkActive label="Sub item 4"></a>
+    <a si-navbar-vertical-next-item routerLink="subItem5" routerLinkActive label="Sub item 5"></a>
+    <a si-navbar-vertical-next-item routerLink="subItem6" routerLinkActive label="Sub item 6"></a>
   </si-navbar-vertical-next-group>
 </ng-template>


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2351/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2351/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2351/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2351/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2351/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2351/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2351/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2351/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2351/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2351/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
