### PR TITLE
fix(charts): retain visual map range

### DIFF
--- a/playwright/e2e/element-examples/charts/si-chart-visual-map.spec.ts
+++ b/playwright/e2e/element-examples/charts/si-chart-visual-map.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { expect, test } from '../../../support/test-helpers';
+
+const EXAMPLE = 'si-charts/generic/generic-custom';
+
+test.describe('si-chart visual map', () => {
+  test(EXAMPLE, async ({ page, si }) => {
+    await si.visitExample(EXAMPLE);
+
+    // Wait for the chart to be fully initialized
+    await page.waitForFunction(() => {
+      const chartEl = document.querySelector('si-chart');
+      if (!chartEl) return false;
+      const component = (window as any).ng?.getComponent(chartEl);
+      return !!component?.chart;
+    });
+
+    // Set a specific range on the visual map slider
+    await page.evaluate(() => {
+      const chartEl = document.querySelector('si-chart')!;
+      const component = (window as any).ng.getComponent(chartEl);
+      component.chart.dispatchAction({
+        type: 'selectDataRange',
+        visualMapIndex: 0,
+        selected: [50, 200]
+      });
+    });
+
+    await si.runVisualAndA11yTests('range-set', { skipAriaSnapshot: true });
+
+    // Trigger theme switch directly on the component
+    await page.evaluate(() => {
+      const chartEl = document.querySelector('si-chart')!;
+      const component = (window as any).ng.getComponent(chartEl);
+      component.themeSwitch();
+    });
+
+    // Verify the visual map range is retained after the theme switch
+    const range = await page.evaluate(() => {
+      const chartEl = document.querySelector('si-chart')!;
+      const component = (window as any).ng.getComponent(chartEl);
+      return component.getOptionNoClone().visualMap[0].range;
+    });
+
+    expect(range).toEqual([50, 200]);
+
+    await si.runVisualAndA11yTests('range-retained-after-theme-switch', { skipAriaSnapshot: true });
+  });
+});

--- a/playwright/snapshots/charts/si-chart-visual-map.spec.ts-snapshots/si-charts--generic--generic-custom--range-retained-after-theme-switch-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/charts/si-chart-visual-map.spec.ts-snapshots/si-charts--generic--generic-custom--range-retained-after-theme-switch-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdd008367cd1c8e32cba1c18e00a6f1ed014a637e125188589c5e1bb6f6e2ca8
+size 22485

--- a/playwright/snapshots/charts/si-chart-visual-map.spec.ts-snapshots/si-charts--generic--generic-custom--range-retained-after-theme-switch-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/charts/si-chart-visual-map.spec.ts-snapshots/si-charts--generic--generic-custom--range-retained-after-theme-switch-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:deccbe9e4a1734bd78df9068c7adac831ac0d5473d891d899571ad6899d9b82e
+size 22529

--- a/playwright/snapshots/charts/si-chart-visual-map.spec.ts-snapshots/si-charts--generic--generic-custom--range-set-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/charts/si-chart-visual-map.spec.ts-snapshots/si-charts--generic--generic-custom--range-set-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdd008367cd1c8e32cba1c18e00a6f1ed014a637e125188589c5e1bb6f6e2ca8
+size 22485

--- a/playwright/snapshots/charts/si-chart-visual-map.spec.ts-snapshots/si-charts--generic--generic-custom--range-set-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/charts/si-chart-visual-map.spec.ts-snapshots/si-charts--generic--generic-custom--range-set-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:deccbe9e4a1734bd78df9068c7adac831ac0d5473d891d899571ad6899d9b82e
+size 22529

--- a/playwright/snapshots/charts/static.spec.ts-snapshots/si-charts--generic--generic-custom-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/charts/static.spec.ts-snapshots/si-charts--generic--generic-custom-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1add706b0b1825ec9b3c50de6f402a3079453d1a7b8998c56b6bb6ca823abc68
-size 61880
+oid sha256:cc88a987c0b9efc433c4f1a4366586949c65a453f4c8ff6d3e419479a49b298e
+size 82897

--- a/playwright/snapshots/charts/static.spec.ts-snapshots/si-charts--generic--generic-custom-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/charts/static.spec.ts-snapshots/si-charts--generic--generic-custom-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8fb8a13dce4aa03067fb1978ae3f3c9c5c051ea6168bf108cd88bf1ee4b161ad
-size 61826
+oid sha256:df65652fae2106a4d6a992d2c09a654285821c952f4a7bc417cea8dea48aa1b8
+size 83216

