### PR TITLE
feat(header-dropdown): add radio and check items

### DIFF
--- a/projects/element-ng/header-dropdown/index.ts
+++ b/projects/element-ng/header-dropdown/index.ts
@@ -5,5 +5,7 @@
 export * from './si-header-dropdown.component';
 export * from './si-header-dropdown-trigger.directive';
 export * from './si-header-dropdown-item.component';
+export * from './si-header-dropdown-radio-item.component';
+export * from './si-header-dropdown-check-item.component';
 export * from './si-header-dropdown-items-factory.component';
 export * from './si-header.model';

--- a/projects/element-ng/header-dropdown/si-header-dropdown-check-item.component.html
+++ b/projects/element-ng/header-dropdown/si-header-dropdown-check-item.component.html
@@ -1,0 +1,20 @@
+@if (icon()) {
+  <si-icon class="icon" [icon]="icon()!" />
+}
+@if (iconBadge()) {
+  <div class="badge-text">{{ iconBadge() }}</div>
+}
+<span class="item-title text-truncate">
+  <ng-content />
+</span>
+<div class="item-end ps-2 d-flex me-n3 ms-auto gap-1">
+  @if (badge()) {
+    <span class="mx-0 me-1 ms-2 badge" [class]="`bg-${badgeColor() || 'default'}`">{{ badge() }}</span>
+  }
+  @if (checked()) {
+    <si-icon class="icon" [icon]="icons.elementOk" />
+  }
+  @if (ownTrigger) {
+    <si-icon class="dropdown-caret m-0 ps-0" [icon]="icons.elementDown2" />
+  }
+</div>

--- a/projects/element-ng/header-dropdown/si-header-dropdown-check-item.component.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown-check-item.component.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, model } from '@angular/core';
+import { elementDown2, elementOk } from '@siemens/element-icons';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
+
+import { SiHeaderDropdownItemBase } from './si-header-dropdown-item-base.directive';
+
+/** Creates a check dropdown item. Must be used within an {@link SiHeaderDropdownComponent}. */
+@Component({
+  selector: 'si-header-dropdown-check-item, a[si-header-dropdown-check-item], button[si-header-dropdown-check-item]',
+  imports: [SiIconComponent],
+  templateUrl: './si-header-dropdown-check-item.component.html',
+  styleUrl: './si-header-dropdown-item.component.scss',
+  host: {
+    class: 'dropdown-item focus-inside',
+    role: 'checkbox',
+    '[attr.aria-checked]': 'checked() ? "true" : "false"',
+    '(click)': 'toggle()'
+  }
+})
+export class SiHeaderDropdownCheckItemComponent extends SiHeaderDropdownItemBase {
+  protected readonly icons = addIcons({ elementDown2, elementOk });
+  /** Whether the check item is checked. Supports two-way binding through `checkedChange`. */
+  readonly checked = model.required<boolean>();
+
+  protected toggle(): void {
+    this.checked.update(checked => !checked);
+    this.click();
+  }
+}

--- a/projects/element-ng/header-dropdown/si-header-dropdown-item-base.directive.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown-item-base.directive.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Directive, inject, input } from '@angular/core';
+
+import { SiHeaderDropdownTriggerDirective } from './si-header-dropdown-trigger.directive';
+import { SI_HEADER_WITH_DROPDOWNS } from './si-header.model';
+
+@Directive()
+export abstract class SiHeaderDropdownItemBase {
+  /** Optional icon that will be rendered before the label. */
+  readonly icon = input<string>();
+  /** Badge that is rendered after the label. */
+  readonly badge = input<string | number>();
+  /** Badge (always red) that is attached to the icon. */
+  readonly iconBadge = input<string | number>();
+  /** Color of the badge (not iconBadge). */
+  readonly badgeColor = input<string>();
+
+  protected readonly ownTrigger = inject(SiHeaderDropdownTriggerDirective, {
+    self: true,
+    optional: true
+  });
+  protected readonly parentTrigger = inject(SiHeaderDropdownTriggerDirective, { skipSelf: true });
+  protected readonly navbar = inject(SI_HEADER_WITH_DROPDOWNS, { optional: true });
+
+  protected click(): void {
+    if (!this.ownTrigger) {
+      this.parentTrigger.close({ all: true });
+      this.navbar?.onDropdownItemTriggered?.();
+    }
+  }
+}

