### PR TITLE
feat(side-panel): support inner navigation

### DIFF
--- a/api-goldens/element-ng/side-panel/index.api.md
+++ b/api-goldens/element-ng/side-panel/index.api.md
@@ -60,6 +60,10 @@ export class SiSidePanelActionComponent {
 export class SiSidePanelActionsComponent {
 }
 
+// @public
+export class SiSidePanelBackButtonComponent {
+}
+
 // @public (undocumented)
 export class SiSidePanelComponent implements OnInit, OnDestroy, OnChanges {
     constructor();

--- a/playwright/e2e/element-examples/si-side-panel.spec.ts
+++ b/playwright/e2e/element-examples/si-side-panel.spec.ts
@@ -7,6 +7,7 @@ import { expect, test } from '../../support/test-helpers';
 test.describe('si-side-panel', () => {
   const example = 'si-side-panel/si-side-panel';
   const exampleCollapsible = 'si-side-panel/si-side-panel-collapsible';
+  const exampleInnerNavigation = 'si-side-panel/si-side-panel-inner-navigation';
 
   const exampleCollapsibleLegacyStatusActions =
     'si-side-panel/si-side-panel-collapsible-legacy-status-actions';
@@ -86,5 +87,22 @@ test.describe('si-side-panel', () => {
     await expect(page.locator('si-side-panel:not(.rpanel-collapsed)')).toBeVisible();
     await expect(page.locator('si-side-panel .fullscreen-button')).toBeHidden();
     await si.runVisualAndA11yTests();
+  });
+
+  test(exampleInnerNavigation, async ({ page, si }) => {
+    await si.visitExample(exampleInnerNavigation);
+
+    await page.getByRole('button', { name: 'Open side panel' }).click();
+    const firstItem = page.getByRole('button', { name: 'Title link item 1' });
+    await firstItem.click();
+
+    const backButton = page.getByRole('button', { name: 'Back to main view' });
+    await expect(backButton).toBeFocused();
+    await expect(page.getByText('Content detail 1', { exact: true })).toBeVisible();
+    await si.runVisualAndA11yTests('detail');
+
+    await backButton.click();
+    await expect(firstItem).toBeFocused();
+    await si.runVisualAndA11yTests('list');
   });
 });

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--detail-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--detail-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f71c9234fe2882e699ce12572e5641c4f954283ed31e678c8d3190dc7cbd305
+size 30346

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--detail-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--detail-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:047b5c18185454676b465cdc629547fc303ed3c2dddff68e189586e5f599776a
+size 29916

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--detail.yaml
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--detail.yaml
@@ -1,0 +1,31 @@
+- button "Back to main view"
+- paragraph: Content detail 1
+- button "Close"
+- text: Property 1
+- textbox "Placeholder"
+- text: Property 2
+- textbox "Placeholder"
+- text: Property 3
+- combobox "Property 3":
+  - option "Placeholder" [disabled] [selected]
+  - option "Option 1"
+  - option "Option 2"
+- text: Property 4
+- spinbutton "Property 4"
+- text: °C Group label
+- checkbox "Label Label Label Label"
+- text: Label
+- checkbox
+- text: Label Group label
+- radio
+- text: Label
+- radio
+- text: Label Section title
+- switch "Toggle label"
+- text: Toggle label
+- main:
+  - link "Siemens logo":
+    - /url: "#/"
+  - heading "Application name" [level=1]
+  - button "Side panel"
+  - button "Open side panel"

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--list-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--list-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59decb2f69799bb9b4e7d4c1c2eb188a412b0f3e72c72e32515806753cbd6333
+size 17023

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--list-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--list-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21463b7bdf4dae2162fbb0ae63fb3e52424d84e102b298338d8540530a6a5038
+size 16863

--- a/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--list.yaml
+++ b/playwright/snapshots/si-side-panel.spec.ts-snapshots/si-side-panel--si-side-panel-inner-navigation--list.yaml
@@ -1,0 +1,19 @@
+- paragraph: Content title 1
+- button "Close"
+- list:
+  - listitem:
+    - button "Title link item 1"
+  - listitem:
+    - button "Title link item 2"
+  - listitem:
+    - button "Title link item 3"
+  - listitem:
+    - button "Title link item 4"
+  - listitem:
+    - button "Title link item 5"
+- main:
+  - link "Siemens logo":
+    - /url: "#/"
+  - heading "Application name" [level=1]
+  - button "Side panel"
+  - button "Open side panel"

--- a/projects/element-ng/side-panel/index.ts
+++ b/projects/element-ng/side-panel/index.ts
@@ -8,4 +8,5 @@ export * from './si-side-panel-content.component';
 export * from './si-side-panel.module';
 export * from './si-side-panel-actions.component';
 export * from './si-side-panel-action.component';
+export * from './si-side-panel-back-button.component';
 export * from './side-panel.model';

--- a/projects/element-ng/side-panel/si-side-panel-back-button.component.ts
+++ b/projects/element-ng/side-panel/si-side-panel-back-button.component.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component } from '@angular/core';
+import { elementLeft4 } from '@siemens/element-icons';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
+
+/**
+ * Back button for navigating from side-panel details to the previous view.
+ *
+ * @example
+ * ```html
+ * <button type="button" siSidePanelBackButton aria-label="Back" (click)="back()"></button>
+ * ```
+ */
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'button[siSidePanelBackButton], a[siSidePanelBackButton]',
+  imports: [SiIconComponent],
+  template: '<si-icon class="flip-rtl" [icon]="icons.elementLeft4" /><ng-content />',
+  host: {
+    class: 'btn btn-icon btn-tertiary ms-4 auto-hide'
+  }
+})
+export class SiSidePanelBackButtonComponent {
+  protected readonly icons = addIcons({ elementLeft4 });
+}

