### PR TITLE
fix(wizard): focus next step content

### DIFF
--- a/projects/element-ng/wizard/si-wizard-step.component.ts
+++ b/projects/element-ng/wizard/si-wizard-step.component.ts
@@ -2,7 +2,15 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { booleanAttribute, Component, input, output, signal } from '@angular/core';
+import {
+  booleanAttribute,
+  Component,
+  ElementRef,
+  inject,
+  input,
+  output,
+  signal
+} from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 @Component({
@@ -10,6 +18,8 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
   templateUrl: './si-wizard-step.component.html'
 })
 export class SiWizardStepComponent {
+  /** @internal */
+  readonly elementRef = inject(ElementRef<HTMLElement>);
   /**
    * Heading displayed for the wizard step.
    *

--- a/projects/element-ng/wizard/si-wizard.component.html
+++ b/projects/element-ng/wizard/si-wizard.component.html
@@ -156,6 +156,7 @@
         </button>
 
         <button
+          #nextButton
           type="button"
           class="btn btn-primary"
           [attr.aria-label]="nextText() | translate"
@@ -171,6 +172,7 @@
       @if (!hideSave()) {
         @if (index === steps().length - 1) {
           <button
+            #saveButton
             type="button"
             class="btn btn-primary save"
             [class.end]="hideNavigation()"
@@ -206,6 +208,7 @@
     @if (!hideNavigation()) {
       <div class="next" [class.invisible]="index === steps().length - 1" (click)="next(1)">
         <button
+          #nextButton
           type="button"
           class="btn btn-primary btn-circle mb-2"
           [disabled]="!currentStep?.isValid()"
@@ -229,6 +232,7 @@
     <div [class.center-save]="!verticalLayout() && inlineNavigation()">
       @if (index === steps().length - 1) {
         <button
+          #saveButton
           type="button"
           class="btn btn-primary save"
           [disabled]="!currentStep?.isValid() || !currentStep?.isNextNavigable()"

--- a/projects/element-ng/wizard/si-wizard.component.spec.ts
+++ b/projects/element-ng/wizard/si-wizard.component.spec.ts
@@ -6,6 +6,7 @@ import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SiResizeObserverModule } from '@siemens/element-ng/resize-observer';
+import { userEvent } from 'vitest/browser';
 
 import { SiWizardStepComponent, SiWizardComponent as TestComponent } from './index';
 
@@ -23,7 +24,12 @@ import { SiWizardStepComponent, SiWizardComponent as TestComponent } from './ind
       [verticalMaxSize]="verticalMaxSize()"
     >
       @for (step of steps(); track step) {
-        <si-wizard-step [heading]="step" />
+        <si-wizard-step [heading]="step">
+          @if ($index === 1 && showStepAction()) {
+            <button type="button" tabindex="-1">Skipped action</button>
+            <button type="button" class="step-action">Step action</button>
+          }
+        </si-wizard-step>
       }
     </si-wizard>
   `,
@@ -44,6 +50,7 @@ class TestHostComponent {
   readonly verticalLayout = signal(false);
   readonly verticalMinSize = signal<string | undefined>(undefined);
   readonly verticalMaxSize = signal<string | undefined>(undefined);
+  readonly showStepAction = signal(true);
   readonly wizard = viewChild.required(TestComponent);
 
   constructor() {
@@ -165,6 +172,10 @@ describe('SiWizardComponent', () => {
       );
     });
 
+    it('should focus the first interactive element in the next step', () => {
+      expect(document.activeElement).toBe(element.querySelector<HTMLElement>('.step-action'));
+    });
+
     describe('when back button is clicked', () => {
       beforeEach(async () => {
         element.querySelector<HTMLElement>('.back')!.click();
@@ -269,6 +280,26 @@ describe('SiWizardComponent', () => {
       await fixture.whenStable();
       expect(element.querySelector<HTMLElement>('[aria-label="Cancel"]')).toBeInTheDocument();
     });
+  });
+
+  it('should focus the next button when the next step has no interactive elements', async () => {
+    hostComponent.showStepAction.set(false);
+    await fixture.whenStable();
+
+    await userEvent.click(element.querySelector<HTMLElement>('.next')!);
+    await fixture.whenStable();
+
+    expect(document.activeElement).toBe(element.querySelector<HTMLElement>('.next button'));
+  });
+
+  it('should focus the save button when the last step has no interactive elements', async () => {
+    await userEvent.click(element.querySelector<HTMLElement>('.next')!);
+    await fixture.whenStable();
+
+    await userEvent.click(element.querySelector<HTMLElement>('.next')!);
+    await fixture.whenStable();
+
+    expect(document.activeElement).toBe(element.querySelector<HTMLElement>('.btn.save'));
   });
 
   it('should calculate visible items', async () => {

--- a/projects/element-ng/wizard/si-wizard.component.ts
+++ b/projects/element-ng/wizard/si-wizard.component.ts
@@ -2,14 +2,17 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
+import { FocusTrapFactory } from '@angular/cdk/a11y';
 import { NgTemplateOutlet } from '@angular/common';
 import {
+  afterNextRender,
   booleanAttribute,
   Component,
   computed,
   contentChildren,
   ElementRef,
   inject,
+  Injector,
   input,
   linkedSignal,
   output,
@@ -75,8 +78,12 @@ export class SiWizardComponent {
   private static readonly stepPadding = 32;
   private readonly translateService = injectSiTranslateService();
   private readonly textMeasureService = inject(TextMeasureService);
+  private readonly focusTrapFactory = inject(FocusTrapFactory);
+  private readonly injector = inject(Injector);
 
   protected readonly containerSteps = viewChild<ElementRef<HTMLDivElement>>('containerSteps');
+  protected readonly nextButton = viewChild<ElementRef<HTMLButtonElement>>('nextButton');
+  protected readonly saveButton = viewChild<ElementRef<HTMLButtonElement>>('saveButton');
 
   /**
    * Description of back button.
@@ -354,6 +361,7 @@ export class SiWizardComponent {
       this.currentStep?.next.emit();
       if (this.currentStep?.isNextNavigable()) {
         this.activate(nextStep);
+        this.focusStepContent();
       }
     }
   }
@@ -401,6 +409,38 @@ export class SiWizardComponent {
     step.isActive.set(true);
     this._currentStep.set(step);
     this._index.set(this.steps().indexOf(step));
+  }
+
+  private focusStepContent(): void {
+    afterNextRender(
+      async () => {
+        const stepElement = this.currentStep?.elementRef.nativeElement as HTMLElement | undefined;
+        if (!stepElement) {
+          this.focusNavigationButton();
+          return;
+        }
+
+        // A little abuse, we only use the focus trap to focus the first tabable element.
+        const focusTrap = this.focusTrapFactory.create(stepElement);
+        try {
+          const focused = await focusTrap.focusFirstTabbableElementWhenReady();
+          if (!focused) {
+            this.focusNavigationButton();
+          }
+        } finally {
+          focusTrap.destroy();
+        }
+      },
+      { injector: this.injector }
+    );
+  }
+
+  private focusNavigationButton(): void {
+    if (this.index === this.steps().length - 1) {
+      this.saveButton()?.nativeElement.focus();
+    } else {
+      this.nextButton()?.nativeElement.focus();
+    }
   }
 
   private measureMaxTextWidth(texts: string[]): number {


### PR DESCRIPTION
Focus the first tabbable control after advancing a step, falling back to the next button when the step has no tabbable control.\n\nCloses #2346<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2372/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2372/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2372/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2372/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2372/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2372/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2372/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2372/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2372/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2372/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->







