### PR TITLE
docs: provide missing input descriptions part 1

### DIFF
--- a/api-goldens/element-ng/accordion/index.api.md
+++ b/api-goldens/element-ng/accordion/index.api.md
@@ -12,11 +12,8 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public (undocumented)
 export class SiAccordionComponent implements AfterContentInit, OnChanges {
-    // (undocumented)
     readonly expandFirstPanel: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
     readonly fullHeight: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    // (undocumented)
     readonly hcollapsed: _angular_core.InputSignal<boolean>;
 }
 

--- a/projects/element-ng/accordion/si-accordion.component.ts
+++ b/projects/element-ng/accordion/si-accordion.component.ts
@@ -34,11 +34,20 @@ const PANEL_MIN_HEIGHT = 100;
   }
 })
 export class SiAccordionComponent implements AfterContentInit, OnChanges {
-  /** @defaultValue true */
+  /**
+   * Whether the first panel is expanded initially.
+   * @defaultValue true
+   */
   readonly expandFirstPanel = input(true, { transform: booleanAttribute });
-  /** @defaultValue false */
+  /**
+   * Whether panels expand to fill the accordion height.
+   * @defaultValue false
+   */
   readonly fullHeight = input(false, { transform: booleanAttribute });
-  /** @defaultValue false */
+  /**
+   * Whether the accordion is horizontally collapsed.
+   * @defaultValue false
+   */
   readonly hcollapsed = input(false);
   /**
    * Indicate whether the accordion is collapsed.

--- a/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-alert-dialog/si-alert-dialog.component.ts
@@ -19,12 +19,20 @@ import { AlertDialogResult } from '../si-action-dialog.types';
   templateUrl: './si-alert-dialog.component.html'
 })
 export class SiAlertDialogComponent {
+  /** ID of the dialog title element used for accessible naming. */
   readonly titleId = input<string>();
-  /** @defaultValue '' */
+  /**
+   * Heading displayed in the dialog.
+   * @defaultValue ''
+   */
   readonly heading = input<TranslatableString>('');
-  /** @defaultValue '' */
+  /**
+   * Message displayed in the dialog.
+   * @defaultValue ''
+   */
   readonly message = input<TranslatableString>('');
   /**
+   * Label displayed on the confirmation button.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_ALERT_DIALOG.OK:OK`)
@@ -32,13 +40,17 @@ export class SiAlertDialogComponent {
    */
   readonly confirmBtnName = input(t(() => $localize`:@@SI_ALERT_DIALOG.OK:OK`));
   /**
+   * Parameters interpolated into the translated heading and message.
    * @defaultValue
    * ```
    * {}
    * ```
    */
   readonly translationParams = input<{ [key: string]: any }>({});
-  /** @defaultValue '' */
+  /**
+   * Icon displayed next to the dialog content.
+   * @defaultValue ''
+   */
   readonly icon = input('');
 
   protected modalRef = inject(ModalRef<SiAlertDialogComponent, AlertDialogResult>);

--- a/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-confirmation-dialog/si-confirmation-dialog.component.ts
@@ -18,12 +18,20 @@ import { ConfirmationDialogResult } from '../si-action-dialog.types';
   templateUrl: './si-confirmation-dialog.component.html'
 })
 export class SiConfirmationDialogComponent {
+  /** ID of the dialog title element used for accessible naming. */
   readonly titleId = input<string>();
-  /** @defaultValue '' */
+  /**
+   * Heading displayed in the dialog.
+   * @defaultValue ''
+   */
   readonly heading = input<TranslatableString>('');
-  /** @defaultValue '' */
+  /**
+   * Message displayed in the dialog.
+   * @defaultValue ''
+   */
   readonly message = input<TranslatableString>('');
   /**
+   * Label displayed on the confirmation button.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_CONFIRMATION_DIALOG.YES:Yes`)
@@ -31,6 +39,7 @@ export class SiConfirmationDialogComponent {
    */
   readonly confirmBtnName = input(t(() => $localize`:@@SI_CONFIRMATION_DIALOG.YES:Yes`));
   /**
+   * Label displayed on the decline button.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_CONFIRMATION_DIALOG.NO:No`)
@@ -38,13 +47,17 @@ export class SiConfirmationDialogComponent {
    */
   readonly declineBtnName = input(t(() => $localize`:@@SI_CONFIRMATION_DIALOG.NO:No`));
   /**
+   * Parameters interpolated into the translated heading and message.
    * @defaultValue
    * ```
    * {}
    * ```
    */
   readonly translationParams = input<{ [key: string]: any }>({});
-  /** @defaultValue '' */
+  /**
+   * Icon displayed next to the dialog content.
+   * @defaultValue ''
+   */
   readonly icon = input('');
 
   protected modalRef = inject(ModalRef<SiConfirmationDialogComponent, ConfirmationDialogResult>);

--- a/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-delete-confirmation-dialog/si-delete-confirmation-dialog.component.ts
@@ -19,10 +19,15 @@ import { DeleteConfirmationDialogResult } from '../si-action-dialog.types';
   templateUrl: './si-delete-confirmation-dialog.component.html'
 })
 export class SiDeleteConfirmationDialogComponent {
+  /** ID of the dialog title element used for accessible naming. */
   readonly titleId = input<string>();
-  /** @defaultValue '' */
+  /**
+   * Heading displayed in the dialog.
+   * @defaultValue ''
+   */
   readonly heading = input<TranslatableString>('');
   /**
+   * Message displayed in the dialog.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_DELETE_CONFIRMATION_DIALOG.MESSAGE:Do you really want to delete the selected elements?`)
@@ -35,6 +40,7 @@ export class SiDeleteConfirmationDialogComponent {
     )
   );
   /**
+   * Label displayed on the delete button.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_DELETE_CONFIRMATION_DIALOG.DELETE_BTN:Delete`)
@@ -44,6 +50,7 @@ export class SiDeleteConfirmationDialogComponent {
     t(() => $localize`:@@SI_DELETE_CONFIRMATION_DIALOG.DELETE_BTN:Delete`)
   );
   /**
+   * Label displayed on the cancel button.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_DELETE_CONFIRMATION_DIALOG.CANCEL_BTN:Cancel`)
@@ -53,13 +60,17 @@ export class SiDeleteConfirmationDialogComponent {
     t(() => $localize`:@@SI_DELETE_CONFIRMATION_DIALOG.CANCEL_BTN:Cancel`)
   );
   /**
+   * Parameters interpolated into the translated heading and message.
    * @defaultValue
    * ```
    * {}
    * ```
    */
   readonly translationParams = input<{ [key: string]: any }>({});
-  /** @defaultValue '' */
+  /**
+   * Icon displayed next to the dialog content.
+   * @defaultValue ''
+   */
   readonly icon = input('');
 
   protected modalRef = inject(

--- a/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.ts
+++ b/projects/element-ng/action-modal/si-edit-discard-dialog/si-edit-discard-dialog.component.ts
@@ -19,10 +19,15 @@ import { EditDiscardDialogResult } from '../si-action-dialog.types';
   templateUrl: './si-edit-discard-dialog.component.html'
 })
 export class SiEditDiscardDialogComponent {
+  /** ID of the dialog title element used for accessible naming. */
   readonly titleId = input<string>();
-  /** @defaultValue '' */
+  /**
+   * Heading displayed in the dialog.
+   * @defaultValue ''
+   */
   readonly heading = input<TranslatableString>('');
   /**
+   * Message displayed in the dialog.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.MESSAGE:Save changes?`)
@@ -30,6 +35,7 @@ export class SiEditDiscardDialogComponent {
    */
   readonly message = input(t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.MESSAGE:Save changes?`));
   /**
+   * Label displayed on the save button.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.SAVE_BTN:Save`)
@@ -37,6 +43,7 @@ export class SiEditDiscardDialogComponent {
    */
   readonly saveBtnName = input(t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.SAVE_BTN:Save`));
   /**
+   * Label displayed on the discard button.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.DISCARD_BTN:Discard`)
@@ -46,15 +53,20 @@ export class SiEditDiscardDialogComponent {
     t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.DISCARD_BTN:Discard`)
   );
   /**
+   * Label displayed on the cancel button.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.CANCEL_BTN:Cancel`)
    * ```
    */
   readonly cancelBtnName = input(t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.CANCEL_BTN:Cancel`));
