### PR TITLE
chore(maps): remove explicit OnPush

### DIFF
--- a/projects/maps-ng/src/components/si-map/components/si-map-popover/si-map-popover.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/components/si-map-popover/si-map-popover.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MapPointMetaData } from '../../models';
@@ -10,8 +10,7 @@ import { SiMapPopoverComponent } from './si-map-popover.component';
 
 @Component({
   selector: 'si-mock-popover',
-  template: '<p>Mocking custom popover component</p>',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: '<p>Mocking custom popover component</p>'
 })
 class MockCustomPopoverComponent {
   readonly mapPoint = input<MapPointMetaData>();

--- a/projects/maps-ng/src/components/si-map/si-map.component.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.ts
@@ -5,7 +5,6 @@
 import {
   AfterViewChecked,
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChild,
@@ -78,8 +77,7 @@ interface ClusterHolder {
   imports: [SiMapTooltipComponent, SiMapPopoverComponent],
   templateUrl: './si-map.component.html',
   styleUrl: './si-map.component.scss',
-  providers: [MapService],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  providers: [MapService]
 })
 export class SiMapComponent implements AfterViewInit, OnChanges, OnDestroy, AfterViewChecked {
   /**


### PR DESCRIPTION
as OnPush is default now with v22

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2354/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2354/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2354/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2354/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2354/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2354/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2354/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2354/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2354/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2354/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
