### PR TITLE
build(api-goldens): bump api extractor

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@commitlint/cli": "21.2.1",
     "@commitlint/config-conventional": "21.2.0",
     "@eslint/js": "10.0.1",
-    "@microsoft/api-extractor": "7.58.9",
+    "@microsoft/api-extractor": "7.58.12",
     "@playwright/test": "1.62.1",
     "@schematics/angular": "22.1.2",
     "@semantic-release/changelog": "7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,8 +161,8 @@ importers:
         specifier: 10.0.1
         version: 10.0.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       '@microsoft/api-extractor':
-        specifier: 7.58.9
-        version: 7.58.9(@types/node@24.13.3)
+        specifier: 7.58.12
+        version: 7.58.12(@types/node@24.13.3)
       '@playwright/test':
         specifier: 1.62.1
         version: 1.62.1
@@ -2092,11 +2092,11 @@ packages:
   '@meteocons/svg-static@0.1.0':
     resolution: {integrity: sha512-dnuXOkt1W5q+XZbyj54dzjuBcKmsC0eLv51IVaW9kzzvzwnhwv9KgNXHKgpvmdN6cX2stMo+k95iMFbcyM4x5Q==, tarball: https://registry.npmjs.org/@meteocons/svg-static/-/svg-static-0.1.0.tgz}
 
-  '@microsoft/api-extractor-model@7.33.8':
-    resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==, tarball: https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.8.tgz}
+  '@microsoft/api-extractor-model@7.33.10':
+    resolution: {integrity: sha512-uPUK17xGxeQ3av6TN7awp+dTTSTvx8fZC0XFL1gyt7hFapYuxND3XLXH8vkmI7UjfW92oogzFAFqHSifmJROaw==, tarball: https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.10.tgz}
 
-  '@microsoft/api-extractor@7.58.9':
-    resolution: {integrity: sha512-S2UF4yza5GoxCmf7hJQNxJNZN9ltOVuOQv8Dy+Z21aol5ERoBNMdWcQHm4MJMPPItW4H/4rZD906iaf4mUojJA==, tarball: https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.9.tgz}
+  '@microsoft/api-extractor@7.58.12':
+    resolution: {integrity: sha512-VNpgC/1LaroLbn+UKmwDYspq+9r3EHyj4vJ3qUy/g8vB0rKt+1Wgs7WFj/JGpgxhG8SNyXs1XwYwe7nqkk8IDg==, tarball: https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.12.tgz}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.18.1':
@@ -3233,8 +3233,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  '@rushstack/node-core-library@5.23.1':
-    resolution: {integrity: sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==, tarball: https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz}
+  '@rushstack/node-core-library@5.23.3':
+    resolution: {integrity: sha512-f6uuza7Um65bwsIJgf0MRs7IPA5IG+A+zs1AYGQvpZmLjtTGdfHowhQw4kwF0pPhJCrU4UHNhK8Qa6tLygYZCA==, tarball: https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.3.tgz}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -3252,16 +3252,16 @@ packages:
   '@rushstack/rig-package@0.7.3':
     resolution: {integrity: sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==, tarball: https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz}
 
-  '@rushstack/terminal@0.24.0':
-    resolution: {integrity: sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==, tarball: https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.0.tgz}
+  '@rushstack/terminal@0.24.2':
+    resolution: {integrity: sha512-KB7PpvzDyKMw/RGU3TxOwxTs3OwZ4gq6+WHlTJN/JfQH4ezliNtWIqver78jTaAJyz/ZAAlJGH7a/M1WyFLFSw==, tarball: https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.2.tgz}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/ts-command-line@5.3.10':
-    resolution: {integrity: sha512-fwI076HYknC0IrMXdY6UmjDv+PH7NHhNJX3/pY2UblSE5XrXgndXZPiOe/6ZtuFpn6DvVDVNhtkIzQ+Qu/MhVQ==, tarball: https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.10.tgz}
+  '@rushstack/ts-command-line@5.3.12':
+    resolution: {integrity: sha512-Vg2n24arSf7JvUNga2DMHYTbxnVq9L5OtVCp4Gfr8YC/kmL/bmdR8FQhGcpMzMYNY9Vdw3+TaimG11Sf+z1Tpw==, tarball: https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.12.tgz}
 
   '@schematics/angular@22.0.8':
     resolution: {integrity: sha512-zD2WLe15SoKYyBZH1GTLLaVABNNObHkH4soQqXb9agN6zkrpE0naeWaBSFSWD+95VKCiMZl8LkiOXvK+6b8S6w==, tarball: https://registry.npmjs.org/@schematics/angular/-/angular-22.0.8.tgz}
@@ -10162,23 +10162,23 @@ snapshots:
 
   '@meteocons/svg-static@0.1.0': {}
 
-  '@microsoft/api-extractor-model@7.33.8(@types/node@24.13.3)':
+  '@microsoft/api-extractor-model@7.33.10(@types/node@24.13.3)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@24.13.3)
+      '@rushstack/node-core-library': 5.23.3(@types/node@24.13.3)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.58.9(@types/node@24.13.3)':
+  '@microsoft/api-extractor@7.58.12(@types/node@24.13.3)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.8(@types/node@24.13.3)
+      '@microsoft/api-extractor-model': 7.33.10(@types/node@24.13.3)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@24.13.3)
+      '@rushstack/node-core-library': 5.23.3(@types/node@24.13.3)
       '@rushstack/rig-package': 0.7.3
