### PR TITLE
test(playwright): use grep for selecting static tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,8 +113,8 @@ pnpm dashboards-demo:build-and-run-all:esm   # ESM, port 4204
 ./e2e-local.sh update-all                       # all snapshots
 ./e2e-local.sh update <test-file-name>          # specific test (glob supported)
 
-# Run specific static test
-PLAYWRIGHT_staticTest=buttons/buttons:badges/badges ./e2e-local.sh run static
+# Run specific static tests
+./e2e-local.sh run static --grep 'buttons/buttons|badges/badges'
 ```
 
 ## State Management

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -129,8 +129,8 @@ pnpm run dashboards-demo:build-and-run-all:esm
 # To only update a specific test, append the file name. Glob patterns are supported.
 ./e2e-local.sh update <test-file-name>
 
-# To run a specific static test, use an environment variable and restrict the to static specs:
-PLAYWRIGHT_staticTest=buttons/buttons:badges/badges ./e2e-local.sh run static
+# To run specific static tests, use --grep and restrict to the static spec:
+./e2e-local.sh run --grep 'buttons/buttons|badges/badges'
 ```
 
 Available parameters for `e2e-local.sh`:
@@ -142,7 +142,6 @@ Available parameters for `e2e-local.sh`:
 # - DOCKER: Override the docker command (default: docker)
 # - PORT: Override the port for the example application (default: 4200)
 # - LOCAL_ADDRESS: Override the local address for the example application (default: localhost)
-# - PLAYWRIGHT_staticTest: Run only the specified static test
 ```
 
 ### Use Podman instead of Docker on Linux

--- a/e2e-local.sh
+++ b/e2e-local.sh
@@ -59,7 +59,6 @@ if [ x$1 = "xshell" ]; then
     -e PORT=$PORT \
     -e PLAYWRIGHT_CONTAINER=true \
     -e PLAYWRIGHT_isvrt=true \
-    -e PLAYWRIGHT_staticTest=$PLAYWRIGHT_staticTest \
     -e PW_WORKERS=$PW_WORKERS \
     -v $CWD:/e2e:rw$MOUNT_FLAGS \
     -w /e2e \
@@ -104,7 +103,6 @@ else
     -e PLAYWRIGHT_CONTAINER=true \
     -e PLAYWRIGHT_isa11y=$PLAYWRIGHT_isa11y \
     -e PLAYWRIGHT_isvrt=$PLAYWRIGHT_isvrt \
-    -e PLAYWRIGHT_staticTest=$PLAYWRIGHT_staticTest \
     -v $CWD:/e2e:rw$MOUNT_FLAGS \
     -w /e2e \
     --net=$NETWORK_MODE \

--- a/playwright/support/test-helpers.ts
+++ b/playwright/support/test-helpers.ts
@@ -45,10 +45,6 @@ export const expect = baseExpect.extend({
 
 const SI_EXAMPLE_NAME_ID = 'siExampleName';
 
-const staticTest = process.env.PLAYWRIGHT_staticTest
-  ? new Set(process.env.PLAYWRIGHT_staticTest.split(':'))
-  : undefined;
-
 export const VIEWPORTS = [
   { name: 'default', width: 0, height: 0 }, // Default, 0 will skip resizing and use the default value
   { name: 'tablet-portrait', width: 768, height: 1024 },
@@ -86,34 +82,32 @@ class SiTestHelpers {
    */
   public async static(options?: StaticTestOptions): Promise<void> {
     const exampleName = this.testInfo.title;
-    if (!staticTest || staticTest.has(exampleName)) {
-      const viewports = (options?.viewports?.length ? options.viewports : ['default'])
-        .map(viewport =>
-          typeof viewport !== 'string' ? viewport : VIEWPORTS.find(v => v.name === viewport)
-        )
-        .filter(viewport => !!viewport)
-        .sort((a, b) => a.width * a.height - a.height * b.height); // This ensures the default viewport is first.
+    const viewports = (options?.viewports?.length ? options.viewports : ['default'])
+      .map(viewport =>
+        typeof viewport !== 'string' ? viewport : VIEWPORTS.find(v => v.name === viewport)
+      )
+      .filter(viewport => !!viewport)
+      .sort((a, b) => a.width * a.height - a.height * b.height); // This ensures the default viewport is first.
 
-      for (const viewport of viewports) {
-        const isDefaultViewport = viewport.height === 0 && viewport.width === 0;
-        const specifyViewport = !isDefaultViewport || viewports.length > 1;
-        const step = specifyViewport ? viewport.name : undefined;
-        if (!isDefaultViewport) {
-          await this.page.setViewportSize({ width: viewport.width, height: viewport.height });
-        }
-        await this.visitExample(exampleName, !options?.skipAutoScaleViewport);
-        if (options?.waitCallback) {
-          await options?.waitCallback(this.page);
-        }
-        if (options?.delay) {
-          await this.page.waitForTimeout(options?.delay);
-        }
-        await this.runVisualAndA11yTests(step, {
-          axeRulesSet: options?.disabledA11yRules?.map(item => ({ id: item, enabled: false })),
-          maxDiffPixels: options?.maxDiffPixels,
-          skipAriaSnapshot: options?.skipAriaSnapshot
-        });
+    for (const viewport of viewports) {
+      const isDefaultViewport = viewport.height === 0 && viewport.width === 0;
+      const specifyViewport = !isDefaultViewport || viewports.length > 1;
+      const step = specifyViewport ? viewport.name : undefined;
+      if (!isDefaultViewport) {
+        await this.page.setViewportSize({ width: viewport.width, height: viewport.height });
       }
+      await this.visitExample(exampleName, !options?.skipAutoScaleViewport);
+      if (options?.waitCallback) {
+        await options?.waitCallback(this.page);
+      }
+      if (options?.delay) {
+        await this.page.waitForTimeout(options?.delay);
+      }
+      await this.runVisualAndA11yTests(step, {
+        axeRulesSet: options?.disabledA11yRules?.map(item => ({ id: item, enabled: false })),
+        maxDiffPixels: options?.maxDiffPixels,
+        skipAriaSnapshot: options?.skipAriaSnapshot
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Use Playwright's built-in `--grep` option to select static tests instead of maintaining a custom environment-variable filter.

Update the local E2E documentation and remove the obsolete container environment forwarding.

## Testing

Not run; this change updates test selection and helper behavior only.
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2556/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2556/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2556/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2556/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2556/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2556/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2556/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2556/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2556/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2556/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
