### PR TITLE
chore(docs): update docs-composer to 11.16.11 for v49

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,7 @@
       "optionalDependencies": {
         "@siemens-ux/design-tokens": "^0.5.0",
         "@simpl/brand": "3.3.0",
-        "@simpl/docs-composer": "11.16.10"
+        "@simpl/docs-composer": "11.16.11"
       }
     },
     "node_modules/@actions/core": {
@@ -12012,9 +12012,9 @@
       }
     },
     "node_modules/@simpl/docs-composer": {
-      "version": "11.16.10",
-      "resolved": "https://code.siemens.com/api/v4/projects/732/packages/npm/@simpl/docs-composer/-/@simpl/docs-composer-11.16.10.tgz",
-      "integrity": "sha1-xMt2CK/OkQXqoTUpYg64AeW2THU=",
+      "version": "11.16.11",
+      "resolved": "https://code.siemens.com/api/v4/projects/732/packages/npm/@simpl/docs-composer/-/@simpl/docs-composer-11.16.11.tgz",
+      "integrity": "sha1-g65SINkpt6REm0iI08o4iY6N75w=",
       "optional": true,
       "dependencies": {
         "ajv": "8.17.1",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
   "optionalDependencies": {
     "@siemens-ux/design-tokens": "^0.5.0",
     "@simpl/brand": "3.3.0",
-    "@simpl/docs-composer": "11.16.10"
+    "@simpl/docs-composer": "11.16.11"
   },
   "overrides": {
     "@microsoft/api-extractor": {

--- a/projects/element-docs-builder/md_extension_element_docs_composer/__init__.py
+++ b/projects/element-docs-builder/md_extension_element_docs_composer/__init__.py
@@ -1,1 +1,1 @@
-from .extension import DocsComposerExtension, makeExtension  # noqa: F401
+from .extension import DocsComposerExtension, makeExtension, structured_output_path  # noqa: F401

--- a/projects/element-docs-builder/md_extension_element_docs_composer/extension.py
+++ b/projects/element-docs-builder/md_extension_element_docs_composer/extension.py
@@ -6,7 +6,7 @@ from markdown.preprocessors import Preprocessor
 
 
 api_enabled = os.environ.get('DOCS_COMPOSER', 'false') in ('true', '1', 'yes', 'y')
-
+structured_output_path = 'source'
 
 class DocsComposerExtension(Extension):
   current_file_path: str = ""
@@ -39,7 +39,7 @@ class DocsComposerPreprocessor(Preprocessor):
         self.extension.current_file_path,
         self.extension.is_serve,
         True,
-        'source',
+        structured_output_path,
         True,
         True,
         timeout=1000 * 60 * 1,  # 1 minute timeout

--- a/projects/element-docs-builder/mkdocs_element_docs_builder/plugin.py
+++ b/projects/element-docs-builder/mkdocs_element_docs_builder/plugin.py
@@ -9,7 +9,7 @@ from mkdocs.structure.files import Files, File
 
 from os.path import dirname
 
-from md_extension_element_docs_composer import DocsComposerExtension
+from md_extension_element_docs_composer import DocsComposerExtension, structured_output_path
 
 api_enabled = os.environ.get('DOCS_COMPOSER', 'false') in ('true', '1', 'yes', 'y')
 api_generate = True if os.environ.get('DOCS_COMPOSER_GENERATE', 'false') in ('true', '1', 'yes', 'y') else (
@@ -104,6 +104,7 @@ class ElementDocsBuilderPlugin(BasePlugin):
         docs_composer.saveLLMsTxt(
           self.docs_composer_configuration,
           '.',
+          structured_output_path,
           timeout=1000 * 60 * 1,  # 1 minute timeout
         )
 


### PR DESCRIPTION
Update @simpl/docs-composer version to use compact version of llms.txt

Backport of #2409 for the v49 release.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2525/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2525/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2525/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2525/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2525/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2525/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2525/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2525/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2525/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2525/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