--- a/projects/element-ng/side-panel/si-side-panel-content.component.html
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.html
@@ -1,5 +1,10 @@
 <div class="rpanel-header pt-5">
-  <p class="si-h5 my-0 ms-6 auto-hide text-truncate">{{ heading() | translate }}</p>
+  <div class="d-flex align-items-center min-width-0 auto-hide">
+    <ng-content select="[siSidePanelBackButton]" />
+    <p class="si-h5 my-0 auto-hide text-truncate header-title">
+      {{ heading() | translate }}
+    </p>
+  </div>
   @if ((primaryActions().length || secondaryActions().length) && focusable()) {
     <si-content-action-bar
       class="auto-hide ms-auto"

--- a/projects/element-ng/side-panel/si-side-panel-content.component.scss
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.scss
@@ -90,6 +90,14 @@
   justify-content: space-between;
 }
 
+.header-title {
+  margin-inline-start: map.get(all-variables.$spacers, 6);
+}
+
+.rpanel-header:has([siSidePanelBackButton]) .header-title {
+  margin-inline-start: map.get(all-variables.$spacers, 2);
+}
+
 .rpanel-wrapper {
   padding-block-start: map.get(all-variables.$spacers-block, 5);
 }

--- a/projects/element-ng/side-panel/si-side-panel-content.component.spec.ts
+++ b/projects/element-ng/side-panel/si-side-panel-content.component.spec.ts
@@ -4,6 +4,7 @@
  */
 import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { page, userEvent } from 'vitest/browser';
 
 import { SiSidePanelModule } from './si-side-panel.module';
 import { SiSidePanelService } from './si-side-panel.service';
@@ -16,11 +17,19 @@ import { SidePanelDisplayMode, SidePanelNavigateConfig } from './side-panel.mode
       heading="Title"
       [displayMode]="displayMode()"
       [navigateConfig]="navigateConfig"
