### PR TITLE
feat(split)!: rename collapse direction API

### DIFF
--- a/api-goldens/element-ng/split/index.api.md
+++ b/api-goldens/element-ng/split/index.api.md
@@ -20,7 +20,7 @@ export interface Action {
 }
 
 // @public (undocumented)
-export type CollapseTo = 'start' | 'end';
+export type CollapseTo = 'to-start' | 'to-end';
 
 // @public (undocumented)
 export interface PartState {
@@ -52,11 +52,11 @@ export class SiSplitPartComponent {
     readonly actions: _angular_core.InputSignal<Action[]>;
     readonly collapseChanged: _angular_core.OutputEmitterRef<boolean>;
     get collapsed(): boolean;
-    readonly collapseDirection: _angular_core.InputSignal<CollapseTo>;
     readonly collapseIconClass: _angular_core.InputSignal<string | undefined>;
     readonly collapseLabel: _angular_core.InputSignal<TranslatableString>;
     readonly collapseOthers: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly collapseToMinSize: _angular_core.InputSignalWithTransform<boolean, unknown>;
+    readonly collapsible: _angular_core.InputSignal<CollapseTo>;
     readonly expanded: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly headerTemplate: _angular_core.InputSignal<TemplateRef<{
         $implicit: SiSplitPartComponent;

--- a/projects/element-ng/schematics/migrations/element-migration/files/expected.split-inline.template.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/expected.split-inline.template.ts
@@ -6,12 +6,12 @@ import { SiSplitModule } from '@siemens/element-ng/split';
   template: `<si-split class="si-layout-fixed-height" [orientation]="'horizontal'" [sizes]="[20, 60, 20]">
     <si-split-part
       heading="Filters"
-      collapseDirection="start"
+      collapsible="to-start"
       class="bg-base-1"
       [minSize]="100"  >
       <p class="p-4 text-secondary">Split Part #1</p>
     </si-split-part>
-    <si-split-part heading="Employees" collapseDirection="start" class="bg-base-1"   [minSize]="200">
+    <si-split-part heading="Employees" collapsible="to-start" class="bg-base-1"   [minSize]="200">
       <div class="si-layout-fixed-height justify-content-center bg-secondary">
         <p class="text-center text-inverse">Split Part with resizable content!</p>
       </div>

--- a/projects/element-ng/schematics/migrations/element-migration/files/split-inline.template.ts
+++ b/projects/element-ng/schematics/migrations/element-migration/files/split-inline.template.ts
@@ -6,12 +6,12 @@ import { SiSplitModule } from '@siemens/element-ng/split';
   template: `<si-split class="si-layout-fixed-height" [orientation]="'horizontal'" [sizes]="[20, 60, 20]">
     <si-split-part
       heading="Filters"
-      collapseDirection="start"
+      collapsible="to-start"
       class="bg-base-1"
       [minSize]="100" [headerStatusColor]="'success'" [headerStatusIconClass]="'si-icon-users'">
       <p class="p-4 text-secondary">Split Part #1</p>
     </si-split-part>
-    <si-split-part heading="Employees" collapseDirection="start" class="bg-base-1" [headerStatusColor]="'success'" [headerStatusIconClass]="'si-icon-users'" [minSize]="200">
+    <si-split-part heading="Employees" collapsible="to-start" class="bg-base-1" [headerStatusColor]="'success'" [headerStatusIconClass]="'si-icon-users'" [minSize]="200">
       <div class="si-layout-fixed-height justify-content-center bg-secondary">
         <p class="text-center text-inverse">Split Part with resizable content!</p>
       </div>

--- a/projects/element-ng/schematics/ng-update/index.spec.ts
+++ b/projects/element-ng/schematics/ng-update/index.spec.ts
@@ -260,4 +260,47 @@ export class SplitComponent {}`,
     expect(modifiedContent).toContain('<si-split-part size="400" heading="Left"  unit="px"/>');
     expect(modifiedContent).toContain('<si-split-part size="200" heading="Right"  unit="px"/>');
   });
+
+  it('should rename split collapse bindings and CollapseTo literals', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component, signal } from '@angular/core';
+import { CollapseTo } from '@siemens/element-ng/split';
+
+@Component({
+  selector: 'app-split',
+  template: \`<si-split-part collapseDirection="start" [collapseDirection]="'end'" />\`
+})
+export class SplitComponent {
+  readonly direction = signal<CollapseTo>('start');
+  currentDirection: CollapseTo = 'end';
+
+  toggle(): void {
+    this.direction.set('end');
+    this.currentDirection = 'start';
+  }
+}`,
+      '/projects/app/src/external-split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-external-split',
+  templateUrl: './split.component.html'
+})
+export class ExternalSplitComponent {}`,
+      '/projects/app/src/split.component.html': `<si-split-part collapseDirection="end" />
+<div collapseDirection="start"></div>`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+    const template = tree.readContent('/projects/app/src/split.component.html');
+
+    expect(component).toContain('collapsible="to-start"');
+    expect(component).toContain(`[collapsible]="'to-end'"`);
+    expect(component).toContain(`signal<CollapseTo>('to-start')`);
+    expect(component).toContain(`this.direction.set('to-end')`);
+    expect(component).toContain(`currentDirection: CollapseTo = 'to-end'`);
+    expect(component).toContain(`this.currentDirection = 'to-start'`);
+    expect(template).toContain('<si-split-part collapsible="to-end" />');
+    expect(template).toContain('<div collapseDirection="start"></div>');
+  });
 });

--- a/projects/element-ng/schematics/ng-update/migrate-split-collapse.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-collapse.ts
@@ -1,0 +1,289 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Rule, SchematicContext, Tree, UpdateRecorder } from '@angular-devkit/schematics';
+import { dirname, join } from 'path/posix';
+import ts from 'typescript';
+
+import {
+  discoverSourceFiles,
+  findElement,
+  getInlineTemplates,
+  getTemplateUrl
+} from '../utils/index.js';
+
+const collapseValues = new Map([
+  ['start', 'to-start'],
+  ['end', 'to-end']
+]);
+
+export const splitCollapseMigrationRule = (options: { path: string }): Rule => {
+  return async (tree: Tree, context: SchematicContext) => {
+    const processedTemplates = new Set<string>();
+
+    for await (const discoveredSourceFile of discoverSourceFiles(tree, context, options.path)) {
+      const { path: filePath, sourceFile } = discoveredSourceFile;
+      const recorder = tree.beginUpdate(filePath);
+
+      for (const template of getInlineTemplates(sourceFile)) {
+        migrateSplitCollapseTemplate(
+          sourceFile.text.substring(template.getStart() + 1, template.getEnd() - 1),
+          template.getStart() + 1,
+          recorder
+        );
+      }
+      migrateCollapseToLiterals(sourceFile, recorder);
+      tree.commitUpdate(recorder);
+
+      for (const templateUrl of getTemplateUrl(sourceFile)) {
+        const templatePath = join(dirname(filePath), templateUrl);
+        if (processedTemplates.has(templatePath) || !tree.exists(templatePath)) {
+          continue;
+        }
+
+        processedTemplates.add(templatePath);
+        const templateRecorder = tree.beginUpdate(templatePath);
+        migrateSplitCollapseTemplate(
+          tree.read(templatePath)!.toString('utf-8'),
+          0,
+          templateRecorder
+        );
+        tree.commitUpdate(templateRecorder);
+      }
+    }
+
+    return tree;
+  };
+};
+
+const migrateSplitCollapseTemplate = (
+  template: string,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  findElement(template, element => element.name === 'si-split-part').forEach(element => {
+    element.attrs
+      .filter(
+        attribute =>
+          attribute.name === 'collapseDirection' || attribute.name === '[collapseDirection]'
+      )
+      .forEach(attribute => {
+        const isBound = attribute.name.startsWith('[');
+        const attributeNameOffset = attribute.sourceSpan.start.offset + offset + (isBound ? 1 : 0);
+        recorder.remove(attributeNameOffset, 'collapseDirection'.length);
+        recorder.insertLeft(attributeNameOffset, 'collapsible');
+
+        const value = isBound
+          ? getStringLiteral(attribute.value)
+          : collapseValues.get(attribute.value);
+        if (!value || !attribute.valueSpan) {
+          return;
+        }
+
+        const valueOffset = attribute.valueSpan.start.offset + offset;
+        recorder.remove(
+          valueOffset,
+          attribute.valueSpan.end.offset - attribute.valueSpan.start.offset
+        );
+        recorder.insertLeft(valueOffset, isBound ? `'${value}'` : value);
+      });
+  });
+};
+
+const getStringLiteral = (value: string): string | undefined => {
+  const expression = ts.createSourceFile(
+    'template-expression.ts',
+    `const value = ${value};`,
+    ts.ScriptTarget.Latest,
+    true
+  ).statements[0];
+  if (!expression || !ts.isVariableStatement(expression)) {
+    return undefined;
+  }
+
+  const initializer = expression.declarationList.declarations[0]?.initializer;
+  return initializer && ts.isStringLiteral(initializer)
+    ? collapseValues.get(initializer.text)
+    : undefined;
+};
+
+const migrateCollapseToLiterals = (sourceFile: ts.SourceFile, recorder: UpdateRecorder): void => {
+  const collapseToTypeNames = getCollapseToTypeNames(sourceFile);
+  if (collapseToTypeNames.size === 0) {
+    return;
+  }
+
+  const collapseToVariables = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      (isCollapseToType(node.type, collapseToTypeNames) ||
+        isCollapseToExpression(node.initializer, collapseToTypeNames))
+    ) {
+      collapseToVariables.add(node.name.text);
+      replaceCollapseLiterals(node.initializer, recorder);
+    }
+
+    if (
+      ts.isPropertyDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      (isCollapseToType(node.type, collapseToTypeNames) ||
+        isCollapseToExpression(node.initializer, collapseToTypeNames))
+    ) {
+      collapseToVariables.add(node.name.text);
+      replaceCollapseLiterals(node.initializer, recorder);
+    }
+
+    if (
+      ts.isParameter(node) &&
+      ts.isIdentifier(node.name) &&
+      isCollapseToType(node.type, collapseToTypeNames)
+    ) {
+      collapseToVariables.add(node.name.text);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  migrateCollapseToSetCalls(sourceFile, collapseToVariables, recorder);
+};
+
+const getCollapseToTypeNames = (sourceFile: ts.SourceFile): Set<string> => {
+  const names = new Set<string>();
+  sourceFile.statements.forEach(statement => {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) {
+      return;
+    }
+
+    const importPath = statement.moduleSpecifier.text;
+    if (!importPath.startsWith('@siemens/element-ng/split')) {
+      return;
+    }
+
+    const imports = statement.importClause?.namedBindings;
+    if (!imports || !ts.isNamedImports(imports)) {
+      return;
+    }
+
+    imports.elements.forEach(importSpecifier => {
+      if ((importSpecifier.propertyName?.text ?? importSpecifier.name.text) === 'CollapseTo') {
+        names.add(importSpecifier.name.text);
+      }
+    });
+  });
+
+  let addedName = true;
+  while (addedName) {
+    addedName = false;
+    for (const statement of sourceFile.statements) {
+      if (
+        ts.isTypeAliasDeclaration(statement) &&
+        isCollapseToType(statement.type, names) &&
+        !names.has(statement.name.text)
+      ) {
+        names.add(statement.name.text);
+        addedName = true;
+      }
+    }
+  }
+
+  return names;
+};
+
+const isCollapseToType = (node: ts.TypeNode | undefined, names: Set<string>): boolean => {
+  if (!node) {
+    return false;
+  }
+
+  if (ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)) {
+    return (
+      names.has(node.typeName.text) ||
+      node.typeArguments?.some(typeArgument => isCollapseToType(typeArgument, names)) === true
+    );
+  }
+
+  if (ts.isArrayTypeNode(node)) {
+    return isCollapseToType(node.elementType, names);
+  }
+
+  if (ts.isParenthesizedTypeNode(node)) {
+    return isCollapseToType(node.type, names);
+  }
+
+  if (ts.isUnionTypeNode(node)) {
+    return node.types.some(type => isCollapseToType(type, names));
+  }
+
+  return false;
+};
+
+const isCollapseToExpression = (node: ts.Expression | undefined, names: Set<string>): boolean =>
+  !!node &&
+  ts.isCallExpression(node) &&
+  node.typeArguments?.some(typeArgument => isCollapseToType(typeArgument, names)) === true;
+
+const migrateCollapseToSetCalls = (
+  sourceFile: ts.SourceFile,
+  collapseToVariables: Set<string>,
+  recorder: UpdateRecorder
+): void => {
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      (node.expression.name.text === 'set' || node.expression.name.text === 'update') &&
+      collapseToVariables.has(getRootIdentifier(node.expression.expression) ?? '')
+    ) {
+      node.arguments.forEach(argument => replaceCollapseLiterals(argument, recorder));
+    }
+
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      collapseToVariables.has(getRootIdentifier(node.left) ?? '')
+    ) {
+      replaceCollapseLiterals(node.right, recorder);
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+};
+
+const getRootIdentifier = (node: ts.Expression): string | undefined => {
+  if (ts.isIdentifier(node)) {
+    return node.text;
+  }
+
+  if (ts.isPropertyAccessExpression(node)) {
+    return node.name.text;
+  }
+
+  return undefined;
+};
+
+const replaceCollapseLiterals = (
+  node: ts.Expression | undefined,
+  recorder: UpdateRecorder
+): void => {
+  if (!node) {
+    return;
+  }
+
+  const visit = (child: ts.Node): void => {
+    if (ts.isStringLiteral(child)) {
+      const replacement = collapseValues.get(child.text);
+      if (replacement) {
+        recorder.remove(child.getStart() + 1, child.getWidth() - 2);
+        recorder.insertLeft(child.getStart() + 1, replacement);
+      }
+    }
+    ts.forEachChild(child, visit);
+  };
+
+  visit(node);
+};

--- a/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
@@ -8,6 +8,7 @@ import { chain, Rule, SchematicContext, Tree } from '@angular-devkit/schematics'
 import { ElementMigrationData, getElementMigrationData } from '../migrations/data/index.js';
 import { elementMigrationRule } from '../migrations/element-migration/element-migration.js';
 import { missingTranslateMigrationRule } from '../migrations/ngx-translate/index.js';
+import { splitCollapseMigrationRule } from './migrate-split-collapse.js';
 import { splitSizesMigrationRule } from './migrate-split-sizes.js';
 
 export const migrateToV51 = (): Rule => {
@@ -18,7 +19,8 @@ export const migrateToV51 = (): Rule => {
     return chain([
       elementMigrationRule(options, migrationData),
       missingTranslateMigrationRule(options),
-      splitSizesMigrationRule(options)
+      splitSizesMigrationRule(options),
+      splitCollapseMigrationRule(options)
     ])(tree, context);
   };
 };

--- a/projects/element-ng/split/si-split-part.component.ts
+++ b/projects/element-ng/split/si-split-part.component.ts
@@ -38,7 +38,7 @@ import {
   styleUrl: './si-split-part.component.scss',
   host: {
     '[class.is-collapsed]': 'collapsedState()',
-    '[class.collapse-start]': 'collapseDirectionState() === "start"',
+    '[class.collapse-start]': 'collapseDirectionState() === "to-start"',
     '[style.grid-area]': '"p-" + this.index'
   }
 })
@@ -51,11 +51,11 @@ export class SiSplitPartComponent {
    */
   readonly actions = input<Action[]>([]);
   /**
-   * Defines which direction the split part collapses to.
+   * Defines whether and in which direction the split part can collapse.
    *
-   * @defaultValue 'start'
+   * @defaultValue 'to-start'
    */
-  readonly collapseDirection = input<CollapseTo>('start');
+  readonly collapsible = input<CollapseTo>('to-start');
 
   /**
    * Sets the icon class that is used in the buttons of split parts to
@@ -191,11 +191,11 @@ export class SiSplitPartComponent {
   readonly collapsedState = linkedSignal(() => !this.expanded());
 
   /**
-   * Internal, mutable collapse direction. Initialized from the {@link collapseDirection}
+   * Internal, mutable collapse direction. Initialized from the {@link collapsible}
    * input but can be overwritten while cascading collapse state to sibling parts.
    * @internal
    */
-  readonly collapseDirectionState = linkedSignal(() => this.collapseDirection());
+  readonly collapseDirectionState = linkedSignal(() => this.collapsible());
 
   /**
    * Get collapsed state.
@@ -279,18 +279,18 @@ export class SiSplitPartComponent {
 
   private refreshCollapsedToEnd(): void {
     const before = this.before();
-    if (before?.collapsedState() && before.collapseDirectionState() === 'end') {
+    if (before?.collapsedState() && before.collapseDirectionState() === 'to-end') {
       this.collapsedState.set(true);
-      this.collapseDirectionState.set('end');
+      this.collapseDirectionState.set('to-end');
       this.after()?.refreshCollapsedToEnd();
     }
   }
 
   private refreshCollapseToStart(): void {
     const after = this.after();
-    if (after?.collapsedState() && after.collapseDirectionState() === 'start') {
+    if (after?.collapsedState() && after.collapseDirectionState() === 'to-start') {
       this.collapsedState.set(true);
-      this.collapseDirectionState.set('start');
+      this.collapseDirectionState.set('to-start');
       this.before()?.refreshCollapseToStart();
     }
   }

--- a/projects/element-ng/split/si-split.component.spec.ts
+++ b/projects/element-ng/split/si-split.component.spec.ts
@@ -40,7 +40,7 @@ class SynchronousMockStore implements UIStateStorage {
         <si-split-part
           #splitPart1
           stateId="one"
-          collapseDirection="start"
+          collapsible="to-start"
           collapseIconClass="element-command-arrow"
           collapseLabel="collapse"
           heading="part 1"
@@ -68,7 +68,7 @@ class SynchronousMockStore implements UIStateStorage {
           showCollapseButton="true"
           showHeader="true"
           [actions]="[]"
-          [collapseDirection]="collapseDirection2()"
+          [collapsible]="collapsible2()"
           [collapseToMinSize]="false"
           [minSize]="0"
           [scale]="scale2()"
@@ -91,7 +91,7 @@ class SynchronousMockStore implements UIStateStorage {
             showCollapseButton="true"
             showHeader="true"
             [actions]="[]"
-            [collapseDirection]="collapseDirection3()"
+            [collapsible]="collapsible3()"
             [collapseToMinSize]="false"
             [minSize]="minSize3()"
             [scale]="scale3()"
@@ -122,12 +122,12 @@ class WrapperComponent {
   readonly size1 = signal(0);
   readonly unit1 = signal<SplitUnit>('px');
   readonly splitPart2 = viewChild.required('splitPart2', { read: ElementRef });
-  readonly collapseDirection2 = signal<CollapseTo>('start');
+  readonly collapsible2 = signal<CollapseTo>('to-start');
   readonly scale2 = signal<Scale>('auto');
   readonly size2 = signal(0);
   readonly unit2 = signal<SplitUnit>('px');
   readonly splitPart3 = viewChild.required('splitPart3', { read: ElementRef });
-  readonly collapseDirection3 = signal<CollapseTo>('start');
+  readonly collapsible3 = signal<CollapseTo>('to-start');
   readonly minSize3 = signal(0);
   readonly scale3 = signal<Scale>('auto');
   readonly size3 = signal(0);
@@ -701,8 +701,8 @@ describe('SiSplitComponent', () => {
         wrapperComponent.setSizes([40, 30, 30], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
-        wrapperComponent.collapseDirection2.set('end');
-        wrapperComponent.collapseDirection3.set('end');
+        wrapperComponent.collapsible2.set('to-end');
+        wrapperComponent.collapsible3.set('to-end');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
@@ -722,8 +722,8 @@ describe('SiSplitComponent', () => {
         wrapperComponent.setSizes([40, 20, 40], 'fr');
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
-        wrapperComponent.collapseDirection2.set('end');
-        wrapperComponent.collapseDirection3.set('end');
+        wrapperComponent.collapsible2.set('to-end');
+        wrapperComponent.collapsible3.set('to-end');
         wrapperComponent.collapseOthers2.set(false);
         await fixture.whenStable();
 
@@ -863,7 +863,7 @@ describe('SiSplitComponent', () => {
       it('should switch to horizontal orientation after collapsed part on click', async () => {
         wrapperComponent.orientation.set('vertical');
         wrapperComponent.setSizes([40, 30, 30], 'fr');
-        wrapperComponent.collapseDirection3.set('end');
+        wrapperComponent.collapsible3.set('to-end');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);

--- a/projects/element-ng/split/si-split.interfaces.ts
+++ b/projects/element-ng/split/si-split.interfaces.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 /** */
-type CollapseTo = 'start' | 'end';
+type CollapseTo = 'to-start' | 'to-end';
 type SplitOrientation = 'horizontal' | 'vertical';
 type SplitUnit = 'px' | 'fr';
 

--- a/src/app/examples/si-split/si-split-auto.html
+++ b/src/app/examples/si-split/si-split-auto.html
@@ -7,7 +7,7 @@
   <si-split class="si-layout-fixed-height" [orientation]="orientation">
     <si-split-part
       heading="Filters"
-      collapseDirection="start"
+      collapsible="to-start"
       class="bg-base-1"
       size="20"
       unit="fr"
@@ -17,26 +17,14 @@
       <p class="p-4 text-secondary">Split Part #1</p>
     </si-split-part>
 
-    <si-split-part
-      heading="Employees"
-      collapseDirection="start"
-      class="bg-base-1"
-      size="60"
-      unit="fr"
-    >
+    <si-split-part heading="Employees" collapsible="to-start" class="bg-base-1" size="60" unit="fr">
       <div class="si-layout-fixed-height justify-content-center bg-secondary">
         <p class="text-center text-inverse">Split Part with resizable content!</p>
       </div>
     </si-split-part>
 
     @if (showDetails) {
-      <si-split-part
-        heading="Details"
-        collapseDirection="end"
-        class="bg-base-1"
-        size="20"
-        unit="fr"
-      >
+      <si-split-part heading="Details" collapsible="to-end" class="bg-base-1" size="20" unit="fr">
         <p class="p-4 text-secondary">Split Part #3</p>
       </si-split-part>
     }

--- a/src/app/examples/si-split/si-split-hide-collapse.html
+++ b/src/app/examples/si-split/si-split-hide-collapse.html
@@ -1,7 +1,7 @@
 <si-split orientation="horizontal" style="height: 300px">
   <si-split-part
     heading="Filters"
-    collapseDirection="start"
+    collapsible="to-start"
     class="bg-base-1"
     size="20"
     unit="fr"

--- a/src/app/examples/si-split/si-split-hide-header.html
+++ b/src/app/examples/si-split/si-split-hide-header.html
@@ -1,7 +1,7 @@
 <si-split orientation="horizontal" style="height: 500px">
   <si-split-part
     heading="Filters"
-    collapseDirection="start"
+    collapsible="to-start"
     class="bg-base-1"
     size="30"
     unit="fr"
@@ -21,7 +21,7 @@
     <si-split orientation="vertical">
       <si-split-part
         heading="Upper"
-        collapseDirection="start"
+        collapsible="to-start"
         class="bg-base-1"
         size="60"
         unit="fr"
@@ -31,7 +31,7 @@
       </si-split-part>
       <si-split-part
         heading="Lower"
-        collapseDirection="start"
+        collapsible="to-start"
         class="bg-base-1"
         size="40"
         unit="fr"

--- a/src/app/examples/si-split/si-split-icons.html
+++ b/src/app/examples/si-split/si-split-icons.html
@@ -1,7 +1,7 @@
 <si-split orientation="horizontal" style="height: 300px">
   <si-split-part
     heading="Filters"
-    collapseDirection="start"
+    collapsible="to-start"
     class="bg-base-1"
     collapseIconClass="element-login"
     size="20"
@@ -14,7 +14,7 @@
 
   <si-split-part
     heading="Employees"
-    collapseDirection="start"
+    collapsible="to-start"
     class="bg-base-1"
     collapseIconClass="element-fan"
     size="60"
@@ -25,7 +25,7 @@
 
   <si-split-part
     heading="Details"
-    collapseDirection="end"
+    collapsible="to-end"
     class="bg-base-1"
     collapseIconClass="element-air"
     size="20"

--- a/src/app/examples/si-split/si-split-mixed.html
+++ b/src/app/examples/si-split/si-split-mixed.html
@@ -2,7 +2,7 @@
   <si-split-part
     heading="Filters"
     stateId="filters"
-    collapseDirection="start"
+    collapsible="to-start"
     scale="none"
     class="bg-base-1"
     size="20"
@@ -53,7 +53,7 @@
   <si-split-part
     heading="Details"
     stateId="details"
-    collapseDirection="end"
+    collapsible="to-end"
     scale="none"
     class="bg-base-1"
     size="20"

--- a/src/app/examples/si-split/si-split-nested.html
+++ b/src/app/examples/si-split/si-split-nested.html
@@ -1,7 +1,7 @@
 <si-split orientation="horizontal" style="height: 500px">
   <si-split-part
     heading="Outer Left"
-    collapseDirection="start"
+    collapsible="to-start"
     class="bg-base-1"
     size="30"
     unit="fr"
@@ -14,17 +14,11 @@
     <p class="p-4 text-secondary">Split Part #1</p>
   </si-split-part>
 
-  <si-split-part
-    heading="Outer Right"
-    collapseDirection="end"
-    class="bg-base-1"
-    size="70"
-    unit="fr"
-  >
+  <si-split-part heading="Outer Right" collapsible="to-end" class="bg-base-1" size="70" unit="fr">
     <si-split orientation="vertical">
       <si-split-part
         heading="Inner Top"
-        collapseDirection="start"
+        collapsible="to-start"
         class="bg-base-1"
         size="60"
         unit="fr"
@@ -34,7 +28,7 @@
       </si-split-part>
       <si-split-part
         heading="Inner Bottom"
-        collapseDirection="end"
+        collapsible="to-end"
         class="bg-base-1"
         size="40"
         unit="fr"

--- a/src/app/examples/si-split/si-split-vertical.html
+++ b/src/app/examples/si-split/si-split-vertical.html
@@ -1,7 +1,7 @@
 <si-split orientation="vertical" style="height: 500px">
   <si-split-part
     heading="Filters"
-    collapseDirection="start"
+    collapsible="to-start"
     class="bg-base-1"
     size="20"
     unit="fr"
@@ -11,17 +11,11 @@
     <p class="p-4 text-secondary">Split Part #1</p>
   </si-split-part>
 
-  <si-split-part
-    heading="Employees"
-    collapseDirection="start"
-    class="bg-base-1"
-    size="60"
-    unit="fr"
-  >
+  <si-split-part heading="Employees" collapsible="to-start" class="bg-base-1" size="60" unit="fr">
     <p class="p-4 text-secondary">Split Part #2</p>
   </si-split-part>
 
-  <si-split-part heading="Details" collapseDirection="end" class="bg-base-1" size="20" unit="fr">
+  <si-split-part heading="Details" collapsible="to-end" class="bg-base-1" size="20" unit="fr">
     <p class="p-4 text-secondary">Split Part #3</p>
   </si-split-part>
 </si-split>


### PR DESCRIPTION
BREAKING CHANGE: Rename `si-split-part` input `collapseDirection` to `collapsible`.

Migrate `CollapseTo` values:
- `start` -> `to-start`
- `end` -> `to-end`

Before:

```html
<si-split-part collapseDirection="start" />
```
After:

```html
<si-split-part collapsible="to-start" />
```

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2456/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2456/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2456/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2456/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2456/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2456/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2456/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2456/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2456/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2456/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


