### PR TITLE
fix(toast-notification): allow passing translation params to constructor function

### DIFF
--- a/api-goldens/element-ng/toast-notification/index.api.md
+++ b/api-goldens/element-ng/toast-notification/index.api.md
@@ -46,7 +46,9 @@ export class SiToastNotificationService implements OnDestroy {
     constructor();
     get activeToasts(): SiToast[];
     hideToastNotification(toast?: SiToast): void;
-    queueToastNotification(state: StatusType, title: string, message: string, disableAutoClose?: boolean, disableManualClose?: boolean, action?: Link): SiToast;
+    queueToastNotification(state: StatusType, title: string, message: string, disableAutoClose?: boolean, disableManualClose?: boolean, action?: Link, translationParams?: {
+        [key: string]: any;
+    }): SiToast;
     showToastNotification(toast: SiToast): SiToast;
 }
 

--- a/projects/element-ng/toast-notification/si-toast-notification.service.spec.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification.service.spec.ts
@@ -29,6 +29,22 @@ describe('SiToastNotificationService', () => {
     expect(activeToast.message).toEqual('A successful event has occurred.');
   });
 
+  it('should queue a toast notification with translation parameters', () => {
+    const translationParams = { fileName: 'report.pdf' };
+
+    const toast = service.queueToastNotification(
+      'danger',
+      'Upload failed',
+      'Could not upload {{fileName}}.',
+      undefined,
+      undefined,
+      undefined,
+      translationParams
+    );
+
+    expect(toast.translationParams).toEqual(translationParams);
+  });
+
   it('should successfully hide all toast notifications', () => {
     service.queueToastNotification('success', 'Success!', 'A successful event has occurred.');
     service.hideToastNotification();

--- a/projects/element-ng/toast-notification/si-toast-notification.service.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification.service.ts
@@ -68,7 +68,8 @@ export class SiToastNotificationService implements OnDestroy {
     message: string,
     disableAutoClose?: boolean,
     disableManualClose?: boolean,
-    action?: Link
+    action?: Link,
+    translationParams?: { [key: string]: any }
   ): SiToast {
     const toast: SiToast = {
       state,
@@ -77,7 +78,8 @@ export class SiToastNotificationService implements OnDestroy {
       disableAutoClose,
       disableManualClose,
       action,
-      hidden: new Subject()
+      hidden: new Subject(),
+      translationParams
     };
     return this.showToastNotification(toast);
   }

--- a/src/app/examples/si-chat-messages/si-chat-container.ts
+++ b/src/app/examples/si-chat-messages/si-chat-container.ts
@@ -309,7 +309,15 @@ export class SampleComponent {
 
   onFileError(error: FileUploadError): void {
     this.logEvent(`File error: ${error.errorText} - ${error.fileName}`);
-    this.toastService.queueToastNotification('danger', error.errorText, error.fileName);
+    this.toastService.queueToastNotification(
+      'danger',
+      error.errorText,
+      error.fileName,
+      undefined,
+      undefined,
+      undefined,
+      error.errorParams
+    );
   }
 
   private simulateAiResponse(userInput: string): void {

--- a/src/app/examples/si-chat-messages/si-chat-input.ts
+++ b/src/app/examples/si-chat-messages/si-chat-input.ts
@@ -82,7 +82,15 @@ export class SampleComponent {
 
   onFileError(error: FileUploadError): void {
     this.logEvent(`File error: ${error.errorText} - ${error.fileName}`);
-    this.toastService.queueToastNotification('danger', error.errorText, error.fileName);
+    this.toastService.queueToastNotification(
+      'danger',
+      error.errorText,
+      error.fileName,
+      undefined,
+      undefined,
+      undefined,
+      error.errorParams
+    );
   }
 
   onInterrupt(): void {


### PR DESCRIPTION
Currently, there is no way to pass translation params while using the toast notification constructor function, which causes us to have malformed errors in the chat component examples.
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2484/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2484/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2484/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2484/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2484/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2484/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2484/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2484/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2484/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2484/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

