### PR TITLE
test(datatable): wait for tooltip

### DIFF
--- a/playwright/e2e/element-examples/datatable-tree.spec.ts
+++ b/playwright/e2e/element-examples/datatable-tree.spec.ts
@@ -14,6 +14,7 @@ test.describe('datatable', () => {
     await ageInput.fill('1');
     await ageInput.blur();
     await ageInput.hover();
+    await expect(page.getByRole('tooltip')).toBeVisible();
     await si.runVisualAndA11yTests('invalid-age');
   });
 


### PR DESCRIPTION
Updating snapshots often lacks the tooltip.
Waiting for it ensures it is always included.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2457/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2457/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2457/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2457/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2457/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2457/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2457/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2457/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2457/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2457/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
