### PR TITLE
refactor(element-theme): remove deprecated css property

### DIFF
--- a/projects/element-ng/select/select-input/si-select-input.component.scss
+++ b/projects/element-ng/select/select-input/si-select-input.component.scss
@@ -8,7 +8,7 @@
   color: all-variables.$element-text-primary;
   padding-inline-end: calc(
     #{map.get(all-variables.$spacers, 2) - all-variables.$input-border-width} +
-      var(--si-feedback-icon-offset, 0px)
+      var(--si-feedback-icon-size, 0px)
   );
 
   &.disabled {

--- a/projects/element-ng/select/si-select-combobox.component.scss
+++ b/projects/element-ng/select/si-select-combobox.component.scss
@@ -1,7 +1,5 @@
 :host-context(.form-control.dropdown) .dropdown-caret {
-  margin-inline-end: calc(
-    (var(--si-feedback-icon-offset, 0px) + var(--si-action-icon-offset)) * -1
-  );
+  margin-inline-end: calc((var(--si-feedback-icon-size, 0px) + var(--si-action-icon-offset)) * -1);
 }
 
 .dropdown-caret {

--- a/projects/element-theme/src/styles/bootstrap/forms/_validation.scss
+++ b/projects/element-theme/src/styles/bootstrap/forms/_validation.scss
@@ -43,9 +43,6 @@
 @mixin form-validation-styles($state, $color, $icon) {
   @if ($state and $icon) {
     --si-feedback-icon: #{$icon};
-    // TODO: remove with v50
-    // DEPRECATED: use --si-feedback-icon-size instead
-    --si-feedback-icon-offset: 1.5rem;
     --si-feedback-icon-size: #{si-vars.$si-icon-font-size};
   }
 


### PR DESCRIPTION
BREAKING CHANGE: Removed css property `--si-feedback-icon-offset`. Use `--si-feedback-icon-size` instead.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2358/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2358/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2358/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2358/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2358/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2358/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2358/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2358/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2358/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2358/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

