### PR TITLE
docs(examples): use si-icon in datatables

### DIFF
--- a/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--invalid-age-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--invalid-age-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c3348fdc614c670d2c10414153e63cff4846e891d00fbb0cc14eb12b57c868c
-size 47608
+oid sha256:a6ce5392c8c9fe3625a22dbf5f5b8325fe1acfc87e60e4fa78b14eaea55fd546
+size 48470

--- a/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--invalid-age-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--invalid-age-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9dc7fb74f4ed2f607b522cb3cfb2a3d79bd84d05d13b570de21d60de6b5b3a6
-size 47709
+oid sha256:005dbb83b7a47b1e56a3114107727e63cac2be07f094079065f7b40b7054aa53
+size 48282

--- a/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--invalid-age.yaml
+++ b/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--invalid-age.yaml
@@ -19,7 +19,7 @@
       - cell "1":
         - textbox "Age": "1"
       - cell "Context menu":
-        - button "Context menu": 
+        - button "Context menu"
     - row /plant status none 2 First 2 Last 2 \d+ Context menu/:
       - cell "plant status none":
         - status "plant status none"
@@ -30,7 +30,7 @@
       - cell /\d+/:
         - textbox "Age": /\d+/
       - cell "Context menu":
-        - button "Context menu": 
+        - button "Context menu"
     - row /plant status none 3 First 3 Last 3 \d+ Context menu/:
       - cell "plant status none":
         - status "plant status none"
@@ -41,7 +41,7 @@
       - cell /\d+/:
         - textbox "Age": /\d+/
       - cell "Context menu":
-        - button "Context menu": 
+        - button "Context menu"
     - row /plant in status info 4 First 4 Last 4 \d+ Context menu/:
       - cell "plant in status info":
         - status "plant in status info"
@@ -52,7 +52,7 @@
       - cell /\d+/:
         - textbox "Age": /\d+/
       - cell "Context menu":
-        - button "Context menu": 
+        - button "Context menu"
     - row /plant status none 5 First 5 Last 5 \d+ Context menu/:
       - cell "plant status none":
         - status "plant status none"
@@ -63,7 +63,7 @@
       - cell /\d+/:
         - textbox "Age": /\d+/
       - cell "Context menu":
-        - button "Context menu": 
+        - button "Context menu"
     - row /plant status none 6 First 6 Last 6 \d+ Context menu/:
       - cell "plant status none":
         - status "plant status none"
@@ -74,7 +74,7 @@
       - cell /\d+/:
         - textbox "Age": /\d+/
       - cell "Context menu":
-        - button "Context menu": 
+        - button "Context menu"
     - row /plant status none 7 First 7 Last 7 \d+ Context menu/:
       - cell "plant status none":
         - status "plant status none"
@@ -85,7 +85,7 @@
       - cell /\d+/:
         - textbox "Age": /\d+/
       - cell "Context menu":
-        - button "Context menu": 
+        - button "Context menu"
     - row /plant in status warning 8 First 8 Last 8 \d+ Context menu/:
       - cell "plant in status warning":
         - status "plant in status warning"
@@ -96,7 +96,7 @@
       - cell /\d+/:
         - textbox "Age": /\d+/
       - cell "Context menu":
-        - button "Context menu": 
+        - button "Context menu"
 - navigation "Pagination":
   - list:
     - listitem:

--- a/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:daf848477c66c29bff47c2107e2f442e1ed254b54ff03d098d22b662d90d810f
-size 42374
+oid sha256:5ab9ad550b4096e4bdd3b90c8f90ae8080831cb2870b412c4ad8129ab0788f31
+size 43371

--- a/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e22aaa6961f4251c47d4b432e34932c7b64cddc675613428652061d88e91ced9
-size 42467
+oid sha256:927d9793f327bd0b41bb36b72b5e32c9e12fe58032b59d4b72de6585265f15ce
+size 43106

--- a/playwright/snapshots/static.spec.ts-snapshots/datatable--bootstrap-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/datatable--bootstrap-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c1f87448fb66f6bf0c2381c9b31673b5336e16c4010df05d2556b357c2dac16
-size 29770
+oid sha256:9b7dcc4a13a5a6c1bb37c24e3669ff654ae2d739a3e5977d7e8cc7210ad6967e
+size 29903

--- a/playwright/snapshots/static.spec.ts-snapshots/datatable--bootstrap-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/datatable--bootstrap-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:794ed5ed65a676953cc9cae7875dd832381d22fbab31ce3a3a6a716f3475e08c
-size 29523
+oid sha256:702123e69b33d20013e1706d5891db256c9ac2977cdb0274b2231174f13d3b58
+size 29538

--- a/playwright/snapshots/static.spec.ts-snapshots/datatable--bootstrap.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/datatable--bootstrap.yaml
@@ -23,7 +23,7 @@
       - cell
       - cell
       - cell /\d+%/:
