### PR TITLE
feat(system-banner): update system banner typography and dimensions

### DIFF
--- a/api-goldens/element-ng/system-banner/index.api.md
+++ b/api-goldens/element-ng/system-banner/index.api.md
@@ -9,7 +9,7 @@ import { TranslatableString } from '@siemens/element-translate-ng/translate';
 
 // @public
 export class SiSystemBannerComponent {
-    readonly message: _angular_core.InputSignal<TranslatableString>;
+    readonly message: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly status: _angular_core.InputSignal<ExtendedStatusType>;
 }
 

--- a/playwright/snapshots/si-layout.spec.ts-snapshots/si-layouts--content-tile-layout-full-scroll-vertical-nav--navbar-collapsed-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-layout.spec.ts-snapshots/si-layouts--content-tile-layout-full-scroll-vertical-nav--navbar-collapsed-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:096f631209543604073b1edf2e8d3123fed59122bb8e27a102360e6d97b9aca5
-size 53105
+oid sha256:dfde6f5462e8210c72ea6d54880765077dc4da8aad213d2eb498ff89d820f92d
+size 52650

--- a/playwright/snapshots/si-layout.spec.ts-snapshots/si-layouts--content-tile-layout-full-scroll-vertical-nav--navbar-collapsed-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-layout.spec.ts-snapshots/si-layouts--content-tile-layout-full-scroll-vertical-nav--navbar-collapsed-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b3c40a50bbc04971e4e71337faf73885f994c3ab1fc85b0bc5a55bbf68a776b
-size 51664
+oid sha256:8b98347537cd7bc85f1f9d020c84c082299caca9e19b2224a4c164b65e0cacc7
+size 51172

--- a/playwright/snapshots/si-layout.spec.ts-snapshots/si-layouts--content-tile-layout-full-scroll-vertical-nav-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-layout.spec.ts-snapshots/si-layouts--content-tile-layout-full-scroll-vertical-nav-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6441749016439a62b4e4ca207331fb38b67c55b8afd2bb9b18c088d2bdbb768c
-size 58528
+oid sha256:c2544dfcb5c619349b5beea1e22456f8ac0cec8a52b8e57a198b15621a613c2a
+size 58090

--- a/playwright/snapshots/si-layout.spec.ts-snapshots/si-layouts--content-tile-layout-full-scroll-vertical-nav-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-layout.spec.ts-snapshots/si-layouts--content-tile-layout-full-scroll-vertical-nav-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1bd361895a678b4a5ebae473297e596fd41cf004d46c65ca7db5b4b2b4d164a
-size 56839
+oid sha256:e8daf33ac5b56eade336c33d0b1d583050b47a1bc4938717d5212672a0110055
+size 56318

--- a/playwright/snapshots/static.spec.ts-snapshots/si-landing-page--si-landing-page-custom--desktop-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-landing-page--si-landing-page-custom--desktop-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdc2c42163beb51cac5b2fbb9391819c4bf0b4b4ab41c60f529ac573a12106ac
-size 618507
+oid sha256:b8900e055c41f1a41e506ce8ed803b71f5996f6a624a0caf525fce40051d73bc
+size 618230

--- a/playwright/snapshots/static.spec.ts-snapshots/si-landing-page--si-landing-page-custom--desktop-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-landing-page--si-landing-page-custom--desktop-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c502a4d76e486ed48278aaba8e55f267269ae67fff9ab1431e9e882740be8148
-size 619433
+oid sha256:11f18afbdff843fa643177c9ca2b028d9250a2d147a229375bf50590193d39d3
+size 619091

--- a/playwright/snapshots/static.spec.ts-snapshots/si-system-banner--si-system-banner-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-system-banner--si-system-banner-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b62666c1aeb951a4a6e98a67307e2b53cdf1ae54baef947a30c426e2eb7053b
-size 10842
+oid sha256:51c5adfda3cb35d4dbed476cb4aaa68e14658c038fedb756ff92b6a4375533da
+size 11993

--- a/playwright/snapshots/static.spec.ts-snapshots/si-system-banner--si-system-banner-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-system-banner--si-system-banner-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a384d8e636142517a07581affc12282d110c64136bfee229366890b8e2168935
-size 10948
+oid sha256:baba782868d59fecdd39ede252d4f8e1b9cc680b0c641219389ef6a90246feb4
+size 12158

--- a/projects/element-ng/system-banner/system-banner.component.html
+++ b/projects/element-ng/system-banner/system-banner.component.html
@@ -1,5 +1,5 @@
 <div
