### PR TITLE
fix(date-range-filter): support entering invalid date time values

### DIFF
--- a/playwright/snapshots/si-date-range-filter.spec.ts-snapshots/si-date-range-filter--si-date-range-filter--date.yaml
+++ b/playwright/snapshots/si-date-range-filter.spec.ts-snapshots/si-date-range-filter--si-date-range-filter--date.yaml
@@ -10,11 +10,11 @@
 - text: From
 - textbox "From Open calendar":
   - /placeholder: Select date
-  - text: ""
+  - text: /8\/\d+\/\d+/
 - button "Open calendar"
 - checkbox "Today"
 - text: Today To
-- textbox "Date":
+- textbox "To Open calendar":
   - /placeholder: Select date
   - text: /4\/5\/\d+/
 - button "Open calendar"

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.html
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.html
@@ -96,7 +96,7 @@
           </span>
         }
       } @else {
-        @let range = dateRange();
+        @let range = safeDateRange();
         {{ range.start | date: pipeFormat() }} -
         @if (range.end) {
           {{ range.end | date: pipeFormat() }}
@@ -192,7 +192,6 @@
         required
         siDatepicker
         [siDatepickerConfig]="datepickerConfigInternal()"
-        [attr.aria-label]="dateLabel() | translate"
         [placeholder]="datePlaceholder() | translate"
         [(ngModel)]="point2date"
         (ngModelChange)="point2Changed()"

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.spec.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.spec.ts
@@ -10,6 +10,7 @@ import { inputBinding, signal, twoWayBinding, WritableSignal } from '@angular/co
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { TestScheduler } from 'rxjs/testing';
+import { page, userEvent } from 'vitest/browser';
 
 import { SiCalendarCellHarness } from '../datepicker/testing/si-calendar-cell.harness';
 import { DateRangeFilter, DateRangePreset, SiDateRangeFilterComponent } from './index';
@@ -404,5 +405,23 @@ describe('SiDateRangeFilterComponent', () => {
     expect(rangeInputValue()).toBe(2);
     expect(rangeSelectContent()).toBe('Days');
     expect(preview()).toEqual(rangeText(from, to, true));
+  });
+
+  it('ignores invalid date input in preview', async () => {
+    const from = new Date('2023-05-13');
+    const to = new Date('2023-08-14');
+
+    range.set({ point1: from, point2: to });
+    enableTimeSelection.set(true);
+    await fixture.whenStable();
+
+    const toInput = page.getByRole('textbox', { name: 'To' });
+    await expect.element(toInput).toBeInTheDocument();
+    // Shouldn't throw error via DatePipe when invalid date is entered
+    await userEvent.fill(toInput, '08/14/2023, 12:40 A');
+    await fixture.whenStable();
+
+    expect(preview()).toContain('- 5/13/23, 12:00');
+    expect(preview()).not.toContain('08/14/2023, 12:40 A');
   });
 });

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.ts
@@ -324,6 +324,12 @@ export class SiDateRangeFilterComponent implements OnChanges {
   protected readonly icons = addIcons({ elementDown2 });
   protected readonly advancedMode = signal(false);
   protected readonly dateRange = signal<DateRange>({ start: undefined, end: undefined });
+  protected readonly safeDateRange = computed(() => {
+    const range = this.dateRange();
+    const start = this.isValidDate(range.start) ? range.start : undefined;
+    const end = this.isValidDate(range.end) ? range.end : undefined;
+    return { start, end };
+  });
 
   protected readonly point1Now = signal(true);
   protected readonly point2Mode = signal<'duration' | 'date'>('duration');
@@ -551,5 +557,9 @@ export class SiDateRangeFilterComponent implements OnChanges {
     if (this.smallScreen) {
       this.presetOpen.set(false);
     }
+  }
+
+  private isValidDate(date: Date | undefined): boolean {
+    return date instanceof Date && !isNaN(date.getTime());
   }
 }


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->


**Before:**

- Entering an invalid date in the `si-date-range-filter` caused an unhandled error since the preview pass the start and end date to the DatePipe which error on invalid dates.

<img width="1028" height="840" alt="image" src="https://github.com/user-attachments/assets/4552df9e-872f-4dc2-b6ed-5245f9c4a7be" />


<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2446/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2446/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2446/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2446/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2446/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2446/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2446/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2446/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2446/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2446/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

