### PR TITLE
fix(dashboards-ng): use svg icon for default placeholder

### DIFF
--- a/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.html
+++ b/projects/dashboards-ng/src/components/gridstack-wrapper/si-gridstack-wrapper.component.html
@@ -10,7 +10,7 @@
         [grid]="grid"
         [editable]="editable()"
         [widgetConfig]="item"
-        [iconClass]="widget?.iconClass ?? 'element-apps'"
+        [widgetIcon]="widget?.iconClass"
         [componentFactory]="widget?.componentFactory"
         (remove)="widgetInstanceRemove.emit(item.id)"
         (edit)="widgetInstanceEdit.emit(item)"

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.ts
@@ -25,6 +25,7 @@ import {
   ViewContainerRef
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { elementApps } from '@siemens/element-icons';
 import { SiActionDialogService } from '@siemens/element-ng/action-modal';
 // We need one import from the main entry.
 // Otherwise, module federation is confused.
@@ -33,6 +34,7 @@ import type { MenuItem as MenuItemLegacy } from '@siemens/element-ng/common';
 import { ContentActionBarMainItem, ViewType } from '@siemens/element-ng/content-action-bar';
 import { SiDashboardCardComponent } from '@siemens/element-ng/dashboard';
 import { SiEmptyStateComponent } from '@siemens/element-ng/empty-state';
+import { addIcons } from '@siemens/element-ng/icon';
 import { MenuItem } from '@siemens/element-ng/menu';
 import {
   injectSiTranslateService,
@@ -72,6 +74,7 @@ export class SiWidgetHostComponent implements AfterViewInit, OnChanges {
   private readonly destroyRef = inject(DestroyRef);
   private readonly translateService = injectSiTranslateService();
   private readonly liveAnnouncer = inject(LiveAnnouncer);
+  private readonly elementAppsIcon = addIcons({ elementApps }).elementApps;
   /** @internal */
   readonly elementRef = inject<ElementRef<GridItemHTMLElement>>(ElementRef).nativeElement;
 
@@ -87,11 +90,11 @@ export class SiWidgetHostComponent implements AfterViewInit, OnChanges {
   readonly componentFactory = input<WidgetComponentFactory>();
 
   /**
-   * CSS icon class for the widget, displayed in the configuration placeholder.
+   * Icon for the widget, displayed in the configuration placeholder.
    *
-   * @defaultValue 'element-apps'
+   * @defaultValue this.elementAppsIcon
    */
-  readonly iconClass = input('element-apps');
+  readonly widgetIcon = input<string>();
 
   /**
    * Sets the widget host into editable mode.
@@ -154,8 +157,7 @@ export class SiWidgetHostComponent implements AfterViewInit, OnChanges {
     }
     return null;
   });
-
-  protected readonly emptyStateIcon = computed(() => `${this.iconClass()} si-display-xl`);
+  protected readonly emptyStateIcon = computed(() => this.widgetIcon() ?? this.elementAppsIcon);
 
   widgetInstance?: WidgetInstance;
   widgetRef?: ComponentRef<WidgetInstance>;


### PR DESCRIPTION
also removes additional size class.

Closes https://github.com/siemens/element/issues/2410 
Closes https://github.com/siemens/element/issues/2414

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2553/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2553/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2553/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2553/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2553/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2553/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2553/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2553/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2553/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2553/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
