### PR TITLE
feat(typography): adopt system typography tokens

### DIFF
--- a/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list-item.directive.ts
+++ b/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list-item.directive.ts
@@ -9,10 +9,11 @@ import { SiAutoCollapsableListMeasurable } from './si-auto-collapsable-list-meas
 @Directive({
   selector: '[siAutoCollapsableListItem]',
   host: {
-    '[style.visibility]': 'isVisible() ? "visible" : "hidden"',
-    '[style.position]': 'isVisible() ? "" : "absolute"',
+    '[class.visible]': 'isVisible()',
+    '[class.invisible]': '!isVisible()',
+    '[class.position-absolute]': '!isVisible()',
     // Ensure hidden items are behind the visible ones. Otherwise, the visible ones are not clickable
-    '[style.z-index]': 'isVisible() ? "" : "-1"'
+    '[class.z-n1]': '!isVisible()'
   },
   exportAs: 'siAutoCollapsableListItem'
 })

--- a/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list.directive.ts
+++ b/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list.directive.ts
@@ -29,8 +29,8 @@ import { SiAutoCollapsableListOverflowItemDirective } from './si-auto-collapsabl
 @Directive({
   selector: '[siAutoCollapsableList]',
   host: {
-    style: 'position: relative',
-    '[style.overflow]': 'siAutoCollapsableList() ? "hidden" : ""'
+    class: 'position-relative',
+    '[class.overflow-hidden]': 'siAutoCollapsableList()'
   },
   exportAs: 'siAutoCollapsableList'
 })

--- a/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-body.component.scss
+++ b/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-body.component.scss
@@ -18,11 +18,7 @@
 .si-weather-widget-condition,
 :host.si-weather-widget-vertical .si-weather-widget-range,
 :host.si-weather-widget-horizontal .si-weather-widget-range {
-  @include typography.si-font(
-    typography.$si-font-size-body-lg,
-    typography.$si-line-height-body-lg,
-    typography.$si-font-weight-body-lg
-  );
+  @include typography.sdl-font(body-lg);
 }
 
 .si-weather-widget-today {
@@ -52,11 +48,7 @@
 }
 
 .si-weather-widget-temperature {
-  @include typography.si-font(
-    typography.$si-font-size-display-xl,
-    typography.$si-line-height-display-xl,
-    typography.$si-font-weight-display-xl
-  );
+  @include typography.sdl-font(display-xl);
   color: variables.$si-sys-text-primary;
 }
 

--- a/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-forecast.component.scss
+++ b/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-forecast.component.scss
@@ -6,11 +6,7 @@
 // day range — matches the today min/max sizing.
 .si-weather-widget-forecast-range,
 .si-weather-widget-forecast.si-weather-widget-horizontal .si-weather-widget-forecast-day-range {
-  @include typography.si-font(
-    typography.$si-font-size-body-lg,
-    typography.$si-line-height-body-lg,
-    typography.$si-font-weight-body-lg
-  );
+  @include typography.sdl-font(body-lg);
 }
 
 // Horizontal-day min/max wrapper. The forecast component owns its own copy of

--- a/projects/element-ng/form/si-form.shared.scss
+++ b/projects/element-ng/form/si-form.shared.scss
@@ -2,6 +2,7 @@
 @use 'sass:math';
 
 @use '@siemens/element-theme/src/styles/all-variables';
+@use '@siemens/element-theme/src/styles/variables/si-typography-map';
 
 :host.si-form-input {
   display: flex;
@@ -48,7 +49,10 @@
     );
     padding-inline: map.get(all-variables.$spacers, 6);
     inline-size: var(--si-form-label-width, math.percentage(math.div(2, 12)));