--- a/projects/element-ng/header-dropdown/si-header-dropdown-item.component.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown-item.component.ts
@@ -2,12 +2,11 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component, inject, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { elementDown2, elementOk, elementRecordFilled } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 
-import { SiHeaderDropdownTriggerDirective } from './si-header-dropdown-trigger.directive';
-import { SI_HEADER_WITH_DROPDOWNS } from './si-header.model';
+import { SiHeaderDropdownItemBase } from './si-header-dropdown-item-base.directive';
 
 /**
  * Creates a dropdown-item. Must be used within an {@link SiHeaderDropdownComponent}.
@@ -23,33 +22,12 @@ import { SI_HEADER_WITH_DROPDOWNS } from './si-header.model';
     '(click)': 'click()'
   }
 })
-export class SiHeaderDropdownItemComponent {
+export class SiHeaderDropdownItemComponent extends SiHeaderDropdownItemBase {
   protected readonly icons = addIcons({ elementDown2, elementOk, elementRecordFilled });
 
-  /** Optional icon that will be rendered before the label. */
-  readonly icon = input<string>();
-  /** Badge that is rendered after the label. */
-  readonly badge = input<string | number>();
-  /** Badge (always red) that is attached to the icon. */
-  readonly iconBadge = input<string | number>();
-  /** Color of the badge (not iconBadge). */
-  readonly badgeColor = input<string>();
-  /** Whether the icon is checked with a radio or check mark. */
+  /**
+   * Whether the icon is checked with a radio or check mark.
+   * @deprecated Use `si-header-dropdown-radio-item` or `si-header-dropdown-check-item` instead.
+   */
   readonly checked = input<'radio' | 'check' | ''>();
-
-  protected readonly ownTrigger = inject(SiHeaderDropdownTriggerDirective, {
-    self: true,
-    optional: true
-  });
-  protected readonly parentTrigger = inject(SiHeaderDropdownTriggerDirective, { skipSelf: true });
-  protected readonly navbar = inject(SI_HEADER_WITH_DROPDOWNS, { optional: true });
-
-  protected click(): void {
-    if (!this.ownTrigger) {
-      this.parentTrigger.close({ all: true });
-      if (this.navbar?.onDropdownItemTriggered) {
-        this.navbar?.onDropdownItemTriggered();
-      }
-    }
-  }
 }

--- a/projects/element-ng/header-dropdown/si-header-dropdown-radio-item.component.html
+++ b/projects/element-ng/header-dropdown/si-header-dropdown-radio-item.component.html
@@ -1,0 +1,20 @@
+@if (icon()) {
+  <si-icon class="icon" [icon]="icon()!" />
+}
+@if (iconBadge()) {
+  <div class="badge-text">{{ iconBadge() }}</div>
+}
+<span class="item-title text-truncate">
+  <ng-content />
+</span>
+<div class="item-end ps-2 d-flex me-n3 ms-auto gap-1">
+  @if (badge()) {
+    <span class="mx-0 me-1 ms-2 badge" [class]="`bg-${badgeColor() || 'default'}`">{{ badge() }}</span>
+  }
+  @if (checked()) {
+    <si-icon class="icon-sm me-2" [icon]="icons.elementRecordFilled" />
+  }
+  @if (ownTrigger) {
+    <si-icon class="dropdown-caret m-0 ps-0" [icon]="icons.elementDown2" />
+  }
+</div>

--- a/projects/element-ng/header-dropdown/si-header-dropdown-radio-item.component.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown-radio-item.component.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, model } from '@angular/core';
+import { elementDown2, elementRecordFilled } from '@siemens/element-icons';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
+
+import { SiHeaderDropdownItemBase } from './si-header-dropdown-item-base.directive';
+
+/** Creates a radio dropdown item. Must be used within an {@link SiHeaderDropdownComponent}. */
+@Component({
+  selector: 'si-header-dropdown-radio-item, a[si-header-dropdown-radio-item], button[si-header-dropdown-radio-item]',
+  imports: [SiIconComponent],
+  templateUrl: './si-header-dropdown-radio-item.component.html',
+  styleUrl: './si-header-dropdown-item.component.scss',
+  host: {
+    class: 'dropdown-item focus-inside',
+    role: 'radio',
+    '[attr.aria-checked]': 'checked() ? "true" : "false"',
+    '(click)': 'select()'
+  }
+})
+export class SiHeaderDropdownRadioItemComponent extends SiHeaderDropdownItemBase {
+  protected readonly icons = addIcons({ elementDown2, elementRecordFilled });
+  /** Whether the radio item is checked. Supports two-way binding through `checkedChange`. */
+  readonly checked = model.required<boolean>();
+
+  protected select(): void {
+    this.checked.set(true);
+    this.click();
+  }
+}

--- a/projects/element-ng/header-dropdown/si-header-dropdown.directive.spec.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown.directive.spec.ts
@@ -8,6 +8,8 @@ import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SiHeaderDropdownItemComponent } from './si-header-dropdown-item.component';
+import { SiHeaderDropdownCheckItemComponent } from './si-header-dropdown-check-item.component';
+import { SiHeaderDropdownRadioItemComponent } from './si-header-dropdown-radio-item.component';
 import { SiHeaderDropdownTriggerDirective } from './si-header-dropdown-trigger.directive';
 import { SiHeaderDropdownComponent } from './si-header-dropdown.component';
 import { HeaderWithDropdowns, SI_HEADER_WITH_DROPDOWNS } from './si-header.model';
