### PR TITLE
fix(breadcrumb): remove obsolete dropdown styling

### DIFF
--- a/projects/element-ng/breadcrumb/si-breadcrumb.component.scss
+++ b/projects/element-ng/breadcrumb/si-breadcrumb.component.scss
@@ -4,10 +4,6 @@
   flex-wrap: nowrap;
 }
 
-.dropdown-menu.show > .dropdown-item {
-  background-color: variables.$element-base-1;
-}
-
 .item {
   display: flex;
   align-items: center;
@@ -21,20 +17,6 @@
 
 .breadcrumb-dropdown-toggle {
   cursor: pointer;
-}
-
-// overwrite some of Bootstrap's dropdown styling
-.dropdown-item {
-  &.active,
-  &:active {
-    background-color: variables.$element-base-1;
-  }
-
-  &:hover,
-  &:focus {
-    background-color: variables.$element-base-0 !important; // stylelint-disable-line declaration-no-important
-    text-decoration: underline;
-  }
 }
 
 .disable-router-link,


### PR DESCRIPTION
Use the shared dropdown styles so breadcrumb overflow menus remain consistent with the active theme.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2437/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2437/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2437/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2437/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2437/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2437/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2437/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2437/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2437/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2437/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
