### PR TITLE
refactor(theme): migrate list and table tokens

### DIFF
--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.scss
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.scss
@@ -39,7 +39,7 @@
       inline-size: 100%;
       block-size: 2px;
       content: '';
-      background-color: variables.$element-focus-default !important; // stylelint-disable-line declaration-no-important
+      background-color: variables.$si-sys-effects-focus !important; // stylelint-disable-line declaration-no-important
     }
 
     > * {
@@ -76,7 +76,7 @@
 
     .si-tree-view-item-end-icons,
     .si-tree-view-li.si-tree-view-li-item {
-      background-color: variables.$element-base-3 !important; // stylelint-disable-line declaration-no-important
+      background-color: variables.$si-sys-background-3 !important; // stylelint-disable-line declaration-no-important
     }
   }
 }
@@ -124,7 +124,7 @@
       cursor: pointer;
 
       .si-tree-view-item-icon {
-        color: variables.$element-text-primary;
+        color: variables.$si-sys-text-primary;
       }
     }
   }
@@ -218,7 +218,7 @@
 .si-tree-view-item-dropdown-caret:hover,
 .si-tree-view-item-icon,
 .si-tree-view-item-icon:hover {
-  color: variables.$element-text-primary;
+  color: variables.$si-sys-text-primary;
   text-decoration: none;
   font-size: var(--si-tree-view-icon-size);
 }

--- a/projects/element-ng/tree-view/si-tree-view-variables.scss
+++ b/projects/element-ng/tree-view/si-tree-view-variables.scss
@@ -1,14 +1,14 @@
 @use '@siemens/element-theme/src/styles/variables';
 
-$si-tree-view-background: variables.$element-base-1;
-$si-tree-view-border-color: variables.$element-ui-4;
+$si-tree-view-background: variables.$si-sys-background-1;
+$si-tree-view-border-color: variables.$si-sys-border-4;
 $si-tree-view-icon-size: variables.$si-icon-font-size;
 
-$si-tree-view-item-hover-color: variables.$element-base-1-hover;
-$si-tree-view-item-select-color: variables.$element-base-1-selected;
+$si-tree-view-item-hover-color: variables.$si-sys-background-hover;
+$si-tree-view-item-select-color: variables.$si-sys-background-selected;
 $si-tree-view-item-line-height: variables.$si-line-height-body;
 $si-tree-view-item-min-height: 40px;
-$si-tree-view-item-object-data-field-1-color: variables.$element-text-secondary;
+$si-tree-view-item-object-data-field-1-color: variables.$si-sys-text-secondary;
 
 :host {
   --si-tree-view-background: #{$si-tree-view-background};

--- a/projects/element-theme/src/styles/components/_datatable.scss
+++ b/projects/element-theme/src/styles/components/_datatable.scss
@@ -4,6 +4,7 @@
 @use '../variables/focus';
 @use '../variables/semantic-tokens';
 @use '../variables/spacers';
+@use '../variables/system-tokens';
 @use '../variables/typography';
 @use '../variables/utilities';
 
@@ -11,10 +12,10 @@
 
 $datatable-header-border-color: variables.$table-border-color !default;
 $datatable-header-background-color: variables.$table-bg !default;
-$datatable-header-color: semantic-tokens.$element-text-primary !default;
+$datatable-header-color: system-tokens.$si-sys-text-primary !default;
 $datatable-footer-background-color: transparent !default;
 
-$datatable-summary-background-color: semantic-tokens.$element-base-4 !default;
+$datatable-summary-background-color: system-tokens.$si-sys-background-2 !default;
 
 $datatable-header-height: 40px !default;
 $datatable-cell-min-width: 40px !default;
@@ -22,12 +23,12 @@ $datatable-body-row-min-height: 48px !default;
 
 $datatable-ghost-cell-container-background: variables.$table-bg !default;
 
-$datatable-ghost-cell-strip-background: semantic-tokens.$element-base-1-hover !default;
+$datatable-ghost-cell-strip-background: system-tokens.$si-sys-background-hover !default;
 $datatable-ghost-cell-strip-background-image: linear-gradient(
   90deg,
-  semantic-tokens.$element-base-1-hover 0%,
-  semantic-tokens.$element-base-1-selected 25%,
-  semantic-tokens.$element-base-1-hover 50%
+  system-tokens.$si-sys-background-hover 0%,
+  system-tokens.$si-sys-background-selected 25%,
+  system-tokens.$si-sys-background-hover 50%
 ) !default;
 $datatable-ghost-cell-strip-radius: 0 !default;
 
@@ -189,7 +190,7 @@ $datatable-ghost-cell-strip-radius: 0 !default;
       .datatable-row-left {
         .datatable-body-cell:last-child,
         .datatable-header-cell:last-child {
-          box-shadow: 0 0 8px var(--element-box-shadow-color-1);
+          box-shadow: 0 0 8px system-tokens.$si-sys-effects-shadow-1;
           clip-path: inset(0 -8px 0 0);
         }
       }
@@ -197,7 +198,7 @@ $datatable-ghost-cell-strip-radius: 0 !default;
       .datatable-row-right {
         .datatable-body-cell:first-child,
         .datatable-header-cell:first-child {
-          box-shadow: 0 0 8px var(--element-box-shadow-color-1);
+          box-shadow: 0 0 8px system-tokens.$si-sys-effects-shadow-1;
           clip-path: inset(0 0 0 -8px);
         }
       }
@@ -224,7 +225,7 @@ $datatable-ghost-cell-strip-radius: 0 !default;
     // Resizable handle
     .resizeable:hover {
       .resize-handle {
-        background-color: semantic-tokens.$element-base-0;
+        background-color: system-tokens.$si-sys-background-0;
         inline-size: 2px;
         border-radius: 2px;
         padding-block: 0;
@@ -322,7 +323,7 @@ $datatable-ghost-cell-strip-radius: 0 !default;
     align-items: flex-end;
     align-content: flex-end;
     background-color: $datatable-footer-background-color;
-    color: semantic-tokens.$element-text-secondary;
+    color: system-tokens.$si-sys-text-secondary;
     font-size: typography.$si-font-size-caption;
     margin-block-start: -1px;
     position: relative;
@@ -341,7 +342,7 @@ $datatable-ghost-cell-strip-radius: 0 !default;
         inset-inline-start: 0;
         inline-size: 100%;
         block-size: 1px;
-        background-color: var(--element-base-0);
+        background-color: system-tokens.$si-sys-background-0;
       }
     }
   }


### PR DESCRIPTION
Migrate Tree View and Data Table styling from legacy Element semantic tokens to the new system tokens.

The mappings follow `migration-map.json` and were checked against the Figma default, hover, selected, and focus states.

Validation:
- `pnpm exec stylelint projects/element-ng/tree-view/**/*.scss projects/element-theme/src/styles/components/_datatable.scss`
- `pnpm exec ng test element-ng --include='**/tree-view/si-tree-view.component.spec.ts' --no-watch`
- `pnpm lib:build`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2493/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2493/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2493/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2493/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2493/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2493/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2493/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2493/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2493/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2493/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

