### PR TITLE
build: parallelize library builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:examples": "ng build",
     "build:examples:prod": "ng build --configuration production",
     "build:examples:aot": "ng build --configuration aot",
-    "build:all": "pnpm run translate:build && pnpm run lib:build && pnpm run schematics:build && pnpm run live-preview:build && pnpm run charts:build && pnpm run native-charts:build && pnpm run dashboards:build && pnpm run map-styles:build && pnpm run maps:build",
+    "build:all": "pnpm run translate:build && pnpm run \"/^(lib|schematics|live-preview|charts|native-charts|dashboards|map-styles|maps):build$/\"",
     "build:all:update-translatable-keys": "pnpm --filter . exec update-translatable-keys",
     "lib:build": "ng build element-ng && cpy \"projects/element-ng/*.scss\" \"./dist/@siemens/element-ng\" && cpy \"README.md\" \"./dist/@siemens/element-ng/\"",
     "lib:test": "ng test element-ng",


### PR DESCRIPTION
## Summary

- build `element-translate-ng` first because other packages consume its generated output
- run the remaining independent library build scripts concurrently using pnpm's regex script selection
- keep the existing `pnpm run build:all` entry point unchanged for CI and local use

## Motivation

The `pnpm run build:all` GitHub Actions step currently takes about 3 minutes because every library build runs serially.

## Validation

- `pnpm run build:all`
- local serial baseline: 114.4 seconds
- local parallel build: 84.5 seconds
- local wall-clock reduction: about 26%

The PR workflow will provide the authoritative GitHub Actions timing.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2514/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2514/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2514/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2514/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2514/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2514/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2514/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2514/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2514/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2514/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


