### PR TITLE
refactor(live-preview): render examples through runtime shell

### DIFF
--- a/api-goldens/live-preview/index.api.md
+++ b/api-goldens/live-preview/index.api.md
@@ -6,6 +6,7 @@
 
 import { ActivatedRoute } from '@angular/router';
 import { AfterViewInit } from '@angular/core';
+import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/router';
@@ -18,7 +19,9 @@ import { OnInit } from '@angular/core';
 import { Provider } from '@angular/core';
 import { Route } from '@angular/router';
 import { Routes } from '@angular/router';
+import { Signal } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
+import { Type } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 import { ViewContainerRef } from '@angular/core';
 
@@ -256,6 +259,7 @@ export interface SiLivePreviewConfig {
         list: string[];
         webcomponentsList: string[];
     };
+    defaultRoutes?: Route[];
     // (undocumented)
     errorHandler?: (err: any) => void;
     // (undocumented)
@@ -263,11 +267,10 @@ export interface SiLivePreviewConfig {
     // (undocumented)
     landscapeToggle?: boolean;
     // (undocumented)
-    modules: any[];
-    // (undocumented)
     rootFontSizes?: number[];
     // (undocumented)
     rtlSwitcher?: boolean;
+    runtimeComponent?: Type<SiLivePreviewRuntimeComponent>;
     // (undocumented)
     themeSwitcher?: boolean;
     // (undocumented)
@@ -411,6 +414,16 @@ class SiLivePreviewRoutingModule {
 }
 export { SiLivePreviewRoutingModule }
 export { SiLivePreviewRoutingModule as SimplLivePreviewRoutingModule }
+
+// @public
+export abstract class SiLivePreviewRuntimeComponent implements AfterViewInit, DoCheck, OnDestroy {
+    // (undocumented)
+    readonly component: i0.InputSignal<Type<unknown>>;
+    // (undocumented)
+    readonly ready: i0.OutputEmitterRef<void>;
+    // (undocumented)
+    readonly renderingError: i0.OutputEmitterRef<Error>;
+}
 
 // @public (undocumented)
 export abstract class SiLivePreviewThemeApi {

--- a/api-goldens/live-preview/webcomponents/index.api.md
+++ b/api-goldens/live-preview/webcomponents/index.api.md
@@ -4,11 +4,17 @@
 
 ```ts
 
+import { AfterViewInit } from '@angular/core';
+import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
+import { Route } from '@angular/router';
+import { Signal } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
+import { Type } from '@angular/core';
+import { ViewContainerRef } from '@angular/core';
 
 // @public (undocumented)
 export class SiLivePreviewWebComponent implements OnChanges {

--- a/projects/live-preview/components/si-live-preview-renderer/si-default-live-preview-runtime.component.ts
+++ b/projects/live-preview/components/si-live-preview-renderer/si-default-live-preview-runtime.component.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, ViewContainerRef, viewChild } from '@angular/core';
+
+import { SiLivePreviewRuntimeComponent } from './si-live-preview-runtime.component';
+
+/** Default standalone shell used to render a live-preview example. */
+@Component({
+  selector: 'si-live-preview-runtime',
+  template: '<ng-container #container />'
+})
+export class SiDefaultLivePreviewRuntimeComponent extends SiLivePreviewRuntimeComponent {
+  readonly container = viewChild.required('container', { read: ViewContainerRef });
+}

--- a/projects/live-preview/components/si-live-preview-renderer/si-live-preview-renderer.component.ts
+++ b/projects/live-preview/components/si-live-preview-renderer/si-live-preview-renderer.component.ts
@@ -3,43 +3,33 @@
  * SPDX-License-Identifier: MIT
  */
 import {
-  AfterViewInit,
   ChangeDetectorRef,
   ɵcompileComponent as compileComponent,
-  ɵcompileNgModule as compileNgModule,
   Compiler,
   Component,
   ComponentRef,
-  createNgModule,
-  DoCheck,
   ElementRef,
-  EnvironmentInjector,
   HostBinding,
   inject,
   Injector,
   Input,
-  NgModule,
-  NgModuleRef,
+  inputBinding,
   OnChanges,
   OnDestroy,
   ɵresetCompiledComponents as resetCompiledComponents,
   SimpleChanges,
   ViewContainerRef,
   viewChild,
-  ViewChild,
   output,
   ChangeDetectionStrategy
 } from '@angular/core';
 import { ɵDomRendererFactory2 as DomRendererFactory2 } from '@angular/platform-browser';
-import { ActivatedRoute, Routes } from '@angular/router';
 
 import { LOG_EVENT } from '../../helpers/log-event';
-import {
-  SI_LIVE_PREVIEW_CONFIG,
-  SI_LIVE_PREVIEW_EXAMPLE_ROUTES,
-  SI_LIVE_PREVIEW_INTERNALS
-} from '../../interfaces/live-preview-config';
+import { SI_LIVE_PREVIEW_CONFIG } from '../../interfaces/live-preview-config';
 import { LandscapeSupportService } from '../../services/landscape-support.service';
+import { SiDefaultLivePreviewRuntimeComponent } from './si-default-live-preview-runtime.component';
+import { SiLivePreviewRuntimeComponent } from './si-live-preview-runtime.component';
 
 // for handling JSON.stringify with circular references, from MDN
 const getCircularReplacer = (): ((_key: any, value: any | null) => any) => {
@@ -91,18 +81,12 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
   readonly inProgress = output<boolean>();
   readonly supportsLandscapeMode = output<boolean>();
 
-  private componentRef?: ComponentRef<unknown>;
-  private moduleRef?: NgModuleRef<unknown>;
-  private hasRenderingError = false;
-
+  private componentRef?: ComponentRef<SiLivePreviewRuntimeComponent>;
   private componentTs?: Promise<any>;
   private componentTsSampleComponent: any;
   private dynamicComponent: any;
   private dynamicComponentId?: string;
   private componentTsFirstLoad = true;
-  private componentTsSampleModule: any;
-  private component: any;
-  private componentModule: any;
   private compiledTemplate?: string;
 
   // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -116,12 +100,8 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
       }
     ]
   });
-  private envInjector = inject(EnvironmentInjector);
   private rendererFactory = inject(DomRendererFactory2);
   private config = inject(SI_LIVE_PREVIEW_CONFIG);
-  private internalConfig = inject(SI_LIVE_PREVIEW_INTERNALS);
-  private activatedRoute = inject(ActivatedRoute);
-  private defaultRoutes = this.activatedRoute.routeConfig?.children ?? [];
   private cdRef = inject(ChangeDetectorRef);
 
   ngOnChanges(changes: SimpleChanges<this>): void {
@@ -162,7 +142,6 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
   }
 
   private setRenderingError(hasError: boolean, msg?: any): void {
-    this.hasRenderingError = hasError;
     this.logRenderingError.emit(msg);
     if (hasError) {
       setTimeout(() => {
@@ -176,7 +155,6 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
     this.logClear.emit();
     this.clear();
     this.componentTsSampleComponent = undefined;
-    this.componentTsSampleModule = undefined;
     this.dynamicComponent = undefined;
     this.componentTsFirstLoad = true;
 
@@ -187,7 +165,6 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
         .then(m => {
           this.componentTsSampleComponent = m.SampleComponent;
           this.dynamicComponent = m.SampleComponent;
-          this.componentTsSampleModule = m.SampleModule;
           this.compileWhenReady();
           if (!this.componentTsSampleComponent && !this.template) {
             setTimeout(() => {
@@ -344,178 +321,8 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
     return obj.decorators?.[0]?.args?.[0];
   }
 
-  private createAbstractComponentClass(ionic: boolean): any {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const self = this;
-
-    this.updateDynamicTemplate();
-
-    @Component({
-      // eslint-disable-next-line @angular-eslint/prefer-standalone
-      standalone: false,
-      template: '',
-      changeDetection: ChangeDetectionStrategy.Eager,
-      jit: true
-    })
-    class AbstractRuntimeComponent implements DoCheck, AfterViewInit, OnDestroy {
-      private changeDetector = inject(ChangeDetectorRef);
-      // NOTE: This must be @ViewChild and not signal query as signal query doesn't work with jit
-      @ViewChild('container', { read: ViewContainerRef })
-      private container!: ViewContainerRef;
-      private childRouteBackup: Routes | undefined;
-
-      logEvent(...msg: any[]): void {
-        self.logMessage.emit(self.stringifyLog(msg));
-      }
-
-      ngDoCheck(): void {
-        if (self.hasRenderingError) {
-          return;
-        }
-        try {
-          this.changeDetector.detectChanges();
-        } catch (error: any) {
-          setTimeout(() => {
-            this.handleError(error);
-            this.changeDetector.markForCheck();
-          });
-        }
-      }
-
-      ngAfterViewInit(): void {
-        const exampleRoutes =
-          this.container?.injector.get(SI_LIVE_PREVIEW_EXAMPLE_ROUTES, undefined, {
-            optional: true,
-            self: true
-          }) ?? self.defaultRoutes;
-
-        const route = self.activatedRoute.routeConfig;
-        if (route) {
-          this.childRouteBackup = route.children;
-          // cannot use router.resetConfig here as it destroys the components on child route navigations
-          route.children = [...exampleRoutes];
-        }
-        queueMicrotask(() => {
-          self.setInProgress(false);
-          self.cdRef.markForCheck();
-        });
-      }
-
-      ngOnDestroy(): void {
-        const route = self.activatedRoute.routeConfig;
-        if (route) {
-          // restore the original child routes
-          route.children = this.childRouteBackup;
-        }
-      }
-
-      private handleError(error: Error): void {
-        let msg = error.message;
-        if (error.stack) {
-          const stack = error.stack.split('\n', 3);
-          stack.forEach(s => (msg += `\n${s}`));
-        }
-        self.setRenderingError(true, msg);
-
-        // since these kind of errors are most likely bugs in the components, forward error
-        self.logError(error);
-      }
-    }
-
-    if (ionic) {
-      @Component({
-        selector: 'si-rendered-example',
-        // eslint-disable-next-line @angular-eslint/prefer-standalone
-        standalone: false,
-        template: '<ion-app><app-sample #container class="ion-page"></app-sample></ion-app>',
-        changeDetection: ChangeDetectionStrategy.Eager,
-        jit: true
-      })
-      class RuntimeComponent extends AbstractRuntimeComponent {}
-
-      return RuntimeComponent;
-    }
-
-    @Component({
-      selector: 'si-rendered-example',
-      // eslint-disable-next-line @angular-eslint/prefer-standalone
-      standalone: false,
-      template: '<app-sample #container></app-sample>',
-      changeDetection: ChangeDetectionStrategy.Eager,
-      jit: true
-    })
-    class RuntimeComponent extends AbstractRuntimeComponent {}
-
-    return RuntimeComponent;
-  }
-
-  private createComponentClass(): any {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const RuntimeComponent = this.createAbstractComponentClass(this.internalConfig.isMobile);
-    const compAnn = this.getAnnotation(RuntimeComponent, Component);
-    if (!Object.prototype.hasOwnProperty.call(RuntimeComponent, 'ɵcmp')) {
-      compileComponent(RuntimeComponent, compAnn);
-    }
-    return RuntimeComponent;
-  }
-
-  private createModule(): any {
-    const meta: NgModule = {
-      declarations: [this.component],
-      imports: [...this.config.modules],
-      jit: true
-    };
-
-    if (this.dynamicComponent) {
-      if (this.dynamicComponent['ɵcmp'].standalone) {
-        meta.imports!.push(this.dynamicComponent);
-      } else {
-        meta.declarations!.push(this.dynamicComponent);
-      }
-    }
-
-    // Merge the provided NgModule into the one to be constructed. This is necessary to have everything at the
-    // right level. Otherwise, the provided module would have to declare and export the component as well
-    const ann = this.getAnnotation(this.componentTsSampleModule, NgModule);
-    if (ann) {
-      for (const field of ['imports', 'declarations', 'exports', 'providers']) {
-        const fieldAnn = ann[field];
-        if (fieldAnn) {
-          if (!(meta as any)[field]) {
-            (meta as any)[field] = [];
-          }
-          (meta as any)[field].push(...fieldAnn);
-        }
-      }
-    }
-
-    @NgModule({
-      imports: meta.imports,
-      declarations: meta.declarations,
-      providers: meta.providers,
-      exports: meta.exports,
-      jit: true
-    })
-    class RuntimeComponentModule {}
-
-    if (!Object.hasOwnProperty.call(RuntimeComponentModule, 'ɵmod')) {
-      compileNgModule(RuntimeComponentModule, this.getAnnotation(RuntimeComponentModule, NgModule));
-    }
-
-    return RuntimeComponentModule;
-  }
-
   private clear(): void {
     this.removeComponentInstance();
-    this.moduleRef?.destroy();
-    this.moduleRef = undefined;
-
-    if (this.componentModule) {
-      this.compiler.clearCacheFor(this.component);
-      this.compiler.clearCacheFor(this.componentModule);
-      this.component = undefined;
-      this.componentModule = undefined;
-    }
 
     if (this.dynamicComponent) {
       this.compiler.clearCacheFor(this.dynamicComponent);
@@ -546,10 +353,7 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
     this.setRenderingError(false);
 
     try {
-      this.component = this.createComponentClass();
-      this.componentModule = this.createModule();
-
-      this.moduleRef = createNgModule(this.componentModule, this.envInjector);
+      this.updateDynamicTemplate();
       this.createComponentInstance();
     } catch (error: any) {
       this.setRenderingError(true, error.toString());
@@ -559,11 +363,26 @@ export class SiLivePreviewRendererComponent implements OnChanges, OnDestroy {
   private createComponentInstance(): void {
     this.dynamicComponentId = this.dynamicComponent?.['ɵcmp']?.id;
 
-    if (this.moduleRef) {
-      this.componentRef = this.renderedExample().createComponent(this.component, {
-        injector: this.injector,
-        ngModuleRef: this.moduleRef
-      });
+    if (!this.dynamicComponent) {
+      return;
     }
+    if (!this.dynamicComponent['ɵcmp']?.standalone) {
+      throw new Error('Live preview examples must be standalone components.');
+    }
+    const runtimeComponent = this.config.runtimeComponent ?? SiDefaultLivePreviewRuntimeComponent;
+    this.componentRef = this.renderedExample().createComponent(runtimeComponent, {
+      injector: this.injector,
+      bindings: [inputBinding('component', () => this.dynamicComponent)]
+    });
+    this.componentRef.instance.ready.subscribe(() => {
+      queueMicrotask(() => {
+        this.setInProgress(false);
+        this.cdRef.markForCheck();
+      });
+    });
+    this.componentRef.instance.renderingError.subscribe(error => {
+      this.setRenderingError(true, error.message);
+      this.logError(error);
+    });
   }
 }

--- a/projects/live-preview/components/si-live-preview-renderer/si-live-preview-runtime.component.ts
+++ b/projects/live-preview/components/si-live-preview-renderer/si-live-preview-runtime.component.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  ComponentRef,
+  Directive,
+  DoCheck,
+  inject,
+  input,
+  OnDestroy,
+  output,
+  Signal,
+  Type,
+  ViewContainerRef
+} from '@angular/core';
+import { ActivatedRoute, Routes } from '@angular/router';
+
+import {
+  SI_LIVE_PREVIEW_CONFIG,
+  SI_LIVE_PREVIEW_EXAMPLE_ROUTES
+} from '../../interfaces/live-preview-config';
+
+/**
+ * Base class for components that act as a live-preview runtime shell.
+ * Extend this class when providing `SiLivePreviewConfig.runtimeComponent`.
+ */
+@Directive()
+export abstract class SiLivePreviewRuntimeComponent implements AfterViewInit, DoCheck, OnDestroy {
+  readonly component = input.required<Type<unknown>>();
+  readonly ready = output<void>();
+  readonly renderingError = output<Error>();
+
+  protected abstract readonly container: Signal<ViewContainerRef>;
+
+  private readonly changeDetector = inject(ChangeDetectorRef);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly config = inject(SI_LIVE_PREVIEW_CONFIG);
+  private componentRef?: ComponentRef<unknown>;
+  private childRouteBackup: Routes | undefined;
+  private hasRenderingError = false;
+
+  ngAfterViewInit(): void {
+    this.componentRef = this.container().createComponent(this.component());
+    const exampleRoutes =
+      this.componentRef.injector.get(SI_LIVE_PREVIEW_EXAMPLE_ROUTES, undefined, {
+        optional: true,
+        self: true
+      }) ??
+      this.config.defaultRoutes ??
+      this.activatedRoute.routeConfig?.children ??
+      [];
+    const route = this.activatedRoute.routeConfig;
+    if (route) {
+      this.childRouteBackup = route.children;
+      // Do not reset the router configuration: that destroys child components during navigation.
+      route.children = [...exampleRoutes];
+    }
+    this.ready.emit();
+  }
+
+  ngOnDestroy(): void {
+    const route = this.activatedRoute.routeConfig;
+    if (route) {
+      route.children = this.childRouteBackup;
+    }
+  }
+
+  ngDoCheck(): void {
+    if (this.hasRenderingError) {
+      return;
+    }
+    try {
+      this.changeDetector.detectChanges();
+    } catch (error: unknown) {
+      this.hasRenderingError = true;
+      this.renderingError.emit(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+}

--- a/projects/live-preview/interfaces/live-preview-config.ts
+++ b/projects/live-preview/interfaces/live-preview-config.ts
@@ -2,12 +2,22 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { InjectionToken } from '@angular/core';
+import { InjectionToken, Type } from '@angular/core';
 import { Route } from '@angular/router';
 
+import type { SiLivePreviewRuntimeComponent } from '../components/si-live-preview-renderer/si-live-preview-runtime.component';
+
 export interface SiLivePreviewConfig {
-  modules: any[];
   errorHandler?: (err: any) => void;
+  /**
+   * Optional shell for rendered examples. The shell receives the standalone example through
+   * `component` and is responsible for rendering it, for example by composing the default shell.
+   */
+  runtimeComponent?: Type<SiLivePreviewRuntimeComponent>;
+  /**
+   * Routes used by rendered examples that do not provide routes through `provideExampleRoutes`.
+   */
+  defaultRoutes?: Route[];
   componentLoader: {
     load: (name: string) => Promise<any>;
     list: string[];

--- a/projects/live-preview/live-preview-routes.ts
+++ b/projects/live-preview/live-preview-routes.ts
@@ -13,39 +13,17 @@ import { SiLivePreviewWrapperComponent } from './components/si-live-preview-wrap
 export const livePreviewRoutes: Routes = [
   {
     path: 'overview',
-    children: [
-      // those need to be explicit for Ionic router related components like tabs
-      { path: 'route1', component: SiDummyComponent },
-      { path: 'route2', component: SiDummyComponent },
-      { path: 'route3', component: SiDummyComponent },
-      { path: 'route4', component: SiDummyComponent },
-      { path: 'route5', component: SiDummyComponent },
-      { path: '**', component: SiExampleOverviewComponent }
-    ]
+    children: [{ path: '**', component: SiExampleOverviewComponent }]
   },
   {
     path: 'viewer/:mode',
     component: SiExampleViewerComponent,
-    children: [
-      { path: 'route1', component: SiDummyComponent },
-      { path: 'route2', component: SiDummyComponent },
-      { path: 'route3', component: SiDummyComponent },
-      { path: 'route4', component: SiDummyComponent },
-      { path: 'route5', component: SiDummyComponent },
-      { path: '**', component: SiDummyComponent }
-    ]
+    children: [{ path: '**', component: SiDummyComponent }]
   },
   {
     path: 'iframe',
     component: SiLivePreviewWrapperComponent,
-    children: [
-      { path: 'route1', component: SiDummyComponent },
-      { path: 'route2', component: SiDummyComponent },
-      { path: 'route3', component: SiDummyComponent },
-      { path: 'route4', component: SiDummyComponent },
-      { path: 'route5', component: SiDummyComponent },
-      { path: '**', component: SiDummyComponent }
-    ]
+    children: [{ path: '**', component: SiDummyComponent }]
   },
   { path: '', redirectTo: 'viewer/editor', pathMatch: 'full' },
   { path: '**', component: SiExampleViewerComponent }

--- a/projects/live-preview/public-api.ts
+++ b/projects/live-preview/public-api.ts
@@ -11,6 +11,7 @@ export * from './components/si-example-viewer/si-example-viewer.component';
 export * from './components/si-live-preview/si-live-preview.component';
 export * from './components/si-live-preview-iframe/si-live-preview-iframe.component';
 export * from './components/si-live-preview-renderer/si-live-preview-renderer.component';
+export * from './components/si-live-preview-renderer/si-live-preview-runtime.component';
 export * from './components/si-live-preview-wrapper/si-live-preview-wrapper.component';
 export * from './components/si-live-preview-qr/si-live-preview-qr.component';
 export * from './components/stackblitz/stackblitz.provider';

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -120,7 +120,6 @@ export const APP_CONFIG: ApplicationConfig = {
       // App internal
       SiLivePreviewModule.forRoot(
         {
-          modules: [],
           componentLoader,
           examplesBaseUrl: 'app/examples/',
           ticketBaseUrl: 'https://github.com/siemens/element/issues/new',


### PR DESCRIPTION
refactor(live-preview): render examples through runtime shell

Render initial standalone examples through an AOT-compiled runtime shell. Compile an example
template only after it is edited.

BREAKING CHANGE: `SampleModule` and the `modules` configuration are removed.

Migrate every preview example to a standalone `SampleComponent`, declaring its dependencies in
the component `imports` and `providers`. Remove the `SampleModule` export and the `modules`
property from the preview configuration.

BREAKING CHANGE: Built-in Ionic runtime rendering is removed.

Restore Ionic rendering with a custom `runtimeComponent` that extends
`SiLivePreviewRuntimeComponent`:

```ts
import { Component, ViewContainerRef, viewChild } from "@angular/core";
import { IonApp } from "@ionic/angular/standalone";
import { SiLivePreviewRuntimeComponent } from "@siemens/live-preview";

@Component({
  imports: [IonApp],
  selector: "app-ionic-preview-runtime",
  template: "<ion-app><ng-container #container /></ion-app>"
})
export class IonicPreviewRuntimeComponent extends SiLivePreviewRuntimeComponent {
  readonly container = viewChild.required("container", { read: ViewContainerRef });
}
```

Configure it with `runtimeComponent: IonicPreviewRuntimeComponent`. The base class renders the
example into `container` and preserves route, ready, and error handling.

BREAKING CHANGE: Built-in dummy routes are removed.

Declare the routes required by an example in that example's `providers`:

```ts
import { Component } from "@angular/core";
import { Route } from "@angular/router";
import { provideExampleRoutes } from "@siemens/live-preview";

const routes: Route[] = [
  { path: "route1", component: RouteOneComponent },
  { path: "route2", component: RouteTwoComponent }
];

@Component({
  providers: [provideExampleRoutes(routes)]
})
export class SampleComponent {}
```

To retain shared fallback routes for examples that do not declare their own, configure
`defaultRoutes` in `SiLivePreviewModule.forRoot()`:

```ts
import { Route } from "@angular/router";
import { SiDummyComponent, SiLivePreviewModule } from "@siemens/live-preview";

const defaultRoutes: Route[] = [
  { path: "route1", component: SiDummyComponent },
  { path: "route2", component: SiDummyComponent }
];

SiLivePreviewModule.forRoot({
  // ...
  defaultRoutes
});
```<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2576/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2576/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2576/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2576/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2576/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2576/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2576/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2576/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2576/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2576/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