-    line-height: all-variables.$input-line-height;
+    line-height: map.get(
+      map.get(si-typography-map.$si-typography, all-variables.$input-font),
+      line-height
+    );
 
     &:empty {
       display: block;

--- a/projects/element-theme/src/styles/bootstrap/_buttons.scss
+++ b/projects/element-theme/src/styles/bootstrap/_buttons.scss
@@ -263,11 +263,7 @@ button {
   --btn-border-color-hover: #{bootstrap-variables.$input-focus-border-color};
   --btn-border-color-active: #{bootstrap-variables.$input-focus-border-color};
 
-  @include typography.si-font(
-    bootstrap-variables.$input-font-size,
-    bootstrap-variables.$input-line-height,
-    bootstrap-variables.$input-font-weight
-  );
+  @include typography.sdl-font(bootstrap-variables.$input-font);
   padding-block: bootstrap-variables.$input-padding-y;
   padding-inline: bootstrap-variables.$input-padding-x;
 

--- a/projects/element-theme/src/styles/bootstrap/_card.scss
+++ b/projects/element-theme/src/styles/bootstrap/_card.scss
@@ -125,11 +125,7 @@ button.card {
   margin-block-end: 0; // Removes the default margin-bottom of <hN>
   color: variables.$card-cap-color;
 
-  @include typography.si-font(
-    typography.$si-font-size-h5,
-    typography.$si-line-height-h5,
-    typography.$si-font-weight-h5
-  );
+  @include typography.sdl-font(h5);
 
   + * .card-body, // for action cards, where we wrap the content
   + .card-body {

--- a/projects/element-theme/src/styles/bootstrap/_reboot.scss
+++ b/projects/element-theme/src/styles/bootstrap/_reboot.scss
@@ -1,6 +1,5 @@
 @use '../variables/typography';
 @use './variables';
-
 // stylelint-disable declaration-no-important, selector-no-qualifying-type, property-no-vendor-prefix
 
 // Reboot
@@ -41,6 +40,7 @@
 // 4. Change the default tap highlight to be completely transparent in iOS.
 
 // scss-docs-start reboot-body-rules
+// TW: Body mapping
 body {
   margin: 0; // 1
   font-family: var(--#{variables.$variable-prefix}body-font-family);
@@ -82,50 +82,47 @@ hr:not([size]) {
 
 %heading {
   margin-block: 0 variables.$headings-margin-bottom; // 1
-  font-family: variables.$headings-font-family;
-  font-style: variables.$headings-font-style;
-  font-weight: variables.$headings-font-weight;
-  line-height: variables.$headings-line-height;
   color: variables.$headings-color;
 }
 
 h1 {
   @extend %heading;
-  font-size: variables.$h1-font-size;
+  @include typography.sdl-font(h1);
 }
 
 h2 {
   @extend %heading;
-  font-size: variables.$h2-font-size;
+  @include typography.sdl-font(h2);
 }
 
 h3 {
   @extend %heading;
-  font-size: variables.$h3-font-size;
+  @include typography.sdl-font(h3);
 }
 
 h4 {
   @extend %heading;
-  font-size: variables.$h4-font-size;
+  @include typography.sdl-font(h4);
 }
 
 h5 {
   @extend %heading;
-  font-size: variables.$h5-font-size;
+  @include typography.sdl-font(h5);
 }
 
 h6 {
   @extend %heading;
-  font-size: variables.$h6-font-size;
+  @include typography.sdl-font(h6);
 }
 
 // Reset margins on paragraphs
 //
 // Similarly, the top margin on `<p>`s get reset. However, we also reset the
 // bottom margin to use `rem` units instead of `em`.
-
+// TW: Review if this mapoping wors
 p {
   margin-block: 0 variables.$paragraph-margin-bottom;
+  @include typography.sdl-font(body-paragraph);
 }
 
 // Abbreviations

--- a/projects/element-theme/src/styles/bootstrap/_type.scss
+++ b/projects/element-theme/src/styles/bootstrap/_type.scss
@@ -33,11 +33,7 @@
 }
 
 .lead {
-  @include typography.si-font(
-    variables.$lead-font-size,
-    variables.$lead-line-height,
-    variables.$lead-font-weight
-  );
+  @include typography.sdl-font(body-lg);
 }
 
 //
@@ -105,11 +101,7 @@
 h1,
 .h1,
 .si-h1 {
-  @include typography.si-font(
-    typography.$si-font-size-h1,
-    typography.$si-line-height-h1,
-    typography.$si-font-weight-h1
-  );
+  @include typography.sdl-font(h1);
 }
 
 .si-h1-bold {
@@ -123,21 +115,13 @@ h1,
 h2,
 .h2,
 .si-h2 {
-  @include typography.si-font(
-    typography.$si-font-size-h2,
-    typography.$si-line-height-h2,
-    typography.$si-font-weight-h2
-  );
+  @include typography.sdl-font(h2);
 }
 
 h3,
 .h3,
 .si-h3 {
-  @include typography.si-font(
-    typography.$si-font-size-h3,
-    typography.$si-line-height-h3,
-    typography.$si-font-weight-h3
-  );
+  @include typography.sdl-font(h3);
 }
 
 .si-h4-bold {
@@ -151,29 +135,23 @@ h3,
 h4,
 .h4,
 .si-h4 {
-  @include typography.si-font(
-    typography.$si-font-size-h4,
-    typography.$si-line-height-h4,
-    typography.$si-font-weight-h4
-  );
+  @include typography.sdl-font(h4);
 }
 
 .si-h5-bold {
-  @include typography.si-font(
-    typography.$si-font-size-h5-bold,
-    typography.$si-line-height-h5-bold,
-    typography.$si-font-weight-h5-bold
-  );
+  @include typography.sdl-font(h5-bold);
 }
 
 h5,
 .h5,
 .si-h5 {
-  @include typography.si-font(
-    typography.$si-font-size-h5,
-    typography.$si-line-height-h5,
-    typography.$si-font-weight-h5
-  );
+  @include typography.sdl-font(h5);
+}
+
+h6,
+.h6,
+.si-h6 {
+  @include typography.sdl-font(h6);
 }
 
 h6,
@@ -187,19 +165,11 @@ h6,
 }
 
 .si-body-lg {
-  @include typography.si-font(
-    typography.$si-font-size-body-lg,
-    typography.$si-line-height-body-lg,
-    typography.$si-font-weight-body-lg
-  );
+  @include typography.sdl-font(body-lg);
 }
 
 .si-body {
-  @include typography.si-font(
-    typography.$si-font-size-body,
-    typography.$si-line-height-body,
-    typography.$si-font-weight-body
-  );
+  @include typography.sdl-font(body);
 }
 
 .si-body-paragraph {
@@ -228,11 +198,7 @@ h6,
 
 .si-display-xl,
 .display-1 {
-  @include typography.si-font(
-    typography.$si-font-size-display-xl,
-    typography.$si-line-height-display-xl,
-    typography.$si-font-weight-display-xl
-  );
+  @include typography.sdl-font(display-xl);
 }
 
 .si-display-xxl {
@@ -245,29 +211,17 @@ h6,
 
 .si-display-lg,
 .display-2 {
-  @include typography.si-font(
-    typography.$si-font-size-display-lg,
-    typography.$si-line-height-display-lg,
-    typography.$si-font-weight-display-lg
-  );
+  @include typography.sdl-font(display-lg);
 }
 
 .si-display-bold,
 .display-3 {
-  @include typography.si-font(
-    typography.$si-font-size-display-bold,
-    typography.$si-line-height-display-bold,
-    typography.$si-font-weight-display-bold
-  );
+  @include typography.sdl-font(display-sbold);
 }
 
 .si-display,
 .display-4 {
-  @include typography.si-font(
-    typography.$si-font-size-display,
-    typography.$si-line-height-display,
-    typography.$si-font-weight-display
-  );
+  @include typography.sdl-font(display);
 }
 
 .si-code-sm,

--- a/projects/element-theme/src/styles/bootstrap/_variables.scss
+++ b/projects/element-theme/src/styles/bootstrap/_variables.scss
@@ -4,6 +4,7 @@
 @use '../variables/semantic-tokens';
 @use '../variables/spacers';
 @use '../variables/typography';
+@use '../variables/si-typography-map';
 @use './functions';
 
 @use 'sass:map';
@@ -326,12 +327,7 @@ $form-label-color: system-tokens.$si-sys-text-secondary !default;
 
 $input-padding-y: (map.get(spacers.$spacers, 4) - 1px); // 8px including 1px border
 $input-padding-x: (map.get(spacers.$spacers, 4) - 1px); // 8px including 1px border
-$input-font-family: null !default;
-$input-font-size: $font-size-base;
-$input-font-weight: $font-weight-base;
-// Use an explicit rem value instead of a unitless ratio to prevent cross-browser
-// rounding differences (Safari rounds 14 × 1.1428... to 15px, Chrome to 16px). See #2031
-$input-line-height: typography.$si-line-height-body-rem !default;
+$input-font: body !default;
 
 $input-bg: system-tokens.$si-sys-background-1 !default;
 $input-disabled-bg: system-tokens.$si-sys-background-1 !default;
@@ -358,7 +354,7 @@ $input-height-border: $input-border-width * 2 !default;
 $input-height: functions.add(1lh, ($input-padding-y + $input-border-width) * 2) !default;
 
 // don't derive from $input-height as it generates a nested calc() expression
-$input-height-inner: functions.add($input-line-height, $input-padding-y * 2) !default;
+$input-height-inner: functions.add(1lh, $input-padding-y * 2) !default;
 // Wrap in parenthesis: `*` binds tighter than `-`, so without them only the border term gets multiplied.
 // DEPRECATED: Calculate it yourself using $input-height-inner
 $input-height-inner-half: calc((#{$input-height-inner}) * 0.5) !default;
@@ -374,7 +370,6 @@ $form-check-inline-margin-end: 1rem !default;
 
 $input-group-addon-padding-y: $input-padding-y !default;
 $input-group-addon-padding-x: $input-padding-x !default;
-$input-group-addon-font-weight: $input-font-weight !default;
 $input-group-addon-color: $input-color !default;
 $input-group-addon-bg: system-tokens.$si-sys-background-1 !default;
 $input-group-addon-border-color: $input-border-color !default;

--- a/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
+++ b/projects/element-theme/src/styles/bootstrap/forms/_form-control.scss
@@ -3,9 +3,13 @@
 @use '../../variables/spacers';
 @use '../../variables/utilities';
 @use '../../variables/si-vars';
+@use '../../variables/si-typography-map';
 @use '../variables';
 
+@use 'sass:math';
 @use 'sass:map';
+
+$input-typography: map.get(si-typography-map.$si-typography, variables.$input-font);
 
 :is(.form-control, .form-select) {
   --border-color: #{system-tokens.$si-sys-border-2};
@@ -23,10 +27,13 @@
   padding-block: variables.$input-padding-y;
   padding-inline-start: variables.$input-padding-x;
   padding-inline-end: var(--si-input-padding-inline-end);
-  font-family: variables.$input-font-family;
-  font-size: variables.$input-font-size;
-  font-weight: variables.$input-font-weight;
-  line-height: variables.$input-line-height;
+  font-size: map.get($input-typography, font-size);
+  font-weight: map.get($input-typography, font-weight);
+  // Use an explicit rem value instead of a unitless ratio to prevent cross-browser
+  // rounding differences (Safari rounds 14 × 1.1428... to 15px, Chrome to 16px). See #2031
+  line-height: math.round(
+    map.get($input-typography, line-height) * map.get($input-typography, font-size)
+  );
   color: system-tokens.$si-sys-text-primary;
   background-color: system-tokens.$si-sys-background-1;
   background-clip: padding-box;
@@ -159,7 +166,6 @@ textarea.form-control {
   padding-block: calc(variables.$input-padding-y - 3px);
   padding-inline-start: calc(variables.$input-padding-x - 3px);
   padding-inline-end: calc(var(--si-input-padding-inline-end) - 3px);
-  line-height: variables.$input-line-height;
   box-shadow: 0 0 0 1px var(--border-color);
   border: 3px solid var(--si-textarea-mask) !important; // stylelint-disable-line declaration-no-important
   outline-offset: 2px !important; // stylelint-disable-line declaration-no-important

--- a/projects/element-theme/src/styles/bootstrap/forms/_input-group.scss
+++ b/projects/element-theme/src/styles/bootstrap/forms/_input-group.scss
@@ -1,4 +1,5 @@
 @use '../variables';
+@use '../../variables/typography';
 
 @use 'sass:string';
 @use 'sass:map';
@@ -49,9 +50,7 @@
   align-items: center;
   padding-block: variables.$input-group-addon-padding-y;
   padding-inline: variables.$input-group-addon-padding-x;
-  font-size: variables.$input-font-size; // Match inputs
-  font-weight: variables.$input-group-addon-font-weight;
-  line-height: variables.$input-line-height;
+  @include typography.sdl-font(variables.$input-font);
   color: variables.$input-group-addon-color;
   text-align: center;
   white-space: nowrap;

--- a/projects/element-theme/src/styles/bootstrap/mixins/_form-layout.scss
+++ b/projects/element-theme/src/styles/bootstrap/mixins/_form-layout.scss
@@ -1,5 +1,6 @@
 @use 'sass:map';
 @use '../../variables/spacers';
+@use '../../variables/si-typography-map';
 @use '../variables';
 
 $form-col-layout-label-width: 16ch !default;
@@ -18,7 +19,10 @@ $form-col-layout-label-width: 16ch !default;
       max-inline-size: var(--si-form-label-width, #{$form-col-layout-label-width});
       align-self: start;
       padding-block: variables.$input-padding-y + variables.$input-border-width;
-      line-height: variables.$input-line-height;
+      line-height: map.get(
+        map.get(si-typography-map.$si-typography, variables.$input-font),
+        line-height
+      );
 
       &:empty {
         display: block;

--- a/projects/element-theme/src/styles/components/_layout.scss
+++ b/projects/element-theme/src/styles/components/_layout.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
 @use '../variables';
 @use '../bootstrap/mixins/breakpoints';
+@use '../variables/typography';
 
 .si-layout-fixed-height {
   &,
@@ -51,11 +52,7 @@
 .si-layout-title {
   grid-area: title;
   margin-block-end: 0;
-  @include variables.si-font(
-    variables.$si-font-size-h3,
-    variables.$si-line-height-h3,
-    variables.$si-font-weight-h3
-  );
+  @include typography.sdl-font(h3);
 
   &.si-layout-top-element + .si-layout-subtitle {
     margin-inline: var(--si-layout-header-first-element-offset, 0)
@@ -68,11 +65,7 @@
   margin-block-start: map.get(variables.$spacers, 4);
   margin-block-end: 0;
   color: variables.$si-sys-text-secondary;
-  @include variables.si-font(
-    variables.$si-font-size-body,
-    variables.$si-line-height-body,
-    variables.$si-font-weight-body
-  );
+  @include typography.sdl-font(body);
 }
 
 .si-layout-actions {
@@ -89,11 +82,7 @@
   }
 
   .si-layout-title {
-    @include variables.si-font(
-      variables.$si-font-size-h2,
-      variables.$si-line-height-h2,
-      variables.$si-font-weight-h2
-    );
+    @include typography.sdl-font(h2);
   }
 }
 

--- a/projects/element-theme/src/styles/components/_list-item.scss
+++ b/projects/element-theme/src/styles/components/_list-item.scss
@@ -23,11 +23,7 @@ ol:has(.list-item) {
   padding-block: map.get(variables.$spacers, 4);
   padding-inline: map.get(variables.$spacers, 6);
 
-  @include typography.si-font(
-    typography.$si-font-size-body,
-    typography.$si-line-height-body,
-    typography.$si-font-weight-body
-  );
+  @include typography.sdl-font(body);
 
   > * {
     grid-column: 2 / -1;
@@ -58,20 +54,12 @@ ol:has(.list-item) {
     padding-block: map.get(variables.$spacers, 4);
     margin-block-end: 0;
 
-    @include typography.si-font(
-      typography.$si-font-size-h5,
-      typography.$si-line-height-h5,
-      typography.$si-font-weight-h5
-    );
+    @include typography.sdl-font(h5);
 
     &.unread {
       position: relative;
 
-      @include typography.si-font(
-        typography.$si-font-size-h5-bold,
-        typography.$si-line-height-h5-bold,
-        typography.$si-font-weight-h5-bold
-      );
+      @include typography.sdl-font(h5-bold);
 
       &::before {
         content: '';

--- a/projects/element-theme/src/styles/variables/_si-typography-map.scss
+++ b/projects/element-theme/src/styles/variables/_si-typography-map.scss
@@ -1,0 +1,350 @@
+// Copy from SDL, do not modify manually
+@use 'sass:map';
+
+$si-typography: (
+  'body': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 400,
+    font-size: 0.875rem,
+    line-height: 1.142857,
+    letter-spacing: 0
+  ),
+  'body-lg': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 400,
+    font-size: 1rem,
+    line-height: 1.25,
+    letter-spacing: 0
+  ),
+  'body-lg-sbold': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 1rem,
+    line-height: 1.25,
+    letter-spacing: 0
+  ),
+  'body-paragraph': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 400,
+    font-size: 0.875rem,
+    line-height: 1.428571,
+    letter-spacing: 0
+  ),
+  'body-paragraph-sbold': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 0.875rem,
+    line-height: 1.428571,
+    letter-spacing: 0
+  ),
+  'body-sbold': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 0.875rem,
+    line-height: 1.142857,
+    letter-spacing: 0
+  ),
+  'body-sm': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 400,
+    font-size: 0.75rem,
+    line-height: 1.333333,
+    letter-spacing: 0
+  ),
+  'body-sm-sbold': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 0.75rem,
+    line-height: 1.333333,
+    letter-spacing: 0
+  ),
+  'code': (
+    font-family: (
+      'JetBrains Mono',
+      monospace
+    ),
+    font-weight: 400,
+    font-size: 0.875rem,
+    line-height: 1.428571,
+    letter-spacing: 0
+  ),
+  'code-lg': (
+    font-family: (
+      'JetBrains Mono',
+      monospace
+    ),
+    font-weight: 400,
+    font-size: 1rem,
+    line-height: 1.25,
+    letter-spacing: 0
+  ),
+  'code-sm': (
+    font-family: (
+      'JetBrains Mono',
+      monospace
+    ),
+    font-weight: 400,
+    font-size: 0.75rem,
+    line-height: 1.333333,
+    letter-spacing: 0
+  ),
+  'display': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 400,
+    font-size: 2rem,
+    line-height: 1.25,
+    letter-spacing: 0
+  ),
+  'display-lg': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 400,
+    font-size: 2.5rem,
+    line-height: 1.3,
+    letter-spacing: 0
+  ),
+  'display-lg-sbold': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 2.5rem,
+    line-height: 1.3,
+    letter-spacing: 0
+  ),
+  'display-sbold': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 2rem,
+    line-height: 1.25,
+    letter-spacing: 0
+  ),
+  'display-xl': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 400,
+    font-size: 3rem,
+    line-height: 1.333333,
+    letter-spacing: 0
+  ),
+  'display-xl-sbold': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 3rem,
+    line-height: 1.333333,
+    letter-spacing: 0
+  ),
+  'display-xxl': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 400,
+    font-size: 3.625rem,
+    line-height: 1.241379,
+    letter-spacing: 0
+  ),
+  'display-xxl-sbold': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 3.625rem,
+    line-height: 1.241379,
+    letter-spacing: 0
+  ),
+  'h1': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 1.75rem,
+    line-height: 1.285714,
+    letter-spacing: 0
+  ),
+  'h2': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 1.5rem,
+    line-height: 1.333333,
+    letter-spacing: 0
+  ),
+  'h3': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 1.25rem,
+    line-height: 1.2,
+    letter-spacing: 0
+  ),
+  'h4': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 1rem,
+    line-height: 1.25,
+    letter-spacing: 0
+  ),
+  'h5': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 0.875rem,
+    line-height: 1.428571,
+    letter-spacing: 0
+  ),
+  'h5-bold': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 700,
+    font-size: 0.875rem,
+    line-height: 1.428571,
+    letter-spacing: 0
+  ),
+  'h6': (
+    font-family: (
+      'SiemensSans Pro VF',
+      'SiemensSans Pro',
+      helvetica,
+      arial,
+      sans-serif
+    ),
+    font-weight: 600,
+    font-size: 0.75rem,
+    line-height: 1.333333,
+    letter-spacing: 0
+  )
+);
+
+/// Apply a typography token by name.
+///
+/// @example scss
+///   .my-heading { @include full-typography(h1); }
+///
+/// @param {String} $name - Typography key (e.g. `body-sm`, `h1`).
+@mixin typography($name) {
+  $config: map.get($si-typography, $name);
+  @if $config == null {
+    @error "Unknown typography token '#{$name}'. Available: #{map.keys($si-typography)}.";
+  }
+  @each $prop, $value in $config {
+    #{$prop}: $value;
+  }
+}

