### PR TITLE
fixup(chat-messages): use background-4 for chat input

### DIFF
--- a/projects/element-ng/chat-messages/si-chat-input.component.scss
+++ b/projects/element-ng/chat-messages/si-chat-input.component.scss
@@ -17,7 +17,7 @@
   &:hover,
   &:active,
   &:focus-within {
-    background-color: variables.$element-base-input-experimental;
+    background-color: variables.$si-sys-background-4;
     border-color: variables.$si-sys-border-1;
   }
 


### PR DESCRIPTION
Replace the experimental `base-input` token with `background-4` for the chat input hover, active, and focus states.

Tests: `pnpm lib:test --include='**/chat-messages/si-chat-input.component.spec.ts' --no-watch` (51 passed)<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2580/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2580/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2580/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2580/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2580/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2580/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2580/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2580/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2580/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2580/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
