### PR TITLE
refactor(theme): reuse input variables for btn-input

### DIFF
--- a/projects/element-theme/src/styles/bootstrap/_buttons.scss
+++ b/projects/element-theme/src/styles/bootstrap/_buttons.scss
@@ -257,29 +257,29 @@ button {
   --btn-color: #{bootstrap-variables.$input-color};
   --btn-color-hover: #{bootstrap-variables.$input-color};
   --btn-color-active: #{bootstrap-variables.$input-color};
-  --btn-border-width: 1px;
-  --btn-border-color: #{semantic-tokens.$element-ui-2};
-  --btn-border-color-hover: #{semantic-tokens.$element-ui-1};
-  --btn-border-color-active: #{semantic-tokens.$element-ui-1};
+  --btn-border-width: #{bootstrap-variables.$input-border-width};
+  --btn-border-color: #{bootstrap-variables.$input-border-color};
+  --btn-border-color-hover: #{bootstrap-variables.$input-focus-border-color};
+  --btn-border-color-active: #{bootstrap-variables.$input-focus-border-color};
 
   @include typography.si-font(
-    typography.$si-font-size-body,
-    typography.$si-line-height-body,
-    typography.$si-font-weight-body
+    bootstrap-variables.$input-font-size,
+    bootstrap-variables.$input-line-height,
+    bootstrap-variables.$input-font-weight
   );
   padding-block: bootstrap-variables.$input-padding-y;
-  padding-inline: bootstrap-variables.$btn-padding-x - bootstrap-variables.$input-border-width;
+  padding-inline: bootstrap-variables.$input-padding-x;
 
   border-radius: bootstrap-variables.$input-border-radius;
   justify-content: flex-start;
 
   &:is(:disabled, .disabled) {
-    --btn-border-color: #{semantic-tokens.$element-ui-3};
-    --btn-color: #{semantic-tokens.$element-text-disabled};
+    --btn-border-color: #{bootstrap-variables.$input-disabled-border-color};
+    --btn-color: #{bootstrap-variables.$input-disabled-color};
     opacity: unset;
   }
 
   &:focus {
-    --btn-border-color: #{semantic-tokens.$element-ui-1};
+    --btn-border-color: #{bootstrap-variables.$input-focus-border-color};
   }
 }

--- a/projects/element-theme/src/styles/bootstrap/_variables.scss
+++ b/projects/element-theme/src/styles/bootstrap/_variables.scss
@@ -335,10 +335,12 @@ $input-line-height: typography.$si-line-height-body-rem !default;
 
 $input-bg: semantic-tokens.$element-base-1 !default;
 $input-disabled-bg: semantic-tokens.$element-base-1 !default;
+$input-disabled-color: semantic-tokens.$element-text-disabled !default;
 $input-disabled-border-color: semantic-tokens.$element-ui-4 !default;
 
 $input-color: semantic-tokens.$element-text-primary !default;
 $input-border-color: semantic-tokens.$element-ui-2 !default;
+$input-focus-border-color: semantic-tokens.$element-ui-1 !default;
 $input-border-width: $border-width !default;
 $input-box-shadow: $box-shadow-inset !default;
 


### PR DESCRIPTION
Use Bootstrap input variables for the button visual states and typography.

Define reusable focus-border and disabled-text input variables for values that previously existed only as direct semantic-token references.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2441/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2441/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2441/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2441/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2441/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2441/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2441/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2441/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2441/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2441/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
