### PR TITLE
feat(tooltip): add overflow tooltip directive

### DIFF
--- a/api-goldens/element-ng/tooltip/index.api.md
+++ b/api-goldens/element-ng/tooltip/index.api.md
@@ -27,6 +27,11 @@ export class SiTooltipDirective {
 export class SiTooltipModule {
 }
 
+// @public
+export class SiTooltipOverflowDirective {
+    constructor();
+}
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/projects/element-ng/tooltip/index.ts
+++ b/projects/element-ng/tooltip/index.ts
@@ -4,4 +4,5 @@
  */
 export * from './si-tooltip.module';
 export * from './si-tooltip.directive';
+export * from './si-tooltip-overflow.directive';
 export * from './si-tooltip.service';

--- a/projects/element-ng/tooltip/si-tooltip-overflow.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip-overflow.directive.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { page } from 'vitest/browser';
+
+import { SiTooltipOverflowDirective } from './si-tooltip-overflow.directive';
+
+describe('SiTooltipOverflowDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let element: HTMLDivElement;
+
+  @Component({
+    imports: [SiTooltipOverflowDirective],
+    template: `<div siTooltipOverflow [style.width.px]="width()">{{ text() }}</div>`
+  })
+  class TestHostComponent {
+    readonly text = signal(
+      'A deliberately long tooltip text that does not fit in a narrow element'
+    );
+    readonly width = signal(100);
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setTimerTickMode('nextTimerAsync');
+    fixture = TestBed.createComponent(TestHostComponent);
+    element = fixture.nativeElement.querySelector('div') as HTMLDivElement;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should show the host text only when it overflows', async () => {
+    await fixture.whenStable();
+
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    await expect.element(page.getByRole('tooltip')).not.toBeInTheDocument();
+    await vi.advanceTimersByTimeAsync(500);
+    await fixture.whenStable();
+
+    await expect
+      .element(
+        page.getByRole('tooltip', {
+          name: 'A deliberately long tooltip text that does not fit in a narrow element'
+        })
+      )
+      .toBeInTheDocument();
+  });
+
+  it('should not show a tooltip when the host text fits', async () => {
+    fixture.componentInstance.width.set(1_000);
+    await vi.advanceTimersByTimeAsync(0);
+    await fixture.whenStable();
+
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    await vi.advanceTimersByTimeAsync(500);
+    await fixture.whenStable();
+
+    await expect.element(page.getByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('should update the visible tooltip when the host text changes', async () => {
+    await fixture.whenStable();
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    await vi.advanceTimersByTimeAsync(500);
+    await fixture.whenStable();
+
+    element.dispatchEvent(new MouseEvent('mouseleave'));
+    fixture.componentInstance.text.set('Updated overflowing tooltip text');
+    await fixture.whenStable();
+
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    await vi.advanceTimersByTimeAsync(500);
+    await fixture.whenStable();
+
+    await expect
+      .element(page.getByRole('tooltip'))
+      .toHaveTextContent('Updated overflowing tooltip text');
+  });
+
+  it('should remove the tooltip when overflow is resolved', async () => {
+    await fixture.whenStable();
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    await vi.advanceTimersByTimeAsync(500);
+    await fixture.whenStable();
+
+    element.dispatchEvent(new MouseEvent('mouseleave'));
+    fixture.componentInstance.width.set(1_000);
+    await vi.advanceTimersByTimeAsync(0);
+    await fixture.whenStable();
+
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    await vi.advanceTimersByTimeAsync(500);
+    await fixture.whenStable();
+
+    await expect.element(page.getByRole('tooltip')).not.toBeInTheDocument();
+  });
+});

--- a/projects/element-ng/tooltip/si-tooltip-overflow.directive.ts
+++ b/projects/element-ng/tooltip/si-tooltip-overflow.directive.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Directive, ElementRef, inject } from '@angular/core';
+
+import { SiTooltipService } from './si-tooltip.service';
+
+/**
+ * Adds a tooltip containing the host element's text when that text is truncated.
+ */
+@Directive({
+  selector: '[siTooltipOverflow]',
+  providers: [SiTooltipService],
+  host: {
+    class: 'text-truncate'
+  }
+})
+export class SiTooltipOverflowDirective {
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly tooltipService = inject(SiTooltipService);
+  private readonly element = this.elementRef.nativeElement;
+
+  constructor() {
+    this.tooltipService.createTooltip({
+      element: this.elementRef,
+      placement: () => 'auto',
+      /*
+       * `canShow` is evaluated everytime before the tooltip is eventually rendered.
+       * So there is no need for any listener.
+       * It also updates the `tooltipText`.
+       */
+      canShow: () => this.canShow(),
+      tooltip: () => this.elementRef,
+      tooltipContext: () => undefined
+    });
+  }
+
+  private canShow(): boolean {
+    return (
+      this.element.scrollWidth > this.element.clientWidth ||
+      this.element.scrollHeight > this.element.clientHeight
+    );
+  }
+}

--- a/src/app/examples/si-tooltip/si-tooltip.html
+++ b/src/app/examples/si-tooltip/si-tooltip.html
@@ -115,11 +115,7 @@
   <section class="mb-5">
     <h4>Other examples</h4>
     <div class="d-flex align-items-start gap-4" style="max-width: 300px">
-      <button
-        type="button"
-        class="btn btn-secondary mt-4 d-inline text-truncate"
-        siTooltip="A long time ago in a galaxy far, far away..."
-      >
+      <button type="button" class="btn btn-secondary mt-4 d-inline text-truncate" siTooltipOverflow>
         A long time ago in a galaxy far, far away...
       </button>
       <si-tabset class="w-50">

--- a/src/app/examples/si-tooltip/si-tooltip.ts
+++ b/src/app/examples/si-tooltip/si-tooltip.ts
@@ -4,12 +4,18 @@
  */
 import { afterNextRender, Component, ElementRef, viewChild } from '@angular/core';
 import { SiIconComponent } from '@siemens/element-ng/icon';
-import { SiTabsetComponent, SiTabComponent } from '@siemens/element-ng/tabs';
-import { SiTooltipDirective } from '@siemens/element-ng/tooltip';
+import { SiTabComponent, SiTabsetComponent } from '@siemens/element-ng/tabs';
+import { SiTooltipDirective, SiTooltipOverflowDirective } from '@siemens/element-ng/tooltip';
 
 @Component({
   selector: 'app-sample',
-  imports: [SiIconComponent, SiTooltipDirective, SiTabsetComponent, SiTabComponent],
+  imports: [
+    SiIconComponent,
+    SiTooltipDirective,
+    SiTooltipOverflowDirective,
+    SiTabsetComponent,
+    SiTabComponent
+  ],
   templateUrl: './si-tooltip.html'
 })
 export class SampleComponent {


### PR DESCRIPTION
### Usage

```html
<span siTooltipOverflow>
  I am very long and maybe I am truncated.
  But my tooltip is only added when I am actually truncated.
</span>
```

### Problem to solve

We have many places where text is eventually truncated if there is not enough space.
Since we do not know upfront if the text is truncated, we need to apply a tooltip conditionally.
Currently, we simply do not apply any tooltips in those cases.

The first place where I plan to use this directive is the breadcrumb. There we currently violate a11y by attaching a menu in case text is truncated. Also the truncation itself is implemented in a poor way.

### Approach

Whenever the target element is hovered / focused we check if the text is truncated and update the tooltip content
based on the `innerText`.
Since we check the truncation and `innerText` always immediately before showing, we don't need any listener for changes.


<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2353/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2353/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2353/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2353/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2353/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2353/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2353/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2353/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2353/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2353/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


