### PR TITLE
fixup(form): respect `SI_FORM_ITEM_CONTROL` in `si-form-field`

### DIFF
--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated.yaml
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form--validated.yaml
@@ -12,7 +12,7 @@
 - text: Minimum 3 characters Name must start with an uppercase letter Description
 - textbox "Description"
 - text: Phone number
-- group:
+- group "Phone number":
   - combobox /Select country Switzerland \+\d+/
   - textbox "Enter phone number":
     - /placeholder: 21 234 56 78

--- a/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form.yaml
+++ b/playwright/snapshots/si-signal-form.spec.ts-snapshots/si-signal-form--si-signal-form.yaml
@@ -1,14 +1,21 @@
 - heading "Signal form" [level=2]
 - group "Role*":
   - text: ""
+  - button "More information about the role"
   - radio "Engineer"
   - text: Engineer
   - radio "Installer"
   - text: Installer
 - text: Name*
+- button "More information about the name"
 - textbox "Name*"
 - text: Description
 - textbox "Description"
+- text: Phone number
+- group "Phone number":
+  - combobox /Select country Switzerland \+\d+/
+  - textbox "Enter phone number":
+    - /placeholder: 21 234 56 78
 - text: Day of birth*
 - textbox "Day of birth*"
 - text: Arrival
@@ -24,6 +31,7 @@
 - spinbutton "Fellow passengers": "0"
 - checkbox "I confirm that I accept all and everything*"
 - text: I confirm that I accept all and everything*
+- button "More information about the terms"
 - checkbox "I confirm that I do not care about my privacy"
 - text: I confirm that I do not care about my privacy
 - button "Cancel"

--- a/projects/element-ng/form/si-form-field/si-form-field.component.html
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.html
@@ -17,9 +17,11 @@
     [class.form-label]="!isFormCheck()"
     [class.form-check-label]="isFormCheck()"
   >
-    <label [for]="controlId()" [class.required]="required() && !isPartOfRadioGroup()">{{
-      label() | translate
-    }}</label>
+    @if (labelledby()) {
+      <span [id]="labelledby()" [class.required]="showRequired()">{{ label() | translate }}</span>
+    } @else {
+      <label [for]="controlId()" [class.required]="showRequired()">{{ label() | translate }}</label>
+    }
     <ng-content select="[si-help-button]" />
   </div>
 </ng-template>

--- a/projects/element-ng/form/si-form-field/si-form-field.component.spec.ts
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.spec.ts
@@ -83,6 +83,8 @@ describe('SiFormFieldComponent', () => {
   it('should mark required controls as required', async () => {
     await expect.element(nameField).toBeRequired();
     await expect.element(termsField).toBeRequired();
+    await expect.element(page.getByText('Name', { exact: true })).toHaveClass('required');
+    await expect.element(page.getByText('Terms', { exact: true })).toHaveClass('required');
   });
 
   it('should not mark as invalid if the field is untouched', async () => {

--- a/projects/element-ng/form/si-form-field/si-form-field.component.ts
+++ b/projects/element-ng/form/si-form-field/si-form-field.component.ts
@@ -10,13 +10,15 @@ import {
   DestroyRef,
   effect,
   inject,
-  input
+  input,
+  isSignal
 } from '@angular/core';
 import { FormField } from '@angular/forms/signals';
 import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiFormFieldsetComponent } from '../form-fieldset/si-form-fieldset.component';
 import { SiFormFieldsetControl } from '../form-fieldset/si-form-fieldset.control';
+import { SI_FORM_ITEM_CONTROL } from '../si-form-item.control';
 import { SiFormValidationErrorService } from '../si-form-validation-error.service';
 
 /**
@@ -44,7 +46,7 @@ import { SiFormValidationErrorService } from '../si-form-validation-error.servic
   templateUrl: './si-form-field.component.html',
   styleUrl: './si-form-field.component.scss',
   host: {
-    '[class.required]': 'required() && !isPartOfRadioGroup()',
+    '[class.required]': 'showRequired()',
     '[class.form-check]': 'isFormCheck()',
     '[class.form-check-inline]': 'fieldset?.inline()'
   }
@@ -59,6 +61,7 @@ export class SiFormFieldComponent implements SiFormFieldsetControl {
   readonly label = input.required<TranslatableString>();
 
   private readonly formField = contentChild.required(FormField);
+  private readonly fieldControl = contentChild(SI_FORM_ITEM_CONTROL, { descendants: true });
 
   protected readonly fieldset = inject(SiFormFieldsetComponent, { optional: true });
 
@@ -67,13 +70,26 @@ export class SiFormFieldComponent implements SiFormFieldsetControl {
   private readonly generatedId = `__si-form-field-${SiFormFieldComponent.idCounter++}`;
 
   /** The id of the connected control, used for the label's `for` attribute. */
-  protected readonly controlId = computed(() => this.formField().element.id || this.generatedId);
+  protected readonly controlId = computed(() => {
+    const id = this.fieldControl()?.id;
+    return (isSignal(id) ? id() : id) ?? (this.formField().element.id || this.generatedId);
+  });
 
-  protected readonly errormessageId = computed(() => `${this.controlId()}-errormessage`);
+  protected readonly errormessageId = computed(() => {
+    const id = this.fieldControl()?.errormessageId;
+    return (isSignal(id) ? id() : id) ?? `${this.controlId()}-errormessage`;
+  });
+
+  protected readonly labelledby = computed(() => {
+    const labelledby = this.fieldControl()?.labelledby;
+    return isSignal(labelledby) ? labelledby() : labelledby;
+  });
 
   /** Whether the connected control is a form-check (checkbox, radio or switch). */
-  protected readonly isFormCheck = computed(() =>
-    this.formField().element.classList.contains('form-check-input')
+  protected readonly isFormCheck = computed(
+    () =>
+      this.fieldControl()?.isFormCheck ??
+      this.formField().element.classList.contains('form-check-input')
   );
 
   private readonly fieldState = computed(() => this.formField().state());
@@ -83,6 +99,9 @@ export class SiFormFieldComponent implements SiFormFieldsetControl {
 
   /** @internal */
   readonly required = computed(() => this.fieldState().required());
+
+  /** @internal  */
+  readonly showRequired = computed(() => this.required() && !this.isPartOfRadioGroup());
 
   private readonly invalid = computed(() => {
     const state = this.fieldState();


### PR DESCRIPTION
Use the provided form item control metadata for IDs, labelling, and form-check semantics.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2397/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2397/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2397/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2397/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2397/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2397/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2397/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2397/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2397/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2397/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



