### PR TITLE
refactor(auto-collapsable-list): avoid inline host styles

### DIFF
--- a/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list-item.directive.ts
+++ b/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list-item.directive.ts
@@ -9,10 +9,11 @@ import { SiAutoCollapsableListMeasurable } from './si-auto-collapsable-list-meas
 @Directive({
   selector: '[siAutoCollapsableListItem]',
   host: {
-    '[style.visibility]': 'isVisible() ? "visible" : "hidden"',
-    '[style.position]': 'isVisible() ? "" : "absolute"',
+    '[class.visible]': 'isVisible()',
+    '[class.invisible]': '!isVisible()',
+    '[class.position-absolute]': '!isVisible()',
     // Ensure hidden items are behind the visible ones. Otherwise, the visible ones are not clickable
-    '[style.z-index]': 'isVisible() ? "" : "-1"'
+    '[class.z-n1]': '!isVisible()'
   },
   exportAs: 'siAutoCollapsableListItem'
 })

--- a/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list.directive.spec.ts
+++ b/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list.directive.spec.ts
@@ -68,7 +68,7 @@ describe('SiAutoCollapsableListDirective', () => {
   let hostElement: HTMLElement;
   const readVisibilityStates = (): string[] =>
     Array.from(hostElement.querySelectorAll<HTMLElement>('[siAutoCollapsableListItem]')).map(
-      element => element.style.visibility
+      element => (element.classList.contains('visible') ? 'visible' : 'hidden')
     );
 
   // Each browser rendering frame runs in order:
@@ -112,13 +112,13 @@ describe('SiAutoCollapsableListDirective', () => {
     fixture.detectChanges();
     hostElement
       .querySelectorAll<HTMLElement>('[siAutoCollapsableListItem]')
-      .forEach(element => expect(element).toHaveStyle({ visibility: 'hidden' }));
+      .forEach(element => expect(element).toHaveClass('invisible'));
 
     await waitForResizeObserver();
     await fixture.whenStable();
     hostElement
       .querySelectorAll<HTMLElement>('[siAutoCollapsableListItem]')
-      .forEach(element => expect(element).toHaveStyle({ visibility: 'visible' }));
+      .forEach(element => expect(element).toHaveClass('visible'));
     component.items().forEach(item => expect(item.canBeVisible()).toBe(true));
   });
 

--- a/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list.directive.ts
+++ b/projects/element-ng/auto-collapsable-list/si-auto-collapsable-list.directive.ts
@@ -29,8 +29,8 @@ import { SiAutoCollapsableListOverflowItemDirective } from './si-auto-collapsabl
 @Directive({
   selector: '[siAutoCollapsableList]',
   host: {
-    style: 'position: relative',
-    '[style.overflow]': 'siAutoCollapsableList() ? "hidden" : ""'
+    class: 'position-relative',
+    '[class.overflow-hidden]': 'siAutoCollapsableList()'
   },
   exportAs: 'siAutoCollapsableList'
 })


### PR DESCRIPTION
## Summary

Use Element utility classes for host visibility, positioning, overflow, and stacking. This avoids Angular-generated inline styles that violate strict Content Security Policy configurations.

## Verification

`pnpm lib:test --include='**/auto-collapsable-list/**/*.spec.ts' --no-watch` *(fails: five existing assertions inspect the removed inline `style.visibility` values; the refactor deliberately replaces those with CSS classes.)*<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2571/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2571/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2571/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2571/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2571/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2571/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2571/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2571/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2571/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2571/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
