### PR TITLE
refactor(application-header): extract launchpad category component

### DIFF
--- a/api-goldens/element-ng/application-header/index.api.md
+++ b/api-goldens/element-ng/application-header/index.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { ActivatedRoute } from '@angular/router';
 import * as _angular_core from '@angular/core';
 import { ConnectedPosition } from '@angular/cdk/overlay';
 import { ElementRef } from '@angular/core';

--- a/projects/element-ng/application-header/launchpad/si-launchpad-category.component.html
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-category.component.html
@@ -1,0 +1,54 @@
+@if (category().name) {
+  <div class="si-h4 launchpad-category-title mt-4 mb-6">
+    {{ category().name | translate }}
+  </div>
+}
+<div class="d-flex flex-wrap gap-4">
+  @for (app of category().apps; track app) {
+    @switch (app.type) {
+      @case ('router-link') {
+        <a
+          si-launchpad-app
+          routerLinkActive="active"
+          [routerLinkActiveOptions]="app.activeMatchOptions ?? { exact: false }"
+          [enableFavoriteToggle]="enableFavorites() && !isFavoriteToggleDisabled(app)"
+          [external]="app.external"
+          [iconUrl]="app.iconUrl"
+          [iconClass]="app.iconClass"
+          [favorite]="!!app.favorite"
+          [routerLink]="app.routerLink"
+          [queryParams]="app.extras?.queryParams"
+          [queryParamsHandling]="app.extras?.queryParamsHandling"
+          [fragment]="app.extras?.fragment"
+          [state]="app.extras?.state"
+          [relativeTo]="app.extras?.relativeTo ?? this.activatedRoute"
+          [preserveFragment]="app.extras?.preserveFragment"
+          [skipLocationChange]="app.extras?.skipLocationChange"
+          [replaceUrl]="app.extras?.replaceUrl"
+          (favoriteChange)="toggleFavorite(app, $event)"
+        >
+          <span app-name>{{ app.name | translate }}</span>
+          <span app-systemName>{{ app.systemName | translate }}</span>
+        </a>
+      }
+      @default {
+        <!--fallback for existing apps that do not have a type defined -->
+        <a
+          si-launchpad-app
+          [enableFavoriteToggle]="enableFavorites() && !isFavoriteToggleDisabled(app)"
+          [favorite]="!!app.favorite"
+          [href]="app.href"
+          [target]="app.target ?? ''"
+          [active]="app.active"
+          [external]="app.external"
+          [iconUrl]="app.iconUrl"
+          [iconClass]="app.iconClass"
+          (favoriteChange)="toggleFavorite(app, $event)"
+        >
+          <span app-name>{{ app.name | translate }}</span>
+          <span app-systemName>{{ app.systemName | translate }}</span>
+        </a>
+      }
+    }
+  }
+</div>

--- a/projects/element-ng/application-header/launchpad/si-launchpad-category.component.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-category.component.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, inject, input, output } from '@angular/core';
+import { ActivatedRoute, RouterLink, RouterLinkActive } from '@angular/router';
+import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
+
+import { SiLaunchpadAppComponent } from './si-launchpad-app.component';
+import { App, AppCategory, FavoriteChangeEvent } from './si-launchpad.model';
+
+@Component({
+  selector: 'si-launchpad-category',
+  imports: [SiLaunchpadAppComponent, SiTranslatePipe, RouterLinkActive, RouterLink],
+  templateUrl: './si-launchpad-category.component.html',
+  host: {
+    class: 'd-block',
+    '[class.has-title]': '!!category().name'
+  }
+})
+export class SiLaunchpadCategoryComponent {
+  readonly category = input.required<AppCategory>();
+  /** @defaultValue false */
+  readonly enableFavorites = input(false);
+
+  readonly favoriteChange = output<FavoriteChangeEvent>();
+
+  protected readonly activatedRoute = inject(ActivatedRoute, { optional: true });
+
+  protected toggleFavorite(app: App, favorite: boolean): void {
+    this.favoriteChange.emit({ app, favorite });
+  }
+
+  protected isFavoriteToggleDisabled(app: App): boolean {
+    return '_noFavorite' in app && !!app._noFavorite;
+  }
+}

