### PR TITLE
chore(test): make e2e-local.sh more reliable

### DIFF
--- a/e2e-local.sh
+++ b/e2e-local.sh
@@ -95,6 +95,9 @@ else
     PLAYWRIGHT_isvrt=true
     echo "Updating all snapshots.."
   fi
+  # The extra 'sleep 1' prevents tests initially failing sometimes with Chrome reporting
+  #   Failed to load resource: net::ERR_NETWORK_CHANGED
+  # The reason is if the container is started but network isn't ready yet
   $DOCKER run -it --rm \
     -e LOCAL_ADDRESS=$LOCAL_ADDRESS \
     -e PORT=$PORT \
@@ -107,6 +110,10 @@ else
     --net=$NETWORK_MODE \
     --ipc=host \
     $PLAYWRIGHT_IMAGE \
+    sh \
+    -c \
+    'sleep 1; exec "$@"' \
+    -- \
     npx \
     playwright \
     test \


### PR DESCRIPTION
Sometimes the first test or so fails with Chrome reporting
  Failed to load resource: net::ERR_NETWORK_CHANGED

This happens when the container is up before networking is completely set up. A one second sleep fixes that.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2533/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2533/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2533/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2533/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2533/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2533/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2533/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2533/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2533/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2533/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
