### PR TITLE
refactor(landing-page): migrate to system tokens

### DIFF
--- a/projects/element-ng/landing-page/si-landing-page.component.scss
+++ b/projects/element-ng/landing-page/si-landing-page.component.scss
@@ -36,7 +36,7 @@ $margin-bottom-footer: map.get(all-variables.$spacers, 9);
   block-size: 100vb;
   overflow-y: auto;
   inline-size: 40%;
-  background-color: all-variables.$element-base-0;
+  background-color: all-variables.$si-sys-background-0;
   padding-block: $margin-bottom-header $margin-bottom-footer;
   padding-inline: $margin-content;
 
@@ -94,7 +94,7 @@ $margin-bottom-footer: map.get(all-variables.$spacers, 9);
 }
 
 footer {
-  color: all-variables.$element-text-secondary;
+  color: all-variables.$si-sys-text-secondary;
 }
 
 // large tablet


### PR DESCRIPTION
## Summary

- migrate the landing page background from the legacy base token to `si-sys-background-0`
- migrate footer text from the legacy secondary text token to `si-sys-text-secondary`
- preserve the existing landing page API, layout, and responsive behavior

## Testing

- `pnpm lib:test --include='**/landing-page/si-landing-page.component.spec.ts' --no-watch`
- `pnpm ng build element-ng`
- `git diff --check`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2504/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2504/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2504/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2504/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2504/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2504/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2504/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2504/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2504/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2504/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