--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.html
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.html
@@ -24,71 +24,17 @@
     </div>
   }
   <div class="apps-scroll ms-n2 ps-2">
-    @for (category of categories(); track category.name; let first = $first) {
-      @if (!enableFavorites() || !hasFavorites() || first || showAllApps) {
-        <div>
-          @if (category.name) {
-            <div
-              class="si-h4 launchpad-category-title mb-6"
-              [class.mt-4]="first"
-              [class.mt-8]="!first"
-            >
-              {{ category.name | translate }}
-            </div>
-          }
-          <div class="d-flex flex-wrap gap-4">
-            @for (app of category.apps; track app) {
-              @switch (app.type) {
-                @case ('router-link') {
-                  <a
-                    si-launchpad-app
-                    routerLinkActive="active"
-                    [routerLinkActiveOptions]="app.activeMatchOptions ?? { exact: false }"
-                    [enableFavoriteToggle]="enableFavorites() && !isFavoriteToggleDisabled(app)"
-                    [external]="app.external"
-                    [iconUrl]="app.iconUrl"
-                    [iconClass]="app.iconClass"
-                    [favorite]="!!app.favorite"
-                    [routerLink]="app.routerLink"
-                    [queryParams]="app.extras?.queryParams"
-                    [queryParamsHandling]="app.extras?.queryParamsHandling"
-                    [fragment]="app.extras?.fragment"
-                    [state]="app.extras?.state"
-                    [relativeTo]="app.extras?.relativeTo ?? this.activatedRoute"
-                    [preserveFragment]="app.extras?.preserveFragment"
-                    [skipLocationChange]="app.extras?.skipLocationChange"
-                    [replaceUrl]="app.extras?.replaceUrl"
-                    (favoriteChange)="toggleFavorite(app, $event)"
-                  >
-                    <span app-name>{{ app.name | translate }}</span>
-                    <span app-systemName>{{ app.systemName | translate }}</span>
-                  </a>
-                }
-                @default {
-                  <!--fallback for existing apps that do not have a type defined -->
-                  <a
-                    si-launchpad-app
-                    [enableFavoriteToggle]="enableFavorites() && !isFavoriteToggleDisabled(app)"
-                    [favorite]="!!app.favorite"
-                    [href]="app.href"
-                    [target]="app.target ?? ''"
-                    [active]="app.active"
-                    [external]="app.external"
-                    [iconUrl]="app.iconUrl"
-                    [iconClass]="app.iconClass"
-                    (favoriteChange)="toggleFavorite(app, $event)"
-                  >
-                    <span app-name>{{ app.name | translate }}</span>
-                    <span app-systemName>{{ app.systemName | translate }}</span>
-                  </a>
-                }
-              }
-            }
-          </div>
-        </div>
+    @for (category of categories(); track category.name) {
+      @if (!enableFavorites() || !hasFavorites() || $first || showAllApps) {
+        <si-launchpad-category
+          [class.pt-6]="!$first && !!category.name"
+          [category]="category"
+          [enableFavorites]="enableFavorites()"
+          (favoriteChange)="toggleFavorite($event)"
+        />
       }
 
-      @if (enableFavorites() && first && hasFavorites()) {
+      @if (enableFavorites() && $first && hasFavorites()) {
         <button
           type="button"
           class="btn btn-link btn-show-all dropdown-toggle text-decoration-none"

--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.scss
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.scss
@@ -47,7 +47,7 @@
     margin-block-end: map.get(variables.$spacers, 8);
   }
 
-  &.show:has(+ div .launchpad-category-title) {
+  &.show:has(+ si-launchpad-category.has-title) {
     margin-block-end: 0;
   }
 }

--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
@@ -4,20 +4,14 @@
  */
 import { A11yModule } from '@angular/cdk/a11y';
 import { booleanAttribute, Component, computed, inject, input, output } from '@angular/core';
-import { ActivatedRoute, RouterLink, RouterLinkActive } from '@angular/router';
 import { elementCancel, elementDown2 } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiLinkModule } from '@siemens/element-ng/link';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
 import { SiApplicationHeaderComponent } from '../si-application-header.component';
-import { SiLaunchpadAppComponent } from './si-launchpad-app.component';
-import { App, AppCategory } from './si-launchpad.model';
-
-export interface FavoriteChangeEvent {
-  app: App;
-  favorite: boolean;
-}
+import { SiLaunchpadCategoryComponent } from './si-launchpad-category.component';
+import { App, AppCategory, FavoriteChangeEvent } from './si-launchpad.model';
 
 @Component({
   selector: 'si-launchpad-factory',
@@ -25,10 +19,8 @@ export interface FavoriteChangeEvent {
     A11yModule,
     SiLinkModule,
     SiTranslatePipe,
-    SiLaunchpadAppComponent,
-    SiIconComponent,
-    RouterLinkActive,
-    RouterLink
+    SiLaunchpadCategoryComponent,
+    SiIconComponent
   ],
   templateUrl: './si-launchpad-factory.component.html',
   styleUrl: './si-launchpad-factory.component.scss'
@@ -128,15 +120,14 @@ export class SiLaunchpadFactoryComponent {
   );
   protected readonly hasFavorites = computed(() => this.favorites().length > 0);
   protected readonly icons = addIcons({ elementDown2, elementCancel });
-  protected readonly activatedRoute = inject(ActivatedRoute, { optional: true });
   private header = inject(SiApplicationHeaderComponent);
 
   protected closeLaunchpad(): void {
     this.header.closeLaunchpad();
   }
 
-  protected toggleFavorite(app: App, favorite: boolean): void {
-    this.favoriteChange.emit({ app, favorite });
+  protected toggleFavorite(event: FavoriteChangeEvent): void {
+    this.favoriteChange.emit(event);
   }
 
   protected escape(): void {
@@ -145,13 +136,5 @@ export class SiLaunchpadFactoryComponent {
 
   protected isCategories(items: App[] | AppCategory[]): items is AppCategory[] {
     return items.some(item => 'apps' in item);
-  }
-
-  protected isFavoriteToggleDisabled(app: App): boolean {
-    if ('_noFavorite' in app) {
-      return !!app._noFavorite;
-    } else {
-      return false;
-    }
   }
 }

--- a/projects/element-ng/application-header/launchpad/si-launchpad.model.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad.model.ts
@@ -51,3 +51,8 @@ export interface AppBase {
 }
 
 export type App = AppLink | AppRouterLink;
+
+export interface FavoriteChangeEvent {
+  app: App;
+  favorite: boolean;
+}

--- a/projects/element-ng/application-header/launchpad/si-launchpad.spec.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad.spec.ts
@@ -8,8 +8,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiApplicationHeaderComponent } from '../si-application-header.component';
 import { SiLaunchpadHarness } from '../testing/si-launchpad.harness';
-import { FavoriteChangeEvent, SiLaunchpadFactoryComponent } from './si-launchpad-factory.component';
-import { App, AppCategory } from './si-launchpad.model';
+import { SiLaunchpadFactoryComponent } from './si-launchpad-factory.component';
+import { App, AppCategory, FavoriteChangeEvent } from './si-launchpad.model';
 
 describe('SiLaunchpad', () => {
   let fixture: ComponentFixture<SiLaunchpadFactoryComponent>;

--- a/projects/element-ng/application-header/testing/si-launchpad-category.harness.ts
+++ b/projects/element-ng/application-header/testing/si-launchpad-category.harness.ts
@@ -7,7 +7,7 @@ import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
 import { SiLaunchpadAppHarness } from './si-launchpad-app.harness';
 
 export class SiLaunchpadCategoryHarness extends ComponentHarness {
-  static readonly hostSelector = '.apps-scroll > div';
+  static readonly hostSelector = 'si-launchpad-category';
 
   static withName(name: string): HarnessPredicate<SiLaunchpadCategoryHarness> {
     return new HarnessPredicate(SiLaunchpadCategoryHarness, {}).add('name', item =>


### PR DESCRIPTION
## Summary

Move launchpad category rendering into a focused component. Apply the extra top spacing to subsequent category hosts in the factory, rather than conditionally styling category titles.

## Validation

- `pnpm lib:test --include='**/application-header/launchpad/si-launchpad.spec.ts' --no-watch`
- `pnpm lib:build`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2453/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2453/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2453/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2453/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2453/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2453/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2453/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2453/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2453/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2453/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->





