### PR TITLE
build(gh-actions): exclude pnpm-lock changes from release commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
         env:
           SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
       # Publishing workspace packages with workspace:* peer dependencies requires pnpm to install those peers.
-      - run: pnpm install --config.auto-install-peers=true
+      - run: pnpm install --no-frozen-lockfile --config.auto-install-peers=true
       - id: before_release
         run: |
           BEFORE_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -88,7 +88,7 @@ export default {
           [
             '@semantic-release/git',
             {
-              assets: ['CHANGELOG.md', 'package.json', 'pnpm-lock.yaml', 'projects/*/package.json'],
+              assets: ['CHANGELOG.md', 'package.json', 'projects/*/package.json'],
               message: 'chore(release): ${nextRelease.version}'
             }
           ]


### PR DESCRIPTION
Upading the version has no impact on the pnpm-lock.yaml. The only changes done is because of the peer depenencies install mode. So we can safely exlcude it from the release commit.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2424/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2424/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2424/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2424/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2424/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2424/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2424/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2424/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2424/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2424/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