@@ -17,6 +19,8 @@ import { SiHeaderDropdownTriggerHarness } from './testing/si-header-dropdown-tri
   imports: [
     SiHeaderDropdownComponent,
     SiHeaderDropdownItemComponent,
+    SiHeaderDropdownCheckItemComponent,
+    SiHeaderDropdownRadioItemComponent,
     SiHeaderDropdownTriggerDirective
   ],
   template: `
@@ -27,6 +31,8 @@ import { SiHeaderDropdownTriggerHarness } from './testing/si-header-dropdown-tri
     <ng-template #dropdown1>
       <si-header-dropdown>
         <si-header-dropdown-item>Item 1-1</si-header-dropdown-item>
+        <si-header-dropdown-check-item [(checked)]="checkItemChecked">Checked item</si-header-dropdown-check-item>
+        <si-header-dropdown-radio-item [(checked)]="radioItemChecked">Radio item</si-header-dropdown-radio-item>
         <si-header-dropdown-item #trigger2 [siHeaderDropdownTriggerFor]="dropdown2">
           Item 1-2
         </si-header-dropdown-item>
@@ -43,6 +49,8 @@ import { SiHeaderDropdownTriggerHarness } from './testing/si-header-dropdown-tri
 })
 class TestHostComponent implements HeaderWithDropdowns {
   readonly inlineDropdown = signal(false);
+  readonly checkItemChecked = signal(true);
+  readonly radioItemChecked = signal(false);
   readonly trigger1 = viewChild.required('trigger1', { read: SiHeaderDropdownTriggerDirective });
   readonly trigger2 = viewChild.required('trigger2', { read: SiHeaderDropdownTriggerDirective });
 }
@@ -117,6 +125,37 @@ describe('SiHeaderDropdown', () => {
         .then(item => item.click());
 
       expect(await trigger1Harness.isOpen()).toBe(false);
+    });
+
+    it('should render checked item alternatives with their semantic roles', async () => {
+      await trigger1Harness.toggle();
+
+      const dropdown = await trigger1Harness.getDropdown();
+      const checkedItem = await dropdown.getItem('Checked item');
+      const radioItem = await dropdown.getItem('Radio item');
+
+      expect(await checkedItem.host().then(host => host.getAttribute('role'))).toBe('checkbox');
+      expect(await checkedItem.host().then(host => host.getAttribute('aria-checked'))).toBe('true');
+      expect(await radioItem.host().then(host => host.getAttribute('role'))).toBe('radio');
+      expect(await radioItem.host().then(host => host.getAttribute('aria-checked'))).toBe('false');
+    });
+
+    it('should update checked models when selection items are activated', async () => {
+      await trigger1Harness.toggle();
+      await trigger1Harness
+        .getDropdown()
+        .then(dropdown => dropdown.getItem('Checked item'))
+        .then(item => item.click());
+
+      expect(fixture.componentInstance.checkItemChecked()).toBe(false);
+
+      await trigger1Harness.toggle();
+      await trigger1Harness
+        .getDropdown()
+        .then(dropdown => dropdown.getItem('Radio item'))
+        .then(item => item.click());
+
+      expect(fixture.componentInstance.radioItemChecked()).toBe(true);
     });
 
     it('should emit only once on close', async () => {

--- a/projects/element-ng/header-dropdown/testing/si-header-dropdown-item.harness.ts
+++ b/projects/element-ng/header-dropdown/testing/si-header-dropdown-item.harness.ts
@@ -6,7 +6,7 @@ import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
 
 export class SiHeaderDropdownItemHarness extends ComponentHarness {
   static readonly hostSelector =
-    'si-header-dropdown-item, a[si-header-dropdown-item], button[si-header-dropdown-item]';
+    'si-header-dropdown-item, a[si-header-dropdown-item], button[si-header-dropdown-item], si-header-dropdown-radio-item, a[si-header-dropdown-radio-item], button[si-header-dropdown-radio-item], si-header-dropdown-check-item, a[si-header-dropdown-check-item], button[si-header-dropdown-check-item]';
 
   static withText(text: string): HarnessPredicate<SiHeaderDropdownItemHarness> {
     return new HarnessPredicate(SiHeaderDropdownItemHarness, {}).addOption(

--- a/src/app/examples/si-application-header/si-application-header.html
+++ b/src/app/examples/si-application-header/si-application-header.html
@@ -29,7 +29,7 @@
       type="button"
       si-header-selection-item
       [siHeaderDropdownTriggerFor]="tenants"
-      >{{ activeTenant }}</button
+      >{{ activeTenant() }}</button
     >
     <button
       type="button"
@@ -46,7 +46,7 @@
         type="button"
         si-header-selection-item
         [siHeaderDropdownTriggerFor]="tenants"
-        >{{ activeTenant }}</button
+        >{{ activeTenant() }}</button
       >
       <button
         si-header-action-item
@@ -75,10 +75,10 @@
   <si-header-dropdown>
     @for (tenant of allTenants; track tenant) {
       <button
-        si-header-dropdown-item
+        si-header-dropdown-check-item
         type="button"
-        [checked]="tenant === activeTenant ? 'check' : undefined"
-        (click)="activeTenant = tenant"
+        [checked]="tenant === activeTenant()"
+        (checkedChange)="activeTenant.set($event ? tenant : activeTenant())"
       >
         {{ tenant }}
       </button>
@@ -110,7 +110,14 @@
     >
       Language
     </button>
-    <button si-header-dropdown-item icon="element-palette" type="button">Design</button>
+    <button
+      si-header-dropdown-item
+      icon="element-palette"
+      type="button"
+      [siHeaderDropdownTriggerFor]="theme"
+    >
+      Theme
+    </button>
     <button si-header-dropdown-item icon="element-user" type="button">Profile</button>
   </si-header-dropdown>
 </ng-template>
@@ -129,6 +136,35 @@
   <si-header-dropdown>
     <button si-header-dropdown-item type="button">English (US)</button>
     <button si-header-dropdown-item type="button">English (UK)</button>
+  </si-header-dropdown>
+</ng-template>
+
+<ng-template #theme>
+  <si-header-dropdown>
+      <button
+        si-header-dropdown-radio-item
+        type="button"
+        [checked]="activeTheme() === 'light'"
+        (checkedChange)="selectTheme('light')"
+      >
+        Light
+      </button>
+      <button
+        si-header-dropdown-radio-item
+        type="button"
+        [checked]="activeTheme() === 'dark'"
+        (checkedChange)="selectTheme('dark')"
+      >
+        Dark
+      </button>
+      <button
+        si-header-dropdown-radio-item
+        type="button"
+        [checked]="activeTheme() === 'auto'"
+        (checkedChange)="selectTheme('auto')"
+      >
+        Auto
+      </button>
   </si-header-dropdown>
 </ng-template>
 

--- a/src/app/examples/si-application-header/si-application-header.ts
+++ b/src/app/examples/si-application-header/si-application-header.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Component } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import {
   SiAccountDetailsComponent,
@@ -19,9 +19,12 @@ import {
 } from '@siemens/element-ng/application-header';
 import {
   SiHeaderDropdownComponent,
+  SiHeaderDropdownCheckItemComponent,
   SiHeaderDropdownItemComponent,
+  SiHeaderDropdownRadioItemComponent,
   SiHeaderDropdownTriggerDirective
 } from '@siemens/element-ng/header-dropdown';
+import { SiThemeService, ThemeType } from '@siemens/element-ng/theme';
 
 @Component({
   selector: 'app-sample',
@@ -35,6 +38,8 @@ import {
     SiHeaderDropdownComponent,
     SiHeaderDropdownTriggerDirective,
     SiHeaderDropdownItemComponent,
+    SiHeaderDropdownCheckItemComponent,
+    SiHeaderDropdownRadioItemComponent,
     SiHeaderNavigationItemComponent,
     SiHeaderAccountItemComponent,
     SiHeaderNavigationComponent,
@@ -46,7 +51,15 @@ import {
   templateUrl: './si-application-header.html'
 })
 export class SampleComponent {
-  allTenants = ['Tenant 1', 'Tenant 2', 'Tenant 3'];
+  private readonly themeService = inject(SiThemeService);
 
-  activeTenant = 'Tenant 1';
+  readonly allTenants = ['Tenant 1', 'Tenant 2', 'Tenant 3'];
+  readonly activeTenant = signal('Tenant 1');
+
+  readonly activeTheme = signal<ThemeType>('auto');
+
+  selectTheme(theme: ThemeType): void {
+    this.activeTheme.set(theme);
+    this.themeService.applyThemeType(theme);
+  }
 }


### PR DESCRIPTION
Adds dedicated radio and check header dropdown items with required two-way checked models.

Deprecates the string-based checked input on si-header-dropdown-item.

Validation:
- pnpm lib:test --include='**/header-dropdown/si-header-dropdown.directive.spec.ts' --no-watch
- pnpm build:examples<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2517/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2517/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2517/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2517/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2517/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2517/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2517/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2517/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2517/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2517/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
