### PR TITLE
fix(popover): emit current state visibility with siPopoverVisibilityC…

### DIFF
--- a/api-goldens/element-ng/popover/index.api.md
+++ b/api-goldens/element-ng/popover/index.api.md
@@ -36,7 +36,7 @@ export class SiPopoverDirective implements OnDestroy {
     readonly siPopover: _angular_core.InputSignal<TranslatableString | TemplateRef<unknown> | undefined>;
     readonly title: _angular_core.InputSignal<TranslatableString | undefined>;
     updatePosition(): void;
-    readonly visibilityChange: _angular_core.OutputEmitterRef<void>;
+    readonly visibilityChange: _angular_core.OutputEmitterRef<boolean>;
 }
 
 // @public (undocumented)

--- a/projects/element-ng/popover/si-popover.directive.ts
+++ b/projects/element-ng/popover/si-popover.directive.ts
@@ -9,7 +9,6 @@ import {
   computed,
   Directive,
   ElementRef,
-  HostListener,
   inject,
   input,
   OnDestroy,
@@ -27,7 +26,8 @@ import { PopoverComponent } from './si-popover.component';
   selector: '[siPopover]',
   host: {
     '[attr.aria-expanded]': 'isOpen()',
-    '[attr.aria-controls]': 'popoverId'
+    '[attr.aria-controls]': 'popoverId',
+    '(click)': 'onClick()'
   },
   exportAs: 'si-popover'
 })
@@ -96,9 +96,9 @@ export class SiPopoverDirective implements OnDestroy {
   readonly scrollStrategy = input<ScrollStrategy>(undefined, { alias: 'siPopoverScrollStrategy' });
 
   /**
-   * Emits an event when the popover is shown/hidden
+   * Emits `true` when the popover is shown, `false` when the popover is hidden.
    */
-  readonly visibilityChange = output<void>({ alias: 'siPopoverVisibilityChange' });
+  readonly visibilityChange = output<boolean>({ alias: 'siPopoverVisibilityChange' });
 
   /** @internal */
   readonly popoverCounter = SiPopoverDirective.idCounter++;
@@ -155,7 +155,7 @@ export class SiPopoverDirective implements OnDestroy {
       .subscribe(change => popoverRef.instance.updateArrow(change, this.elementRef));
 
     this.isOpen.set(true);
-    this.visibilityChange.emit();
+    this.visibilityChange.emit(true);
   }
 
   /**
@@ -165,7 +165,7 @@ export class SiPopoverDirective implements OnDestroy {
     if (this.overlayref?.hasAttached()) {
       this.overlayref?.detach();
       this.isOpen.set(false);
-      this.visibilityChange.emit();
+      this.visibilityChange.emit(false);
       this.destroyer.next();
     }
   }
@@ -177,7 +177,6 @@ export class SiPopoverDirective implements OnDestroy {
     this.overlayref?.updatePosition();
   }
 
-  @HostListener('click')
   protected onClick(): void {
     if (this.overlayref?.hasAttached()) {
       this.hide();


### PR DESCRIPTION
…hange

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2370/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2370/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2370/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2370/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2370/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2370/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2370/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2370/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2370/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2370/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


