### PR TITLE
fix(empty-state): keep overflowing content reachable

### DIFF
--- a/projects/element-ng/empty-state/si-empty-state.component.scss
+++ b/projects/element-ng/empty-state/si-empty-state.component.scss
@@ -3,7 +3,7 @@
 @use '@siemens/element-theme/src/styles/variables';
 
 .list-group-item-empty {
-  block-size: 100%;
+  min-block-size: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
Allow the empty-state content container to grow beyond its available height so centered content remains within the scrollable area. Previously, fixed-height centered content could overflow above the reachable scroll range in short widget cards.

Cover constrained-height rendering with a browser regression test.

## Testing

- `pnpm lib:test --include='**/empty-state/si-empty-state.component.spec.ts' --no-watch`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2551/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2551/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2551/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2551/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2551/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2551/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2551/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2551/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2551/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2551/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