--- a/projects/element-theme/src/styles/variables/_typography.scss
+++ b/projects/element-theme/src/styles/variables/_typography.scss
@@ -1,9 +1,28 @@
 @use 'sass:math';
+@use 'sass:map';
+@use 'si-typography-map';
 
 @mixin si-font($font-size, $line-height, $font-weight) {
   font-size: $font-size;
   font-weight: $font-weight;
   line-height: $line-height;
+}
+
+@mixin sdl-font($name) {
+  $config: map.get(si-typography-map.$si-typography, $name);
+  @if $config == null {
+    @error "Unknown typography token '#{$name}'. Available: #{map.keys(si-typography-map.$si-typography)}.";
+  }
+  $body-config: map.get(si-typography-map.$si-typography, body);
+  font-weight: map.get($config, font-weight);
+  font-size: map.get($config, font-size);
+  line-height: map.get($config, line-height);
+  @if map.get($config, font-family) != map.get($body-config, font-family) {
+    font-family: map.get($config, font-family);
+  }
+  @if map.get($config, letter-spacing) != map.get($body-config, letter-spacing) {
+    letter-spacing: map.get($config, letter-spacing);
+  }
 }
 
 @function px-to-rem($value) {
@@ -15,8 +34,8 @@
   @return math.div($ratio, $ratio * 0 + 1);
 }
 
