### PR TITLE
refactor(theme): rename element-base-input token

### DIFF
--- a/projects/element-ng/chat-messages/si-chat-input.component.scss
+++ b/projects/element-ng/chat-messages/si-chat-input.component.scss
@@ -17,7 +17,7 @@
   &:hover,
   &:active,
   &:focus-within {
-    background-color: variables.$element-base-input-experimental;
+    background-color: variables.$element-base-input;
     border-color: variables.$element-ui-1;
   }
 

--- a/projects/element-ng/filtered-search/si-filtered-search.component.scss
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.scss
@@ -8,13 +8,13 @@ $filtered-search-criteria-margin: map.get(variables.$spacers, 2);
 :host {
   --search-bar-icon-color: #{variables.$element-text-primary};
   --input-background-color: #{variables.$element-base-1};
-  --input-background-hover-color: #{variables.$element-base-1};
+  --input-background-hover-color: #{variables.$element-base-input};
   --filter-search-background-color: #{variables.$element-base-1};
   --filter-pill-background-color: #{variables.$element-base-4};
 
   &.dark-background {
     --input-background-color: #{variables.$element-base-4};
-    --input-background-hover-color: #{variables.$element-ui-4};
+    --input-background-hover-color: #{variables.$element-base-input};
     --filter-search-background-color: #{variables.$element-base-4};
     --filter-pill-background-color: #{variables.$element-base-1};
   }

--- a/projects/element-ng/search-bar/si-search-bar.component.scss
+++ b/projects/element-ng/search-bar/si-search-bar.component.scss
@@ -5,7 +5,7 @@
 :host {
   --search-bar-icon-color: #{variables.$element-text-secondary};
   --input-background-color: #{variables.$element-base-1};
-  --input-background-hover-color: #{variables.$element-base-1};
+  --input-background-hover-color: #{variables.$element-base-input};
 
   div:hover,
   div.focus {
@@ -18,7 +18,7 @@
 
 .dark-background {
   --input-background-color: #{variables.$element-base-4};
-  --input-background-hover-color: #{variables.$element-ui-4};
+  --input-background-hover-color: #{variables.$element-base-input};
 }
 
 input {
@@ -28,7 +28,7 @@ input {
   border-width: 0;
 
   &.form-control:focus-visible {
-    background-color: var(--input-background-color);
+    background-color: var(--input-background-hover-color);
   }
 }
 

--- a/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
+++ b/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
@@ -70,8 +70,8 @@
 
   &:is(:focus, :hover, :has(+ .form-control-actions:is(:hover, :focus-within))) {
     --border-color: #{semantic-tokens.$element-ui-1};
-    --si-textarea-mask: #{semantic-tokens.$element-base-input-experimental};
-    background-color: semantic-tokens.$element-base-input-experimental;
+    --si-textarea-mask: #{semantic-tokens.$element-base-input};
+    background-color: semantic-tokens.$element-base-input;
   }
 
   &:is(.readonly, [readonly]) {

--- a/projects/element-theme/src/styles/variables/_semantic-tokens.scss
+++ b/projects/element-theme/src/styles/variables/_semantic-tokens.scss
@@ -24,8 +24,7 @@ $element-base-danger: var(--element-base-danger);
 $element-base-critical: var(--element-base-critical);
 $element-base-translucent-1: var(--element-base-translucent-1);
 $element-base-translucent-2: var(--element-base-translucent-2);
-// EXPERIMENTAL: Do not use
-$element-base-input-experimental: var(--element-base-input-experimental);
+$element-base-input: var(--element-base-input);
 
 $element-radius-0: var(--element-radius-0);
 $element-radius-1: var(--element-radius-1);

--- a/projects/element-theme/src/theme/_theme-element.scss
+++ b/projects/element-theme/src/theme/_theme-element.scss
@@ -44,8 +44,7 @@ $theme-element-light: (
   element-base-critical: data.$color-data-orchid-100,
   element-base-translucent-1: rgba(base.$color-black, 0.3),
   element-base-translucent-2: rgba(base.$color-deep-blue-900, 0.88),
-  // EXPERIMENTAL: Do not use
-  element-base-input-experimental: base.$color-experimental-deep-blue-25,
+  element-base-input: base.$color-experimental-deep-blue-25,
   element-action-primary: base.$color-interactive-blue-500,
   element-action-primary-hover: base.$color-teal,
   element-action-primary-text: base.$color-white,
@@ -250,8 +249,7 @@ $theme-element-dark: (
   element-base-critical: data.$color-data-orchid-700,
   element-base-translucent-1: rgba(base.$color-black, 0.7),
   element-base-translucent-2: rgba(base.$color-white, 0.88),
-  // EXPERIMENTAL: Do not use
-  element-base-input-experimental: base.$color-experimental-deep-blue-850,
+  element-base-input: base.$color-experimental-deep-blue-850,
   element-action-primary: base.$color-interactive-coral,
   element-action-primary-hover: base.$color-bold-green,
   element-action-primary-text: base.$color-deep-blue-900,


### PR DESCRIPTION
Rename the stable base input theme token and update internal consumers.

BREAKING CHANGE: Token `element-base-input-experimental` renamed to `element-base-input`.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2403/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2403/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2403/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2403/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2403/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2403/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2403/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2403/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2403/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2403/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