--- a/projects/charts-ng/common/si-chart-base.component.spec.ts
+++ b/projects/charts-ng/common/si-chart-base.component.spec.ts
@@ -6,14 +6,14 @@ import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { echarts, EChartOption } from '@siemens/charts-ng/common';
 import { LineChart } from 'echarts/charts';
-import { GridComponent } from 'echarts/components';
+import { GridComponent, VisualMapContinuousComponent } from 'echarts/components';
 
 import { SiChartBaseComponent } from './si-chart-base.component';
 
 // Register chart types and components needed by the tests.
 // The base component only registers renderers + title/tooltip.
 // Without this, ECharts silently drops series with unregistered types.
-echarts.use([LineChart, GridComponent]);
+echarts.use([LineChart, GridComponent, VisualMapContinuousComponent]);
 
 @Component({
   imports: [SiChartBaseComponent],
@@ -82,6 +82,25 @@ describe('SiChartBase', () => {
       expect(options).toBeDefined();
       expect(options.series).toHaveLength(1);
       expect(options.series[0].data).toHaveLength(4);
+    });
+
+    it('should retain the selected visual map range when switching themes', () => {
+      component.options.visualMap = {
+        type: 'continuous',
+        min: 1,
+        max: 4,
+        calculable: true
+      };
+      fixture.detectChanges();
+      component.chartComponent().chart.dispatchAction({
+        type: 'selectDataRange',
+        visualMapIndex: 0,
+        selected: [2, 3]
+      });
+
+      component.chartComponent().themeSwitch();
+
+      expect(component.chartComponent().getOptionNoClone().visualMap[0].range).toEqual([2, 3]);
     });
   });
 });

--- a/projects/charts-ng/common/si-chart-base.component.ts
+++ b/projects/charts-ng/common/si-chart-base.component.ts
@@ -594,6 +594,10 @@ export class SiChartBaseComponent implements AfterViewInit, OnChanges, OnInit, O
       return;
     }
 
+    const visualMapRanges = this.getOptionNoClone()?.visualMap?.map(
+      ({ range }: { range?: number[] }) => range?.slice()
+    );
+
     this.applyTheme();
     this.chart.setTheme(this.activeTheme);
 
@@ -607,12 +611,21 @@ export class SiChartBaseComponent implements AfterViewInit, OnChanges, OnInit, O
       this.applyColorsToCustomLegends();
     });
     this.chart.setOption(this.actualOptions);
+    this.restoreVisualMapRanges(visualMapRanges);
 
     if (this.externalZoomSlider()) {
       this.extZoomSliderChart.setTheme(this.activeTheme);
       this.extZoomSliderChart.setOption(this.extZoomSliderOptions);
     }
     this.cdRef.markForCheck();
