### PR TITLE
fix(tabs): remove tabindex from non-scrollable panels

### DIFF
--- a/projects/element-ng/tabs/si-tabset.component.html
+++ b/projects/element-ng/tabs/si-tabset.component.html
@@ -35,7 +35,7 @@
         role="tabpanel"
         [id]="`content-${activeTab.tabId}`"
         [class.tab-scroll]="contentOverflowAuto()"
-        [tabIndex]="contentOverflowAuto() ? '0' : null"
+        [attr.tabindex]="contentOverflowAuto() ? '0' : null"
         [attr.aria-labelledby]="`tab-${activeTab.tabId}`"
       >
         @if (tabContent) {

--- a/projects/element-ng/tabs/si-tabset.component.spec.ts
+++ b/projects/element-ng/tabs/si-tabset.component.spec.ts
@@ -182,6 +182,15 @@ describe('SiTabset', () => {
     expect(await tabsetHarness.getTabItemsLength()).toEqual(3);
   });
 
+  it('should not make tab content focusable without automatic overflow', async () => {
+    vi.setTimerTickMode('nextTimerAsync');
+    testComponent.tabs = ['1'];
+    testComponent.activeTab.set(0);
+    await fixture.whenStable();
+
+    expect(await (await tabsetHarness.getTabContent()).getAttribute('tabindex')).toBeNull();
+  });
+
   it('should be possible to select a tab', async () => {
     testComponent.tabs = ['1', '2', '3'];
     fixture.detectChanges();


### PR DESCRIPTION
Fix tab panels receiving `tabindex="0"` when `contentOverflowAuto` is disabled.

Use an attribute binding so Angular removes the attribute when the panel is not scrollable.

Tests: `pnpm lib:test --include='**/tabs/si-tabset.component.spec.ts' --no-watch`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2518/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2518/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2518/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2518/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2518/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2518/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2518/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2518/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2518/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2518/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