-        - textbox "value" [disabled]
+        - textbox "value" [disabled]: /\d+%/
     - row "selected open dropdown Cooling coil cooling request Control Mode":
       - cell "selected":
         - checkbox "selected"
@@ -48,7 +48,7 @@
       - cell
       - cell
       - cell /\d+%/:
-        - textbox "value" [disabled]
+        - textbox "value" [disabled]: /\d+%/
     - row /selected open dropdown Cooling coil available for cooling \d+%/:
       - cell "selected":
         - checkbox "selected"
@@ -60,7 +60,7 @@
       - cell
       - cell
       - cell /\d+%/:
-        - textbox "value" [disabled]
+        - textbox "value" [disabled]: /\d+%/
 - text: Settings Condensed rows
 - checkbox "Check to apply the table-sm class for condensed row height."
 - text: Check to apply the table-sm class for condensed row height. Hoverable rows

--- a/src/app/examples/datatable/bootstrap.html
+++ b/src/app/examples/datatable/bootstrap.html
@@ -38,25 +38,31 @@
             <td class="text-center">
               <button
                 type="button"
-                class="btn btn-tertiary btn-circle element-down-2"
+                class="btn btn-tertiary btn-circle"
                 title="open dropdown"
                 aria-label="open dropdown"
-              ></button>
+              >
+                <si-icon [icon]="icons.elementDown2" />
+              </button>
             </td>
-            <td class="text-center"><si-icon class="icon" icon="element-config-value" /></td>
+            <td class="text-center">
+              <si-icon class="icon" [icon]="icons.elementConfigValue" />
+            </td>
             <td>
               <span class="si-h5">Cooling coil device mode</span><br /><span
                 class="si-body text-secondary"
                 >B1'Flr_1'RSegm1'HVAC</span
               >
             </td>
-            <td class="text-center"
-              ><si-icon class="icon text-secondary" icon="element-transient" />
+            <td class="text-center">
+              <si-icon class="icon text-secondary" [icon]="icons.elementTransient" />
             </td>
             <td class="text-center">
-              <si-icon class="icon status-warning" icon="element-maintenance-filled" />
+              <si-icon class="icon status-warning" [icon]="icons.elementMaintenanceFilled" />
             </td>
-            <td class="text-center"><si-icon class="icon" icon="element-alarm" /></td>
+            <td class="text-center">
+              <si-icon class="icon" [icon]="icons.elementAlarm" />
+            </td>
             <td class="si-body">
               <input type="text" class="form-control" value="50%" aria-label="value" disabled />
             </td>
@@ -72,16 +78,20 @@
             <td class="text-center">
               <button
                 type="button"
-                class="btn btn-tertiary btn-circle element-down-2"
+                class="btn btn-tertiary btn-circle"
                 title="open dropdown"
                 aria-label="open dropdown"
-              ></button>
+              >
+                <si-icon [icon]="icons.elementDown2" />
+              </button>
             </td>
-            <td class="text-center"><si-icon class="icon" icon="element-physical-input" /></td>
+            <td class="text-center">
+              <si-icon class="icon" [icon]="icons.elementPhysicalInput" />
+            </td>
             <td class="si-h5">Cooling coil cooling request</td>
             <td class="text-center"></td>
             <td class="text-center">
-              <si-icon class="icon status-danger" icon="element-manual-filled" />
+              <si-icon class="icon status-danger" [icon]="icons.elementManualFilled" />
             </td>
             <td class="text-center"></td>
             <td class="si-body">
@@ -101,19 +111,23 @@
             <td class="text-center">
               <button
                 type="button"
-                class="btn btn-tertiary btn-circle element-down-2"
+                class="btn btn-tertiary btn-circle"
                 title="open dropdown"
                 aria-label="open dropdown"
-              ></button>
+              >
+                <si-icon [icon]="icons.elementDown2" />
+              </button>
             </td>
-            <td class="text-center"><si-icon class="icon" icon="element-physical-input" /></td>
+            <td class="text-center">
+              <si-icon class="icon" [icon]="icons.elementPhysicalInput" />
+            </td>
             <td class="si-h5">Cooling coil dehumidification request</td>
             <td class="text-center"></td>
             <td class="text-center">
-              <si-icon class="icon status-warning" icon="element-manual-filled" />
+              <si-icon class="icon status-warning" [icon]="icons.elementManualFilled" />
             </td>
             <td class="text-center">
-              <si-icon class="icon status-danger" icon="element-alarm-filled" />
+              <si-icon class="icon status-danger" [icon]="icons.elementAlarmFilled" />
             </td>
             <td class="si-body">
               <input type="text" class="form-control" value="50%" aria-label="value" disabled />
@@ -130,21 +144,25 @@
             <td class="text-center">
               <button
                 type="button"
