### PR TITLE
refactor(maps): remove deprecated extraProps from created features

### DIFF
--- a/projects/maps-ng/src/components/si-map/services/map.service.ts
+++ b/projects/maps-ng/src/components/si-map/services/map.service.ts
@@ -204,9 +204,6 @@ export class MapService {
           marker: point.marker,
           label: alwaysShowLabels ? ({ text: point.name } as LabelOptions) : undefined,
           group: point.group,
-          // TODO: Remove extraProps in v50
-          // For backward compatibility, extraProps is still supported, but extraProperties should be used going forward
-          extraProps: point.extraProperties,
           extraProperties: point.extraProperties,
           click: point.click
         })

--- a/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
@@ -133,7 +133,7 @@ describe('SiMapComponent', () => {
       click: (params: any) => {
         spy(params.buildingType);
       },
-      extraProps: { buildingType: 'office' }
+      extraProperties: { buildingType: 'office' }
     });
     component.featureClick(feature);
     expect(component.popoverOverlay.getPosition()).toEqual([1373214.9745276642, 5690661.889241241]);

--- a/projects/maps-ng/src/components/si-map/si-map.component.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.ts
@@ -1102,7 +1102,7 @@ export class SiMapComponent implements AfterViewInit, OnChanges, OnDestroy, Afte
   }
 
   private setPopOver(feature: Feature, zoom: boolean | undefined, event: any): void {
-    const extraProperties = feature.getProperties().extraProps;
+    const extraProperties = feature.getProperties().extraProperties;
     const geometry = feature?.getGeometry();
 
     /*If a Point geometry is present on top of a GeoJson layer, and when clicked on the point,


### PR DESCRIPTION
BREAKING CHANGE: Features returned by the public `MapService.createFeatures()` no longer include the `extraProps` property. Read `extraProperties` instead.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2362/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2362/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2362/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2362/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2362/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2362/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2362/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2362/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2362/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2362/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