-$si-font-family: 'SiemensSans Pro VF', 'SiemensSans Pro', helvetica, arial, sans-serif;
-$si-font-family-mono: 'JetBrains Mono', monospace;
+$si-font-family: map.get(si-typography-map.$si-typography, body, font-family);
+$si-font-family-mono: map.get(si-typography-map.$si-typography, code, font-family);
 
 $si-font-weight-lighter: lighter !default;
 $si-font-weight-light: 300 !default;
@@ -27,93 +46,101 @@ $si-font-weight-bold: 700 !default;
 $si-font-weight-bolder: bolder !default;
 $si-font-weight-black: 900 !default;
 
-$si-font-size-h1-bold: px-to-rem(28px);
-$si-line-height-h1-bold: px-to-ratio($si-font-size-h1-bold, 36px);
-$si-font-weight-h1-bold: $si-font-weight-bold;
+$si-font-size-h1-bold: map.get(si-typography-map.$si-typography, h1, font-size);
+$si-line-height-h1-bold: map.get(si-typography-map.$si-typography, h1, line-height);
+$si-font-weight-h1-bold: map.get(si-typography-map.$si-typography, h1, font-weight);
 
-$si-font-size-h1: px-to-rem(28px);
-$si-line-height-h1: px-to-ratio($si-font-size-h1, 36px);
-$si-font-weight-h1: $si-font-weight-normal;
+$si-font-size-h1: map.get(si-typography-map.$si-typography, h1, font-size);
+$si-line-height-h1: map.get(si-typography-map.$si-typography, h1, line-height);
+$si-font-weight-h1: map.get(si-typography-map.$si-typography, h1, font-weight);
 
