### PR TITLE
fix(empty-state): use relative size for icon

### DIFF
--- a/projects/element-ng/empty-state/si-empty-state.component.scss
+++ b/projects/element-ng/empty-state/si-empty-state.component.scss
@@ -14,5 +14,5 @@
 
 .state-icon {
   color: variables.$element-ui-2;
-  font-size: 80px;
+  font-size: 5rem;
 }


### PR DESCRIPTION
empty state icon size should scale when root font size is changed.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2485/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2485/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2485/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2485/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2485/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2485/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2485/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2485/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2485/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2485/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


