### PR TITLE
refactor(tooltip): gate display at interaction time

### DIFF
--- a/api-goldens/element-ng/form/index.api.md
+++ b/api-goldens/element-ng/form/index.api.md
@@ -166,7 +166,8 @@ export interface SiFormValidationErrorMapper {
 }
 
 // @public
-export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
+export class SiFormValidationTooltipDirective implements DoCheck {
+    constructor();
     // (undocumented)
     readonly formErrorMapper: _angular_core.InputSignal<SiFormValidationErrorMapper | undefined>;
 }

--- a/api-goldens/element-ng/tooltip/index.api.md
+++ b/api-goldens/element-ng/tooltip/index.api.md
@@ -8,14 +8,14 @@ import { ConnectionPositionPair } from '@angular/cdk/overlay';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
 import { Injector } from '@angular/core';
-import { OnDestroy } from '@angular/core';
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import { TemplateRef } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 import { Type } from '@angular/core';
 
 // @public (undocumented)
-export class SiTooltipDirective implements OnDestroy {
+export class SiTooltipDirective {
+    constructor();
     readonly isDisabled: i0.InputSignalWithTransform<boolean, unknown>;
     readonly placement: i0.InputSignal<"auto" | "start" | "end" | "top" | "bottom">;
     readonly siTooltip: i0.InputSignal<TemplateRef<any> | TranslatableString>;

--- a/api-goldens/element-ng/tooltip/index.api.md
+++ b/api-goldens/element-ng/tooltip/index.api.md
@@ -16,7 +16,6 @@ import { Type } from '@angular/core';
 
 // @public (undocumented)
 export class SiTooltipDirective implements OnDestroy {
-    constructor();
     readonly isDisabled: i0.InputSignalWithTransform<boolean, unknown>;
     readonly placement: i0.InputSignal<"auto" | "start" | "end" | "top" | "bottom">;
     readonly siTooltip: i0.InputSignal<TemplateRef<any> | TranslatableString>;

--- a/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
+++ b/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
@@ -9,11 +9,10 @@ import {
   inject,
   input,
   OnChanges,
-  OnDestroy,
   Signal,
   SimpleChanges
 } from '@angular/core';
-import { SiTooltipDirective, SiTooltipService, TooltipRef } from '@siemens/element-ng/tooltip';
+import { SiTooltipDirective, SiTooltipService } from '@siemens/element-ng/tooltip';
 
 import { SiHeaderActionItemBase } from './si-header-action-item.base';
 
@@ -24,7 +23,7 @@ import { SiHeaderActionItemBase } from './si-header-action-item.base';
 @Directive({})
 export abstract class SiHeaderActionIconItemBase
   extends SiHeaderActionItemBase
-  implements OnChanges, OnDestroy
+  implements OnChanges
 {
   /**
    * Adds a badge to the header item.
@@ -42,16 +41,10 @@ export abstract class SiHeaderActionIconItemBase
   private readonly canShowTooltip = computed(
     () =>
       this.visuallyHideTitle() &&
-      (!this.existingTooltip || this.existingTooltip.isDisabled() || !this.existingTooltip.siTooltip())
+      (!this.existingTooltip ||
+        this.existingTooltip.isDisabled() ||
+        !this.existingTooltip.siTooltip())
   );
-  private readonly tooltipRef: TooltipRef = this.tooltipService.createTooltip({
-    element: this.elementRef,
-    placement: () => 'auto',
-    canShow: this.canShowTooltip,
-    // Subclass field initializers run after this base constructor. So we cannot directly pass `this.itemTitle`.
-    tooltip: () => this.itemTitle(),
-    tooltipContext: () => undefined
-  });
 
   protected readonly badgeDot = computed(() =>
     typeof this.badge() === 'boolean' ? (this.badge() as boolean) : false
@@ -63,8 +56,16 @@ export abstract class SiHeaderActionIconItemBase
       : undefined;
   });
 
-  ngOnDestroy(): void {
-    this.tooltipRef.destroy();
+  constructor() {
+    super();
+    this.tooltipService.createTooltip({
+      element: this.elementRef,
+      placement: () => 'auto',
+      canShow: this.canShowTooltip,
+      // Subclass field initializers run after this base constructor. So we cannot directly pass `this.itemTitle`.
+      tooltip: () => this.itemTitle(),
+      tooltipContext: () => undefined
+    });
   }
 
   ngOnChanges(changes: SimpleChanges<this>): void {

--- a/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
+++ b/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
@@ -10,11 +10,10 @@ import {
   input,
   OnChanges,
   OnDestroy,
-  OnInit,
   Signal,
   SimpleChanges
 } from '@angular/core';
-import { SiTooltipDirective, SiTooltipService } from '@siemens/element-ng/tooltip';
+import { SiTooltipDirective, SiTooltipService, TooltipRef } from '@siemens/element-ng/tooltip';
 
 import { SiHeaderActionItemBase } from './si-header-action-item.base';
 
@@ -25,7 +24,7 @@ import { SiHeaderActionItemBase } from './si-header-action-item.base';
 @Directive({})
 export abstract class SiHeaderActionIconItemBase
   extends SiHeaderActionItemBase
-  implements OnChanges, OnDestroy, OnInit
+  implements OnChanges, OnDestroy
 {
   /**
    * Adds a badge to the header item.
@@ -45,10 +44,11 @@ export abstract class SiHeaderActionIconItemBase
       this.visuallyHideTitle() &&
       (!this.existingTooltip || this.existingTooltip.isDisabled() || !this.existingTooltip.siTooltip())
   );
-  private readonly tooltipRef = this.tooltipService.createTooltip({
+  private readonly tooltipRef: TooltipRef = this.tooltipService.createTooltip({
     element: this.elementRef,
     placement: () => 'auto',
     canShow: this.canShowTooltip,
+    // Subclass field initializers run after this base constructor. So we cannot directly pass `this.itemTitle`.
     tooltip: () => this.itemTitle(),
     tooltipContext: () => undefined
   });

--- a/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
+++ b/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
@@ -65,7 +65,7 @@ export abstract class SiHeaderActionIconItemBase
     if (this.visuallyHideTitle() && !hasActiveTooltip) {
       const tooltipRef = this.tooltipService.createTooltip({
         element: this.elementRef,
-        placement: 'auto',
+        placement: () => 'auto',
         tooltip: this.itemTitle,
         tooltipContext: () => undefined
       });

--- a/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
+++ b/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
@@ -5,12 +5,11 @@
 import {
   computed,
   Directive,
-  effect,
-  EffectCleanupRegisterFn,
   ElementRef,
   inject,
   input,
   OnChanges,
+  OnDestroy,
   OnInit,
   Signal,
   SimpleChanges
@@ -26,7 +25,7 @@ import { SiHeaderActionItemBase } from './si-header-action-item.base';
 @Directive({})
 export abstract class SiHeaderActionIconItemBase
   extends SiHeaderActionItemBase
-  implements OnChanges, OnInit
+  implements OnChanges, OnDestroy, OnInit
 {
   /**
    * Adds a badge to the header item.
@@ -41,6 +40,18 @@ export abstract class SiHeaderActionIconItemBase
   private readonly tooltipService = inject(SiTooltipService);
   private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly existingTooltip = inject(SiTooltipDirective, { optional: true, host: true });
+  private readonly canShowTooltip = computed(
+    () =>
+      this.visuallyHideTitle() &&
+      (!this.existingTooltip || this.existingTooltip.isDisabled() || !this.existingTooltip.siTooltip())
+  );
+  private readonly tooltipRef = this.tooltipService.createTooltip({
+    element: this.elementRef,
+    placement: () => 'auto',
+    canShow: this.canShowTooltip,
+    tooltip: () => this.itemTitle(),
+    tooltipContext: () => undefined
+  });
 
   protected readonly badgeDot = computed(() =>
     typeof this.badge() === 'boolean' ? (this.badge() as boolean) : false
@@ -52,25 +63,8 @@ export abstract class SiHeaderActionIconItemBase
       : undefined;
   });
 
-  constructor() {
-    super();
-    effect(onCleanup => this.setupTooltip(onCleanup));
-  }
-
-  private setupTooltip(onCleanup: EffectCleanupRegisterFn): void {
-    const hasActiveTooltip =
-      !!this.existingTooltip &&
-      !this.existingTooltip.isDisabled() &&
-      !!this.existingTooltip.siTooltip();
-    if (this.visuallyHideTitle() && !hasActiveTooltip) {
-      const tooltipRef = this.tooltipService.createTooltip({
-        element: this.elementRef,
-        placement: () => 'auto',
-        tooltip: this.itemTitle,
-        tooltipContext: () => undefined
-      });
-      onCleanup(() => tooltipRef.destroy());
-    }
+  ngOnDestroy(): void {
+    this.tooltipRef.destroy();
   }
 
   ngOnChanges(changes: SimpleChanges<this>): void {

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
@@ -10,7 +10,6 @@ import {
   inject,
   Injector,
   input,
-  OnDestroy,
   signal
 } from '@angular/core';
 import { NgControl, ValidationErrors } from '@angular/forms';
@@ -44,7 +43,7 @@ import {
     '[attr.aria-describedby]': 'describedBy'
   }
 })
-export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
+export class SiFormValidationTooltipDirective implements DoCheck {
   private static idCounter = 0;
 
   private tooltipService = inject(SiTooltipService);
@@ -58,19 +57,22 @@ export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
   private readonly errors = signal<SiFormError[]>([]);
   private readonly touched = signal(false);
   private readonly canShowTooltip = computed(() => this.errors().length > 0 && this.touched());
-  private readonly tooltipRef = this.tooltipService.createTooltip({
-    placement: () => 'auto',
-    element: this.elementRef,
-    describedBy: this.describedBy,
-    injector: Injector.create({
-      providers: [{ provide: SI_FORM_VALIDATION_TOOLTIP_DATA, useValue: this.errors }]
-    }),
-    canShow: this.canShowTooltip,
-    tooltip: () => SiFormValidationTooltipComponent,
-    // Not actually used, but errors in the context triggers a resize if the errors changes.
-    tooltipContext: this.errors
-  });
   private currentErrors: ValidationErrors | null = null;
+
+  constructor() {
+    this.tooltipService.createTooltip({
+      placement: () => 'auto',
+      element: this.elementRef,
+      describedBy: this.describedBy,
+      injector: Injector.create({
+        providers: [{ provide: SI_FORM_VALIDATION_TOOLTIP_DATA, useValue: this.errors }]
+      }),
+      canShow: this.canShowTooltip,
+      tooltip: () => SiFormValidationTooltipComponent,
+      // Not actually used, but errors in the context triggers a resize if the errors changes.
+      tooltipContext: this.errors
+    });
+  }
 
   ngDoCheck(): void {
     const nextErrors = this.ngControl.errors;
@@ -80,10 +82,6 @@ export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
       this.currentErrors = nextErrors;
       this.updateErrors();
     }
-  }
-
-  ngOnDestroy(): void {
-    this.tooltipRef.destroy();
   }
 
   private updateErrors(): void {

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
@@ -97,7 +97,7 @@ export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
 
   private createTooltip(): void {
     this.tooltipRef ??= this.tooltipService.createTooltip({
-      placement: 'auto',
+      placement: () => 'auto',
       element: this.elementRef,
       describedBy: this.describedBy,
       injector: Injector.create({

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
@@ -56,7 +56,8 @@ export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
 
   protected readonly describedBy = `__si-form-validation-tooltip-${SiFormValidationTooltipDirective.idCounter++}`;
   private readonly errors = signal<SiFormError[]>([]);
-  private readonly canShowTooltip = computed(() => this.errors().length > 0 && !!this.ngControl.touched);
+  private readonly touched = signal(false);
+  private readonly canShowTooltip = computed(() => this.errors().length > 0 && this.touched());
   private readonly tooltipRef = this.tooltipService.createTooltip({
     placement: () => 'auto',
     element: this.elementRef,
@@ -66,18 +67,17 @@ export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
     }),
     canShow: this.canShowTooltip,
     tooltip: () => SiFormValidationTooltipComponent,
-    tooltipContext: () => this.errors()
+    // Not actually used, but errors in the context triggers a resize if the errors changes.
+    tooltipContext: this.errors
   });
   private currentErrors: ValidationErrors | null = null;
-  private touched: boolean | null = null;
 
   ngDoCheck(): void {
     const nextErrors = this.ngControl.errors;
-    const nextTouched = this.ngControl.touched;
+    this.touched.set(!!this.ngControl.touched);
 
-    if (this.currentErrors !== nextErrors || this.touched !== nextTouched) {
+    if (this.currentErrors !== nextErrors) {
       this.currentErrors = nextErrors;
-      this.touched = nextTouched;
       this.updateErrors();
     }
   }

--- a/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
+++ b/projects/element-ng/form/si-form-validation-tooltip/si-form-validation-tooltip.directive.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import {
+  computed,
   Directive,
   DoCheck,
   ElementRef,
@@ -13,7 +14,7 @@ import {
   signal
 } from '@angular/core';
 import { NgControl, ValidationErrors } from '@angular/forms';
-import { SiTooltipService, TooltipRef } from '@siemens/element-ng/tooltip';
+import { SiTooltipService } from '@siemens/element-ng/tooltip';
 
 import { SiFormContainerComponent } from '../si-form-container/si-form-container.component';
 import { SiFormError } from '../si-form-item/si-form-item.component';
@@ -53,11 +54,22 @@ export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
   private ngControl = inject(NgControl);
   private elementRef = inject(ElementRef);
 
-  private tooltipRef?: TooltipRef;
+  protected readonly describedBy = `__si-form-validation-tooltip-${SiFormValidationTooltipDirective.idCounter++}`;
   private readonly errors = signal<SiFormError[]>([]);
+  private readonly canShowTooltip = computed(() => this.errors().length > 0 && !!this.ngControl.touched);
+  private readonly tooltipRef = this.tooltipService.createTooltip({
+    placement: () => 'auto',
+    element: this.elementRef,
+    describedBy: this.describedBy,
+    injector: Injector.create({
+      providers: [{ provide: SI_FORM_VALIDATION_TOOLTIP_DATA, useValue: this.errors }]
+    }),
+    canShow: this.canShowTooltip,
+    tooltip: () => SiFormValidationTooltipComponent,
+    tooltipContext: () => this.errors()
+  });
   private currentErrors: ValidationErrors | null = null;
   private touched: boolean | null = null;
-  protected readonly describedBy = `__si-form-validation-tooltip-${SiFormValidationTooltipDirective.idCounter++}`;
 
   ngDoCheck(): void {
     const nextErrors = this.ngControl.errors;
@@ -71,7 +83,7 @@ export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
   }
 
   ngOnDestroy(): void {
-    this.destroyTooltip();
+    this.tooltipRef.destroy();
   }
 
   private updateErrors(): void {
@@ -84,33 +96,6 @@ export class SiFormValidationTooltipDirective implements OnDestroy, DoCheck {
       )
       .filter(error => !!error.message);
 
-    const shouldShow = errors.length > 0 && !!this.ngControl.touched;
-
-    if (shouldShow) {
-      this.createTooltip();
-    } else {
-      this.destroyTooltip();
-    }
-
     this.errors.set(errors);
-  }
-
-  private createTooltip(): void {
-    this.tooltipRef ??= this.tooltipService.createTooltip({
-      placement: () => 'auto',
-      element: this.elementRef,
-      describedBy: this.describedBy,
-      injector: Injector.create({
-        providers: [{ provide: SI_FORM_VALIDATION_TOOLTIP_DATA, useValue: this.errors }]
-      }),
-      tooltip: () => SiFormValidationTooltipComponent,
-      // Not actually used, but errors in the context triggers a resize if the errors changes.
-      tooltipContext: () => this.errors()
-    });
-  }
-
-  private destroyTooltip(): void {
-    this.tooltipRef?.destroy();
-    this.tooltipRef = undefined;
   }
 }

--- a/projects/element-ng/tabs/si-tab-base.directive.ts
+++ b/projects/element-ng/tabs/si-tab-base.directive.ts
@@ -20,7 +20,7 @@ import {
 } from '@angular/core';
 import { elementCancel } from '@siemens/element-icons';
 import { addIcons } from '@siemens/element-ng/icon';
-import { SiTooltipDirective, SiTooltipService, TooltipRef } from '@siemens/element-ng/tooltip';
+import { SiTooltipDirective, SiTooltipService } from '@siemens/element-ng/tooltip';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SI_TABSET } from './si-tabs-tokens';
@@ -93,7 +93,18 @@ export abstract class SiTabBaseDirective implements OnDestroy, FocusableOption {
   private indexBeforeClose = -1;
   private readonly tooltipService = inject(SiTooltipService);
   private readonly existingTooltip = inject(SiTooltipDirective, { optional: true });
-  private tooltipRef?: TooltipRef;
+  private readonly canShowTooltip = computed(
+    () =>
+      !!this.icon() &&
+      (!this.existingTooltip || this.existingTooltip.isDisabled() || !this.existingTooltip.siTooltip())
+  );
+  private readonly tooltipRef = this.tooltipService.createTooltip({
+    element: this.tabButton,
+    placement: () => 'auto',
+    canShow: this.canShowTooltip,
+    tooltip: () => this.heading(),
+    tooltipContext: () => undefined
+  });
 
   /** @internal */
   tabId = `${SiTabBaseDirective.tabCounter++}`;
@@ -102,8 +113,6 @@ export abstract class SiTabBaseDirective implements OnDestroy, FocusableOption {
   private readonly index = computed(() => this.tabset.tabPanels().indexOf(this));
 
   constructor() {
-    this.setupIconTooltip();
-
     // Update the focusKeyManager if a tab is added that is active or if the tab is set active by the app.
     // This effect should not run, if active was already applied to the focusKeyManager.
     effect(() => {
@@ -117,33 +126,8 @@ export abstract class SiTabBaseDirective implements OnDestroy, FocusableOption {
     });
   }
 
-  private setupIconTooltip(): void {
-    effect(onCleanup => {
-      const icon = this.icon();
-      // Only add an automatic tooltip if the consumer has not already applied an
-      // active `siTooltip` directive (i.e. one that is not disabled and has a tooltip).
-      const hasActiveTooltip =
-        !!this.existingTooltip &&
-        !this.existingTooltip.isDisabled() &&
-        !!this.existingTooltip.siTooltip();
-
-      if (icon && !hasActiveTooltip) {
-        this.tooltipRef = this.tooltipService.createTooltip({
-          element: this.tabButton,
-          placement: () => 'auto',
-          tooltip: () => this.heading(),
-          tooltipContext: () => undefined
-        });
-      }
-
-      onCleanup(() => {
-        this.tooltipRef?.destroy();
-        this.tooltipRef = undefined;
-      });
-    });
-  }
-
   ngOnDestroy(): void {
+    this.tooltipRef.destroy();
     if (this.indexBeforeClose >= 0) {
       this.tabset.removedTabByUser(this.indexBeforeClose, this.active());
     }

--- a/projects/element-ng/tabs/si-tab-base.directive.ts
+++ b/projects/element-ng/tabs/si-tab-base.directive.ts
@@ -130,7 +130,7 @@ export abstract class SiTabBaseDirective implements OnDestroy, FocusableOption {
       if (icon && !hasActiveTooltip) {
         this.tooltipRef = this.tooltipService.createTooltip({
           element: this.tabButton,
-          placement: 'auto',
+          placement: () => 'auto',
           tooltip: () => this.heading(),
           tooltipContext: () => undefined
         });

--- a/projects/element-ng/tabs/si-tab-base.directive.ts
+++ b/projects/element-ng/tabs/si-tab-base.directive.ts
@@ -102,7 +102,7 @@ export abstract class SiTabBaseDirective implements OnDestroy, FocusableOption {
     element: this.tabButton,
     placement: () => 'auto',
     canShow: this.canShowTooltip,
-    tooltip: () => this.heading(),
+    tooltip: this.heading,
     tooltipContext: () => undefined
   });
 

--- a/projects/element-ng/tabs/si-tab-base.directive.ts
+++ b/projects/element-ng/tabs/si-tab-base.directive.ts
@@ -96,16 +96,10 @@ export abstract class SiTabBaseDirective implements OnDestroy, FocusableOption {
   private readonly canShowTooltip = computed(
     () =>
       !!this.icon() &&
-      (!this.existingTooltip || this.existingTooltip.isDisabled() || !this.existingTooltip.siTooltip())
+      (!this.existingTooltip ||
+        this.existingTooltip.isDisabled() ||
+        !this.existingTooltip.siTooltip())
   );
-  private readonly tooltipRef = this.tooltipService.createTooltip({
-    element: this.tabButton,
-    placement: () => 'auto',
-    canShow: this.canShowTooltip,
-    tooltip: this.heading,
-    tooltipContext: () => undefined
-  });
-
   /** @internal */
   tabId = `${SiTabBaseDirective.tabCounter++}`;
   protected readonly icons = addIcons({ elementCancel });
@@ -113,6 +107,14 @@ export abstract class SiTabBaseDirective implements OnDestroy, FocusableOption {
   private readonly index = computed(() => this.tabset.tabPanels().indexOf(this));
 
   constructor() {
+    this.tooltipService.createTooltip({
+      element: this.tabButton,
+      placement: () => 'auto',
+      canShow: this.canShowTooltip,
+      tooltip: this.heading,
+      tooltipContext: () => undefined
+    });
+
     // Update the focusKeyManager if a tab is added that is active or if the tab is set active by the app.
     // This effect should not run, if active was already applied to the focusKeyManager.
     effect(() => {
@@ -127,7 +129,6 @@ export abstract class SiTabBaseDirective implements OnDestroy, FocusableOption {
   }
 
   ngOnDestroy(): void {
-    this.tooltipRef.destroy();
     if (this.indexBeforeClose >= 0) {
       this.tabset.removedTabByUser(this.indexBeforeClose, this.active());
     }

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
-import { Component, ElementRef, inject, signal, viewChild } from '@angular/core';
+import { Component, ElementRef, inject, Injector, runInInjectionContext, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { page } from 'vitest/browser';
 
@@ -242,14 +242,17 @@ describe('SiTooltipDirective', () => {
       readonly anchor = viewChild.required<ElementRef<HTMLButtonElement>>('anchor');
       readonly content = viewChild.required<ElementRef<HTMLDivElement>>('content');
       private readonly tooltipService = inject(SiTooltipService);
+      private readonly injector = inject(Injector);
 
       createTooltip(): void {
-        this.tooltipService.createTooltip({
-          element: this.anchor(),
-          placement: () => 'auto',
-          tooltip: this.content,
-          tooltipContext: () => undefined
-        });
+        runInInjectionContext(this.injector, () =>
+          this.tooltipService.createTooltip({
+            element: this.anchor(),
+            placement: () => 'auto',
+            tooltip: this.content,
+            tooltipContext: () => undefined
+          })
+        );
       }
     }
 

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -74,6 +74,18 @@ describe('SiTooltipDirective', () => {
       await expect.element(page.getByRole('tooltip')).not.toBeInTheDocument();
     });
 
+    it('should hide a visible tooltip when disabled', async () => {
+      button.dispatchEvent(new FocusEvent('focus'));
+      await vi.advanceTimersByTimeAsync(0);
+      await fixture.whenStable();
+      await expect.element(page.getByRole('tooltip', { name: 'test tooltip' })).toBeInTheDocument();
+
+      component.isDisabled.set(true);
+      await fixture.whenStable();
+
+      await expect.element(page.getByRole('tooltip')).not.toBeInTheDocument();
+    });
+
     it('should cancel pending tooltip when disabled while waiting', async () => {
       button.dispatchEvent(new MouseEvent('mouseenter'));
       await vi.advanceTimersByTimeAsync(0);

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -246,7 +246,7 @@ describe('SiTooltipDirective', () => {
       createTooltip(): void {
         this.tooltipService.createTooltip({
           element: this.anchor(),
-          placement: 'auto',
+          placement: () => 'auto',
           tooltip: this.content,
           tooltipContext: () => undefined
         });

--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -3,7 +3,15 @@
  * SPDX-License-Identifier: MIT
  */
 import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
-import { Component, ElementRef, inject, Injector, runInInjectionContext, signal, viewChild } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  inject,
+  Injector,
+  runInInjectionContext,
+  signal,
+  viewChild
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { page } from 'vitest/browser';
 

--- a/projects/element-ng/tooltip/si-tooltip.directive.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.ts
@@ -10,7 +10,6 @@ import {
   ElementRef,
   inject,
   input,
-  OnDestroy,
   TemplateRef
 } from '@angular/core';
 import { positions } from '@siemens/element-ng/common';
@@ -25,7 +24,7 @@ import { SiTooltipService } from './si-tooltip.service';
     '[attr.aria-describedby]': 'isDisabled() ? null : describedBy'
   }
 })
-export class SiTooltipDirective implements OnDestroy {
+export class SiTooltipDirective {
   private static idCounter = 0;
 
   /**
@@ -65,17 +64,16 @@ export class SiTooltipDirective implements OnDestroy {
   private readonly canShow = computed(() => !!this.siTooltip() && !this.isDisabled());
   private readonly tooltipService = inject(SiTooltipService);
   private readonly elementRef = inject(ElementRef);
-  private readonly tooltipRef = this.tooltipService.createTooltip({
-    describedBy: this.describedBy,
-    element: this.elementRef,
-    placement: this.placement,
-    canShow: this.canShow,
-    tooltip: this.siTooltip,
-    tooltipContext: this.tooltipContext,
-    scrollStrategy: this.tooltipScrollStrategy
-  });
 
-  ngOnDestroy(): void {
-    this.tooltipRef.destroy();
+  constructor() {
+    this.tooltipService.createTooltip({
+      describedBy: this.describedBy,
+      element: this.elementRef,
+      placement: this.placement,
+      canShow: this.canShow,
+      tooltip: this.siTooltip,
+      tooltipContext: this.tooltipContext,
+      scrollStrategy: this.tooltipScrollStrategy
+    });
   }
 }

--- a/projects/element-ng/tooltip/si-tooltip.directive.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.ts
@@ -68,7 +68,7 @@ export class SiTooltipDirective implements OnDestroy {
   private readonly tooltipRef = this.tooltipService.createTooltip({
     describedBy: this.describedBy,
     element: this.elementRef,
-    placement: this.placement(),
+    placement: this.placement,
     canShow: this.canShow,
     tooltip: this.siTooltip,
     tooltipContext: this.tooltipContext,

--- a/projects/element-ng/tooltip/si-tooltip.directive.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.ts
@@ -5,8 +5,8 @@
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import {
   booleanAttribute,
+  computed,
   Directive,
-  effect,
   ElementRef,
   inject,
   input,
@@ -62,32 +62,20 @@ export class SiTooltipDirective implements OnDestroy {
 
   protected describedBy = `__tooltip_${SiTooltipDirective.idCounter++}`;
 
-  private tooltipRef?: TooltipRef;
-  private tooltipService = inject(SiTooltipService);
-  private elementRef = inject(ElementRef);
-
-  constructor() {
-    effect(() => {
-      const tooltip = this.siTooltip();
-      const disabled = this.isDisabled();
-
-      if (tooltip && !disabled) {
-        this.tooltipRef ??= this.tooltipService.createTooltip({
-          describedBy: this.describedBy,
-          element: this.elementRef,
-          placement: this.placement(),
-          tooltip: this.siTooltip,
-          tooltipContext: this.tooltipContext,
-          scrollStrategy: this.tooltipScrollStrategy
-        });
-      } else if (this.tooltipRef) {
-        this.tooltipRef.destroy();
-        this.tooltipRef = undefined;
-      }
-    });
-  }
+  private readonly canShow = computed(() => !!this.siTooltip() && !this.isDisabled());
+  private readonly tooltipService = inject(SiTooltipService);
+  private readonly elementRef = inject(ElementRef);
+  private readonly tooltipRef: TooltipRef = this.tooltipService.createTooltip({
+    describedBy: this.describedBy,
+    element: this.elementRef,
+    placement: this.placement(),
+    canShow: this.canShow,
+    tooltip: this.siTooltip,
+    tooltipContext: this.tooltipContext,
+    scrollStrategy: this.tooltipScrollStrategy
+  });
 
   ngOnDestroy(): void {
-    this.tooltipRef?.destroy();
+    this.tooltipRef.destroy();
   }
 }

--- a/projects/element-ng/tooltip/si-tooltip.directive.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.ts
@@ -16,7 +16,7 @@ import {
 import { positions } from '@siemens/element-ng/common';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
-import { SiTooltipService, TooltipRef } from './si-tooltip.service';
+import { SiTooltipService } from './si-tooltip.service';
 
 @Directive({
   selector: '[siTooltip]',
@@ -65,7 +65,7 @@ export class SiTooltipDirective implements OnDestroy {
   private readonly canShow = computed(() => !!this.siTooltip() && !this.isDisabled());
   private readonly tooltipService = inject(SiTooltipService);
   private readonly elementRef = inject(ElementRef);
-  private readonly tooltipRef: TooltipRef = this.tooltipService.createTooltip({
+  private readonly tooltipRef = this.tooltipService.createTooltip({
     describedBy: this.describedBy,
     element: this.elementRef,
     placement: this.placement(),

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -7,6 +7,7 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { isPlatformBrowser } from '@angular/common';
 import {
   ComponentRef,
+  DestroyRef,
   effect,
   ElementRef,
   EffectRef,
@@ -16,7 +17,12 @@ import {
   inputBinding,
   PLATFORM_ID
 } from '@angular/core';
-import { getOverlay, getOverlayPositions, getPositionStrategy, positions } from '@siemens/element-ng/common';
+import {
+  getOverlay,
+  getOverlayPositions,
+  getPositionStrategy,
+  positions
+} from '@siemens/element-ng/common';
 import { fromEvent, Subject, Subscription, timer } from 'rxjs';
 import { delayWhen, filter, takeUntil } from 'rxjs/operators';
 
@@ -44,6 +50,7 @@ class NoopTooltipRef {
  * @internal
  */
 class BrowserTooltipRef {
+  private readonly destroyRef = inject(DestroyRef);
   private readonly destroy$ = new Subject<void>();
   private isFocused = false;
   private isHovered = false;
@@ -66,6 +73,7 @@ class BrowserTooltipRef {
     }
   ) {
     const nativeElement = this.config.element.nativeElement;
+    this.destroyRef.onDestroy(() => this.destroy());
 
     if (this.config.canShow) {
       this.canShowEffect = effect(() => this.updateCanShow());
@@ -105,9 +113,7 @@ class BrowserTooltipRef {
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.onTouchStart());
 
-    if (!this.config.canShow) {
-      this.showForCurrentInteraction();
-    }
+    this.showForCurrentInteraction();
   }
 
   private updateCanShow(): void {

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -7,7 +7,9 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { isPlatformBrowser } from '@angular/common';
 import {
   ComponentRef,
+  effect,
   ElementRef,
+  EffectRef,
   inject,
   Injectable,
   Injector,
@@ -47,6 +49,7 @@ class BrowserTooltipRef {
   private isHovered = false;
   private overlayRef?: OverlayRef;
   private positionSubscription?: Subscription;
+  private canShowEffect?: EffectRef;
 
   constructor(
     private config: {
@@ -55,12 +58,23 @@ class BrowserTooltipRef {
       injector?: Injector;
       overlay: Overlay;
       placement: keyof typeof positions;
+      canShow?: () => boolean;
       scrollStrategy?: () => ScrollStrategy | undefined;
       tooltip: () => SiTooltipContent;
       tooltipContext: () => unknown;
     }
   ) {
     const nativeElement = this.config.element.nativeElement;
+
+    if (this.config.canShow) {
+      this.canShowEffect = effect(() => {
+        if (!this.config.canShow!()) {
+          this.isFocused = false;
+          this.isHovered = false;
+          this.hide();
+        }
+      });
+    }
 
     fromEvent(nativeElement, 'focus')
       .pipe(
@@ -154,6 +168,10 @@ class BrowserTooltipRef {
   }
 
   private show(): void {
+    if (this.config.canShow && !this.config.canShow()) {
+      return;
+    }
+
     const overlayRef = this.getOrCreateOverlay();
     if (overlayRef.hasAttached()) {
       return;
@@ -189,6 +207,7 @@ class BrowserTooltipRef {
   destroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+    this.canShowEffect?.destroy();
     this.overlayRef?.dispose();
     this.positionSubscription?.unsubscribe();
   }
@@ -212,6 +231,7 @@ export class SiTooltipService {
     element: ElementRef;
     placement: keyof typeof positions;
     injector?: Injector;
+    canShow?: () => boolean;
     tooltip: () => SiTooltipContent;
     tooltipContext: () => unknown;
     scrollStrategy?: () => ScrollStrategy | undefined;

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -16,7 +16,7 @@ import {
   inputBinding,
   PLATFORM_ID
 } from '@angular/core';
-import { getOverlay, getPositionStrategy, positions } from '@siemens/element-ng/common';
+import { getOverlay, getOverlayPositions, getPositionStrategy, positions } from '@siemens/element-ng/common';
 import { fromEvent, Subject, Subscription, timer } from 'rxjs';
 import { delayWhen, filter, takeUntil } from 'rxjs/operators';
 
@@ -50,14 +50,16 @@ class BrowserTooltipRef {
   private overlayRef?: OverlayRef;
   private positionSubscription?: Subscription;
   private canShowEffect?: EffectRef;
+  private placementEffect?: EffectRef;
 
   constructor(
+    private injector: Injector,
     private config: {
       describedBy?: string;
       element: ElementRef;
       injector?: Injector;
       overlay: Overlay;
-      placement: keyof typeof positions;
+      placement: () => keyof typeof positions;
       canShow?: () => boolean;
       scrollStrategy?: () => ScrollStrategy | undefined;
       tooltip: () => SiTooltipContent;
@@ -67,14 +69,21 @@ class BrowserTooltipRef {
     const nativeElement = this.config.element.nativeElement;
 
     if (this.config.canShow) {
-      this.canShowEffect = effect(() => {
-        if (!this.config.canShow!()) {
-          this.isFocused = false;
-          this.isHovered = false;
-          this.hide();
-        }
-      });
+      this.canShowEffect = effect(
+        () => {
+          if (!this.config.canShow!()) {
+            this.isFocused = false;
+            this.isHovered = false;
+            this.hide();
+          }
+        },
+        { injector: this.injector }
+      );
     }
+
+    this.placementEffect = effect(() => this.updatePlacement(this.config.placement()), {
+      injector: this.injector
+    });
 
     fromEvent(nativeElement, 'focus')
       .pipe(
@@ -159,7 +168,7 @@ class BrowserTooltipRef {
       this.config.element,
       this.config.overlay,
       false,
-      this.config.placement,
+      this.getPlacement(),
       false,
       true,
       this.config.scrollStrategy?.()
@@ -196,6 +205,18 @@ class BrowserTooltipRef {
     );
   }
 
+  private getPlacement(): keyof typeof positions {
+    return this.config.placement();
+  }
+
+  private updatePlacement(placement: keyof typeof positions): void {
+    const positionStrategy = this.overlayRef && getPositionStrategy(this.overlayRef);
+    if (positionStrategy) {
+      positionStrategy.withPositions(getOverlayPositions(this.config.element, placement));
+      this.overlayRef?.updatePosition();
+    }
+  }
+
   private hide(): void {
     if (this.isFocused || this.isHovered) {
       return;
@@ -208,6 +229,7 @@ class BrowserTooltipRef {
     this.destroy$.next();
     this.destroy$.complete();
     this.canShowEffect?.destroy();
+    this.placementEffect?.destroy();
     this.overlayRef?.dispose();
     this.positionSubscription?.unsubscribe();
   }
@@ -224,12 +246,13 @@ class BrowserTooltipRef {
 @Injectable()
 export class SiTooltipService {
   private overlay = inject(Overlay);
+  private injector = inject(Injector);
   private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   createTooltip(config: {
     describedBy?: string;
     element: ElementRef;
-    placement: keyof typeof positions;
+    placement: () => keyof typeof positions;
     injector?: Injector;
     canShow?: () => boolean;
     tooltip: () => SiTooltipContent;
@@ -240,7 +263,7 @@ export class SiTooltipService {
       return new NoopTooltipRef();
     }
 
-    return new BrowserTooltipRef({
+    return new BrowserTooltipRef(this.injector, {
       ...config,
       overlay: this.overlay
     });

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -53,7 +53,6 @@ class BrowserTooltipRef {
   private placementEffect?: EffectRef;
 
   constructor(
-    private injector: Injector,
     private config: {
       describedBy?: string;
       element: ElementRef;
@@ -69,21 +68,10 @@ class BrowserTooltipRef {
     const nativeElement = this.config.element.nativeElement;
 
     if (this.config.canShow) {
-      this.canShowEffect = effect(
-        () => {
-          if (!this.config.canShow!()) {
-            this.isFocused = false;
-            this.isHovered = false;
-            this.hide();
-          }
-        },
-        { injector: this.injector }
-      );
+      this.canShowEffect = effect(() => this.updateCanShow());
     }
 
-    this.placementEffect = effect(() => this.updatePlacement(this.config.placement()), {
-      injector: this.injector
-    });
+    this.placementEffect = effect(() => this.updatePlacement(this.config.placement()));
 
     fromEvent(nativeElement, 'focus')
       .pipe(
@@ -117,11 +105,27 @@ class BrowserTooltipRef {
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.onTouchStart());
 
-    // The tooltip may be created lazily, after the element is already focused or
-    // hovered (e.g. when validation errors appear on blur while the pointer still
-    // hovers the element). In that case the initial `focus`/`mouseenter` was
-    // missed, so show the tooltip immediately based on the live `:focus-visible`
-    // and `:hover` state.
+    if (!this.config.canShow) {
+      this.showForCurrentInteraction();
+    }
+  }
+
+  private updateCanShow(): void {
+    if (!this.config.canShow!()) {
+      this.isFocused = false;
+      this.isHovered = false;
+      this.hide();
+      return;
+    }
+
+    this.showForCurrentInteraction();
+  }
+
+  private showForCurrentInteraction(): void {
+    const nativeElement = this.config.element.nativeElement;
+    // The tooltip may become eligible after the element is already focused or
+    // hovered (e.g. validation errors appear on blur while the pointer still
+    // hovers the element). In that case show it based on the live interaction state.
     if (nativeElement === document.activeElement && nativeElement.matches(':focus-visible')) {
       this.isFocused = true;
       this.show();
@@ -246,7 +250,6 @@ class BrowserTooltipRef {
 @Injectable()
 export class SiTooltipService {
   private overlay = inject(Overlay);
-  private injector = inject(Injector);
   private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   createTooltip(config: {
@@ -263,7 +266,7 @@ export class SiTooltipService {
       return new NoopTooltipRef();
     }
 
-    return new BrowserTooltipRef(this.injector, {
+    return new BrowserTooltipRef({
       ...config,
       overlay: this.overlay
     });


### PR DESCRIPTION
Evaluate tooltip eligibility when hover or focus attempts to show it.

Use reactive `canShow` and placement callbacks to preserve delayed hover behavior, hide dynamically disabled tooltips, resolve bound placement inputs after construction, and gate automatic tooltips. Tooltip refs clean themselves up with the caller `DestroyRef`.

Tests:
- `npm run lib:test -- --include='**/{tooltip/si-tooltip.directive.spec.ts,application-header/si-application-header.component.spec.ts,tabs/si-tabset.component.spec.ts,form/si-form-validation-tooltip/si-form-validation-tooltip.spec.ts}' --no-watch`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2357/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2357/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2357/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2357/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2357/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2357/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2357/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2357/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2357/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2357/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


