### PR TITLE
fix(application-header): launchpad `Show more/less` should have `aria-expanded`

### DIFF
--- a/api-goldens/element-ng/application-header/index.api.md
+++ b/api-goldens/element-ng/application-header/index.api.md
@@ -134,7 +134,8 @@ export class SiLaunchpadFactoryComponent {
     readonly favoriteAppsText: _angular_core.InputSignal<TranslatableString>;
     // (undocumented)
     readonly favoriteChange: _angular_core.OutputEmitterRef<FavoriteChangeEvent>;
-    readonly showLessAppsText: _angular_core.InputSignal<TranslatableString>;
+    // @deprecated (undocumented)
+    readonly showLessAppsText: _angular_core.InputSignal<unknown>;
     readonly showMoreAppsText: _angular_core.InputSignal<TranslatableString>;
     readonly subtitleText: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly titleText: _angular_core.InputSignal<TranslatableString>;

--- a/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad-categories-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad-categories-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b57693d9cade5c5595eb910b6bd666ef99cf2402303aff7a10f9c9162c3f3d45
-size 30990
+oid sha256:1352b7bdd943d81138ecb562164db880e24b9e0d3f3ab2bb3856849db9d0f18f
+size 31050

--- a/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad-categories-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad-categories-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aca1e3bf76c4649b19c6a2d1707eddf138bd976e415a0443e79ba87dc5b95bad
-size 29976
+oid sha256:322dcc5f3e906744dab29cf13addd88cadf8e7a146d2ef4d8cd49f012a3b527d
+size 30055

--- a/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad-categories.yaml
+++ b/playwright/snapshots/navbar-launchpad.spec.ts-snapshots/si-navbar--si-navbar-launchpad-categories.yaml
@@ -17,7 +17,7 @@
   - text: Favorites
   - link "Water":
     - /url: .
-  - button "Show less"
+  - button "Show more" [expanded]
   - text: Phishing Apps
   - link "Water":
     - /url: .

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a85bcd3a7fe95ae46b4ff1b3291a818e356d3c62090b00cbe747f215f83ab64
-size 31988
+oid sha256:d0e5e9849a24bf3a800e5a53d54f4da8bed561bb49d2b9964fbc999fd0ed2a29
+size 32044

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aebce744b68eff5140d273888f1948eb46fc749912869c94ea1c3437a0c52ef7
-size 31157
+oid sha256:6e38e4c3eeeb3a1fc318abb6578ce389e99c32317b8d4f59397e11747f9b31d2
+size 31233

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile.yaml
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--mobile.yaml
@@ -14,7 +14,7 @@
     - /url: "#/viewer/viewer/stats"
   - link "Rocket System name":
     - /url: .
-  - button "Show less"
+  - button "Show more" [expanded]
   - link "Assets System name":
     - /url: .
   - link "Fischbach System name":

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3dcdd53781193e6cc700344f82441710c20fe4ba17506f52388921b6b1cf4ce
-size 40820
+oid sha256:e48b713bfad2ef3310aeffecd5a2b5fe4663600edf025669682bad5fff039858
+size 40900

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:49cda89aafa827fd44a44164ecc77f7c97b7ddc33db9ece5a9cc87dbbc0cc1b8
-size 40036
+oid sha256:a17c9675cb4c6557c390cbcf07bc36982a8d1480fbe683943427574e04302f98
+size 40083

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite.yaml
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad--new-favorite.yaml
@@ -12,7 +12,7 @@
     - /url: "#/viewer/viewer/stats"
   - link "Rocket System name":
     - /url: .
-  - button "Show less"
+  - button "Show more" [expanded]
   - link "Assets System name":
     - /url: .
   - link "Fischbach System name":

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06b55a1d1895ff3271d931fa592e16476dc9a49d471d200fc57be66780ba3e38
-size 42533
+oid sha256:475afd8aea43b8a24088a804abc7d8b0f572781dbd95795485d289f3dcdae873
+size 42592

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2ef022cfe59186a43a087710da9e8fc7d6c7d7804ef28cc4d25eee314a2438b
-size 41685
+oid sha256:0e16f5f98e88eeffbaa7f0f33ff3255c30c5a5dde87ca08672d831240928e99b
+size 41761

--- a/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad.yaml
+++ b/playwright/snapshots/si-launchpad.spec.ts-snapshots/si-application-header--si-launchpad.yaml
@@ -14,7 +14,7 @@
     - /url: "#/viewer/viewer/stats"
   - link "Rocket System name":
     - /url: .
-  - button "Show less"
+  - button "Show more" [expanded]
   - link "Assets System name":
     - /url: .
   - link "Fischbach System name":

--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.html
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.html
@@ -34,22 +34,26 @@
         type="button"
         class="btn btn-link btn-show-all dropdown-toggle text-decoration-none"
         [class.show]="showAllApps"
+        [attr.aria-expanded]="showAllApps"
+        [attr.aria-controls]="allAppsId"
         (click)="showAllApps = !showAllApps"
       >
-        <b>{{ (showAllApps ? showLessAppsText() : showMoreAppsText()) | translate }}</b>
+        <b>{{ showMoreAppsText() | translate }}</b>
         <si-icon class="link-icon dropdown-caret" [icon]="icons.elementDown2" />
       </button>
     }
 
