### PR TITLE
chore: remove expired pnpm release age exception

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,6 +42,3 @@ allowBuilds:
 # registries (e.g. resolves to brand-3.1.0.tgz instead of @simpl/brand-3.1.0.tgz).
 # That mismatch causes ERR_PNPM_FETCH_404 on a clean install.
 lockfileIncludeTarballUrl: true
-
-minimumReleaseAgeExclude:
-  - '@maplibre/ngx-maplibre-gl@22.0.0'


### PR DESCRIPTION
## Summary

Remove the version-specific `minimumReleaseAgeExclude` entry for `@maplibre/ngx-maplibre-gl@22.0.0`. The release is now older than pnpm's one-day minimum release age, so the exception no longer affects dependency resolution.

## Validation

- `pnpm config get minimumReleaseAgeExclude` returns `undefined`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2512/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2512/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2512/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2512/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2512/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2512/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2512/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2512/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2512/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2512/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
