### PR TITLE
refactor(buttons): drop useless hover border

### DIFF
--- a/projects/element-theme/src/styles/bootstrap/_buttons.scss
+++ b/projects/element-theme/src/styles/bootstrap/_buttons.scss
@@ -144,8 +144,8 @@ button {
   --btn-color-hover: #{semantic-tokens.$element-action-warning-text};
   --btn-color-active: #{semantic-tokens.$element-action-warning-text};
   --btn-border-color: #{semantic-tokens.$element-action-secondary-warning};
-  --btn-border-color-hover: #{semantic-tokens.$element-action-warning-hover};
-  --btn-border-color-active: #{semantic-tokens.$element-action-warning-active};
+  --btn-border-color-hover: transparent;
+  --btn-border-color-active: transparent;
 }
 
 .btn-secondary-danger,
@@ -156,8 +156,8 @@ button {
   --btn-color-hover: #{semantic-tokens.$element-action-danger-text};
   --btn-color-active: #{semantic-tokens.$element-action-danger-text};
   --btn-border-color: #{semantic-tokens.$element-action-secondary-danger};
-  --btn-border-color-hover: #{semantic-tokens.$element-action-danger-hover};
-  --btn-border-color-active: #{semantic-tokens.$element-action-danger-active};
+  --btn-border-color-hover: transparent;
+  --btn-border-color-active: transparent;
 }
 
 .btn-secondary-ghost,


### PR DESCRIPTION
For secondary/tertiarry we don't need
an explicitlx border.
Dropping it prepares for the system token migration.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2439/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2439/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2439/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2439/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2439/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2439/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2439/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2439/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2439/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2439/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
