### PR TITLE
refactor(dashboard): migrate widgets to system tokens

### DIFF
--- a/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.scss
+++ b/projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.scss
@@ -2,7 +2,7 @@
 @use '@siemens/element-theme/src/styles/variables';
 
 :host {
-  background-color: variables.$element-base-1;
+  background-color: variables.$si-sys-background-1;
   border-radius: variables.$element-radius-3;
   display: flex;
   flex-direction: column;

--- a/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-body.component.scss
+++ b/projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-body.component.scss
@@ -2,7 +2,7 @@
 @use '@siemens/element-theme/src/styles/variables';
 
 :host {
-  background-color: variables.$element-base-1;
+  background-color: variables.$si-sys-background-1;
   flex: auto;
   overflow: hidden;
 }

--- a/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-body.component.scss
+++ b/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-body.component.scss
@@ -57,16 +57,16 @@
     typography.$si-line-height-display-xl,
     typography.$si-font-weight-display-xl
   );
-  color: variables.$element-text-primary;
+  color: variables.$si-sys-text-primary;
 }
 
 .si-weather-widget-condition {
-  color: variables.$element-text-primary;
+  color: variables.$si-sys-text-primary;
 }
 
 .si-weather-widget-location {
   font-weight: variables.$si-font-weight-semibold;
-  color: variables.$element-text-primary;
+  color: variables.$si-sys-text-primary;
 }
 
 .si-weather-widget-range {
@@ -75,11 +75,11 @@
 }
 
 .si-weather-widget-range-min {
-  color: variables.$element-text-secondary;
+  color: variables.$si-sys-text-secondary;
 }
 
 .si-weather-widget-range-max {
-  color: variables.$element-text-primary;
+  color: variables.$si-sys-text-primary;
   font-weight: variables.$si-font-weight-semibold;
 }
 
@@ -101,11 +101,11 @@
 }
 
 .si-weather-widget-metric-label {
-  color: variables.$element-text-secondary;
+  color: variables.$si-sys-text-secondary;
 }
 
 .si-weather-widget-metric-value {
-  color: variables.$element-text-primary;
+  color: variables.$si-sys-text-primary;
   font-weight: variables.$si-font-weight-semibold;
   text-align: end;
 }

--- a/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-forecast.component.scss
+++ b/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-forecast.component.scss
@@ -22,11 +22,11 @@
 }
 
 .si-weather-widget-forecast-range-min {
-  color: variables.$element-text-secondary;
+  color: variables.$si-sys-text-secondary;
 }
 
 .si-weather-widget-forecast-range-max {
-  color: variables.$element-text-primary;
+  color: variables.$si-sys-text-primary;
   font-weight: variables.$si-font-weight-semibold;
 }
 
@@ -132,7 +132,7 @@
 }
 
 .si-weather-widget-forecast-day-label {
-  color: variables.$element-text-secondary;
+  color: variables.$si-sys-text-secondary;
   margin-block: map.get(variables.$spacers, 4);
   // The label track is `max-content`; prevent wrapping if the container
   // ever constrains the row below `max-content` (e.g. very large root font
@@ -289,6 +289,6 @@
   display: inline-flex;
   vertical-align: middle;
   margin-inline-end: map.get(variables.$spacers, 1);
-  color: variables.$element-text-secondary;
+  color: variables.$si-sys-text-secondary;
   margin-block: map.get(variables.$spacers, 3);
 }


### PR DESCRIPTION
## Summary

- migrate List and Timeline widget backgrounds to semantic system tokens
- migrate Weather widget text colors to primary and secondary semantic system tokens
- preserve existing layout and component behavior

## Testing

- `pnpm lib:test --include='**/dashboard/widgets/si-{weather,timeline,list}-widget/**/*.spec.ts' --no-watch` (79 tests passed)
- `pnpm exec stylelint projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-body.component.scss projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-forecast.component.scss projects/element-ng/dashboard/widgets/si-timeline-widget/si-timeline-widget-body.component.scss projects/element-ng/dashboard/widgets/si-list-widget/si-list-widget-body.component.scss`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2502/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2502/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2502/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2502/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2502/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2502/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2502/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2502/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2502/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2502/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