+  }
+
+  private restoreVisualMapRanges(ranges?: (number[] | undefined)[]): void {
+    ranges?.forEach((selected, visualMapIndex) => {
+      if (selected) {
+        this.chart.dispatchAction({ type: 'selectDataRange', visualMapIndex, selected });
+      }
+    });
   }
 
   /**

--- a/src/app/examples/si-charts/generic/generic-custom.ts
+++ b/src/app/examples/si-charts/generic/generic-custom.ts
@@ -92,6 +92,16 @@ export class SampleComponent {
         yAxisIndex: 1,
         data: [7, 6, 4.5, 8, 9, 8, 13, 16, 10, 8, 13, 7]
       }
-    ]
+    ],
+    visualMap: {
+      type: 'continuous',
+      min: 0,
+      max: 250,
+      calculable: true,
+      orient: 'horizontal',
+      right: 0,
+      top: 0,
+      dimension: 1
+    }
   };
 }


### PR DESCRIPTION
The visual map should be retained, see- [example](https://element.siemens.io/element-examples/#/viewer/editor?theme=dark&locale=en&t=%3Cdiv%20class%3D%22card%20m-5%20p-3%22%3E%0A%20%20%3Csi-chart-cartesian%0A%20%20%20%20%23chart%0A%20%20%20%20class%3D%22bg-base-1%22%0A%20%20%20%20style%3D%22height%3A%20500px%22%0A%20%20%20%20%5Btitle%5D%3D%22chartData.title%22%0A%20%20%20%20%5Bseries%5D%3D%22chartData.series%22%0A%20%20%20%20%5BtooltipFormatter%5D%3D%22chartData.tooltip%3F.formatter%22%0A%20%20%20%20%5BmaxEntries%5D%3D%22chartData.maxEntries%20%3F%3F%200%22%0A%20%20%20%20%5BvisibleEntries%5D%3D%22chartData.visibleEntries%20%3F%3F%200%22%0A%20%20%20%20%5BshowLegend%5D%3D%22chartData.showLegend%22%0A%20%20%20%20%5BzoomSlider%5D%3D%22!!chartData.zoomSlider%22%0A%20%20%20%20%5BxAxis%5D%3D%22chartData.xAxis%22%0A%20%20%20%20%5ByAxis%5D%3D%22chartData.yAxis%22%0A%20%20%20%20%5BadditionalOptions%5D%3D%22%7B%0A%20%20%20%20%20%20tooltip%3A%20%7B%20trigger%3A%20'item'%20%7D%2C%0A%20%20%20%20%20%20visualMap%3A%20%7B%0A%20%20%20%20%20%20%20%20%20min%3A%200%2C%0A%20%20%20%20%20%20%20%20%20max%3A%2010%2C%0A%20%20%20%20%20%20%20%20%20calculable%3A%20true%2C%0A%20%20%20%20%20%20%20%20%20orient%3A%20'horizontal'%2C%0A%20%20%20%20%20%20%20%20%20left%3A%20'center'%2C%0A%20%20%20%20%20%20%20%20%20top%3A%20'1%25'%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%22%0A%20%20%20%20(siResizeObserver)%3D%22chart.resize()%22%0A%20%20%2F%3E%0A%3C%2Fdiv%3E%0A%0A%40if%20(chartData.liveUpdate%20!%3D%3D%20undefined)%20%7B%0A%20%20%3Cdiv%20class%3D%22p-5%22%3E%0A%20%20%20%20%40if%20(chartData.liveUpdate)%20%7B%0A%20%20%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22btn%20btn-secondary%22%20(click)%3D%22stopLive()%22%3EStop%20live%20update%3C%2Fbutton%3E%0A%20%20%20%20%7D%20%40else%20%7B%0A%20%20%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22btn%20btn-secondary%22%20(click)%3D%22startLive()%22%0A%20%20%20%20%20%20%20%20%3EStart%20live%20update%3C%2Fbutton%0A%20%20%20%20%20%20%3E%0A%20%20%20%20%7D%0A%20%20%3C%2Fdiv%3E%0A%7D%0A%0A%40if%20(chartData.progressIndication%20!%3D%3D%20undefined)%20%7B%0A%20%20%3Cdiv%20class%3D%22p-5%22%3E%0A%20%20%20%20%40if%20(chartData.progressIndication)%20%7B%0A%20%20%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22btn%20btn-secondary%22%20(click)%3D%22stopProgressIndication()%22%0A%20%20%20%20%20%20%20%20%3EStop%20progress%20indication%3C%2Fbutton%0A%20%20%20%20%20%20%3E%0A%20%20%20%20%7D%20%40else%20%7B%0A%20%20%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22btn%20btn-secondary%22%20(click)%3D%22startProgressIndication()%22%0A%20%20%20%20%20%20%20%20%3EStart%20progress%20indication%3C%2Fbutton%0A%20%20%20%20%20%20%3E%0A%20%20%20%20%7D%0A%20%20%3C%2Fdiv%3E%0A%7D%0A%0A%40if%20(chartData.addSeries%20!%3D%3D%20undefined)%20%7B%0A%20%20%3Cdiv%20class%3D%22p-5%22%3E%0A%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22btn%20btn-secondary%22%20(click)%3D%22addSeries()%22%3EAdd%20Series%3C%2Fbutton%3E%0A%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22btn%20btn-secondary%20ms-4%22%20(click)%3D%22changeData()%22%3EChange%20Data%3C%2Fbutton%3E%0A%20%20%3C%2Fdiv%3E%0A%7D%0A&e=si-charts%2Fcartesian%2Fheatmap)<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2536/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2536/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2536/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2536/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2536/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2536/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2536/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2536/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2536/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2536/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->





