### PR TITLE
fix(translate-cli): avoid shell expansion for glob

### DIFF
--- a/projects/element-translate-cli/bin/update-translatable-keys.js
+++ b/projects/element-translate-cli/bin/update-translatable-keys.js
@@ -13,7 +13,7 @@ console.log('Running localize-extract');
 const args = ['-s', toolConfig.files, '-f', 'xlf2', '-o', 'messages.xlf'];
 const extract = spawn('localize-extract', args, {
   stdio: ['ignore', 'ignore', 'inherit'],
-  shell: true
+  shell: false
 });
 extract.on('error', error => console.log(`error: ${error.message}`));
 


### PR DESCRIPTION
Disable shell execution when invoking `localize-extract`. Angular itself interpolates the glob, so shell expansion is not needed.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2561/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2561/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2561/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2561/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2561/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2561/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2561/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2561/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2561/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2561/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
