### PR TITLE
refactor(theme): migrate dropdown to system tokens

### DIFF
--- a/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu--dropdown-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu--dropdown-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64d7d828e5a90d7ae68bf2c7a74bbccd58d67816430d1812edf479c17422d034
-size 28397
+oid sha256:fc9304b1970723bddcbdff922eeff4e52e71e2887231fe8404e0c0e8b82ce49b
+size 28211

--- a/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu-factory--dropdown-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu-factory--dropdown-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64d7d828e5a90d7ae68bf2c7a74bbccd58d67816430d1812edf479c17422d034
-size 28397
+oid sha256:fc9304b1970723bddcbdff922eeff4e52e71e2887231fe8404e0c0e8b82ce49b
+size 28211

--- a/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu-factory-legacy--dropdown-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu-factory-legacy--dropdown-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57c350f6c3657d72b0a65f3a9dedff7ffbc190e90d7e59978be7373f0c432867
-size 21559
+oid sha256:4e26be77e10cf9a903158606d2e2d4697034b2f142002cb98cd030ed6f19821c
+size 21416

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--filter-opened-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--filter-opened-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96e0ed40a13460cb31ceb137e701d886bfcda7d9f47eb7d59002aa47c3a14b1a
-size 23596
+oid sha256:0d3551dbf8eadcab8e64a804009ed9d61fb920006869c6535afa558ad583a9ec
+size 23547

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--filter-searched-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--filter-searched-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:69049a8939b0cbb0c253b6e9e6f5665f18f7ff1ad6db9cf7c3c934b7869adc56
-size 23574
+oid sha256:06d07b426785841a42237a72db0e41ef37f0258a3322497ddfebe72a7bddc699
+size 23469

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--form-select-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--form-select-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe2bc8d5f7d10355ef2ce2fba6c7d017b6322b6c08d423b6afa483ac7c6febfa
-size 24268
+oid sha256:fe494397439b1b0ade35a16b290d12ca2d74d0af28d8fb98882e8dfd55e41031
+size 24160

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--multi-select-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--multi-select-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3aa7b0f562dbbc337b0a73de055bb800b68cd7cf30b55b5f17e9dac7ea757f65
-size 24053
+oid sha256:9b91da700dfd7792a5f2071cb85fac2605f0985c71fd1e0e1856fb2e454f3caa
+size 23948

--- a/projects/element-theme/src/styles/bootstrap/_dropdowns.scss
+++ b/projects/element-theme/src/styles/bootstrap/_dropdowns.scss
@@ -1,6 +1,7 @@
 @use '../variables';
 @use '../variables/semantic-tokens';
 @use '../variables/spacers';
+@use '../variables/system-tokens';
 @use '../variables/typography';
 @use '../variables/zindex';
 @use './variables' as bootstrap-variables;
@@ -126,15 +127,15 @@
 
   // duplicating hover styles from bootstrap. To split them from focus styles. Otherwise hover on focus elements will not work.
   &:hover {
-    color: semantic-tokens.$element-text-primary;
-    background-color: semantic-tokens.$element-base-1-hover;
+    color: system-tokens.$si-sys-text-primary;
+    background-color: system-tokens.$si-sys-background-hover;
     text-decoration: none;
   }
 
   // duplicating hover styles from bootstrap. To split them from focus styles. Otherwise hover on focus elements will not work.
   &:is(:active, .active) {
-    color: var(--element-text-primary);
-    background-color: var(--element-base-1-selected);
+    color: var(--si-sys-text-primary);
+    background-color: var(--si-sys-background-selected);
   }
 
   &:is(.disabled, :disabled) {
@@ -162,7 +163,7 @@
 // FIXME: drop when dropping si-menu-legacy
 .dropdown-item-static {
   &:is(.active, :active, :hover, :hover:focus:not(:focus-visible), :focus) {
-    background-color: semantic-tokens.$element-base-1;
+    background-color: system-tokens.$si-sys-background-1;
   }
 }
 

--- a/projects/element-theme/src/styles/bootstrap/_variables.scss
+++ b/projects/element-theme/src/styles/bootstrap/_variables.scss
@@ -2,6 +2,7 @@
 @use '../variables/elevation';
 @use '../variables/semantic-tokens';
 @use '../variables/spacers';
+@use '../variables/system-tokens';
 @use '../variables/typography';
 @use './functions';
 
@@ -454,16 +455,16 @@ $dropdown-font-size: $font-size-base !default;
 // this is to have room for icon and badges
 $dropdown-line-height: $badge-height;
 $dropdown-color: $body-color !default;
-$dropdown-bg: semantic-tokens.$element-base-1 !default;
+$dropdown-bg: system-tokens.$si-sys-background-1 !default;
 $dropdown-border-radius: semantic-tokens.$element-radius-2 !default;
-$dropdown-divider-bg: semantic-tokens.$element-ui-4 !default;
+$dropdown-divider-bg: system-tokens.$si-sys-border-4 !default;
 $dropdown-divider-margin-y: 4px !default;
 $dropdown-box-shadow: elevation.$element-elevation-2 !default;
-$dropdown-link-color: semantic-tokens.$element-text-primary !default;
-$dropdown-link-disabled-color: semantic-tokens.$element-text-disabled !default;
+$dropdown-link-color: system-tokens.$si-sys-text-primary !default;
+$dropdown-link-disabled-color: system-tokens.$si-sys-text-disabled !default;
 $dropdown-item-padding-y: map.get(spacers.$spacers, 2);
 $dropdown-item-padding-x: map.get(spacers.$spacers, 5);
-$dropdown-header-color: semantic-tokens.$element-text-primary !default;
+$dropdown-header-color: system-tokens.$si-sys-text-primary !default;
 
 // Cards
 


### PR DESCRIPTION
Use system tokens for dropdown surfaces, text states, and dividers.
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2440/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2440/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2440/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2440/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2440/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2440/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2440/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2440/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2440/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2440/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
