### PR TITLE
docs(datepicker): align the form spacing with our guidelines

### DIFF
--- a/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-focus-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-focus-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:10cc7109558f8eea42847334fb0d541bf07a183cd52606ffb61dc9f7115c7c47
+oid sha256:50895caaaabbb5f52b6a218ab4ae30235cb2cfb76b1db2ffb7285696e5ff22cb
 size 31749

--- a/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-focus-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-focus-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b164612d6a3ad84fcbc512df3a66c58da3460b1d2d1a4b457f30fb4461861b37
-size 31082
+oid sha256:66f247f42e5f2399c5b91b023bf2a5b9dc2c5f7afb0839322931e058a5cc578e
+size 31086

--- a/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-hover-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-hover-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d6c862a550e4d07e860f3f6c6693c1fddccf2a00c105a5b8a82f5cad3eba95c
-size 31451
+oid sha256:b0b8c0fdda6d2e8c50edd3fbaf005f42675f5079f551536f802ca844742a9a59
+size 31452

--- a/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-hover-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-datepicker.spec.ts-snapshots/si-datepicker--si-datepicker-input--calendar-button-hover-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2dff615fc2f70b6615d2f6a2d9a3851618e8f0334cd3cf9077ed45d9d2ebb8b
-size 30861
+oid sha256:f78249823349a6c9481fcb4b3852ea147b093d8f5a1d7753b1b3379cdbc9e8eb
+size 30865

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--button-focus-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--button-focus-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9bb2e216ece6d99d84afb0092b7be74127b60f11ff69284d73229017efbe2a6b
+oid sha256:66fb3f1b0eadbefb4ae6906e3d8e32b86a93e4a3063a48e627b824b3f68e57bc
 size 12381

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--button-focus-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--button-focus-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c922790e5c5b054f829bfadf5026da239275f8f119d8ad049ed3027aae5da1f
+oid sha256:1b1874d7b41d3ccc6bf37b8bededdebe7c703933ce409efec2455b7c755f6662
 size 12351

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--input-focus-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--input-focus-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:00d19f7aed52f071c26eacbdc8c6a3d944a3ff1578c59bc949f55fb059f0bdd2
-size 11667
+oid sha256:cf8f73b8554989f69e47f59b72f700602c2e9232b4df0071da18a723376e7cbb
+size 11664

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--input-focus-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--input-focus-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0baf551af354f3c01417d25780be1cdaa35ce4d9d411b7a1bf906bbaf11ec1b
+oid sha256:0644ad2353ff82576d7a97b07114dfaa5594446294c2fc54b669a5b4dce85085
 size 11636

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--selection-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--selection-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c2f4d2a4e7c1c0f167ba04a100d7d92acdcb0b2cbccc371ffe8fb1d09351b07
-size 38103
+oid sha256:3d78eeaf98d9d48ba6915cf3adc72e334902d2a4bf63020c816b8046dbadb19c
+size 38172

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--selection-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range--selection-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb41a372b4637d5809f93786072ff23d3e709e0cb2b0fbca434b2f1c084678fa
-size 38499
+oid sha256:6d550df193eb3b7bd0ab09800a5e03891b5481993c7c87180e3aeec78caea380
+size 38211

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3524f6ca7de6fe5dbd97fb52f10d5bd29571efaed03e53715fc248c6d7186aa
+oid sha256:4f6479b280cdd526dabe7b18ce42f52af39c0228e6d6ef5d6f06c65d9b943427
 size 12017

--- a/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-daterange.spec.ts-snapshots/si-datepicker--si-date-range-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1c1639e43b041d60303f613b9dad5e9ee02472bf4724f59878d4abda748ba86
+oid sha256:34920547d91bdae1576ce1c8a55079afbbaa518e411c9e09599829c605fecacf
 size 12020

--- a/playwright/snapshots/static.spec.ts-snapshots/si-datepicker--si-timepicker-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-datepicker--si-timepicker-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cdd7c77c09f9d1f8154cd485c7d24778611b5476670704ce078087b257aae08e
-size 18111
+oid sha256:3223e40c6a3b6d3f487234fe0135064aad20ddfeed182c3383ffc351a60e0db0
+size 18106

--- a/playwright/snapshots/static.spec.ts-snapshots/si-datepicker--si-timepicker-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-datepicker--si-timepicker-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c4682d11a7bd4228698079c4d7f2d08d3b1a616f0817dac556caab6625ceb1a
-size 17742
+oid sha256:6262fe0ed36a515b9b6722054b72d139cf4585b1148d0b6ca9c9da099dae5d0f
+size 17737

--- a/src/app/examples/si-datepicker/si-date-input.html
+++ b/src/app/examples/si-datepicker/si-date-input.html
@@ -1,21 +1,23 @@
 <div class="row justify-content-center mx-0">
   {{ date }}
 </div>
