### PR TITLE
fix(chat-messages): pass messages to action handlers

### DIFF
--- a/src/app/examples/si-chat-messages/si-chat-container.html
+++ b/src/app/examples/si-chat-messages/si-chat-container.html
@@ -3,6 +3,7 @@
     @for (message of messages(); track message) {
       @if (message.type === 'user') {
         <si-user-message
+          [actionParam]="message"
           [actions]="getMessagePrimaryActions(message)"
           [secondaryActions]="getMessageSecondaryActions(message)"
           [attachments]="message.attachments ?? []"
@@ -12,6 +13,7 @@
       }
       @if (message.type === 'ai') {
         <si-ai-message
+          [actionParam]="message"
           [actions]="getMessagePrimaryActions(message)"
           [secondaryActions]="getMessageSecondaryActions(message)"
         >


### PR DESCRIPTION
## Summary

Pass the current chat message to user and AI action handlers in the chat-container example. Previously, export callbacks received `undefined` and failed when reading the message content.

## Testing

- `element-examples` lint
- Clicked both **Export message** buttons in the live preview and confirmed there were no page or console errors<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2559/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2559/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2559/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2559/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2559/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2559/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2559/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2559/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2559/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2559/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
