### PR TITLE
refactor(about): use classes as intended

### DIFF
--- a/playwright/snapshots/static.spec.ts-snapshots/si-about--si-about-text-api-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-about--si-about-text-api-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98febd0fc4d77dcc2427c973b9a221d750da6267ca88ba629a923c8aef192c36
-size 80602
+oid sha256:5cecd7b2e14af58849d3d7b6e6c39911aeb33def90bb242155e5a2880cb7109c
+size 80649

--- a/playwright/snapshots/static.spec.ts-snapshots/si-about--si-about-text-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-about--si-about-text-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:739c767e050831f0a03876ff9fb7a29fbd4b5ba682f2dfb9428bbdf4962e09a9
-size 32141
+oid sha256:28264e25c4fd7cbf55ffb1bc64548e9360f54d403bb2e65256c1532f30459ebe
+size 32222

--- a/playwright/snapshots/static.spec.ts-snapshots/si-about--si-about-text-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-about--si-about-text-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c8d9c5848e3e122a571dc5a41950c01ddb6964f4033d06d9ea2184c008fee73
-size 30504
+oid sha256:3dee1b78063facad17c0168bfa65c7ac0f8609356660216d994a0f0ec5469a53
+size 30549

--- a/projects/element-ng/about/si-about.component.html
+++ b/projects/element-ng/about/si-about.component.html
@@ -5,7 +5,7 @@
         {{ aboutTitle() }}
       </div>
 
-      <div>
+      <div class="list-group">
         <div class="list-group-item text-center">
           @let appIcon = iconName();
           @if (icon()) {
@@ -73,7 +73,7 @@
 
       <div class="h-100">
         @if (licenseInfo().text) {
-          <pre class="list-group-item">{{ licenseInfo().text }}</pre>
+          <pre class="border-0 border-bottom my-0 px-6 py-4">{{ licenseInfo().text }}</pre>
         }
 
         @if (sanitizedUrl()) {


### PR DESCRIPTION
`list-group-items` require a wrapping `list-group`. Single `list-group-items` are useless.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2449/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2449/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2449/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2449/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2449/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2449/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2449/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2449/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2449/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2449/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