-$si-font-size-h2: px-to-rem(24px);
-$si-line-height-h2: px-to-ratio($si-font-size-h2, 32px);
-$si-font-weight-h2: $si-font-weight-semibold;
+$si-font-size-h2: map.get(si-typography-map.$si-typography, h2, font-size);
+$si-line-height-h2: map.get(si-typography-map.$si-typography, h2, line-height);
+$si-font-weight-h2: map.get(si-typography-map.$si-typography, h2, font-weight);
 
-$si-font-size-h3: px-to-rem(20px);
-$si-line-height-h3: px-to-ratio($si-font-size-h3, 24px);
-$si-font-weight-h3: $si-font-weight-semibold;
+$si-font-size-h3: map.get(si-typography-map.$si-typography, h3, font-size);
+$si-line-height-h3: map.get(si-typography-map.$si-typography, h3, line-height);
+$si-font-weight-h3: map.get(si-typography-map.$si-typography, h3, font-weight);
 
-$si-font-size-h4: px-to-rem(16px);
-$si-line-height-h4: px-to-ratio($si-font-size-h4, 20px);
-$si-font-weight-h4: $si-font-weight-semibold;
+$si-font-size-h4: map.get(si-typography-map.$si-typography, h4, font-size);
+$si-line-height-h4: map.get(si-typography-map.$si-typography, h4, line-height);
+$si-font-weight-h4: map.get(si-typography-map.$si-typography, h4, font-weight);
 