-    @if (!enableFavorites() || !hasFavorites() || showAllApps) {
-      @for (category of categories(); track category.name) {
-        <si-launchpad-category
-          [class.pt-6]="!!category.name && (hasFavorites() || !$first)"
-          [category]="category"
-          [enableFavorites]="enableFavorites()"
-          (favoriteChange)="toggleFavorite($event)"
-        />
+    <div class="all-apps" [id]="allAppsId">
+      @if (!enableFavorites() || !hasFavorites() || showAllApps) {
+        @for (category of categories(); track category.name) {
+          <si-launchpad-category
+            [class.pt-6]="!!category.name && (hasFavorites() || !$first)"
+            [category]="category"
+            [enableFavorites]="enableFavorites()"
+            (favoriteChange)="toggleFavorite($event)"
+          />
+        }
       }
-    }
+    </div>
   </div>
 </div>

--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.scss
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.scss
@@ -47,7 +47,7 @@
     margin-block-end: map.get(variables.$spacers, 8);
   }
 
-  &.show:has(+ si-launchpad-category.has-title) {
+  &.show:has(+ .all-apps > si-launchpad-category.has-title) {
     margin-block-end: 0;
   }
 }

--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
@@ -82,19 +82,13 @@ export class SiLaunchpadFactoryComponent {
    */
   readonly showMoreAppsText = input(t(() => $localize`:@@SI_LAUNCHPAD.SHOW_MORE:Show more`));
 
-  /**
-   * Title of the show less apps button.
-   *
-   * @defaultValue
-   * ```
-   * t(() => $localize`:@@SI_LAUNCHPAD.SHOW_LESS:Show less`)
-   * ```
-   */
-  readonly showLessAppsText = input(t(() => $localize`:@@SI_LAUNCHPAD.SHOW_LESS:Show less`));
+  /** @deprecated This input no longer has an effect. {@link showMoreAppsText} is shown in all cases. */
+  readonly showLessAppsText = input();
 
   readonly favoriteChange = output<FavoriteChangeEvent>();
 
   protected showAllApps = false;
+  protected readonly allAppsId = '__si-launchpad-factory-all-apps';
   protected readonly categories = computed(() => {
     const apps = this.apps();
     if (this.isCategories(apps)) {

--- a/projects/element-ng/application-header/launchpad/si-launchpad.spec.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad.spec.ts
@@ -55,8 +55,13 @@ describe('SiLaunchpad', () => {
           }
         ]);
         expect(await harness.hasToggle()).toBe(true);
+        expect(await harness.isExpanded()).toBe(false);
+        const controlledRegionId = await harness.getControlledRegionId();
+        expect(controlledRegionId).not.toBeNull();
+        expect(fixture.nativeElement.querySelector(`#${controlledRegionId}`)).toBeInTheDocument();
         expect(await harness.getCategories()).toHaveLength(1);
         await harness.toggleMore();
+        expect(await harness.isExpanded()).toBe(true);
         expect(await harness.getCategories()).toHaveLength(2);
         expect(await harness.getCategory('C-1').then(category => category.getApps())).toHaveLength(
           2

--- a/projects/element-ng/application-header/testing/si-launchpad.harness.ts
+++ b/projects/element-ng/application-header/testing/si-launchpad.harness.ts
@@ -32,6 +32,16 @@ export class SiLaunchpadHarness extends ComponentHarness {
     return this.toggleButton().then(toggle => !!toggle);
   }
 
+  async isExpanded(): Promise<boolean> {
+    return (await this.toggleButton())!
+      .getAttribute('aria-expanded')
+      .then(value => value === 'true');
+  }
+
+  async getControlledRegionId(): Promise<string | null> {
+    return this.toggleButton().then(toggle => toggle!.getAttribute('aria-controls'));
+  }
+
   async toggleMore(): Promise<void> {
     return this.toggleButton().then(toggle => toggle!.click());
   }


### PR DESCRIPTION
Expose the Show more toggle state through `aria-expanded` so assistive technologies can identify whether the launchpad app list is expanded.
Always show `Show more` never `Show less`.

DEPRECATED: `SiLaunchpadFactoryComponent.showLessAppsText` input is deprecated and no longer used.
`SiLaunchpadFactoryComponent.showMoreAppsText` is always displayed, independent of the state.

<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2400/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2400/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2400/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2400/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2400/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2400/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2400/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2400/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2400/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2400/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->






