### PR TITLE
style(lint): prevent explicit OnPush change detection

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -122,6 +122,12 @@ export const tsConfig = defineConfig({
       {
         selector: 'TSTypeReference:not([typeArguments]) > Identifier[name="SimpleChanges"]',
         message: 'Use SimpleChanges<this> instead of plain SimpleChanges'
+      },
+      {
+        selector:
+          'Property[key.name="changeDetection"] :matches(Identifier[name="OnPush"], Literal[value="OnPush"])',
+        message:
+          'Do not explicitly set changeDetection: ChangeDetectionStrategy.OnPush. OnPush is the default in Angular v22+'
       }
     ]
   }

--- a/projects/element-translate-ng/ngx-translate/si-translate-ngxt.test-module.mock.ts
+++ b/projects/element-translate-ng/ngx-translate/si-translate-ngxt.test-module.mock.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component, NgModule } from '@angular/core';
+import { Component, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 // eslint-disable-next-line no-restricted-imports
 import { provideChildTranslateService, TranslateLoader, TranslatePipe } from '@ngx-translate/core';
@@ -10,8 +10,7 @@ import { of } from 'rxjs';
 
 @Component({
   imports: [TranslatePipe],
-  template: `{{ 'KEY-1' | translate }}`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `{{ 'KEY-1' | translate }}`
 })
 class TestComponent {}
 

--- a/projects/element-translate-ng/translate/si-translate.pipe.spec.ts
+++ b/projects/element-translate-ng/translate/si-translate.pipe.spec.ts
@@ -2,13 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  inject,
-  Injectable
-} from '@angular/core';
+import { ChangeDetectorRef, Component, inject, Injectable } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { injectSiTranslateService, t } from '@siemens/element-translate-ng/translate';
 import { BehaviorSubject, Observable, of } from 'rxjs';
@@ -20,8 +14,7 @@ import { provideMockTranslateServiceBuilder } from './testing/si-translate.mock-
 
 @Component({
   imports: [SiTranslatePipe],
-  template: `{{ toTranslateKey | translate: params }}`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: `{{ toTranslateKey | translate: params }}`
 })
 class TestComponent {
   toTranslateKey = t(() => $localize`:@@KEY:Test {{value}}`);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,13 +2,12 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   imports: [RouterOutlet],
-  template: '<router-outlet />',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: '<router-outlet />'
 })
 export class AppComponent {}


### PR DESCRIPTION
Add ESLint rule to disallow explicitly setting `changeDetection: ChangeDetectionStrategy.OnPush` in component decorators, as OnPush is the default change detection strategy in Angular v22+.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2359/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2359/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2359/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2359/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2359/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2359/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2359/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2359/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2359/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2359/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