-$si-font-size-h4-bold: px-to-rem(16px);
-$si-line-height-h4-bold: px-to-ratio($si-font-size-h4-bold, 20px);
-$si-font-weight-h4-bold: $si-font-weight-bold;
+$si-font-size-h4-bold: map.get(si-typography-map.$si-typography, h4, font-size);
+$si-line-height-h4-bold: map.get(si-typography-map.$si-typography, h4, line-height);
+$si-font-weight-h4-bold: map.get(si-typography-map.$si-typography, h4, font-weight);
 
-$si-font-size-h5: px-to-rem(14px);
-$si-line-height-h5: px-to-ratio($si-font-size-h5, 20px);
-$si-font-weight-h5: $si-font-weight-semibold;
+$si-font-size-h5: map.get(si-typography-map.$si-typography, h5, font-size);
+$si-line-height-h5: map.get(si-typography-map.$si-typography, h5, line-height);
+$si-font-weight-h5: map.get(si-typography-map.$si-typography, h5, font-weight);
 
-$si-font-size-h5-bold: px-to-rem(14px);
-$si-line-height-h5-bold: px-to-ratio($si-font-size-h5-bold, 20px);
-$si-font-weight-h5-bold: $si-font-weight-bold;
+$si-font-size-h5-bold: map.get(si-typography-map.$si-typography, h5-bold, font-size);
+$si-line-height-h5-bold: map.get(si-typography-map.$si-typography, h5-bold, line-height);
+$si-font-weight-h5-bold: map.get(si-typography-map.$si-typography, h5-bold, font-weight);
 
