### PR TITLE
fix(datepicker): propagate date range validation to signal forms

### DIFF
--- a/api-goldens/element-ng/datepicker/index.api.md
+++ b/api-goldens/element-ng/datepicker/index.api.md
@@ -398,6 +398,8 @@ export class SiDateRangeComponent implements ControlValueAccessor, Validator, Af
     // (undocumented)
     registerOnTouched(fn: () => void): void;
     // (undocumented)
+    registerOnValidatorChange(fn: () => void): void;
+    // (undocumented)
     setDisabledState(isDisabled: boolean): void;
     readonly siDatepickerConfig: _angular_core.ModelSignal<DatepickerInputConfig>;
     readonly siDatepickerRangeChange: _angular_core.OutputEmitterRef<DateRange | undefined>;

--- a/projects/element-ng/datepicker/si-date-input.directive.ts
+++ b/projects/element-ng/datepicker/si-date-input.directive.ts
@@ -121,6 +121,8 @@ export class SiDateInputDirective
 
   /** @internal */
   validatorOnChange: () => void = () => {};
+  /** @internal */
+  readonly validationChange = output<void>();
   /**
    * Date form input validator function, validating text format, min and max value.
    */
@@ -159,6 +161,8 @@ export class SiDateInputDirective
       if (this.date && formatChanged) {
         this.updateNativeValue();
       }
+      this.validatorOnChange();
+      this.validationChange.emit();
     }
   }
 

--- a/projects/element-ng/datepicker/si-date-range.component.html
+++ b/projects/element-ng/datepicker/si-date-range.component.html
@@ -11,6 +11,7 @@
   [disabled]="disabled()"
   [readonly]="readonly()"
   (ngModelChange)="onInputChanged({ start: $event, end: value()?.end })"
+  (validationChange)="onValidatorChange()"
 />
 <span class="mx-3">-</span>
 <input
@@ -26,6 +27,7 @@
   [disabled]="disabled()"
   [readonly]="readonly()"
   (ngModelChange)="onInputChanged({ start: value()?.start, end: $event })"
+  (validationChange)="onValidatorChange()"
 />
 <div class="form-control-actions">
   <button

--- a/projects/element-ng/datepicker/si-date-range.component.spec.ts
+++ b/projects/element-ng/datepicker/si-date-range.component.spec.ts
@@ -7,6 +7,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { form, FormField } from '@angular/forms/signals';
 
 import {
   DatepickerInputConfig,
@@ -243,6 +244,36 @@ class FormWrapperComponent {
 
   readonly siDateRangeComponent = viewChild.required(SiDateRangeComponent);
 }
+
+@Component({
+  imports: [FormField, SiDateRangeComponent],
+  template: `<si-date-range
+    [formField]="form.dateRange"
+    [siDatepickerConfig]="{ dateFormat: 'dd-MM-yyyy' }"
+  />`
+})
+class SignalFormWrapperComponent {
+  readonly model = signal<{ dateRange: DateRange }>({
+    dateRange: { start: undefined, end: undefined }
+  });
+  readonly form = form(this.model);
+}
+
+describe('SiDateRangeComponent with a signal form field', () => {
+  it('should expose invalid start date format errors', async () => {
+    const fixture = TestBed.createComponent(SignalFormWrapperComponent);
+    await fixture.whenStable();
+
+    enterValue(startInput(fixture.nativeElement), 'INVALID DATE');
+    startInput(fixture.nativeElement).dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.form.dateRange().errors()).toEqual([
+      expect.objectContaining({ kind: 'invalidStartDateFormat' })
+    ]);
+  });
+});
+
 describe('SiDateRangeComponent within form', () => {
   let fixture: ComponentFixture<FormWrapperComponent>;
   let component: FormWrapperComponent;
@@ -332,6 +363,25 @@ describe('SiDateRangeComponent within form', () => {
           minString: '2/1/2023',
           start: new Date(2023, 0, 1),
           end: null
+        }
+      });
+    });
+
+    it('should validate the date range when the min date changes', async () => {
+      component.form.controls.dateRange.setValue({
+        start: new Date(2023, 0, 1),
+        end: new Date(2023, 0, 2)
+      });
+      await fixture.whenStable();
+
+      updateConfig({ minDate: new Date(2023, 1, 1) });
+      await fixture.whenStable();
+
+      expect(component.form.controls.dateRange.errors).toMatchObject({
+        rangeBeforeMinDate: {
+          min: component.config().minDate,
+          start: new Date(2023, 0, 1),
+          end: new Date(2023, 0, 2)
         }
       });
     });

--- a/projects/element-ng/datepicker/si-date-range.component.ts
+++ b/projects/element-ng/datepicker/si-date-range.component.ts
@@ -228,6 +228,7 @@ export class SiDateRangeComponent
   private validator!: ValidatorFn;
   private onChange = (val: any): void => {};
   private onTouch = (): void => {};
+  protected onValidatorChange = (): void => {};
 
   protected readonly icons = addIcons({ elementCalendar });
   protected readonly disabled = computed(() => this.disabledInput() || this.disabledNgControl());
@@ -258,6 +259,7 @@ export class SiDateRangeComponent
         this.updateValue(this.value());
       }
     }
+    this.onValidatorChange();
     this.overlayToggle.setInputs({ config: this.siDatepickerConfig(), dateRange: this.value() });
   }
 
@@ -292,6 +294,10 @@ export class SiDateRangeComponent
     this.onTouch = fn;
   }
 
+  registerOnValidatorChange(fn: () => void): void {
+    this.onValidatorChange = fn;
+  }
+
   setDisabledState(isDisabled: boolean): void {
     this.disabledNgControl.set(isDisabled);
   }
@@ -322,6 +328,7 @@ export class SiDateRangeComponent
     this.updateValue(dateRange);
 
     this.onChange(this.value());
+    this.onValidatorChange();
     this.siDatepickerRangeChange.emit(this.value());
   }
 


### PR DESCRIPTION
## Summary

Notify Signal Forms when nested date inputs change so date-range format errors are re-evaluated.

## Testing

- `pnpm exec ng test element-ng --include='**/datepicker/si-date-range.component.spec.ts' --no-watch`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2426/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2426/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2426/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2426/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2426/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2426/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2426/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2426/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2426/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2426/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



