### PR TITLE
build(api-goldens): configure worker count

### DIFF
--- a/tools/api-goldens/index_npm_packages.ts
+++ b/tools/api-goldens/index_npm_packages.ts
@@ -44,7 +44,10 @@ export async function main(
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PackageJson;
   const entryPoints = findEntryPointsWithinNpmPackage(npmPackageDir, packageJson);
   const worker = new Piscina<Parameters<typeof testApiGolden>, string>({
-    filename: path.resolve(__dirname, './test_api_report.ts')
+    filename: path.resolve(__dirname, './test_api_report.ts'),
+    maxThreads: process.env.API_GOLDENS_WORKERS
+      ? parseInt(process.env.API_GOLDENS_WORKERS, 10)
+      : 4
   });
 
   const processEntryPoint = async (subpath: string, typesEntryPointPath: string) => {


### PR DESCRIPTION
## Summary

Configure API goldens worker concurrency through the `API_GOLDENS_WORKERS` environment variable, defaulting to 4 workers.

## Validation

- `pnpm exec prettier --check tools/api-goldens/index_npm_packages.ts`
- TypeScript check with `tsc --noEmit`
- `git diff --check`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2360/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2360/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2360/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2360/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2360/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2360/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2360/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2360/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2360/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2360/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