-<div class="row justify-content-center mx-0">
-  <div class="col-xs-12 col-12 col-md-4 my-6">
-    <si-form-item label="Datepicker">
-      <input
-        type="text"
-        class="form-control"
-        siDateInput
-        [siDatepickerConfig]="config"
-        [(ngModel)]="date"
-      />
-    </si-form-item>
+<div class="pt-6">
+  <div class="row justify-content-center mx-0">
+    <div class="col-12 col-md-4">
+      <si-form-item label="Datepicker">
+        <input
+          type="text"
+          class="form-control"
+          siDateInput
+          [siDatepickerConfig]="config"
+          [(ngModel)]="date"
+        />
+      </si-form-item>
+    </div>
   </div>
-</div>
-<div class="row justify-content-center mx-0">
-  <div class="col-xs-12 col-12 col-md-4 my-6">
-    <si-datepicker class="d-inline-block me-6" [config]="config" [(date)]="date" />
+  <div class="row justify-content-center mx-0">
+    <div class="col-12 col-md-4">
+      <si-datepicker class="d-inline-block me-6" [config]="config" [(date)]="date" />
+    </div>
   </div>
 </div>

--- a/src/app/examples/si-datepicker/si-date-range.html
+++ b/src/app/examples/si-datepicker/si-date-range.html
@@ -1,5 +1,5 @@
-<div class="row justify-content-center">
-  <div class="col-xs-3 col-2 col-md-2 my-6">
+<div class="row justify-content-center pt-6">
+  <div class="col-2 col-md-2">
     <si-form-item label="Date range">
       <si-date-range [formControl]="dateRange" />
     </si-form-item>

--- a/src/app/examples/si-datepicker/si-datepicker-input-playground.html
+++ b/src/app/examples/si-datepicker/si-datepicker-input-playground.html
@@ -1,75 +1,81 @@
 <div class="p-5">
-  <div class="row justify-content-center mx-0">
-    <div class="col-xs-12 col-12 col-md-4 my-6">
-      <si-form-item label="Date input (empty with placeholder)">
-        <input
-          autocomplete="off"
-          class="form-control"
-          id="si-datetime-input-0"
-          type="text"
-          siDatepicker
-          [placeholder]="placeholder"
-          [required]="required"
-          [readonly]="readonly"
-          [disabled]="disabled"
-          [autoClose]="autoClose"
-          [siDatepickerConfig]="config"
-          (siDatepickerClose)="logEvent('siDatepickerClosed', $event)"
-          (siDatepickerDisabledTime)="logEvent('siDatepickerDisabledTime', $event)"
-        />
-        <small class="form-text">Placeholder text not displayed for disabled input</small>
-      </si-form-item>
+  <div class="pt-6">
+    <div class="row justify-content-center mx-0">
+      <div class="col-12 col-md-4">
+        <si-form-item label="Date input (empty with placeholder)">
+          <input
+            autocomplete="off"
+            class="form-control"
+            id="si-datetime-input-0"
+            type="text"
+            siDatepicker
+            [placeholder]="placeholder"
+            [required]="required"
+            [readonly]="readonly"
+            [disabled]="disabled"
+            [autoClose]="autoClose"
+            [siDatepickerConfig]="config"
+            (siDatepickerClose)="logEvent('siDatepickerClosed', $event)"
+            (siDatepickerDisabledTime)="logEvent('siDatepickerDisabledTime', $event)"
+          />
+          <small class="form-text">Placeholder text not displayed for disabled input</small>
+        </si-form-item>
+      </div>
     </div>
-  </div>
-  <div class="row justify-content-center mx-0">
-    <div class="col-xs-12 col-12 col-md-4 my-6">
-      <si-form-item label="Date input">
-        <input
-          #control="ngModel"
-          #validation="ngModel"
-          autocomplete="off"
-          class="form-control"
-          id="si-datetime-input-1"
-          type="text"
-          siDatepicker
-          [placeholder]="placeholder"
-          [required]="required"
-          [readonly]="readonly"
-          [disabled]="disabled"
-          [autoClose]="autoClose"
-          [siDatepickerConfig]="config"
-          [(ngModel)]="value"
-          (siDatepickerClose)="logEvent('siDatepickerClosed', $event)"
-          (siDatepickerDisabledTime)="logEvent('siDatepickerDisabledTime', $event)"
-        />
-      </si-form-item>
+    <div class="row justify-content-center mx-0">
+      <div class="col-12 col-md-4">
+        <si-form-item label="Date input">
+          <input
+            #control="ngModel"
+            #validation="ngModel"
+            autocomplete="off"
+            class="form-control"
+            id="si-datetime-input-1"
+            type="text"
+            siDatepicker
+            [placeholder]="placeholder"
+            [required]="required"
+            [readonly]="readonly"
+            [disabled]="disabled"
+            [autoClose]="autoClose"
+            [siDatepickerConfig]="config"
+            [(ngModel)]="value"
+            (siDatepickerClose)="logEvent('siDatepickerClosed', $event)"
+            (siDatepickerDisabledTime)="logEvent('siDatepickerDisabledTime', $event)"
+          />
+        </si-form-item>
+      </div>
     </div>
