### PR TITLE
fix(menu): preserve submenus when items update

### DIFF
--- a/projects/element-ng/menu/si-menu-factory.component.html
+++ b/projects/element-ng/menu/si-menu-factory.component.html
@@ -1,5 +1,5 @@
 <si-menu>
-  @for (item of items(); track item) {
+  @for (item of items(); track trackItem($index, item)) {
     <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item }" />
   }
   <ng-template #itemTemplate let-item siMenuFactoryItemGuard>

--- a/projects/element-ng/menu/si-menu-factory.component.ts
+++ b/projects/element-ng/menu/si-menu-factory.component.ts
@@ -49,6 +49,19 @@ export class SiMenuFactoryComponent {
   private linkActionService = inject(SiLinkActionService, { optional: true });
   private menuActionService = inject(SiMenuActionService, { optional: true });
 
+  protected trackItem(index: number, item: MenuItemLegacy | MenuItem): string | number {
+    if ('id' in item && item.id) {
+      return item.id;
+    }
+    if ('label' in item && item.label) {
+      return item.label;
+    }
+    if ('title' in item && item.title) {
+      return item.title;
+    }
+    return index;
+  }
+
   protected isNewItemStyle(item: MenuItemLegacy | MenuItem): item is MenuItem {
     return 'label' in item || item.type === 'divider' || item.type === 'radio-group';
   }

--- a/projects/element-ng/tree-view/si-tree-view.component.spec.ts
+++ b/projects/element-ng/tree-view/si-tree-view.component.spec.ts
@@ -5,8 +5,10 @@
 import { Component, signal, TrackByFunction, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
 import { MenuItem } from '@siemens/element-ng/menu';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, map } from 'rxjs';
+import { page, userEvent } from 'vitest/browser';
 
 import { SiTreeViewItemHeightService } from './si-tree-view-item-height.service';
 import { SiTreeViewComponent } from './si-tree-view.component';
@@ -651,6 +653,37 @@ describe('SiTreeViewComponent', () => {
 
         await fixture.whenStable();
       }
+    });
+
+    it('should keep the context menu open when closing a submenu by click', async () => {
+      const createMenuItems = (): MenuItemLegacy[] => [
+        { title: 'Parent item', items: [{ title: 'Child item', disabled: true }] }
+      ];
+      const menuItems = new BehaviorSubject(createMenuItems());
+      component.contextMenuItems.set(() => menuItems.pipe(map(() => createMenuItems())));
+      await fixture.whenStable();
+
+      await userEvent.click(element.querySelector<HTMLElement>('si-tree-view-item')!, {
+        button: 'right'
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await fixture.whenStable();
+
+      const submenuTrigger = page.getByRole('menuitem', { name: 'Parent item' });
+      // userEvent.click cannot be used here as its pointer sequence hover-opens the submenu and the
+      // following click toggles it closed again
+      (submenuTrigger.element() as HTMLElement).click();
+      await fixture.whenStable();
+      await expect.element(page.getByRole('menuitem', { name: 'Child item' })).toBeInTheDocument();
+
+      menuItems.next(createMenuItems());
+      await fixture.whenStable();
+      await expect.element(page.getByRole('menuitem', { name: 'Child item' })).toBeInTheDocument();
+
+      await userEvent.click(submenuTrigger);
+      await fixture.whenStable();
+      expect(page.getByRole('menuitem', { name: 'Child item' }).elements()).toHaveLength(0);
+      await expect.element(submenuTrigger).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Observable tree-view menu providers can rebuild menu item objects while a submenu is open. Tracking those objects by identity destroyed the active CDK trigger and closed the complete context-menu stack.

Track menu items by their configured ID, or by position when no ID is available, so rebuilt item objects preserve active menu directives. Add a browser-backed TreeView regression test using an observable legacy menu provider with a disabled child.

Closes #2335

## Testing

- `pnpm lib:test --include='**/si-tree-view.component.spec.ts' --no-watch`
- `pnpm lib:test --include='**/si-menu.spec.ts' --no-watch`
- `pnpm lib:test --no-watch` (1,988 passed, 11 skipped)
- ESLint and Prettier on changed files<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2486/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2486/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2486/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2486/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2486/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2486/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2486/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2486/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2486/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2486/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