-      '@rushstack/terminal': 0.24.0(@types/node@24.13.3)
-      '@rushstack/ts-command-line': 5.3.10(@types/node@24.13.3)
+      '@rushstack/terminal': 0.24.2(@types/node@24.13.3)
+      '@rushstack/ts-command-line': 5.3.12(@types/node@24.13.3)
       diff: 8.0.4
       minimatch: 10.2.3
       resolve: 1.22.12
@@ -11119,10 +11119,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  '@rushstack/node-core-library@5.23.1(@types/node@24.13.3)':
+  '@rushstack/node-core-library@5.23.3(@types/node@24.13.3)':
     dependencies:
-      ajv: 8.18.0
-      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-draft-04: 1.0.0(ajv@8.20.0)
       ajv-formats: 3.0.1
       fs-extra: 11.3.6
       import-lazy: 4.0.0
@@ -11141,17 +11141,17 @@ snapshots:
       jju: 1.4.0
       resolve: 1.22.12
 
-  '@rushstack/terminal@0.24.0(@types/node@24.13.3)':
+  '@rushstack/terminal@0.24.2(@types/node@24.13.3)':
     dependencies:
-      '@rushstack/node-core-library': 5.23.1(@types/node@24.13.3)
+      '@rushstack/node-core-library': 5.23.3(@types/node@24.13.3)
       '@rushstack/problem-matcher': 0.2.1(@types/node@24.13.3)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 24.13.3
 
-  '@rushstack/ts-command-line@5.3.10(@types/node@24.13.3)':
+  '@rushstack/ts-command-line@5.3.12(@types/node@24.13.3)':
     dependencies:
-      '@rushstack/terminal': 0.24.0(@types/node@24.13.3)
+      '@rushstack/terminal': 0.24.2(@types/node@24.13.3)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -12016,9 +12016,9 @@ snapshots:
       clean-stack: 5.3.0
       indent-string: 5.0.0
 
-  ajv-draft-04@1.0.0(ajv@8.18.0):
+  ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv-formats@2.1.1:
     dependencies:

--- a/tools/api-goldens/test_api_report.ts
+++ b/tools/api-goldens/test_api_report.ts
@@ -7,7 +7,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {
-  ApiReportVariant,
   ConsoleMessageId,
   Extractor,
   ExtractorConfig,
@@ -20,7 +19,6 @@ import { AstDeclaration } from '@microsoft/api-extractor/lib/analyzer/AstDeclara
 import { AstModule } from '@microsoft/api-extractor/lib/analyzer/AstModule';
 import { ExportAnalyzer } from '@microsoft/api-extractor/lib/analyzer/ExportAnalyzer';
 import { Collector } from '@microsoft/api-extractor/lib/collector/Collector';
-import { ApiReportGenerator } from '@microsoft/api-extractor/lib/generators/ApiReportGenerator';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -48,12 +46,10 @@ const _angularLifecycleHooks = [
   'ngAfterViewChecked',
   'ngOnDestroy'
 ];
+const _internalReleaseTag = 1;
 
-/**
- * Original definition of private static `ApiReportGenerator#_shouldIncludeDeclaration` for
- * monkey patching to skip Angular related stuff.
- */
-const _orig_shouldIncludeDeclaration = (ApiReportGenerator as any)._shouldIncludeDeclaration;
+/** Original `Collector#fetchApiItemMetadata` method, patched for Angular declarations below. */
+const _origFetchApiItemMetadata = Collector.prototype.fetchApiItemMetadata;
 
 function skipAngular(astDeclaration: AstDeclaration): boolean {
   // check if this is an Angular component/directive/module
@@ -185,20 +181,22 @@ export async function testApiGolden(
     return info;
   };
 
-  // Patch the report generator to skip some Angular related stuff
-  (ApiReportGenerator as any)._shouldIncludeDeclaration = function (
-     collector: Collector,
-     astDeclaration: AstDeclaration,
-     reportVariant: ApiReportVariant
-  ): boolean {
-   if (skipAngular(astDeclaration)) {
-     return false;
-   }
-   return _orig_shouldIncludeDeclaration.apply(
-     ApiReportGenerator,
-     [collector, astDeclaration, reportVariant]
-   );
-  }
+  Collector.prototype.fetchApiItemMetadata = function (astDeclaration: AstDeclaration) {
+    const metadata = _origFetchApiItemMetadata.apply(this, [astDeclaration]);
+    if (!skipAngular(astDeclaration)) {
+      return metadata;
+    }
+
+    // `effectiveReleaseTag` is readonly, therefore proxy the report-time read and treat ignored
+    // Angular declarations as `@internal`.
+    return new Proxy(metadata, {
+      get(target, property, receiver) {
+        return property === 'effectiveReleaseTag'
+          ? _internalReleaseTag
+          : Reflect.get(target, property, receiver);
+      }
+    });
+  };
 
   const reportTmpOutPath = path.join(
     tempDir,


### PR DESCRIPTION
The new version no longer allows filtering items as before. Adjusting the code to only use pulic APIs.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2501/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2501/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2501/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2501/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2501/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2501/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2501/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2501/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2501/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2501/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