-  class="text-center text-truncate si-h5 banner"
+  class="text-center text-truncate si-body banner"
   role="alert"
   aria-atomic="true"
   aria-live="assertive"

--- a/projects/element-ng/system-banner/system-banner.component.html
+++ b/projects/element-ng/system-banner/system-banner.component.html
@@ -4,5 +4,5 @@
   aria-atomic="true"
   aria-live="assertive"
 >
-  {{ message() | translate }}
+  <ng-content>{{ message() | translate }}</ng-content>
 </div>

--- a/projects/element-ng/system-banner/system-banner.component.scss
+++ b/projects/element-ng/system-banner/system-banner.component.scss
@@ -8,7 +8,12 @@
 
   .banner {
     padding-block: variables.$si-system-banner-padding-y;
-    padding-inline: map.get(variables.$spacers-inline, 5);
+    padding-inline: map.get(variables.$spacers-inline, 4);
+
+    ::ng-deep a {
+      color: inherit;
+      text-decoration: underline;
+    }
   }
 
   &.banner-info {

--- a/projects/element-ng/system-banner/system-banner.component.spec.ts
+++ b/projects/element-ng/system-banner/system-banner.component.spec.ts
@@ -2,11 +2,22 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { inputBinding, signal, WritableSignal } from '@angular/core';
+import { Component, inputBinding, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ExtendedStatusType } from '@siemens/element-ng/common';
 
 import { SiSystemBannerComponent } from './system-banner.component';
+
+@Component({
+  imports: [SiSystemBannerComponent],
+  template: `
+    <si-system-banner>
+      <span>Update available</span>&nbsp;
+      <a href="https://element.siemens.io/">Learn more</a>
+    </si-system-banner>
+  `
+})
+class TestHostComponent {}
 
 describe('SiSystemBannerComponent', () => {
   let fixture: ComponentFixture<SiSystemBannerComponent>;
@@ -32,6 +43,16 @@ describe('SiSystemBannerComponent', () => {
     await fixture.whenStable();
 
     expect(element).toHaveTextContent('Test');
+  });
+
+  it('should display projected content instead of a message', async () => {
+    const hostFixture = TestBed.createComponent(TestHostComponent);
+    await hostFixture.whenStable();
+
+    const alert = hostFixture.nativeElement.querySelector('[role="alert"]');
+
+    expect(alert).toHaveTextContent(/Update available\s+Learn more/);
+    expect(alert.querySelector('a')).toHaveAttribute('href', 'https://element.siemens.io/');
   });
 
   it('should have default banner type', () => {

--- a/projects/element-ng/system-banner/system-banner.component.ts
+++ b/projects/element-ng/system-banner/system-banner.component.ts
@@ -30,7 +30,7 @@ export class SiSystemBannerComponent {
   /**
    * Message to be displayed in the system banner.
    */
-  readonly message = input.required<TranslatableString>();
+  readonly message = input<TranslatableString>();
 
   protected readonly bannerClass = computed(() => `banner-${this.status()}`);
 }

--- a/projects/element-theme/src/styles/variables/_si-vars.scss
+++ b/projects/element-theme/src/styles/variables/_si-vars.scss
@@ -21,7 +21,7 @@ $btn-width-normal: map.get(sizing.$sizing, 120);
 $si-application-header-height: calc(map.get(sizing.$sizing, 100) + 1px);
 $si-titlebar-padding-y: map.get(spacers.$spacers-block, 3);
 $si-titlebar-height: calc(1.5rem + 2 * $si-titlebar-padding-y);
-$si-system-banner-padding-y: map.get(spacers.$spacers-block, 1);
+$si-system-banner-padding-y: map.get(spacers.$spacers-block, 2);
 $si-system-banner-height: calc(1rem + 2 * $si-system-banner-padding-y);
 
 // allows adding a custom titlebar on top

--- a/src/app/examples/si-system-banner/si-system-banner.html
+++ b/src/app/examples/si-system-banner/si-system-banner.html
@@ -4,4 +4,8 @@
   <si-system-banner message="This is a caution" status="caution" />
   <si-system-banner message="This is an error" status="danger" />
   <si-system-banner message="This is a critical error" status="critical" />
+  <si-system-banner>
+    <span>Update available</span>&nbsp;
+    <a href="https://element.siemens.io/">Learn more</a>
+  </si-system-banner>
 </div>


### PR DESCRIPTION
- Add support for links and other content
- Use body text styling instead of body-bold.
- Adjust banner spacing for a 24px height.
- Add a system banner example with a link.

Closes #2491

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2572/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2572/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2572/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2572/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2572/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2572/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2572/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2572/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2572/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2572/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->














