### PR TITLE
fix(popover): reopen after close scroll strategy

### DIFF
--- a/projects/element-ng/popover/si-popover.directive.spec.ts
+++ b/projects/element-ng/popover/si-popover.directive.spec.ts
@@ -212,4 +212,22 @@ describe('with scrollStrategy', () => {
 
     expect(document.querySelector('.popover')).not.toBeInTheDocument();
   });
+
+  it('should reopen popover after the close scroll strategy detached it', async () => {
+    const overlay = TestBed.inject(Overlay);
+    fixture.componentInstance.scrollStrategy.set(overlay.scrollStrategies.close());
+    await fixture.whenStable();
+    const button = page.getByRole('button', { name: 'Test' });
+
+    await userEvent.click(button);
+    document.dispatchEvent(new Event('scroll', { bubbles: true }));
+    await fixture.whenStable();
+
+    await userEvent.click(button);
+
+    expect(document.querySelector('.popover')).toBeInTheDocument();
+    await expect.element(button).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.click(button);
+  });
 });

--- a/projects/element-ng/popover/si-popover.directive.ts
+++ b/projects/element-ng/popover/si-popover.directive.ts
@@ -109,6 +109,7 @@ export class SiPopoverDirective implements OnDestroy {
   protected readonly isOpen = signal<boolean>(false);
 
   private overlayref?: OverlayRef;
+  private popoverRef?: ComponentRef<PopoverComponent>;
   private overlay = inject(Overlay);
   private elementRef = inject(ElementRef);
   private destroyer = new Subject<void>();
@@ -126,33 +127,13 @@ export class SiPopoverDirective implements OnDestroy {
     if (this.overlayref?.hasAttached()) {
       return;
     }
-    this.overlayref = getOverlay(
-      this.elementRef,
-      this.overlay,
-      false,
-      this.placementInternal(),
-      false,
-      true,
-      this.scrollStrategy()
-    );
-    this.overlayref
-      .outsidePointerEvents()
-      .pipe(takeUntil(this.destroyer))
-      .subscribe(({ target }) => {
-        if (target !== this.elementRef.nativeElement) {
-          this.hide();
-        }
-      });
+
+    this.overlayref ??= this.createOverlay();
 
     const popoverPortal = new ComponentPortal(PopoverComponent);
-    const popoverRef: ComponentRef<PopoverComponent> = this.overlayref.attach(popoverPortal);
+    this.popoverRef = this.overlayref.attach(popoverPortal);
 
-    popoverRef.setInput('popoverDirective', this);
-
-    const positionStrategy = getPositionStrategy(this.overlayref);
-    positionStrategy?.positionChanges
-      .pipe(takeUntil(this.destroyer))
-      .subscribe(change => popoverRef.instance.updateArrow(change, this.elementRef));
+    this.popoverRef.setInput('popoverDirective', this);
 
     this.isOpen.set(true);
     this.visibilityChange.emit(true);
@@ -162,12 +143,7 @@ export class SiPopoverDirective implements OnDestroy {
    * Hides the popover and emits 'hidden' event.
    */
   hide(): void {
-    if (this.overlayref?.hasAttached()) {
-      this.overlayref?.detach();
-      this.isOpen.set(false);
-      this.visibilityChange.emit(false);
-      this.destroyer.next();
-    }
+    this.overlayref?.detach();
   }
 
   /**
@@ -183,5 +159,39 @@ export class SiPopoverDirective implements OnDestroy {
     } else {
       this.show();
     }
+  }
+
+  private createOverlay(): OverlayRef {
+    const overlayRef = getOverlay(
+      this.elementRef,
+      this.overlay,
+      false,
+      this.placementInternal(),
+      false,
+      true,
+      this.scrollStrategy()
+    );
+    overlayRef
+      .detachments()
+      .pipe(takeUntil(this.destroyer))
+      .subscribe(() => {
+        this.popoverRef = undefined;
+        if (this.isOpen()) {
+          this.isOpen.set(false);
+          this.visibilityChange.emit(false);
+        }
+      });
+    overlayRef
+      .outsidePointerEvents()
+      .pipe(takeUntil(this.destroyer))
+      .subscribe(({ target }) => {
+        if (target !== this.elementRef.nativeElement) {
+          this.hide();
+        }
+      });
+    getPositionStrategy(overlayRef)
+      ?.positionChanges.pipe(takeUntil(this.destroyer))
+      .subscribe(change => this.popoverRef?.instance.updateArrow(change, this.elementRef));
+    return overlayRef;
   }
 }


### PR DESCRIPTION
Reuse the overlay reference and synchronize popover state when the scroll strategy detaches it.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2487/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2487/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2487/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2487/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2487/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2487/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2487/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2487/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2487/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2487/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

