### PR TITLE
refactor(ip-input): drop HostListener in favour for component host bi…

### DIFF
--- a/projects/element-ng/ip-input/si-ip-input.directive.ts
+++ b/projects/element-ng/ip-input/si-ip-input.directive.ts
@@ -7,7 +7,6 @@ import {
   computed,
   Directive,
   ElementRef,
-  HostListener,
   inject,
   input,
   Renderer2,
@@ -42,7 +41,9 @@ export interface AddrInputEvent {
   ],
   host: {
     '[id]': 'id()',
-    '[disabled]': 'disabled() || null'
+    '[disabled]': 'disabled() || null',
+    '(input)': 'onInput($event)',
+    '(blur)': 'onBlur()'
   }
 })
 export abstract class SiIpInputDirective {
@@ -95,7 +96,6 @@ export abstract class SiIpInputDirective {
     this.renderer.setProperty(this.inputEl, 'value', value ?? '');
   }
 
-  @HostListener('input', ['$event'])
   protected onInput(e: Event): void {
     const el = e.target as HTMLInputElement;
     const selStart = el.selectionStart ?? 0;
@@ -112,8 +112,7 @@ export abstract class SiIpInputDirective {
     this.onChange(this.value);
   }
   /** @internal */
-  @HostListener('blur')
-  protected blur(): void {
+  protected onBlur(): void {
     this.leaveInput();
     this.onTouched();
   }


### PR DESCRIPTION
…ndings

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2384/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2384/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2384/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2384/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2384/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2384/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2384/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2384/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2384/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2384/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
