### PR TITLE
refactor(search-bar): use host object instead of @HostListener

### DIFF
--- a/projects/element-ng/search-bar/si-search-bar.component.ts
+++ b/projects/element-ng/search-bar/si-search-bar.component.ts
@@ -7,7 +7,6 @@ import {
   Component,
   computed,
   ElementRef,
-  HostListener,
   input,
   numberAttribute,
   OnChanges,
@@ -39,7 +38,8 @@ import { debounceTime } from 'rxjs/operators';
     }
   ],
   host: {
-    '[class.readonly]': 'readonly()'
+    '[class.readonly]': 'readonly()',
+    '(focus)': 'focus()'
   }
 })
 export class SiSearchBarComponent implements OnInit, OnDestroy, ControlValueAccessor, OnChanges {
@@ -189,7 +189,6 @@ export class SiSearchBarComponent implements OnInit, OnDestroy, ControlValueAcce
   }
 
   /** @internal */
-  @HostListener('focus')
   focus(): void {
     this.inputRef().nativeElement.focus();
   }


### PR DESCRIPTION
Move focus event binding from @HostListener decorator to component's host object, following Angular best practices.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2368/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2368/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2368/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2368/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2368/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2368/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2368/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2368/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2368/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2368/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