-  /** @defaultValue false */
+  /**
+   * Whether the save button is disabled.
+   * @defaultValue false
+   */
   readonly disableSave = input(false, { transform: booleanAttribute });
   /**
+   * Message displayed when saving is disabled.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.DISABLE_SAVE_MESSAGE:Discard changes?`)
@@ -64,6 +76,7 @@ export class SiEditDiscardDialogComponent {
     t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.DISABLE_SAVE_MESSAGE:Discard changes?`)
   );
   /**
+   * Label displayed on the discard button when saving is disabled.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.DISABLE_SAVE_DISCARD_BTN:Discard`)
@@ -73,13 +86,17 @@ export class SiEditDiscardDialogComponent {
     t(() => $localize`:@@SI_EDIT_DISCARD_DIALOG.DISABLE_SAVE_DISCARD_BTN:Discard`)
   );
   /**
+   * Parameters interpolated into the translated heading and message.
    * @defaultValue
    * ```
    * {}
    * ```
    */
   readonly translationParams = input<{ [key: string]: any }>({});
-  /** @defaultValue '' */
+  /**
+   * Icon displayed next to the dialog content.
+   * @defaultValue ''
+   */
   readonly icon = input('');
 
   protected modalRef = inject(ModalRef<SiEditDiscardDialogComponent, EditDiscardDialogResult>);


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2458/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2458/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2458/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2458/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2458/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2458/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2458/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2458/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2458/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2458/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
