### PR TITLE
fix(summary-chip): make single-digit chips circular

### DIFF
--- a/projects/element-ng/summary-chip/si-summary-chip.component.scss
+++ b/projects/element-ng/summary-chip/si-summary-chip.component.scss
@@ -4,8 +4,10 @@
 .chip {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  min-inline-size: calc(1lh + 2 * map.get(variables.$spacers, 4));
   border: 1px solid variables.$element-ui-3;
-  border-radius: map.get(variables.$spacers, 6);
+  border-radius: 1lh;
   padding-block: (map.get(variables.$spacers, 4) - 1px);
   padding-inline: map.get(variables.$spacers, 4);
   gap: map.get(variables.$spacers, 2);


### PR DESCRIPTION
currently there is deviation between badge and summary chip when having single digit value.


<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2387/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2387/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2387/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2387/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2387/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2387/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2387/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2387/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2387/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2387/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