-  </div>
-  <div class="row justify-content-center mx-0">
-    <div class="col-xs-12 col-12 col-md-4 my-6">
-      <label for="si-datetime-input-2" class="form-label" [class.required]="required && !readonly">
-        Date input with calendar button
-      </label>
-      <si-calendar-button class="w-100">
-        <input
-          #control="ngModel"
-          #validation="ngModel"
-          autocomplete="off"
-          class="form-control"
-          id="si-datetime-input-2"
-          type="text"
-          siDatepicker
-          [placeholder]="placeholder"
-          [required]="required"
-          [readonly]="readonly"
-          [disabled]="disabled"
-          [autoClose]="autoClose"
-          [siDatepickerConfig]="config"
-          [(ngModel)]="value"
-          (siDatepickerClose)="logEvent('siDatepickerClosed', $event)"
-          (siDatepickerDisabledTime)="logEvent('siDatepickerDisabledTime', $event)"
-        />
-      </si-calendar-button>
+    <div class="row justify-content-center mx-0">
+      <div class="col-12 col-md-4">
+        <label
+          for="si-datetime-input-2"
+          class="form-label"
+          [class.required]="required && !readonly"
+        >
+          Date input with calendar button
+        </label>
+        <si-calendar-button class="w-100">
+          <input
+            #control="ngModel"
+            #validation="ngModel"
+            autocomplete="off"
+            class="form-control"
+            id="si-datetime-input-2"
+            type="text"
+            siDatepicker
+            [placeholder]="placeholder"
+            [required]="required"
+            [readonly]="readonly"
+            [disabled]="disabled"
+            [autoClose]="autoClose"
+            [siDatepickerConfig]="config"
+            [(ngModel)]="value"
+            (siDatepickerClose)="logEvent('siDatepickerClosed', $event)"
+            (siDatepickerDisabledTime)="logEvent('siDatepickerDisabledTime', $event)"
+          />
+        </si-calendar-button>
+      </div>
     </div>
   </div>
   <div class="card mt-6 e2e-ignore">

--- a/src/app/examples/si-datepicker/si-datepicker-input.html
+++ b/src/app/examples/si-datepicker/si-datepicker-input.html
@@ -1,99 +1,101 @@
-<div class="row justify-content-center mx-0">
-  {{ date }}
-</div>
-<div class="row justify-content-center mx-0">
-  <div class="col-xs-12 col-12 col-md-4 my-4">
-    <si-form-item label="Date">
-      <si-calendar-button class="w-100">
-        <input type="text" class="form-control" siDatepicker [(ngModel)]="date" />
-      </si-calendar-button>
-    </si-form-item>
+<div class="pt-6">
+  <div class="row justify-content-center mx-0">
+    {{ date }}
   </div>
-</div>
-<div class="row justify-content-center mx-0">
-  <div class="col-xs-12 col-12 col-md-4 my-4">
-    <si-form-item label="Date with custom format">
-      <si-calendar-button class="w-100">
-        <input
-          type="text"
-          class="form-control"
-          siDatepicker
-          [siDatepickerConfig]="{ dateFormat: 'dd.MM.yyyy' }"
-          [(ngModel)]="date"
-        />
-      </si-calendar-button>
-    </si-form-item>
+  <div class="row justify-content-center mx-0">
+    <div class="col-12 col-md-4">
+      <si-form-item label="Date">
+        <si-calendar-button class="w-100">
+          <input type="text" class="form-control" siDatepicker [(ngModel)]="date" />
+        </si-calendar-button>
+      </si-form-item>
+    </div>
   </div>
-</div>
-<div class="row justify-content-center mx-0">
-  <div class="col-xs-12 col-12 col-md-4 my-4">
-    <si-form-item label="Date and time">
-      <si-calendar-button class="w-100">
-        <input
-          type="text"
-          class="form-control"
-          siDatepicker
-          [siDatepickerConfig]="{
-            showTime: true,
-            dateFormat: 'dd.MM.yyyy',
-            dateTimeFormat: 'dd.MM.yyyy HH:mm'
-          }"
-          [(ngModel)]="date"
-        />
-      </si-calendar-button>
-    </si-form-item>
+  <div class="row justify-content-center mx-0">
+    <div class="col-12 col-md-4">
+      <si-form-item label="Date with custom format">
+        <si-calendar-button class="w-100">
+          <input
+            type="text"
+            class="form-control"
+            siDatepicker
+            [siDatepickerConfig]="{ dateFormat: 'dd.MM.yyyy' }"
+            [(ngModel)]="date"
+          />
+        </si-calendar-button>
+      </si-form-item>
+    </div>
   </div>
