### PR TITLE
refactor(theme): use system tokens for links

### DIFF
--- a/projects/element-theme/src/styles/bootstrap/_variables.scss
+++ b/projects/element-theme/src/styles/bootstrap/_variables.scss
@@ -1,8 +1,8 @@
 @use '../variables/animations';
 @use '../variables/elevation';
 @use '../variables/semantic-tokens';
-@use '../variables/spacers';
 @use '../variables/system-tokens';
+@use '../variables/spacers';
 @use '../variables/typography';
 @use './functions';
 
@@ -51,10 +51,10 @@ $body-text-align: null !default;
 //
 // Style anchor elements.
 
-$link-color: semantic-tokens.$element-ui-0;
+$link-color: system-tokens.$si-sys-text-accent;
 $link-decoration: none !default;
 $link-shade-percentage: 20% !default;
-$link-hover-color: semantic-tokens.$element-ui-0-hover;
+$link-hover-color: system-tokens.$si-sys-text-accent-hover;
 $link-hover-decoration: underline !default;
 $link-border-radius: semantic-tokens.$element-button-radius;
 

--- a/projects/live-preview/styles/_variables.scss
+++ b/projects/live-preview/styles/_variables.scss
@@ -23,6 +23,6 @@ $live-preview-focus-outline-offset: variables.$focus-style-outline-offset;
 $live-preview-focus-outline-inside-offset: variables.$focus-style-outline-inside-offset;
 $live-preview-font-color: variables.$element-text-primary;
 
-$live-preview-link-color: variables.$element-action-secondary-text;
-$live-preview-link-hover-color: variables.$element-action-secondary-text-hover;
+$live-preview-link-color: variables.$si-sys-text-accent;
+$live-preview-link-hover-color: variables.$si-sys-text-accent-hover;
 $live-preview-link-inactive-color: variables.$element-text-primary;


### PR DESCRIPTION
Use the system accent text tokens for global and live-preview link colors.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2442/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2442/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2442/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2442/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2442/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2442/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2442/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2442/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2442/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2442/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

