### PR TITLE
feat(info-page): adjust illustration size and spacing defaults

### DIFF
--- a/docs/components/pages/info-page.md
+++ b/docs/components/pages/info-page.md
@@ -67,8 +67,9 @@ to inject `Actions`.
 
 ### Illustrations
 
-Use the `&lt;img/&gt;` element and add the `.si-info-image` CSS class to change the info page image to
-an illustration.
+Use the `&lt;img/&gt;` element with Angular's `NgOptimizedImage` directive and add the `.si-info-image`
+CSS class to change the info page image to an illustration. Provide the image using `ngSrc` and set
+its `width` and `height` up front, preserving the source image's aspect ratio to prevent distortion.
 
 <si-docs-component example="si-info-page/si-info-page-illustration" height="650"></si-docs-component>
 

--- a/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93dd7db704158e4631ea3d9fef58b864053288bcdaf1ebf9b00a50117c9c815f
-size 20979
+oid sha256:18a7b8d1c2246bfc2e2bdfaca6c9acb0938559e2be43d66814da5f0b1767c424
+size 20977

--- a/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e7ef6e5d7a7e57d819c22acc48c082beee7d3c515b5c3a4725d55136b513ac5
-size 21105
+oid sha256:339cef432f2a877eba9a7591483e66d88ea5f77815e579941688ee2e84a57f47
+size 21222

--- a/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-illustration-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-illustration-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:447c2ee7f9b2f681444be15ce5a13abee85592d0e66f74d47586fe69782eeb40
-size 30470
+oid sha256:fd9ecd3748871e914c69d9949ea2b0813fed5ef557a919e915a9d84e93ecf278
+size 25531

--- a/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-illustration-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-illustration-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b576b3c4b23db2b1c66187042925fc9ab070775266068f95918d44dc564cd34
-size 30289
+oid sha256:c88a3e8b717bfa5dca7cd4eccff74ea5bb291a317cb12d2ed696881d22e8dca5
+size 25774

--- a/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-stacked-icon-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-stacked-icon-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0dcef0c8e89a274307bb9f630a1da449ab90261cd708675adc586fa7effd952a
-size 23307
+oid sha256:d188338136a9d4c4b23b5e026dccc2224c3e26a364b9ccfca8d75ecfee7d4145
+size 23522

--- a/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-stacked-icon-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-info-page--si-info-page-stacked-icon-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1bec339c260c151ae78e26852fc311f7d2cb533caefb75167479dfbd7c027d67
-size 23627
+oid sha256:598d0eb12d18fa9bb8f0f7b972d408fdfc4a1138213349abeaec94065be1673b
+size 23870

--- a/projects/element-ng/info-page/si-info-page.component.html
+++ b/projects/element-ng/info-page/si-info-page.component.html
@@ -1,16 +1,20 @@
-<div class="h-100 d-flex flex-column justify-content-center align-items-center p-6">
+<div class="h-100 d-flex flex-column justify-content-center align-items-center text-center p-6">
   <ng-content select=".si-info-image">
     <si-icon class="icon-size" [class]="iconColor()" [icon]="icon()" />
   </ng-content>
-  <h1 class="my-9">{{ titleText() | translate }}</h1>
+  <h1 class="si-h1-bold si-info-page-title">{{ titleText() | translate }}</h1>
   @if (copyText()) {
-    <h2 class="mb-9">{{ copyText() | translate }}</h2>
+    <h2 class="mt-6 mb-0"> {{ copyText() | translate }} </h2>
   }
   @if (instructions()) {
-    <p class="text-pre-wrap text-center si-body-lg mb-9">{{ instructions() | translate }}</p>
+    <p class="text-pre-wrap si-body-lg mt-6 mb-0">{{ instructions() | translate }}</p>
   }
   @if (link()?.title) {
-    <a class="btn btn-primary" [siLink]="link()">{{ link()?.title | translate }}</a>
+    <a class="btn btn-primary si-info-page-link" [siLink]="link()">
+      {{ link()?.title | translate }}
+    </a>
   }
-  <ng-content select=".si-info-actions" />
+  <div class="si-info-action-container">
+    <ng-content select=".si-info-actions" />
+  </div>
 </div>

--- a/projects/element-ng/info-page/si-info-page.component.scss
+++ b/projects/element-ng/info-page/si-info-page.component.scss
@@ -1,3 +1,38 @@
+@use 'sass:map';
+
+@use '@siemens/element-theme/src/styles/all-variables';
+
+:host {
+  display: block;
+  block-size: 100%;
+}
+
 :host ::ng-deep .icon-size {
   font-size: 96px;
+}
+
+.si-info-page-title {
+  margin-block-start: 40px;
+  margin-block-end: 0;
+}
+
+.si-info-page-link,
+.si-info-action-container:not(:empty) {
+  margin-block-start: map.get(all-variables.$spacers, 9);
+}
+
+@include all-variables.media-breakpoint-down(sm) {
+  :host ::ng-deep .si-info-actions {
+    display: flex;
+    flex-direction: column;
+
+    > * {
+      inline-size: 100%;
+      margin-inline-end: 0;
+    }
+  }
+
+  .si-info-action-container:not(:empty) {
+    align-self: stretch;
+  }
 }

--- a/src/app/examples/si-info-page/si-info-page-illustration.html
+++ b/src/app/examples/si-info-page/si-info-page-illustration.html
@@ -5,8 +5,9 @@
   <img
     alt="Nice illustration"
     class="si-info-image"
-    src="./assets/images/illustration-single-theme-hand.png"
-    style="max-height: 500px; width: 50%"
+    ngSrc="./assets/images/illustration-single-theme-hand.png"
+    width="258.22"
+    height="196"
   />
   <div class="si-info-actions">
     <button type="button" class="btn btn-secondary me-6 mb-6" (click)="logEvent('Contact support')"

--- a/src/app/examples/si-info-page/si-info-page-illustration.ts
+++ b/src/app/examples/si-info-page/si-info-page-illustration.ts
@@ -2,13 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
+import { NgOptimizedImage } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { SiInfoPageComponent } from '@siemens/element-ng/info-page';
 import { LOG_EVENT } from '@siemens/live-preview';
 
 @Component({
   selector: 'app-sample',
-  imports: [SiInfoPageComponent],
+  imports: [SiInfoPageComponent, NgOptimizedImage],
   templateUrl: './si-info-page-illustration.html'
 })
 export class SampleComponent {


### PR DESCRIPTION
- Set the default illustration slot size to 260x196px (overridable by projects).
- Adjust gap between the image and title
- Update playwright snapshots

Closes #2374 

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2398/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2398/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2398/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2398/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2398/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2398/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2398/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2398/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2398/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2398/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->