-    />
+    >
+      @if (projectBackButton()) {
+        <button type="button" siSidePanelBackButton aria-label="Go back" (click)="back()">
+          Back
+        </button>
+      }
+    </si-side-panel-content>
   </si-side-panel>`
 })
 class TestHostComponent {
+  readonly projectBackButton = signal(false);
   readonly displayMode = signal<SidePanelDisplayMode | undefined>(undefined);
+  readonly back = vi.fn();
   readonly navigateConfig: SidePanelNavigateConfig = {
     type: 'link',
     label: 'Navigate',
@@ -53,6 +62,25 @@ describe('SiSidePanelContentComponent', () => {
     fixture.detectChanges();
 
     expect(sidePanelService.toggle).toHaveBeenCalled();
+  });
+
+  it('should project a custom back button into the header slot', async () => {
+    const backButton = page.getByRole('button', { name: 'Go back' });
+
+    await expect.element(backButton).not.toBeInTheDocument();
+
+    component.projectBackButton.set(true);
+    await fixture.whenStable();
+
+    await expect.element(backButton).toBeInTheDocument();
+    await expect
+      .element(backButton)
+      .toHaveClass('btn', 'btn-icon', 'btn-tertiary', 'ms-4', 'auto-hide');
+    await expect.element(backButton).toHaveTextContent('Back');
+
+    await userEvent.click(backButton);
+
+    expect(component.back).toHaveBeenCalledOnce();
   });
 
   it('should show fullscreen/navigation button based on display mode', () => {

--- a/projects/element-ng/side-panel/si-side-panel.module.ts
+++ b/projects/element-ng/side-panel/si-side-panel.module.ts
@@ -6,6 +6,7 @@ import { NgModule } from '@angular/core';
 
 import { SiSidePanelActionComponent } from './si-side-panel-action.component';
 import { SiSidePanelActionsComponent } from './si-side-panel-actions.component';
+import { SiSidePanelBackButtonComponent } from './si-side-panel-back-button.component';
 import { SiSidePanelContentComponent } from './si-side-panel-content.component';
 import { SiSidePanelComponent } from './si-side-panel.component';
 
@@ -14,13 +15,15 @@ import { SiSidePanelComponent } from './si-side-panel.component';
     SiSidePanelComponent,
     SiSidePanelContentComponent,
     SiSidePanelActionsComponent,
-    SiSidePanelActionComponent
+    SiSidePanelActionComponent,
+    SiSidePanelBackButtonComponent
   ],
   exports: [
     SiSidePanelComponent,
     SiSidePanelContentComponent,
     SiSidePanelActionsComponent,
-    SiSidePanelActionComponent
+    SiSidePanelActionComponent,
+    SiSidePanelBackButtonComponent
   ]
 })
 export class SiSidePanelModule {}

--- a/src/app/examples/si-side-panel/si-side-panel-inner-navigation.html
+++ b/src/app/examples/si-side-panel/si-side-panel-inner-navigation.html
@@ -1,0 +1,110 @@
+<si-side-panel [collapsed]="collapsed()" (closed)="collapsed.set(true)">
+  <main class="has-navbar-fixed-top px-6">
+    <si-application-header>
+      <si-header-brand>
+        <a siHeaderLogo routerLink="/" class="d-none d-md-flex"></a>
+        <h1 class="application-name">Application name</h1>
+      </si-header-brand>
+
+      <si-header-actions>
+        <button
+          type="button"
+          si-header-action-item
+          icon="element-menu"
+          (click)="collapsed.set(false)"
+        >
+          Side panel
+        </button>
+      </si-header-actions>
+    </si-application-header>
+
+    <div class="pt-6">
+      <button type="button" class="btn btn-secondary" (click)="collapsed.set(false)">
+        Open side panel
+      </button>
+    </div>
+  </main>
+
+  <si-side-panel-content [heading]="selectedItem()?.detailTitle ?? 'Content title 1'">
+    @if (selectedItem()) {
+      <button
+        #backButton
+        type="button"
+        siSidePanelBackButton
+        aria-label="Back to main view"
+        (click)="showNavigation()"
+      ></button>
+    }
+    @if (selectedItem()) {
+      <form class="p-6">
+        <si-form-item label="Property 1">
+          <input class="form-control" type="text" placeholder="Placeholder" required />
+        </si-form-item>
+        <si-form-item class="mt-5" label="Property 2">
+          <input class="form-control" type="text" placeholder="Placeholder" required />
+        </si-form-item>
+        <si-form-item class="mt-5" label="Property 3">
+          <select class="form-select" aria-label="Property 3" required>
+            <option value="" selected disabled>Placeholder</option>
+            <option>Option 1</option>
+            <option>Option 2</option>
+          </select>
+        </si-form-item>
+        <si-form-item class="mt-5" label="Property 4">
+          <si-number-input
+            inputId="exampleInput"
+            class="form-control"
+            unit="°C"
+            placeholder="Value"
+            [min]="0"
+            [max]="100"
+            [step]="1"
+            [showButtons]="true"
+            [class.text-end]="false"
+          />
+        </si-form-item>
+        <si-form-item class="mt-5 mb-2" label="Group label">
+          <div class="form-check">
+            <input id="role-editor" class="form-check-input" type="checkbox" />
+            <label class="form-check-label" for="role-editor">Label</label>
+          </div>
+          <div class="form-check">
+            <input id="role-editor" class="form-check-input" type="checkbox" />
+            <label class="form-check-label" for="role-editor">Label</label>
+          </div>
+        </si-form-item>
+        <si-form-item class="mt-5 mb-2" label="Group label">
+          <div class="form-check">
+            <input id="role-editor" class="form-check-input" type="radio" />
+            <label class="form-check-label" for="role-editor">Label</label>
+          </div>
+          <div class="form-check">
+            <input id="role-editor" class="form-check-input" type="radio" />
+            <label class="form-check-label" for="role-editor">Label</label>
+          </div>
+        </si-form-item>
+        <si-form-item class="mt-5 mb-2" label="Section title">
+          <div class="form-check form-switch">
+            <input type="checkbox" class="form-check-input" role="switch" id="switch4" />
+            <label for="switch4" class="form-check-label">Toggle label</label>
+          </div>
+        </si-form-item>
+      </form>
+    } @else {
+      <ul>
+        @for (item of navigationItems; track item.id) {
+          <li class="py-2">
+            <button
+              #navigationButton
+              type="button"
+              class="list-item list-item-action"
+              (click)="showDetails(item, $index)"
+            >
+              <span class="list-item-title py-0">{{ item.title }}</span>
+            </button>
+          </li>
+        }
+      </ul>
+    }
+  </si-side-panel-content>
+</si-side-panel>

--- a/src/app/examples/si-side-panel/si-side-panel-inner-navigation.ts
+++ b/src/app/examples/si-side-panel/si-side-panel-inner-navigation.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import {
+  afterRenderEffect,
+  Component,
+  ElementRef,
+  signal,
+  viewChild,
+  viewChildren
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import {
+  SiApplicationHeaderComponent,
+  SiHeaderActionItemComponent,
+  SiHeaderActionsDirective,
+  SiHeaderBrandDirective,
+  SiHeaderLogoDirective
+} from '@siemens/element-ng/application-header';
+import { SiFormItemComponent } from '@siemens/element-ng/form';
+import { SiNumberInputComponent } from '@siemens/element-ng/number-input';
+import {
+  SiSidePanelBackButtonComponent,
+  SiSidePanelComponent,
+  SiSidePanelContentComponent
+} from '@siemens/element-ng/side-panel';
+
+interface NavigationItem {
+  id: string;
+  title: string;
+  detailTitle: string;
+}
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    RouterLink,
+    SiApplicationHeaderComponent,
+    SiHeaderActionItemComponent,
+    SiHeaderActionsDirective,
+    SiHeaderBrandDirective,
+    SiHeaderLogoDirective,
+    SiFormItemComponent,
+    SiSidePanelBackButtonComponent,
+    SiSidePanelComponent,
+    SiNumberInputComponent,
+    SiSidePanelContentComponent
+  ],
+  templateUrl: './si-side-panel-inner-navigation.html'
+})
+export class SampleComponent {
+  readonly collapsed = signal(true);
+  readonly selectedItem = signal<NavigationItem | undefined>(undefined);
+  readonly navigationItems: NavigationItem[] = [
+    {
+      id: 'title-link-item-1',
+      title: 'Title link item 1',
+      detailTitle: 'Content detail 1'
+    },
+    {
+      id: 'title-link-item-2',
+      title: 'Title link item 2',
+      detailTitle: 'Content detail 2'
+    },
+    {
+      id: 'title-link-item-3',
+      title: 'Title link item 3',
+      detailTitle: 'Content detail 3'
+    },
+    {
+      id: 'title-link-item-4',
+      title: 'Title link item 4',
+      detailTitle: 'Content detail 4'
+    },
+    {
+      id: 'title-link-item-5',
+      title: 'Title link item 5',
+      detailTitle: 'Content detail 5'
+    }
+  ];
+
+  private readonly backButton = viewChild('backButton', {
+    read: ElementRef<HTMLButtonElement>
+  });
+  private readonly navigationButtons =
+    viewChildren<ElementRef<HTMLButtonElement>>('navigationButton');
+  private originIndex?: number;
+
+  constructor() {
+    afterRenderEffect(() => {
+      if (this.selectedItem()) {
+        this.backButton()?.nativeElement.focus();
+      } else if (this.originIndex !== undefined) {
+        this.navigationButtons()[this.originIndex]?.nativeElement.focus();
+      }
+    });
+  }
+
+  showDetails(item: NavigationItem, index: number): void {
+    this.originIndex = index;
+    this.selectedItem.set(item);
+  }
+
+  showNavigation(): void {
+    this.selectedItem.set(undefined);
+  }
+}


### PR DESCRIPTION
Add an optional back button with a configurable label, output, and focus API.

Fixes #2381

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2582/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2582/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2582/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2582/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2582/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2582/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2582/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2582/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2582/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2582/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->














