### PR TITLE
docs: provide missing input descriptions part 3

### DIFF
--- a/projects/element-ng/card/si-card-header.component.ts
+++ b/projects/element-ng/card/si-card-header.component.ts
@@ -28,18 +28,35 @@ import { SiTranslatePipe, TranslatableString } from '@siemens/element-translate-
   }
 })
 export class SiCardHeaderComponent {
+  /** The primary title text displayed in the card header. */
   readonly heading = input<TranslatableString>();
+  /** The secondary title text displayed below the main heading. */
   readonly subHeading = input<TranslatableString>();
+  /** HTML `id` applied to the heading element, used to associate `aria-labelledby` attributes. */
   readonly headingId = input<string>();
+  /** HTML `id` applied to the sub-heading element, used to associate `aria-labelledby` attributes. */
   readonly subHeadingId = input<string>();
-  /** @defaultValue [] */
+  /**
+   * Primary action items rendered as buttons in the content action bar.
+   * @defaultValue []
+   */
   readonly primaryActions = input<(MenuItemLegacy | ContentActionBarMainItem)[]>([]);
-  /** @defaultValue [] */
+  /**
+   * Secondary action items rendered in the content action bar overflow menu.
+   * @defaultValue []
+   */
   readonly secondaryActions = input<(MenuItemLegacy | MenuItem)[]>([]);
+  /** Optional parameter passed to action item callbacks when an action is triggered. */
   readonly actionParam = input<unknown>();
-  /** @defaultValue 'collapsible' */
+  /**
+   * Controls how the content action bar renders its actions.
+   * @defaultValue 'collapsible'
+   */
   readonly actionBarViewType = input<ViewType>('collapsible');
-  /** @defaultValue '' */
+  /**
+   * Accessible title for the content action bar, used as an `aria-label`.
+   * @defaultValue ''
+   */
   readonly actionBarTitle = input<TranslatableString>('');
 
   readonly displayContentActionBar = computed(

--- a/projects/element-ng/column-selection-dialog/column-selection-editor/si-column-selection-editor.component.ts
+++ b/projects/element-ng/column-selection-dialog/column-selection-editor/si-column-selection-editor.component.ts
@@ -32,9 +32,13 @@ import { Column } from '../si-column-selection-dialog.types';
   }
 })
 export class SiColumnSelectionEditorComponent {
+  /** The column data object being displayed and edited, including its id, title, visibility, and editable state. */
   readonly column = input.required<Column>();
+  /** Whether this column item is currently selected (visible) in the listbox. */
   readonly selected = input.required<boolean>();
+  /** Accessible label for the rename input field shown when editing the column title. */
   readonly renameInputLabel = input.required<string>();
+  /** Whether the visibility of this column can be toggled by the user. When `false`, the visibility toggle button is hidden. */
   readonly columnVisibilityConfigurable = input.required<boolean>();
 
   readonly titleChange = output();

--- a/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.ts
+++ b/projects/element-ng/column-selection-dialog/si-column-selection-dialog.component.ts
@@ -60,10 +60,14 @@ const dragConfig = {
   providers: [{ provide: CDK_DRAG_CONFIG, useValue: dragConfig }]
 })
 export class SiColumnSelectionDialogComponent implements OnInit {
+  /** HTML `id` applied to the dialog title element, used for `aria-labelledby` association. */
   readonly titleId = input<string>();
+  /** The dialog title text displayed in the modal header. */
   readonly heading = input<TranslatableString>();
+  /** The section title displayed above the column list. */
   readonly bodyTitle = input<TranslatableString>();
   /**
+   * Label for the submit button that applies the column selection.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.SUBMIT:Apply`)
@@ -73,6 +77,7 @@ export class SiColumnSelectionDialogComponent implements OnInit {
     t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.SUBMIT:Apply`)
   );
   /**
+   * Label for the cancel button that discards changes and closes the dialog.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.CANCEL:Cancel`)
@@ -82,6 +87,7 @@ export class SiColumnSelectionDialogComponent implements OnInit {
     t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.CANCEL:Cancel`)
   );
   /**
+   * Label for the button that resets the column configuration to its original default state.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.RESTORE_TO_DEFAULT:Restore to default`)
@@ -91,6 +97,7 @@ export class SiColumnSelectionDialogComponent implements OnInit {
     t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.RESTORE_TO_DEFAULT:Restore to default`)
   );
   /**
+   * Label shown next to a column that is currently hidden.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.HIDDEN:Hidden`)
@@ -100,6 +107,7 @@ export class SiColumnSelectionDialogComponent implements OnInit {
     t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.HIDDEN:Hidden`)
   );
   /**
+   * Label shown next to a column that is currently visible.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.VISIBLE:Visible`)
@@ -108,10 +116,18 @@ export class SiColumnSelectionDialogComponent implements OnInit {
   readonly visibleText = input<TranslatableString>(
     t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.VISIBLE:Visible`)
   );
-  /** @defaultValue false */
+  /**
+   * Whether to show the "Restore to default" button.
+   * @defaultValue false
+   */
   readonly restoreEnabled = input(false, { transform: booleanAttribute });
+  /**
+   * Two-way bound array of `Column` objects defining the column list state.
+   * Changes are reflected back to the parent on reorder, visibility toggle, or rename.
+   */
   readonly columns = model.required<Column[]>();
   /**
+   * Additional interpolation parameters passed to translatable strings.
    * @defaultValue
    * ```
    * {}
@@ -120,6 +136,7 @@ export class SiColumnSelectionDialogComponent implements OnInit {
   readonly translationParams = input<Record<string, unknown>>({});
 
   /**
+   * Accessible label for the column list, used as an `aria-label`. Describes available keyboard shortcuts for reordering and renaming.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.LIST_ARIA_LABEL:List of possible columns. Items can be moved using Alt+ArrowUp or Alt+ArrowDown. Press Enter to rename supported items.`)
@@ -133,6 +150,7 @@ export class SiColumnSelectionDialogComponent implements OnInit {
   );
 
   /**
+   * Accessible label for the rename input field inside each column editor row.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.RENAME_INPUT_ARIA_LABEL:Rename column`)
@@ -143,6 +161,7 @@ export class SiColumnSelectionDialogComponent implements OnInit {
   );
 
   /**
+   * Live-region message announced after a column is successfully moved to a new position. Supports `{{targetPosition}}` interpolation.
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.ITEM_MOVED:Item is now at position {{targetPosition}}`)
@@ -155,6 +174,7 @@ export class SiColumnSelectionDialogComponent implements OnInit {
     )
   );
   /**
+   * Live-region message announced when a column could not be moved (e.g. already at the boundary).
    * @defaultValue
    * ```
    * t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.ITEM_NOT_MOVED:Item was not moved`)
@@ -164,7 +184,10 @@ export class SiColumnSelectionDialogComponent implements OnInit {
   readonly a11yItemNotMovedMessage = input<TranslatableString>(
     t(() => $localize`:@@SI_COLUMN_SELECTION_DIALOG.ITEM_NOT_MOVED:Item was not moved`)
   );
-  /** @defaultValue true */
+  /**
+   * Whether column visibility can be toggled by the user. When `false`, visibility controls are hidden for all columns.
+   * @defaultValue true
+   */
   readonly columnVisibilityConfigurable = input(true, { transform: booleanAttribute });
 
   private readonly listOptions = viewChildren(CdkOption);

--- a/projects/element-ng/content-action-bar/si-content-action-bar-toggle.component.ts
+++ b/projects/element-ng/content-action-bar/si-content-action-bar-toggle.component.ts
@@ -14,5 +14,6 @@ import { SiIconComponent } from '@siemens/element-ng/icon';
   host: { class: 'dropdown-item flex-grow-0 focus-inside' }
 })
 export class SiContentActionBarToggleComponent {
+  /** Icon identifier rendered inside the toggle button. */
   readonly icon = input.required<string>();
 }


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2460/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2460/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2460/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2460/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2460/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2460/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2460/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2460/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2460/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2460/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
