### PR TITLE
ci(vrt-update): authenticate against private registry during install

### DIFF
--- a/.github/workflows/vrt-update-all.yaml
+++ b/.github/workflows/vrt-update-all.yaml
@@ -17,3 +17,5 @@ jobs:
     with:
       ref: ${{ inputs.ref }}
       regenerate_all: true
+    secrets:
+      SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}

--- a/.github/workflows/vrt-update.yaml
+++ b/.github/workflows/vrt-update.yaml
@@ -28,6 +28,10 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      SIEMENS_NPM_TOKEN:
+        description: 'Token for the private Siemens npm registry'
+        required: false
 
 jobs:
   vrt-update:
@@ -155,7 +159,11 @@ jobs:
           path: dist
           run-id: ${{ steps.get-workflow.outputs.workflow-run-id }}
           github-token: ${{ github.token }}
-      # Not injecting the token will exclude the brand packages, but this is fine for e2e tests.
+      - name: Set up registry authentication
+        if: env.SIEMENS_NPM_TOKEN != ''
+        run: pnpm config set "//code.siemens.com/:_authToken" "${SIEMENS_NPM_TOKEN}"
+        env:
+          SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
       - run: pnpm install
 
       - name: Update VRTs


### PR DESCRIPTION
 
vrt-update is failing currently

<img width="1012" height="567" alt="image" src="https://github.com/user-attachments/assets/779262da-552b-476c-bd53-21ffb8936449" />

 
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2388/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2388/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2388/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2388/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2388/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2388/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2388/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2388/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2388/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2388/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
