### PR TITLE
docs(datatable): modernize example event bindings

### DIFF
--- a/src/app/examples/datatable/data.service.ts
+++ b/src/app/examples/datatable/data.service.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Injectable } from '@angular/core';
+import { SortPropDir } from '@siemens/ngx-datatable';
 import { Observable, of } from 'rxjs';
 import { delay } from 'rxjs/operators';
 
@@ -23,10 +24,7 @@ export interface PageRequest {
   // An optional filter parameter
   filter?: string;
   // An optional sort parameter
-  sort?: {
-    prop: string;
-    dir: 'asc' | 'desc';
-  };
+  sort?: SortPropDir;
 }
 
 export class Page {

--- a/src/app/examples/datatable/datatable-filter-sort-server.html
+++ b/src/app/examples/datatable/datatable-filter-sort-server.html
@@ -22,7 +22,7 @@
     [footerHeight]="0"
     [ghostLoadingIndicator]="isLoading"
     [externalSorting]="true"
-    (sort)="onSort($event)"
+    (sortsChange)="onSort($event)"
   >
     <si-empty-state empty-content icon="element-users" heading="No users to display" />
   </ngx-datatable>

--- a/src/app/examples/datatable/datatable-filter-sort-server.ts
+++ b/src/app/examples/datatable/datatable-filter-sort-server.ts
@@ -5,7 +5,7 @@
 import { ChangeDetectorRef, Component, inject, OnDestroy, viewChild } from '@angular/core';
 import { SI_DATATABLE_CONFIG, SiDatatableModule } from '@siemens/element-ng/datatable';
 import { SiEmptyStateComponent } from '@siemens/element-ng/empty-state';
-import { DatatableComponent, NgxDatatableModule } from '@siemens/ngx-datatable';
+import { DatatableComponent, NgxDatatableModule, SortPropDir } from '@siemens/ngx-datatable';
 import { Subscription } from 'rxjs';
 
 import { CorporateEmployee, DataService, PageRequest } from './data.service';
@@ -62,8 +62,7 @@ export class SampleComponent implements OnDestroy {
     const val = event.target.value.toLowerCase();
     this.fetchData({ offset: 0, pageSize: 50, filter: val });
   }
-  onSort(event: any): void {
-    const sort = event.sorts[0];
-    this.fetchData({ offset: 0, pageSize: 50, sort });
+  onSort(sorts: SortPropDir[]): void {
+    this.fetchData({ offset: 0, pageSize: 50, sort: sorts[0] });
   }
 }

--- a/src/app/examples/datatable/datatable-selection.html
+++ b/src/app/examples/datatable/datatable-selection.html
@@ -29,9 +29,8 @@
         [footerHeight]="0"
         [virtualization]="false"
         [scrollbarV]="true"
-        [selected]="selected"
         [datatableInteractionAutoSelect]="true"
-        (select)="selected = $event.selected"
+        [(selected)]="selected"
       />
     </div>
     <div class="col-sm p-5">

--- a/src/app/examples/si-list-details/si-list-details-router.html
+++ b/src/app/examples/si-list-details/si-list-details-router.html
@@ -67,10 +67,10 @@
         [externalSorting]="true"
         [count]="totalElements"
         [offset]="pageNumber"
-        [selected]="selectedEntities"
         [datatableInteractionAutoSelect]="container.hasLargeSize()"
+        [(selected)]="selectedEntities"
         (page)="setPage($event)"
-        (select)="datatableOnSelect($event.selected)"
+        (selectedChange)="datatableOnSelect()"
       >
         <si-empty-state empty-content icon="element-users" heading="No users to display" />
       </ngx-datatable>

--- a/src/app/examples/si-list-details/si-list-details-router.ts
+++ b/src/app/examples/si-list-details/si-list-details-router.ts
@@ -215,8 +215,7 @@ export class SampleComponent implements AfterViewInit {
       .then(() => this.router.navigate(['.'], { relativeTo: this.activatedRoute }));
   }
 
-  datatableOnSelect(items: CorporateEmployee[]): void {
-    this.selectedEntities = [...items];
+  datatableOnSelect(): void {
     this.selectedEntity = this.selectedEntities[0];
     this.detailsActive = true;
     this.logEvent(this.selectedEntities);

--- a/src/app/examples/si-list-details/si-list-details.html
+++ b/src/app/examples/si-list-details/si-list-details.html
@@ -68,10 +68,10 @@
           [externalSorting]="true"
           [count]="totalElements"
           [offset]="pageNumber"
-          [selected]="selectedEntities"
           [datatableInteractionAutoSelect]="container.hasLargeSize()"
+          [(selected)]="selectedEntities"
           (page)="setPage($event)"
-          (select)="datatableOnSelect($event.selected)"
+          (selectedChange)="datatableOnSelect()"
           (siResizeObserver)="table.recalculate()"
         >
           <si-empty-state empty-content icon="element-users" heading="No users to display" />

--- a/src/app/examples/si-list-details/si-list-details.ts
+++ b/src/app/examples/si-list-details/si-list-details.ts
@@ -152,8 +152,7 @@ export class SampleComponent {
     this.logEvent('Save');
   }
 
-  datatableOnSelect(items: CorporateEmployee[]): void {
-    this.selectedEntities = [...items];
+  datatableOnSelect(): void {
     this.selectedEntity = this.selectedEntities[0];
     this.detailsActive = true;
     this.logEvent(this.selectedEntities);

--- a/src/app/examples/si-main-detail-container/si-main-detail-container-block.html
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container-block.html
@@ -43,10 +43,10 @@
     [externalSorting]="true"
     [count]="totalElements"
     [offset]="pageNumber"
-    [selected]="selectedEntities"
     [datatableInteractionAutoSelect]="isLarge"
+    [(selected)]="selectedEntities"
     (page)="setPage($event)"
-    (select)="datatableOnSelect($event.selected)"
+    (selectedChange)="datatableOnSelect()"
   >
     <si-empty-state empty-content icon="element-users" heading="No users to display" />
   </ngx-datatable>

--- a/src/app/examples/si-main-detail-container/si-main-detail-container-block.ts
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container-block.ts
@@ -97,8 +97,7 @@ export class SampleComponent {
     }
   ];
 
-  datatableOnSelect(items: CorporateEmployee[]): void {
-    this.selectedEntities = [...items];
+  datatableOnSelect(): void {
     this.selectedEntity = this.selectedEntities[0];
     this.detailsActive = true;
     this.logEvent(this.selectedEntities);

--- a/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.html
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.html
@@ -51,9 +51,9 @@
     [footerHeight]="0"
     [scrollbarV]="true"
     [count]="filteredRows.length"
-    [selected]="selectedEntities"
     [datatableInteractionAutoSelect]="isLarge"
-    (select)="datatableOnSelect($event.selected)"
+    [(selected)]="selectedEntities"
+    (selectedChange)="datatableOnSelect()"
   >
     <si-empty-state empty-content icon="element-users" heading="No users to display" />
   </ngx-datatable>

--- a/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.ts
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.ts
@@ -82,8 +82,7 @@ export class SampleComponent {
     this.updateFilter(this.searchCriteria);
   }
 
-  datatableOnSelect(items: CorporateEmployee[]): void {
-    this.selectedEntities = [...items];
+  datatableOnSelect(): void {
     this.selectedEntity = this.selectedEntities[0];
     this.detailsActive = true;
     this.logEvent(this.selectedEntities);

--- a/src/app/examples/si-main-detail-container/si-main-detail-container.html
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container.html
@@ -45,10 +45,10 @@
     [externalSorting]="true"
     [count]="totalElements"
     [offset]="pageNumber"
-    [selected]="selectedEntities"
     [datatableInteractionAutoSelect]="isLarge"
+    [(selected)]="selectedEntities"
     (page)="setPage($event)"
-    (select)="datatableOnSelect($event.selected)"
+    (selectedChange)="datatableOnSelect()"
   >
     <si-empty-state empty-content icon="element-users" heading="No users to display" />
   </ngx-datatable>

--- a/src/app/examples/si-main-detail-container/si-main-detail-container.ts
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container.ts
@@ -101,8 +101,7 @@ export class SampleComponent {
   ];
   private readonly table = viewChild.required(DatatableComponent);
 
-  datatableOnSelect(items: CorporateEmployee[]): void {
-    this.selectedEntities = [...items];
+  datatableOnSelect(): void {
     this.selectedEntity = this.selectedEntities[0];
     this.detailsActive = true;
     this.logEvent(this.selectedEntities);


### PR DESCRIPTION
Replace deprecated DataTable selection and sorting events with supported bindings.\n\nValidation: npm run build:examples<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2395/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2395/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2395/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2395/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2395/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2395/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2395/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2395/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2395/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2395/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