-                class="btn btn-tertiary btn-circle element-down-2"
+                class="btn btn-tertiary btn-circle"
                 title="open dropdown"
                 aria-label="open dropdown"
-              ></button>
+              >
+                <si-icon [icon]="icons.elementDown2" />
+              </button>
             </td>
-            <td class="text-center"><si-icon class="icon" icon="element-calculated-value" /></td>
+            <td class="text-center">
+              <si-icon class="icon" [icon]="icons.elementCalculatedValue" />
+            </td>
             <td class="si-h5">Cooling coil available for cooling</td>
             <td class="text-center">
-              <si-icon class="icon status-danger" icon="element-cancel-filled" />
+              <si-icon class="icon status-danger" [icon]="icons.elementCancelFilled" />
             </td>
             <td class="text-center"></td>
             <td class="text-center">
               <span class="icon icon-stack">
-                <si-icon class="status-danger" icon="element-alarm-background-filled" />
-                <si-icon class="text-secondary" icon="element-alarm-tick" />
+                <si-icon class="status-danger" [icon]="icons.elementAlarmBackgroundFilled" />
+                <si-icon class="text-secondary" [icon]="icons.elementAlarmTick" />
               </span>
             </td>
             <td class="si-body">

--- a/src/app/examples/datatable/bootstrap.ts
+++ b/src/app/examples/datatable/bootstrap.ts
@@ -4,8 +4,22 @@
  */
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import {
+  elementAlarm,
+  elementAlarmBackgroundFilled,
+  elementAlarmFilled,
+  elementAlarmTick,
+  elementCalculatedValue,
+  elementCancelFilled,
+  elementConfigValue,
+  elementDown2,
+  elementMaintenanceFilled,
+  elementManualFilled,
+  elementTransient,
+  elementPhysicalInput
+} from '@siemens/element-icons';
 import { SiFormItemComponent } from '@siemens/element-ng/form';
-import { SiIconComponent } from '@siemens/element-ng/icon';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 
 @Component({
   selector: 'app-sample',
@@ -14,6 +28,20 @@ import { SiIconComponent } from '@siemens/element-ng/icon';
   host: { class: 'p-5' }
 })
 export class SampleComponent {
+  readonly icons = addIcons({
+    elementAlarm,
+    elementAlarmBackgroundFilled,
+    elementAlarmFilled,
+    elementAlarmTick,
+    elementCalculatedValue,
+    elementCancelFilled,
+    elementConfigValue,
+    elementDown2,
+    elementMaintenanceFilled,
+    elementManualFilled,
+    elementTransient,
+    elementPhysicalInput
+  });
   useHover = false;
   useSmallTable = false;
 }

--- a/src/app/examples/datatable/datatable-bulk-actions.html
+++ b/src/app/examples/datatable/datatable-bulk-actions.html
@@ -44,7 +44,7 @@
               (cdkMenuClosed)="statusMenuOpen.set(false)"
             >
               Change status
-              <i aria-hidden="true" class="dropdown-caret icon element-down-2"></i>
+              <si-icon class="dropdown-caret" [icon]="icons.elementDown2" />
             </button>
             <button type="button" class="btn btn-tertiary" (click)="delete()"> Delete </button>
             <button type="button" class="btn btn-tertiary" (click)="export()"> Export </button>

--- a/src/app/examples/datatable/datatable-responsive.html
+++ b/src/app/examples/datatable/datatable-responsive.html
@@ -37,15 +37,15 @@
 </ng-template>
 <ng-template #otherStatusCellTempl let-value="value" let-row="row" ngx-datatable-cell-template>
   <div class="d-flex gap-1">
-    <si-icon class="icon status-danger" icon="element-cancel-filled" />
-    <si-icon class="icon status-warning" icon="element-manual-filled" />
-    <si-icon class="icon status-danger" icon="element-alarm-filled" />
+    <si-icon class="icon status-danger" [icon]="icons.elementCancelFilled" />
+    <si-icon class="icon status-warning" [icon]="icons.elementManualFilled" />
+    <si-icon class="icon status-danger" [icon]="icons.elementAlarmFilled" />
   </div>
 </ng-template>
 
 <ng-template #contextCellTempl let-value="value" let-row="row" ngx-datatable-cell-template>
   <div role="button" aria-label="Context menu" [cdkMenuTriggerFor]="menu">
-    <i class="icon element-options-vertical"></i>
+    <si-icon class="icon" [icon]="icons.elementOptionsVertical" />
   </div>
 </ng-template>
 

--- a/src/app/examples/datatable/datatable-responsive.ts
+++ b/src/app/examples/datatable/datatable-responsive.ts
@@ -4,10 +4,16 @@
  */
 import { CdkMenuTrigger } from '@angular/cdk/menu';
 import { Component, OnDestroy, OnInit, TemplateRef, viewChild } from '@angular/core';
