### PR TITLE
test(markdown-renderer): stabilize visual snapshot

### DIFF
--- a/playwright/e2e/element-examples/static.spec.ts
+++ b/playwright/e2e/element-examples/static.spec.ts
@@ -114,7 +114,13 @@ test('typography/type-styles', ({ si }) => si.static());
 test('typography/display-styles', ({ si }) => si.static());
 test('typography/typography', ({ si }) => si.static());
 test('si-markdown-renderer/si-markdown-renderer', ({ si }) =>
-  si.static({ disabledA11yRules: ['link-in-text-block'] }));
+  si.static({
+    disabledA11yRules: ['link-in-text-block'],
+    waitCallback: async page => {
+      await page.getByRole('heading', { name: 'AI Assistant Response' }).waitFor();
+      await page.evaluate(() => document.fonts.ready);
+    }
+  }));
 test('si-chat-messages/si-ai-message', ({ si }) => si.static());
 test('si-chat-messages/si-user-message', ({ si }) => si.static());
 test('si-chat-messages/si-chat-message', ({ si }) => si.static());

--- a/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-markdown-renderer--si-markdown-renderer-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18ec6e88bdaba4e40b05e5ac2176f353d307edab562bfe1e963f72713d4ecb21
-size 138948
+oid sha256:2a0918b8d6a1538f84ed6c7a7e40cba731a31c0af349970b92557974f5908c4d
+size 138931


### PR DESCRIPTION
The markdown example fetches its content asynchronously, while the live-preview readiness marker can become visible before that request completes. This allowed viewport measurement and the visual snapshot to run against either the empty or rendered page.

Wait for the rendered `AI Assistant Response` heading before continuing, then wait for fonts again because the dynamically inserted content can initiate font loading after the helper's initial font check. Regenerate the light-theme baseline from the stable 1669 px layout.

Verification:

- `PLAYWRIGHT_staticTest='si-markdown-renderer/si-markdown-renderer' ./e2e-local.sh run playwright/e2e/element-examples/static.spec.ts '--project=element-examples/*'`
- 226 passed, 2 skipped across light and dark projects<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2479/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2479/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2479/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2479/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2479/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2479/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2479/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2479/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2479/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2479/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
