### PR TITLE
refactor(skip-links): use signals and input bindings

### DIFF
--- a/projects/element-ng/skip-links/skip-link.service.ts
+++ b/projects/element-ng/skip-links/skip-link.service.ts
@@ -9,7 +9,9 @@ import {
   EnvironmentInjector,
   inject,
   Injectable,
-  DOCUMENT
+  DOCUMENT,
+  signal,
+  inputBinding
 } from '@angular/core';
 
 import { SiSkipLinkTargetDirective } from './si-skip-link-target.directive';
@@ -23,25 +25,19 @@ export class SkipLinkService {
   private appRef = inject(ApplicationRef);
   private environmentInjector = inject(EnvironmentInjector);
   private document = inject(DOCUMENT);
-  private registeredTargets: SiSkipLinkTargetDirective[] = [];
+  private readonly registeredTargets = signal<SiSkipLinkTargetDirective[]>([]);
 
   registerLink(skipLink: SiSkipLinkTargetDirective): void {
     if (!this.skipLinksComponentRef) {
       this.createSkipLinksComponent();
     }
-
-    this.registeredTargets.push(skipLink);
-    this.skipLinksComponentRef!.setInput('skipLinks', this.registeredTargets);
-    this.skipLinksComponentRef!.changeDetectorRef.markForCheck();
+    this.registeredTargets.update(targets => [...targets, skipLink]);
   }
 
   unregisterLink(skipLink: SiSkipLinkTargetDirective): void {
-    this.registeredTargets.splice(this.registeredTargets.indexOf(skipLink), 1);
+    this.registeredTargets.update(targets => targets.filter(t => t !== skipLink));
 
-    if (this.registeredTargets.length && this.skipLinksComponentRef) {
-      this.skipLinksComponentRef.setInput('skipLinks', this.registeredTargets);
-      this.skipLinksComponentRef.changeDetectorRef.markForCheck();
-    } else {
+    if (!this.registeredTargets().length && this.skipLinksComponentRef) {
       this.skipLinksComponentRef?.destroy();
       this.skipLinksComponentRef = undefined;
     }
@@ -49,7 +45,8 @@ export class SkipLinkService {
 
   private createSkipLinksComponent(): void {
     this.skipLinksComponentRef = createComponent(SiSkipLinksComponent, {
-      environmentInjector: this.environmentInjector
+      environmentInjector: this.environmentInjector,
+      bindings: [inputBinding('skipLinks', this.registeredTargets)]
     });
 
     this.appRef.attachView(this.skipLinksComponentRef.hostView);


### PR DESCRIPTION
Replaces manual state management with signal-based approach.

Changes:
- Replace array-based registeredTargets with signal for reactive state
- Use inputBinding() instead of manual setInput() calls
- Remove explicit change detection calls (OnPush handles this automatically)
- Simplify register/unregister logic with signal update operations<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2369/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2369/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2369/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2369/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2369/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2369/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2369/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2369/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2369/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2369/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
