### PR TITLE
feat(tree-view): support tracking immutable items

### DIFF
--- a/api-goldens/element-ng/tree-view/index.api.md
+++ b/api-goldens/element-ng/tree-view/index.api.md
@@ -21,6 +21,7 @@ import { Signal } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
+import { TrackByFunction } from '@angular/core';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
 import { TranslatableString as TranslatableString_2 } from '@siemens/element-translate-ng/translate-types';
 
@@ -205,6 +206,7 @@ export class SiTreeViewComponent implements OnInit, OnChanges, OnDestroy, AfterV
     showTreeItem(item: TreeItem): void;
     readonly singleSelectMode: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly templates: Signal<readonly SiTreeViewItemTemplateDirective[]>;
+    readonly trackBy: _angular_core.InputSignal<TrackByFunction<TreeItem<any>>>;
     readonly treeItemCheckboxClicked: _angular_core.OutputEmitterRef<CheckboxClickEventArgs>;
     readonly treeItemClicked: _angular_core.OutputEmitterRef<TreeItem<any>>;
     readonly treeItemFolderClicked: _angular_core.OutputEmitterRef<FolderStateEventArgs>;

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
@@ -81,7 +81,10 @@ export class SiTreeViewItemComponent implements OnInit, AfterViewInit, Focusable
   protected treeItemContext = inject(TREE_ITEM_CONTEXT);
   protected treeViewComponent = this.treeItemContext.parent;
   /** @internal */
-  treeItem: TreeItem = this.treeItemContext.record.item;
+  // The differ may replace this item while retaining the component instance.
+  get treeItem(): TreeItem {
+    return this.treeItemContext.record.item;
+  }
   private scrollIntoView: Subject<TreeItem> = this.treeViewComponent.scrollChildIntoView;
   private childrenLoaded: Subject<TreeItem> = this.treeViewComponent.childrenLoaded;
 

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.directive.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.directive.ts
@@ -33,6 +33,7 @@ export class SiTreeViewItemDirective implements AfterViewInit, OnDestroy {
   private differs = inject(IterableDiffers);
   private cdRef = inject(ChangeDetectorRef);
   private differ: IterableDiffer<TreeItem> | null = null;
+  private trackBy?: (index: number, item: TreeItem) => unknown;
   private subscription!: OutputRefSubscription;
   private itemsVirtualizedDirty = true;
 
@@ -41,7 +42,7 @@ export class SiTreeViewItemDirective implements AfterViewInit, OnDestroy {
       this.itemsVirtualizedDirty = false;
       const value = this.parent.itemsVirtualized;
       if (!this.differ && value) {
-        this.differ = this.differs.find(value).create((_index, item) => item);
+        this.differ = this.differs.find(value).create(this.parent.trackBy());
       }
     }
     queueMicrotask(() => this.evaluateDiffer());
@@ -56,8 +57,15 @@ export class SiTreeViewItemDirective implements AfterViewInit, OnDestroy {
   }
 
   private evaluateDiffer(): void {
+    const items = this.parent.itemsVirtualized;
+    const trackBy = this.parent.trackBy();
+    if (this.trackBy !== trackBy) {
+      this.trackBy = trackBy;
+      this.differ = this.differs.find(items).create(trackBy);
+      this.viewContainerRef.clear();
+    }
     if (this.differ) {
-      const changes = this.differ.diff(this.parent.itemsVirtualized);
+      const changes = this.differ.diff(items);
       if (changes) this.applyChanges(changes);
     }
   }
@@ -115,7 +123,7 @@ export class SiTreeViewItemDirective implements AfterViewInit, OnDestroy {
     }
 
     changes.forEachIdentityChange((record: IterableChangeRecord<TreeItem>) => {
-      if (record.currentIndex) {
+      if (record.currentIndex !== null) {
         const viewRef = viewContainer.get(record.currentIndex) as EmbeddedViewRef<TreeItemContext>;
         viewRef.context = {
           treeItem: record.item,

--- a/projects/element-ng/tree-view/si-tree-view.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, signal, viewChild } from '@angular/core';
+import { Component, signal, TrackByFunction, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MenuItem } from '@siemens/element-ng/menu';
@@ -19,6 +19,7 @@ import { LoadChildrenEventArgs, MenuItemsProvider, TreeItem } from './si-tree-vi
     [style]="style()"
     [class.tree-xs]="smallSize()"
     [items]="items()"
+    [trackBy]="trackBy()"
     [enableSelection]="enableSelection()"
     [enableIcon]="enableIcon()"
     [singleSelectMode]="singleSelectMode()"
@@ -67,6 +68,7 @@ class WrapperComponent {
       ]
     }
   ]);
+  readonly trackBy = signal<TrackByFunction<TreeItem>>((_index, item) => item);
   loadChildren = (e: LoadChildrenEventArgs): void => {};
   readonly style = signal('');
   readonly smallSize = signal(false);
@@ -138,6 +140,25 @@ describe('SiTreeViewComponent', () => {
   it('should contain set items', () => {
     const icon = element.querySelector('.si-tree-view-item-icon');
     expect(icon?.getAttribute('data-icon')).toBe('element-project');
+  });
+
+  it('should retain item views when trackBy matches immutable item replacements', async () => {
+    component.trackBy.set((_index, item) => (item.customData as { id: string }).id);
+    component.items.set([
+      { label: 'Original item', customData: { id: 'item-1' } },
+      { label: 'Other item', customData: { id: 'item-2' } }
+    ]);
+    await fixture.whenStable();
+
+    const originalItem = element.querySelector<HTMLElement>('si-tree-view-item')!;
+    component.items.set([
+      { label: 'Updated item', customData: { id: 'item-1' } },
+      { label: 'Other item', customData: { id: 'item-2' } }
+    ]);
+    await fixture.whenStable();
+
+    expect(element.querySelector('si-tree-view-item')).toBe(originalItem);
+    expect(originalItem.innerText).toContain('Updated item');
   });
 
   it('should contain folder state start', async () => {

--- a/projects/element-ng/tree-view/si-tree-view.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.ts
@@ -31,6 +31,7 @@ import {
   Signal,
   SimpleChanges,
   TemplateRef,
+  TrackByFunction,
   viewChild,
   viewChildren
 } from '@angular/core';
@@ -225,6 +226,17 @@ export class SiTreeViewComponent
    * @defaultref {@link _items}
    */
   readonly items = input<TreeItem[]>([]);
+
+  /**
+   * Identifies tree items when the items input is replaced. Provide a stable key to retain
+   * rendered item views for immutable data updates.
+   *
+   * @defaultValue
+   * ```
+   * (_index, item) => item
+   * ```
+   */
+  readonly trackBy = input<TrackByFunction<TreeItem>>((_index, item) => item);
 
   /**
    * Sets the tree item to be selected.


### PR DESCRIPTION
Retain tree item views when consumers replace items with stable keys.

Fixes #2405

Tests: `npm run lib:test -- --include='**/tree-view/si-tree-view.component.spec.ts' --no-watch`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2407/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2407/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2407/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2407/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2407/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2407/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2407/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2407/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2407/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2407/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