-$si-font-size-h6: px-to-rem(12px);
-$si-line-height-h6: px-to-ratio($si-font-size-h6, 16px);
-$si-font-weight-h6: $si-font-weight-semibold;
+$si-font-size-h6: map.get(si-typography-map.$si-typography, h6, font-size);
+$si-line-height-h6: map.get(si-typography-map.$si-typography, h6, line-height);
+$si-font-weight-h6: map.get(si-typography-map.$si-typography, h6, font-weight);
 
-$si-font-size-body-lg: px-to-rem(16px);
-$si-line-height-body-lg: px-to-ratio($si-font-size-body-lg, 20px);
-$si-font-weight-body-lg: $si-font-weight-normal;
+$si-font-size-body-lg: map.get(si-typography-map.$si-typography, body-lg, font-size);
+$si-line-height-body-lg: map.get(si-typography-map.$si-typography, body-lg, line-height);
+$si-font-weight-body-lg: map.get(si-typography-map.$si-typography, body-lg, font-weight);
 
-$si-font-size-body: px-to-rem(14px);
-$si-line-height-body: px-to-ratio($si-font-size-body, 16px);
-$si-line-height-body-rem: px-to-rem(16px);
-$si-font-weight-body: $si-font-weight-normal;
+$si-font-size-body: map.get(si-typography-map.$si-typography, body, font-size);
+$si-line-height-body: map.get(si-typography-map.$si-typography, body, line-height);
+$si-line-height-body-rem: $si-line-height-body * $si-font-size-body;
+$si-font-weight-body: map.get(si-typography-map.$si-typography, body, font-weight);
 
-$si-font-size-body-paragraph: px-to-rem(14px);
-$si-line-height-body-paragraph: px-to-ratio($si-font-size-body-paragraph, 20px);
-$si-font-weight-body-paragraph: $si-font-weight-normal;
+$si-font-size-body-paragraph: map.get(si-typography-map.$si-typography, body-paragraph, font-size);
+$si-line-height-body-paragraph: map.get(
+  si-typography-map.$si-typography,
+  body-paragraph,
+  line-height
+);
+$si-font-weight-body-paragraph: map.get(
+  si-typography-map.$si-typography,
+  body-paragraph,
+  font-weight
+);
 
-$si-font-size-body-sm: px-to-rem(12px);
-$si-line-height-body-sm: px-to-ratio($si-font-size-body-sm, 16px);
-$si-font-weight-body-sm: $si-font-weight-normal;
+$si-font-size-body-sm: map.get(si-typography-map.$si-typography, body-sm, font-size);
+$si-line-height-body-sm: map.get(si-typography-map.$si-typography, body-sm, line-height);
+$si-font-weight-body-sm: map.get(si-typography-map.$si-typography, body-sm, font-weight);
 
