### PR TITLE
feat(navbar-vertical): add tooltipOverride to items

### DIFF
--- a/api-goldens/element-ng/navbar-vertical/index.api.md
+++ b/api-goldens/element-ng/navbar-vertical/index.api.md
@@ -33,6 +33,7 @@ export interface NavbarVerticalItemBase {
     icon?: string;
     id?: string;
     label: TranslatableString;
+    tooltipOverride?: TranslatableString;
 }
 
 // @public (undocumented)

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical.component.html
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical.component.html
@@ -87,8 +87,8 @@
         [expanded]="
           (item.id ? uiStateExpandedItems()[item.id] : undefined) ?? item.expanded ?? false
         "
-        [siTooltip]="item.label | translate"
-        [isDisabled]="!collapsed()"
+        [siTooltip]="item.tooltipOverride || item.label | translate"
+        [isDisabled]="!collapsed() && !item.tooltipOverride"
       >
         {{ item.label | translate }}
       </button>
@@ -99,8 +99,8 @@
         placement="end"
         [si-navbar-vertical-item]="item"
         [activeOverride]="item.active"
-        [siTooltip]="item.label | translate"
-        [isDisabled]="!collapsed()"
+        [siTooltip]="item.tooltipOverride || item.label | translate"
+        [isDisabled]="!collapsed() && !item.tooltipOverride"
       >
         {{ item.label | translate }}
       </button>
@@ -120,8 +120,8 @@
         [preserveFragment]="item.extras?.preserveFragment"
         [skipLocationChange]="item.extras?.skipLocationChange"
         [replaceUrl]="item.extras?.replaceUrl"
-        [siTooltip]="item.label | translate"
-        [isDisabled]="!collapsed()"
+        [siTooltip]="item.tooltipOverride || item.label | translate"
+        [isDisabled]="!collapsed() && !item.tooltipOverride"
       >
         {{ item.label | translate }}
       </a>
@@ -132,8 +132,8 @@
         [si-navbar-vertical-item]="item"
         [href]="item.href"
         [target]="item.target"
-        [siTooltip]="item.label | translate"
-        [isDisabled]="!collapsed()"
+        [siTooltip]="item.tooltipOverride || item.label | translate"
+        [isDisabled]="!collapsed() && !item.tooltipOverride"
       >
         {{ item.label | translate }}
       </a>

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical.model.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical.model.ts
@@ -25,6 +25,13 @@ export interface NavbarVerticalItemBase {
    * By default, badges are always visible (both expanded and collapsed).
    */
   hideBadgeWhenCollapsed?: boolean;
+  /**
+   * **Warning:** Using this property is an indication of weak labels and a violation of UX guidelines.
+   *
+   * The navbar shows automatically a tooltip when collapsed to show only icons.
+   * Setting this property will apply a tooltip in collapsed and expanded mode.
+   */
+  tooltipOverride?: TranslatableString;
 }
 
 /** Use this type to create a group that can hold multiple items. */


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->

Allow consumers to override the automatic tooltip text (defaults to item label) on collapsed navbar items via a new `tooltipOverride` property on the item model. When provided, the tooltip is also enabled in the expanded state so it can be shown whenever needed.

## Changes

- Added `tooltipOverride?: TranslatableString` to `NavbarVerticalItemBase`
- Updated `[siTooltip]` bindings to use `item.tooltipOverride ?? item.label`
- Updated `[isDisabled]` so tooltip stays enabled in expanded state when `tooltipOverride` is provided<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2352/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2352/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2352/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2352/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2352/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2352/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2352/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2352/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2352/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2352/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



