### PR TITLE
refactor(application-header): separate launchpad favorites

### DIFF
--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.html
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.html
@@ -24,26 +24,31 @@
     </div>
   }
   <div class="apps-scroll ms-n2 ps-2">
-    @for (category of categories(); track category.name) {
-      @if (!enableFavorites() || !hasFavorites() || $first || showAllApps) {
+    @if (enableFavorites() && hasFavorites()) {
+      <si-launchpad-category
+        [category]="{ name: favoriteAppsText(), apps: favorites() }"
+        [enableFavorites]="enableFavorites()"
+        (favoriteChange)="toggleFavorite($event)"
+      />
+      <button
+        type="button"
+        class="btn btn-link btn-show-all dropdown-toggle text-decoration-none"
+        [class.show]="showAllApps"
+        (click)="showAllApps = !showAllApps"
+      >
+        <b>{{ (showAllApps ? showLessAppsText() : showMoreAppsText()) | translate }}</b>
+        <si-icon class="link-icon dropdown-caret" [icon]="icons.elementDown2" />
+      </button>
+    }
+
+    @if (!enableFavorites() || !hasFavorites() || showAllApps) {
+      @for (category of categories(); track category.name) {
         <si-launchpad-category
-          [class.pt-6]="!$first && !!category.name"
+          [class.pt-6]="!!category.name && (hasFavorites() || !$first)"
           [category]="category"
           [enableFavorites]="enableFavorites()"
           (favoriteChange)="toggleFavorite($event)"
         />
-      }
-
-      @if (enableFavorites() && $first && hasFavorites()) {
-        <button
-          type="button"
-          class="btn btn-link btn-show-all dropdown-toggle text-decoration-none"
-          [class.show]="showAllApps"
-          (click)="showAllApps = !showAllApps"
-        >
-          <b>{{ (showAllApps ? showLessAppsText() : showMoreAppsText()) | translate }}</b>
-          <si-icon class="link-icon dropdown-caret" [icon]="icons.elementDown2" />
-        </button>
       }
     }
   </div>

--- a/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
+++ b/projects/element-ng/application-header/launchpad/si-launchpad-factory.component.ts
@@ -97,21 +97,10 @@ export class SiLaunchpadFactoryComponent {
   protected showAllApps = false;
   protected readonly categories = computed(() => {
     const apps = this.apps();
-    const favorites = this.favorites();
-    const categories: AppCategory[] = [];
-    if (this.enableFavorites() && this.hasFavorites()) {
-      categories.push({
-        name: this.favoriteAppsText(),
-        apps: favorites
-      });
-    }
-
     if (this.isCategories(apps)) {
-      categories.push(...apps);
-    } else {
-      categories.push({ name: '', apps: [...apps] });
+      return apps;
     }
-    return categories;
+    return [{ name: '', apps: [...apps] }];
   });
   protected readonly favorites = computed(() =>
     this.apps()


### PR DESCRIPTION
Keep favorite apps separate from the supplied launchpad categories while preserving the collapsed Show more behavior.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2532/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2532/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2532/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2532/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2532/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2532/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2532/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2532/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2532/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2532/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