-$si-font-size-caption: $si-font-size-body-sm;
-$si-line-height-caption: $si-line-height-body-sm;
-$si-font-weight-caption: $si-font-weight-normal;
+$si-font-size-caption: map.get(si-typography-map.$si-typography, body-sm, font-size);
+$si-line-height-caption: map.get(si-typography-map.$si-typography, body-sm, line-height);
+$si-font-weight-caption: map.get(si-typography-map.$si-typography, body-sm, font-weight);
 
-$si-font-size-display-xxl: px-to-rem(58px);
-$si-line-height-display-xxl: px-to-ratio($si-font-size-display-xxl, 72px);
-$si-font-weight-display-xxl: $si-font-weight-normal;
+$si-font-size-display-xxl: map.get(si-typography-map.$si-typography, display-xxl, font-size);
+$si-line-height-display-xxl: map.get(si-typography-map.$si-typography, display-xxl, line-height);
+$si-font-weight-display-xxl: map.get(si-typography-map.$si-typography, display-xxl, font-weight);
 
-$si-font-size-display-xl: px-to-rem(48px);
-$si-line-height-display-xl: px-to-ratio($si-font-size-display-xl, 64px);
-$si-font-weight-display-xl: $si-font-weight-normal;
+$si-font-size-display-xl: map.get(si-typography-map.$si-typography, display-xl, font-size);
+$si-line-height-display-xl: map.get(si-typography-map.$si-typography, display-xl, line-height);
+$si-font-weight-display-xl: map.get(si-typography-map.$si-typography, display-xl, font-weight);
 
-$si-font-size-display-lg: px-to-rem(40px);
-$si-line-height-display-lg: px-to-ratio($si-font-size-display-lg, 52px);
-$si-font-weight-display-lg: $si-font-weight-normal;
+$si-font-size-display-lg: map.get(si-typography-map.$si-typography, display-lg, font-size);
+$si-line-height-display-lg: map.get(si-typography-map.$si-typography, display-lg, line-height);
+$si-font-weight-display-lg: map.get(si-typography-map.$si-typography, display-lg, font-weight);
 
-$si-font-size-display-bold: $si-font-size-display-lg;
-$si-line-height-display-bold: $si-line-height-display-lg;
-$si-font-weight-display-bold: $si-font-weight-bold;
+$si-font-size-display-bold: map.get(si-typography-map.$si-typography, display-sbold, font-size);
+$si-line-height-display-bold: map.get(si-typography-map.$si-typography, display-sbold, line-height);
+$si-font-weight-display-bold: map.get(si-typography-map.$si-typography, display-sbold, font-weight);
 
-$si-font-size-display: px-to-rem(32px);
-$si-line-height-display: px-to-ratio($si-font-size-display, 40px);
-$si-font-weight-display: $si-font-weight-normal;
+$si-font-size-display: map.get(si-typography-map.$si-typography, display, font-size);
+$si-line-height-display: map.get(si-typography-map.$si-typography, display, line-height);
+$si-font-weight-display: map.get(si-typography-map.$si-typography, display, font-weight);
 
-$si-font-size-code-sm: px-to-rem(12px);
-$si-line-height-code-sm: px-to-ratio($si-font-size-code-sm, 16px);
-$si-font-weight-code-sm: $si-font-weight-normal;
+$si-font-size-code-sm: map.get(si-typography-map.$si-typography, code-sm, font-size);
+$si-line-height-code-sm: map.get(si-typography-map.$si-typography, code-sm, line-height);
+$si-font-weight-code-sm: map.get(si-typography-map.$si-typography, code-sm, font-weight);
 
-$si-font-size-code: px-to-rem(14px);
-$si-line-height-code: px-to-ratio($si-font-size-code, 20px);
-$si-font-weight-code: $si-font-weight-normal;
+$si-font-size-code: map.get(si-typography-map.$si-typography, code, font-size);
+$si-line-height-code: map.get(si-typography-map.$si-typography, code, line-height);
+$si-font-weight-code: map.get(si-typography-map.$si-typography, code, font-weight);
 
-$si-font-size-code-lg: px-to-rem(16px);
-$si-line-height-code-lg: px-to-ratio($si-font-size-code-lg, 20px);
-$si-font-weight-code-lg: $si-font-weight-normal;
+$si-font-size-code-lg: map.get(si-typography-map.$si-typography, code-lg, font-size);
+$si-line-height-code-lg: map.get(si-typography-map.$si-typography, code-lg, line-height);
+$si-font-weight-code-lg: map.get(si-typography-map.$si-typography, code-lg, font-weight);
 
-$si-letter-spacing-normal: 0;
+$si-letter-spacing-normal: map.get(si-typography-map.$si-typography, body, letter-spacing);


### PR DESCRIPTION
Copy the typography map in element-theme and apply its tokens across theme and form styles.

Replace legacy input font variables with a single configurable input token while retaining
legacy scales that have no token equivalent.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2545/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2545/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2545/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2545/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2545/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2545/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2545/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2545/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2545/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2545/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


