### PR TITLE
fix(datatable): show complete header focus ring

### DIFF
--- a/projects/element-ng/ag-grid/parts/color-scheme.part.ts
+++ b/projects/element-ng/ag-grid/parts/color-scheme.part.ts
@@ -27,6 +27,13 @@ import { Part, ThemeDefaultParams, createPart } from 'ag-grid-community';
  */
 export const elementColorScheme: Part = createPart({
   feature: 'colorScheme',
+  css: `
+    .ag-header-cell:focus-visible,
+    .ag-header-group-cell:focus-visible {
+      outline: var(--element-button-focus-width) solid var(--element-focus-default);
+      outline-offset: calc(-1 * var(--element-button-focus-width));
+    }
+  `,
   params: {
     // Typography
     buttonFontWeight: '600',

--- a/projects/element-theme/src/styles/components/_datatable.scss
+++ b/projects/element-theme/src/styles/components/_datatable.scss
@@ -246,7 +246,7 @@ $datatable-ghost-cell-strip-radius: 0 !default;
     }
 
     .datatable-header-cell:focus-visible {
-      @include focus.make-outline-focus();
+      @include focus.make-outline-focus-inside();
     }
   }
 


### PR DESCRIPTION
Use an inside focus outline for datatable header cells so the ring remains fully visible within the fixed-height header.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2519/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2519/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2519/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2519/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2519/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2519/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2519/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2519/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2519/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2519/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

