### PR TITLE
refactor(maps): migrate to system tokens

### DIFF
--- a/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.scss
+++ b/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.scss
@@ -8,8 +8,8 @@
   max-inline-size: max-content;
   padding-block: map.get(variables.$spacers, 2);
   padding-inline: map.get(variables.$spacers, 4);
-  color: variables.$element-ui-5;
-  background-color: variables.$element-ui-1;
+  color: variables.$si-sys-text-inverse;
+  background-color: variables.$si-sys-background-inverse;
   border-radius: variables.$element-radius-1;
 
   &::before {

--- a/projects/maps-ng/src/components/si-map/shared/themes/element.ts
+++ b/projects/maps-ng/src/components/si-map/shared/themes/element.ts
@@ -14,32 +14,32 @@ export const themeElement = {
   style: () => {
     const style = window.getComputedStyle(document.documentElement);
     const status: Record<MarkerStatusType, string> = {
-      info: getProp(style, '--element-status-information'), // $element-status-information / $siemens-blue-500
-      success: getProp(style, '--element-status-success'), // $element-status-success / $siemens-green-700
-      warning: getProp(style, '--element-status-warning'), // $element-status-warning / $siemens-orange-700
-      danger: getProp(style, '--element-status-danger'), // $element-status-danger / $siemens-red-500
-      caution: getProp(style, '--element-status-caution'), // $element-status-caution / $siemens-yellow-500
-      critical: getProp(style, '--element-status-critical'), // $element-status-critical / $siemens-red-900
-      default: getProp(style, '--element-ui-0'), // $element-ui-0 / $siemens-interactive-blue-500
-      unknown: getProp(style, '--element-ui-3') // $element-ui-3 / $siemens-deep-blue-400
+      info: getProp(style, '--si-sys-background-information'),
+      success: getProp(style, '--si-sys-background-success'),
+      warning: getProp(style, '--si-sys-background-warning'),
+      danger: getProp(style, '--si-sys-background-danger'),
+      caution: getProp(style, '--si-sys-background-caution'),
+      critical: getProp(style, '--si-sys-background-critical'),
+      default: getProp(style, '--si-sys-background-accent'),
+      unknown: getProp(style, '--si-sys-background-neutral')
     };
 
     return {
-      fillColor: getProp(style, '--element-base-1'), // $element-base-1 / $siemens-white
-      strokeColor: getProp(style, '--element-base-1'), // $element-base-1 / $siemens-white
-      textColor: getProp(style, '--element-text-primary'), // $element-text-primary / $siemens-deep-blue-900
-      defaultMarkerColor: getProp(style, '--element-text-primary'), // $element-text-primary / $siemens-deep-blue-900
+      fillColor: getProp(style, '--si-sys-background-1'),
+      strokeColor: getProp(style, '--si-sys-background-1'),
+      textColor: getProp(style, '--si-sys-text-primary'),
+      defaultMarkerColor: getProp(style, '--si-sys-text-primary'),
       status,
       colorPalette: {
         status: [status.info, status.success, status.warning, status.danger],
         element: [
-          getProp(style, '--element-data-red-2'), // $siemens-red-500
-          getProp(style, '--element-data-orange-4'), // $siemens-orange-700
-          getProp(style, '--element-status-caution'), // $siemens-yellow-300
-          getProp(style, '--element-data-green-2'), // $siemens-green-500
-          getProp(style, '--element-status-information'), // $siemens-blue-500
-          getProp(style, '--element-petrol'), // $element-petrol
-          getProp(style, '--element-data-17') // $siemens-deep-blue-500
+          getProp(style, '--si-sys-data-sequential-red-2'),
+          getProp(style, '--si-sys-data-sequential-orange-4'),
+          getProp(style, '--si-sys-background-caution'),
+          getProp(style, '--si-sys-data-sequential-green-2'),
+          getProp(style, '--si-sys-background-information'),
+          getProp(style, '--si-sys-data-categorial-1'),
+          getProp(style, '--si-sys-data-categorial-17')
         ]
       } as ColorPalettes
     };

--- a/projects/maps-ng/src/components/si-map/si-map.component.scss
+++ b/projects/maps-ng/src/components/si-map/si-map.component.scss
@@ -24,8 +24,8 @@ $main-button-margin: 1px;
       align-items: center;
       justify-content: center;
       position: relative;
-      background: variables.$element-base-3;
-      color: variables.$element-action-secondary-text;
+      background: variables.$si-sys-background-3;
+      color: variables.$si-sys-text-accent;
       margin: 0;
       line-height: 1;
       border-radius: 0;
@@ -35,8 +35,8 @@ $main-button-margin: 1px;
       outline: none;
 
       &:hover {
-        color: variables.$element-action-secondary-text-hover;
-        background: variables.$element-action-secondary-hover;
+        color: variables.$si-sys-text-accent-hover;
+        background: variables.$si-sys-background-accent-secondary-hover;
       }
 
       &:focus-visible {

--- a/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
@@ -30,21 +30,21 @@ describe('SiMapComponent', () => {
 
   beforeAll(() => {
     // Define style variables from element.ts to prevent test failures
-    document.documentElement.style.setProperty('--element-status-information', '#0070F2');
-    document.documentElement.style.setProperty('--element-status-success', '#00A04B');
-    document.documentElement.style.setProperty('--element-status-warning', '#FF7F00');
-    document.documentElement.style.setProperty('--element-status-danger', '#D8371C');
-    document.documentElement.style.setProperty('--element-status-caution', '#FFD322');
-    document.documentElement.style.setProperty('--element-status-critical', '#B71E24');
-    document.documentElement.style.setProperty('--element-ui-0', '#0070F2');
-    document.documentElement.style.setProperty('--element-ui-3', '#004987');
-    document.documentElement.style.setProperty('--element-base-1', '#FFFFFF');
-    document.documentElement.style.setProperty('--element-text-primary', '#1F2937');
-    document.documentElement.style.setProperty('--element-data-red-2', '#D8371C');
-    document.documentElement.style.setProperty('--element-data-orange-4', '#FF7F00');
-    document.documentElement.style.setProperty('--element-data-green-2', '#00A04B');
-    document.documentElement.style.setProperty('--element-petrol', '#007C7C');
-    document.documentElement.style.setProperty('--element-data-17', '#004A87');
+    document.documentElement.style.setProperty('--si-sys-background-information', '#0070F2');
+    document.documentElement.style.setProperty('--si-sys-background-success', '#00A04B');
+    document.documentElement.style.setProperty('--si-sys-background-warning', '#FF7F00');
+    document.documentElement.style.setProperty('--si-sys-background-danger', '#D8371C');
+    document.documentElement.style.setProperty('--si-sys-background-caution', '#FFD322');
+    document.documentElement.style.setProperty('--si-sys-background-critical', '#B71E24');
+    document.documentElement.style.setProperty('--si-sys-background-accent', '#0070F2');
+    document.documentElement.style.setProperty('--si-sys-border-3', '#004987');
+    document.documentElement.style.setProperty('--si-sys-background-1', '#FFFFFF');
+    document.documentElement.style.setProperty('--si-sys-text-primary', '#1F2937');
+    document.documentElement.style.setProperty('--si-sys-data-sequential-red-2', '#D8371C');
+    document.documentElement.style.setProperty('--si-sys-data-sequential-orange-4', '#FF7F00');
+    document.documentElement.style.setProperty('--si-sys-data-sequential-green-2', '#00A04B');
+    document.documentElement.style.setProperty('--si-sys-data-categorial-1', '#007C7C');
+    document.documentElement.style.setProperty('--si-sys-data-categorial-17', '#004A87');
   });
 
   beforeEach(() => {


### PR DESCRIPTION
Migrate maps component styling and the runtime OpenLayers color palette from legacy Element tokens to the new system tokens. Update the map component test setup to use the same system-token contract.

The existing radius token remains unchanged because `migration-map.json` does not define a system-token replacement.

Tests: `pnpm maps:test --no-watch` (32 passed)<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2503/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2503/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2503/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2503/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2503/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2503/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2503/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2503/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2503/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2503/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

