### PR TITLE
test(tooltip): stabilize ElementRef interaction test

### DIFF
--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -270,6 +270,7 @@ describe('SiTooltipDirective', () => {
       component = fixture.componentInstance;
       fixture.detectChanges();
       button = component.anchor().nativeElement;
+      button.style.pointerEvents = 'none';
       vi.spyOn(button, 'matches').mockImplementation(selector => selector === ':focus-visible');
       component.createTooltip();
     });


### PR DESCRIPTION
Disable native pointer interaction for the ElementRef tooltip fixture so browser hover state cannot reopen the tooltip during synthetic focus-event tests.

This was missing before the second describe block.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2508/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2508/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2508/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2508/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2508/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2508/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2508/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2508/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2508/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2508/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
