### PR TITLE
docs(overlay): overlays in scrolling container

### DIFF
--- a/docs/patterns/overlays-in-scroll-containers.md
+++ b/docs/patterns/overlays-in-scroll-containers.md
@@ -1,0 +1,50 @@
+# Overlays in scroll containers
+
+All Element components that open CDK overlays (like typeahead, popovers, ...)
+automatically configure the overlays to reposition on scroll.
+
+**Important:** If Element components with overlays are placed within a container that can scroll,
+apply the `cdkScrollable` directive to it.
+By default, the CDK only listens to scroll events on the document.
+
+## Customizing the scroll strategy
+
+By default, all overlays by Element components will reposition themselves on scroll.
+You can change this globally by overriding the default configuration of CDK Overlays
+using the [OVERLAY_DEFAULT_CONFIG](https://material.angular.dev/cdk/overlay/api#OVERLAY_DEFAULT_CONFIG)
+injection token.
+
+In addition, you can set the input of the respective Element component.
+
+## Available scroll strategies
+
+Read the [related documentation of the CDK](https://material.angular.dev/cdk/overlay/overview#scroll-strategies)
+to find a list of available strategies.
+
+## Code ---
+
+Add `cdkScrollable` to the element that actually scrolls. The directive
+registers the element with Angular CDK's `ScrollDispatcher`, allowing overlay
+scroll strategies to react to its scroll events.
+
+To create a custom strategy,
+use either the `Overlay` or the `ScrollStrategyOptions` from the CDK.
+Always create a new instance for each overlay.
+
+```ts
+import { Overlay, ScrollStrategyOptions } from '@angular/cdk/overlay';
+import { inject } from '@angular/core';
+
+class MyComponent {
+  // Using the Overlay
+  scrollStrategy = inject(Overlay).scrollStrategies.reposition();
+  // Using the ScrollStrategyOptions
+  scrollStrategy = inject(ScrollStrategyOptions).reposition();
+}
+```
+
+The following example uses the close strategy for a popover inside a non-root
+scrolling container. The typeahead uses the default reposition strategy.
+
+<!-- prettier-ignore -->
+<si-docs-component example="overlay-scroll-strategy/overlay-scroll-strategy" height="520"></si-docs-component>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,6 +187,7 @@ nav:
     - Overview:                           'patterns/index.md'
     - Backdrop:                           'patterns/backdrop.md'
     - Drag & drop:                        'patterns/drag-and-drop.md'
+    - Overlays in scroll containers: 'patterns/overlays-in-scroll-containers.md'
     - Loading:                            'patterns/loading.md'
     - Notifications:                      'patterns/notifications.md'
     - Filter:                             'patterns/filter.md'

--- a/src/app/examples/overlay-scroll-strategy/overlay-scroll-strategy.html
+++ b/src/app/examples/overlay-scroll-strategy/overlay-scroll-strategy.html
@@ -1,0 +1,45 @@
+<div class="p-6">
+  <p class="mb-4">
+    Open each overlay, then scroll this container. The typeahead dropdown repositions, while the
+    popover closes.
+  </p>
+
+  <div
+    class="border rounded-2 overflow-auto p-6"
+    style="block-size: 360px"
+    cdkScrollable
+    tabindex="0"
+    aria-label="Scrollable overlay examples"
+  >
+    <p class="d-flex align-items-center">This container is scrollable. </p>
+
+    <div class="d-flex flex-column align-items-start gap-6">
+      <si-form-item label="Country (overlay will reposition)">
+        <!-- This is using the default strategy: reposition -->
+        <input
+          id="country"
+          type="text"
+          class="form-control"
+          placeholder="Select a country"
+          [siTypeahead]="countries"
+          [typeaheadMinLength]="0"
+          [(ngModel)]="selectedCountry"
+        />
+      </si-form-item>
+
+      <button
+        type="button"
+        class="btn btn-secondary"
+        siPopoverTitle="Nested scrolling"
+        siPopover="This popover closes when its container scrolls."
+        [siPopoverScrollStrategy]="popoverScrollStrategy"
+      >
+        Show popover
+      </button>
+    </div>
+
+    <div class="d-flex align-items-end text-secondary" style="block-size: 460px">
+      End of scroll container
+    </div>
+  </div>
+</div>

--- a/src/app/examples/overlay-scroll-strategy/overlay-scroll-strategy.ts
+++ b/src/app/examples/overlay-scroll-strategy/overlay-scroll-strategy.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Overlay } from '@angular/cdk/overlay';
+import { CdkScrollable } from '@angular/cdk/scrolling';
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SiFormItemComponent } from '@siemens/element-ng/form';
+import { SiPopoverDirective } from '@siemens/element-ng/popover';
+import { SiTooltipDirective } from '@siemens/element-ng/tooltip';
+import { SiTypeaheadDirective } from '@siemens/element-ng/typeahead';
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    CdkScrollable,
+    FormsModule,
+    SiPopoverDirective,
+    SiTypeaheadDirective,
+    SiFormItemComponent
+  ],
+  templateUrl: './overlay-scroll-strategy.html'
+})
+export class SampleComponent {
+  private readonly overlay = inject(Overlay);
+
+  readonly popoverScrollStrategy = this.overlay.scrollStrategies.close();
+
+  readonly countries = ['Canada', 'France', 'Germany', 'India', 'Japan', 'United Kingdom'];
+  selectedCountry = '';
+}


### PR DESCRIPTION
Using a CDK Overlay in a scrolling container
can be tricky.
Since this is not well documented by the CDK.
Adding this under pattern since it is not a component.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2548/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2548/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2548/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2548/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2548/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2548/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2548/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2548/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2548/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2548/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

