### PR TITLE
fix(shadow-root): sync overlay styles

### DIFF
--- a/projects/element-ng/shadow-root/si-shadow-root.directive.spec.ts
+++ b/projects/element-ng/shadow-root/si-shadow-root.directive.spec.ts
@@ -10,8 +10,19 @@ import { SiShadowRootDirective } from './si-shadow-root.directive';
 
 describe('ShadowRootDirective', () => {
   @Component({
+    selector: 'si-late-styled',
+    template: `<span id="late-styled" class="late-style">Late styled</span>`,
+    styles: `
+      .late-style {
+        color: #f00;
+      }
+    `
+  })
+  class LateStyledComponent {}
+
+  @Component({
     selector: 'si-test',
-    imports: [CdkConnectedOverlay, CdkOverlayOrigin],
+    imports: [CdkConnectedOverlay, CdkOverlayOrigin, LateStyledComponent],
     template: ` <button #trigger="cdkOverlayOrigin" type="button" cdkOverlayOrigin>Open</button>
       <ng-template
         cdkConnectedOverlay
@@ -19,6 +30,9 @@ describe('ShadowRootDirective', () => {
         [cdkConnectedOverlayOrigin]="trigger"
       >
         <span id="in-shadow" class="test-style">Text</span>
+        @if (showLateStyled()) {
+          <si-late-styled />
+        }
       </ng-template>`,
     styles: `
       .test-style {
@@ -30,13 +44,14 @@ describe('ShadowRootDirective', () => {
   })
   class WithOverlayComponent {
     readonly open = input(false);
+    readonly showLateStyled = input(false);
   }
 
   @Component({
     imports: [WithOverlayComponent],
     template: `
       <span id="out-shadow" class="test-style">Text</span>
-      <si-test [open]="open()" />
+      <si-test [open]="open()" [showLateStyled]="showLateStyled()" />
     `,
     styles: `
       .test-style {
@@ -46,6 +61,7 @@ describe('ShadowRootDirective', () => {
   })
   class TestHostComponent {
     readonly open = signal(false);
+    readonly showLateStyled = signal(false);
   }
 
   let fixture: ComponentFixture<TestHostComponent>;
@@ -65,5 +81,17 @@ describe('ShadowRootDirective', () => {
         document.querySelector('element-overlay-root')!.shadowRoot!.getElementById('in-shadow')!
       ).color
     ).toBe('rgb(255, 255, 255)');
+  });
+
+  it('should copy styles registered after the overlay container was created', async () => {
+    fixture.componentInstance.open.set(true);
+
+    fixture.componentInstance.showLateStyled.set(true);
+    await fixture.whenStable();
+
+    const overlayShadowRoot = document.querySelector('element-overlay-root')!.shadowRoot!;
+    expect(getComputedStyle(overlayShadowRoot.getElementById('late-styled')!).color).toBe(
+      'rgb(255, 0, 0)'
+    );
   });
 });

--- a/projects/element-ng/shadow-root/si-shadow-root.directive.ts
+++ b/projects/element-ng/shadow-root/si-shadow-root.directive.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Overlay, OverlayContainer } from '@angular/cdk/overlay';
-import { Directive, ElementRef, inject, DOCUMENT } from '@angular/core';
+import { Directive, ElementRef, inject, DOCUMENT, DestroyRef } from '@angular/core';
 
 /**
  * This directive is intended to be used in applications that do NOT load element styles in the root HTML element.
@@ -38,20 +38,46 @@ import { Directive, ElementRef, inject, DOCUMENT } from '@angular/core';
 export class SiShadowRootDirective extends OverlayContainer {
   private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private document = inject(DOCUMENT);
+  private destroyRef = inject(DestroyRef);
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   protected override _createContainer(): void {
-    const root = document.createElement('element-overlay-root');
+    const sourceShadow = this.elementRef.nativeElement.shadowRoot!;
+    const root = this.document.createElement('element-overlay-root');
     this.document.body.append(root);
     const shadow = root.attachShadow({ mode: 'open' });
-    const shadowElement = document.createElement('div');
+    const shadowElement = this.document.createElement('div');
     shadowElement.classList.add('cdk-overlay-container');
-    shadow.append(
-      ...Array.from(this.elementRef.nativeElement.shadowRoot!.styleSheets).map(styleSheet =>
-        styleSheet.ownerNode!.cloneNode(true)
-      ),
-      shadowElement
-    );
+    shadow.append(shadowElement);
+
+    const styleCopies = new Map<CSSStyleSheet, Node>();
+    const syncStyleElements = (): void => {
+      const sourceStyleSheets = new Set(sourceShadow.styleSheets);
+
+      styleCopies.forEach((copy, source) => {
+        if (!sourceStyleSheets.has(source)) {
+          copy.parentNode?.removeChild(copy);
+          styleCopies.delete(source);
+        }
+      });
+
+      sourceStyleSheets.forEach(source => {
+        let copy = styleCopies.get(source);
+        if (!copy) {
+          copy = source.ownerNode!.cloneNode(true);
+          styleCopies.set(source, copy);
+        }
+        shadow.insertBefore(copy, shadowElement);
+      });
+    };
+
+    syncStyleElements();
+    const observer = new MutationObserver(syncStyleElements);
+    observer.observe(sourceShadow, { childList: true });
+    this.destroyRef.onDestroy(() => {
+      observer.disconnect();
+      root.remove();
+    });
 
     this._containerElement = shadowElement;
   }


### PR DESCRIPTION
Keep the detached overlay shadow root synchronized with styles registered after its container is created.

Fixes #2447

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2448/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2448/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2448/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2448/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2448/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2448/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2448/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2448/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2448/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2448/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