+import {
+  elementAlarmFilled,
+  elementCancelFilled,
+  elementManualFilled,
+  elementOptionsVertical
+} from '@siemens/element-icons';
 import { SiCircleStatusModule } from '@siemens/element-ng/circle-status';
 import { StatusType } from '@siemens/element-ng/common';
 import { SiDatatableModule } from '@siemens/element-ng/datatable';
-import { SiIconComponent } from '@siemens/element-ng/icon';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiMenuFactoryComponent } from '@siemens/element-ng/menu';
 import { SiPaginationComponent } from '@siemens/element-ng/pagination';
 import {
@@ -34,6 +40,12 @@ import { Subject } from 'rxjs';
   styleUrl: './datatable.scss'
 })
 export class SampleComponent implements OnInit, OnDestroy {
+  readonly icons = addIcons({
+    elementAlarmFilled,
+    elementCancelFilled,
+    elementManualFilled,
+    elementOptionsVertical
+  });
   readonly statusCellTempl = viewChild.required<TemplateRef<any>>('statusCellTempl');
   readonly otherStatusCellTempl = viewChild.required<TemplateRef<any>>('otherStatusCellTempl');
   readonly contextCellTempl = viewChild.required<TemplateRef<any>>('contextCellTempl');

--- a/src/app/examples/datatable/datatable.html
+++ b/src/app/examples/datatable/datatable.html
@@ -81,9 +81,9 @@
 </ng-template>
 <ng-template #otherStatusCellTempl let-value="value" let-row="row" ngx-datatable-cell-template>
   <div class="d-flex gap-1">
-    <si-icon class="icon status-danger" icon="element-cancel-filled" />
-    <si-icon class="icon status-warning" icon="element-manual-filled" />
-    <si-icon class="icon status-danger" icon="element-alarm-filled" />
+    <si-icon class="icon status-danger" [icon]="icons.elementCancelFilled" />
+    <si-icon class="icon status-warning" [icon]="icons.elementManualFilled" />
+    <si-icon class="icon status-danger" [icon]="icons.elementAlarmFilled" />
   </div>
 </ng-template>
 
@@ -103,7 +103,7 @@
 
 <ng-template #contextCellTempl let-value="value" let-row="row" ngx-datatable-cell-template>
   <div role="button" aria-label="Context menu" [cdkMenuTriggerFor]="menu">
-    <i class="icon element-options-vertical"></i>
+    <si-icon class="icon" [icon]="icons.elementOptionsVertical" />
   </div>
 </ng-template>
 

--- a/src/app/examples/datatable/datatable.ts
+++ b/src/app/examples/datatable/datatable.ts
@@ -5,11 +5,17 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu';
 import { Component, OnInit, TemplateRef, viewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import {
+  elementAlarmFilled,
+  elementCancelFilled,
+  elementManualFilled,
+  elementOptionsVertical
+} from '@siemens/element-icons';
 import { SiCircleStatusComponent } from '@siemens/element-ng/circle-status';
 import { StatusType } from '@siemens/element-ng/common';
 import { SiDatatableInteractionDirective } from '@siemens/element-ng/datatable';
 import { SiFormItemComponent, SiFormValidationTooltipDirective } from '@siemens/element-ng/form';
-import { SiIconComponent } from '@siemens/element-ng/icon';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiMenuFactoryComponent } from '@siemens/element-ng/menu';
 import { SiPaginationComponent } from '@siemens/element-ng/pagination';
 import { NgxDatatableModule, SelectionType, TableColumn } from '@siemens/ngx-datatable';
@@ -32,6 +38,12 @@ import { NgxDatatableModule, SelectionType, TableColumn } from '@siemens/ngx-dat
   styleUrl: './datatable.scss'
 })
 export class SampleComponent implements OnInit {
+  readonly icons = addIcons({
+    elementAlarmFilled,
+    elementCancelFilled,
+    elementManualFilled,
+    elementOptionsVertical
+  });
   readonly statusCellTempl = viewChild.required('statusCellTempl', {
     read: TemplateRef<any>
   });


### PR DESCRIPTION
## Summary

Replace legacy icon-font markup with `si-icon` in datatable examples and update only the related Playwright snapshots.

## Verification

- `pnpm run build:examples`
- `AGENT=1 ./e2e-local.sh update playwright/e2e/element-examples/static.spec.ts --project="element-examples/*" --grep="datatable/bootstrap"`
- `AGENT=1 ./e2e-local.sh update playwright/e2e/element-examples/datatable-tree.spec.ts --project="element-examples/*" --grep="datatable/datatable$"`
- `pnpm exec prettier --check` on changed templates<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2581/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2581/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2581/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2581/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2581/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2581/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2581/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2581/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2581/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2581/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

