### PR TITLE
fix(theme): align table captions with typography

### DIFF
--- a/playwright/snapshots/static.spec.ts-snapshots/typography--typography.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/typography--typography.yaml
@@ -16,3 +16,5 @@
 - paragraph: Body Large
 - paragraph: Body
 - paragraph: Caption
+- table:
+  - caption: Caption

--- a/projects/element-theme/src/styles/bootstrap/_reboot.scss
+++ b/projects/element-theme/src/styles/bootstrap/_reboot.scss
@@ -341,6 +341,11 @@ table {
 }
 
 caption {
+  @include typography.si-font(
+    typography.$si-font-size-caption,
+    typography.$si-line-height-caption,
+    typography.$si-font-weight-caption
+  );
   padding-block: variables.$table-cell-padding-y;
   color: variables.$table-caption-color;
   text-align: start;

--- a/src/app/examples/typography/typography.html
+++ b/src/app/examples/typography/typography.html
@@ -20,3 +20,9 @@
 <p class="si-body-lg">Body Large</p>
 <p class="si-body">Body</p>
 <p class="si-caption">Caption</p>
+
+<table class="table">
+  <caption>
+    Caption
+  </caption>
+</table>


### PR DESCRIPTION
Align native HTML table captions with the `.si-caption` typography style and add a caption to the typography example.

Follow-up to #2421.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2546/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2546/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2546/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2546/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2546/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2546/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2546/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2546/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2546/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2546/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
