### PR TITLE
fix(accordion): prevent initial panel animation

### DIFF
--- a/playwright/snapshots/static.spec.ts-snapshots/si-accordion--si-collapsible-panel-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-accordion--si-collapsible-panel-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2f8bfb27259a2770da07bb1c81026ffc22c04e3f1183ce41f3fdff5ead3b9b03
-size 11807
+oid sha256:e7cbc6a1d94c6d5166a9ff0e3e288f86dab33951267ab4274ab9ba849aad9abf
+size 21057

--- a/playwright/snapshots/static.spec.ts-snapshots/si-accordion--si-collapsible-panel-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-accordion--si-collapsible-panel-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a24e9b2fb4f6fd81bf95f75af676bc629d68d9f10da77cc5937c6bd5b2766480
-size 11596
+oid sha256:c33608a5e3a3aeff93d97e17e3d89d5bcc70935378b5059c55cdf0c747a74115
+size 21078

--- a/projects/element-ng/accordion/si-collapsible-panel.component.html
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.html
@@ -54,7 +54,7 @@
   [class.full-height]="fullHeight()"
 >
   @if (opened()) {
-    <div class="content-motion" animate.leave="content-leave">
+    <div class="content-motion" animate.enter="content-enter" animate.leave="content-leave">
       <div class="overflow-hidden">
         <div [class]="contentCssClasses()">
           <ng-content />

--- a/projects/element-ng/accordion/si-collapsible-panel.component.scss
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.scss
@@ -99,10 +99,16 @@
 .content-motion {
   display: grid;
   grid-template-rows: 1fr;
-  transition: grid-template-rows variables.$element-default-transition-duration;
 
-  @starting-style {
-    grid-template-rows: 0fr;
+  &.content-enter,
+  &.content-leave {
+    transition: grid-template-rows variables.$element-default-transition-duration;
+  }
+
+  &.content-enter {
+    @starting-style {
+      grid-template-rows: 0fr;
+    }
   }
 
   &.content-leave {

--- a/projects/element-ng/accordion/si-collapsible-panel.component.ts
+++ b/projects/element-ng/accordion/si-collapsible-panel.component.ts
@@ -37,7 +37,8 @@ let controlIdCounter = 1;
     '[class.opened]': 'opened()',
     '[class.hcollapsed]': 'hcollapsed()',
     '[class.full-height]': 'fullHeight()',
-    '[style.--element-animations-enabled]': 'disableAnimation() ? "0" : undefined'
+    '[class.disable-animations]': 'disableAnimation()',
+    'animate.enter': 'disable-animations'
   }
 })
 export class SiCollapsiblePanelComponent {

--- a/projects/element-theme/src/styles/_accessibility.scss
+++ b/projects/element-theme/src/styles/_accessibility.scss
@@ -2,6 +2,10 @@
   --element-animations-enabled: 1;
 }
 
+.disable-animations {
+  --element-animations-enabled: 0;
+}
+
 @media (prefers-reduced-motion) {
   :root {
     --element-animations-enabled: 0;

--- a/src/app/examples/si-accordion/si-collapsible-panel.html
+++ b/src/app/examples/si-accordion/si-collapsible-panel.html
@@ -15,4 +15,16 @@
     <span si-panel-heading>Heading via content projection</span>
     Nothing to see here
   </si-collapsible-panel>
+
+  <h4 class="mt-8">Initially opened panel in tabs</h4>
+  <si-tabset>
+    <si-tab heading="First tab">
+      <p class="p-6">Initially opened panel in second tab</p>
+    </si-tab>
+    <si-tab heading="Initially opened panel" [active]="true">
+      <si-collapsible-panel heading="Initially opened" contentCssClasses="p-6" [opened]="true">
+        No animation on initial render
+      </si-collapsible-panel>
+    </si-tab>
+  </si-tabset>
 </div>

--- a/src/app/examples/si-accordion/si-collapsible-panel.ts
+++ b/src/app/examples/si-accordion/si-collapsible-panel.ts
@@ -4,10 +4,11 @@
  */
 import { Component } from '@angular/core';
 import { SiCollapsiblePanelComponent } from '@siemens/element-ng/accordion';
+import { SiTabComponent, SiTabsetComponent } from '@siemens/element-ng/tabs';
 
 @Component({
   selector: 'app-sample',
-  imports: [SiCollapsiblePanelComponent],
+  imports: [SiCollapsiblePanelComponent, SiTabComponent, SiTabsetComponent],
   templateUrl: './si-collapsible-panel.html'
 })
 export class SampleComponent {}


### PR DESCRIPTION
Use explicit enter and leave animation classes so initially opened panels do not animate when tab content is rendered.

Closes #2347<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2363/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2363/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2363/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2363/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2363/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2363/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2363/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2363/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2363/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2363/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