-</div>
-<div class="row justify-content-center mx-0">
-  <div class="col-xs-12 col-12 col-md-4 my-4">
-    <si-form-item label="Date and time with seconds">
-      <si-calendar-button class="w-100">
-        <input
-          type="text"
-          class="form-control"
-          siDatepicker
-          [siDatepickerConfig]="{ showTime: true, showSeconds: true, mandatoryTime: true }"
-          [(ngModel)]="date"
-        />
-      </si-calendar-button>
-    </si-form-item>
+  <div class="row justify-content-center mx-0">
+    <div class="col-12 col-md-4">
+      <si-form-item label="Date and time">
+        <si-calendar-button class="w-100">
+          <input
+            type="text"
+            class="form-control"
+            siDatepicker
+            [siDatepickerConfig]="{
+              showTime: true,
+              dateFormat: 'dd.MM.yyyy',
+              dateTimeFormat: 'dd.MM.yyyy HH:mm'
+            }"
+            [(ngModel)]="date"
+          />
+        </si-calendar-button>
+      </si-form-item>
+    </div>
   </div>
-</div>
-<div class="row justify-content-center mx-0">
-  <div class="col-xs-12 col-12 col-md-4 my-4">
-    <si-form-item label="Datepicker without initial value">
-      <si-calendar-button class="w-100">
-        <input
-          type="text"
-          placeholder="Datepicker without initial value"
-          class="form-control"
-          siDatepicker
-        />
-      </si-calendar-button>
-    </si-form-item>
+  <div class="row justify-content-center mx-0">
+    <div class="col-12 col-md-4">
+      <si-form-item label="Date and time with seconds">
+        <si-calendar-button class="w-100">
+          <input
+            type="text"
+            class="form-control"
+            siDatepicker
+            [siDatepickerConfig]="{ showTime: true, showSeconds: true, mandatoryTime: true }"
+            [(ngModel)]="date"
+          />
+        </si-calendar-button>
+      </si-form-item>
+    </div>
   </div>
-</div>
-<div class="row justify-content-center mx-0">
-  <div class="col-xs-12 col-12 col-md-4 my-4">
-    <si-form-item label="Show validation status">
-      <si-calendar-button class="w-100">
-        <input
-          #validation="ngModel"
-          type="text"
-          placeholder="Datepicker with validation state"
-          class="form-control"
-          siDatepicker
-          [siDatepickerConfig]="{
-            showTime: true,
-            dateFormat: 'dd.MM.yyyy',
-            minDate: minDate,
-            maxDate: maxDate,
-            enableTimeValidation: true
-          }"
-          [(ngModel)]="validationDate"
-        />
-      </si-calendar-button>
-    </si-form-item>
-    <div class="pt-2">Date is {{ validation.control.status }}</div>
+  <div class="row justify-content-center mx-0">
+    <div class="col-12 col-md-4">
+      <si-form-item label="Datepicker without initial value">
+        <si-calendar-button class="w-100">
+          <input
+            type="text"
+            placeholder="Datepicker without initial value"
+            class="form-control"
+            siDatepicker
+          />
+        </si-calendar-button>
+      </si-form-item>
+    </div>
+  </div>
+  <div class="row justify-content-center mx-0">
+    <div class="col-12 col-md-4">
+      <si-form-item label="Show validation status">
+        <si-calendar-button class="w-100">
+          <input
+            #validation="ngModel"
+            type="text"
+            placeholder="Datepicker with validation state"
+            class="form-control"
+            siDatepicker
+            [siDatepickerConfig]="{
+              showTime: true,
+              dateFormat: 'dd.MM.yyyy',
+              minDate: minDate,
+              maxDate: maxDate,
+              enableTimeValidation: true
+            }"
+            [(ngModel)]="validationDate"
+          />
+        </si-calendar-button>
+      </si-form-item>
+      <div class="pt-2">Date is {{ validation.control.status }}</div>
+    </div>
   </div>
 </div>

--- a/src/app/examples/si-datepicker/si-timepicker.html
+++ b/src/app/examples/si-datepicker/si-timepicker.html
@@ -1,6 +1,6 @@
 <div class="p-5">
-  <div class="row justify-content-center">
-    <div class="col-xs-12 col-12 col-md-4 my-6">
+  <div class="row justify-content-center pt-6">
+    <div class="col-12 col-md-4">
       <si-form-item label="Timepicker on date object">
         <si-timepicker
           #control="ngModel"


### PR DESCRIPTION
Use the standard spacing of forms in the datepicker examples.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2474/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2474/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2474/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2474/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2474/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2474/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2474/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2474/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2474/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2474/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
