### PR TITLE
fix(datepicker): reset manually edited input value

### DIFF
--- a/projects/element-ng/datepicker/si-date-input.directive.spec.ts
+++ b/projects/element-ng/datepicker/si-date-input.directive.spec.ts
@@ -5,6 +5,7 @@
 import { ChangeDetectionStrategy, Component, ElementRef, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl } from '@angular/forms';
+import { userEvent } from 'vitest/browser';
 
 import { SiDateInputDirective } from './si-date-input.directive';
 import { DatepickerInputConfig } from './si-datepicker.model';
@@ -22,7 +23,7 @@ import { dispatchEvents, enterValue } from './testing/test-helper';
     siDateInput
     [disabled]="disabled()"
     [siDatepickerConfig]="config()"
-    [ngModel]="date"
+    [ngModel]="date()"
     (ngModelChange)="onModelChange($event)"
   />`,
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -31,13 +32,15 @@ class WrapperComponent {
   readonly siDateInput = viewChild.required<ElementRef>('siDateInput');
   readonly validation = viewChild.required<NgControl>('validation');
   readonly siDateInputDirective = viewChild.required(SiDateInputDirective);
-  date: Date | string = new Date('2022-03-12');
+  readonly date = signal<Date | string>(new Date('2022-03-12'));
   readonly disabled = signal(false);
   readonly config = signal<DatepickerInputConfig>({
     showTime: true,
     disabledTime: false
   });
-  onModelChange(d: Date): void {}
+  onModelChange(d: Date): void {
+    this.date.set(d);
+  }
 }
 
 describe('SiDateInputDirective', () => {
@@ -73,7 +76,7 @@ describe('SiDateInputDirective', () => {
   };
 
   it('should consider short time format', async () => {
-    component.date = getTestDate();
+    component.date.set(getTestDate());
     await updateConfig({
       showTime: true,
       dateTimeFormat: 'dd.MM.yyyy, HH:mm'
@@ -84,7 +87,7 @@ describe('SiDateInputDirective', () => {
   });
 
   it('should consider default time format if showSeconds true', async () => {
-    component.date = getTestDate();
+    component.date.set(getTestDate());
     await updateConfig({
       showTime: true,
       showSeconds: true
@@ -98,7 +101,7 @@ describe('SiDateInputDirective', () => {
 
   it('should consider minDate criteria with time', async () => {
     vi.spyOn(component.siDateInputDirective(), 'validate');
-    component.date = new Date('2020-03-12T13:13:13');
+    component.date.set(new Date('2020-03-12T13:13:13'));
     await updateConfig({
       showTime: true,
       showSeconds: true,
@@ -110,7 +113,7 @@ describe('SiDateInputDirective', () => {
 
     expect(component.validation().errors).toBeDefined();
     expect(component.validation().errors?.minDate).toEqual({
-      actual: component.date,
+      actual: component.date(),
       min: component.config().minDate,
       minString: '3/12/2021, 1:13:12 PM'
     });
@@ -118,7 +121,7 @@ describe('SiDateInputDirective', () => {
 
   it('should consider minDate criteria only date', async () => {
     vi.spyOn(component.siDateInputDirective(), 'validate');
-    component.date = new Date('2020-03-12');
+    component.date.set(new Date('2020-03-12'));
     await updateConfig({
       showTime: true,
       showSeconds: true,
@@ -129,7 +132,7 @@ describe('SiDateInputDirective', () => {
     await fixture.whenStable();
 
     expect(component.validation().errors?.minDate).toEqual({
-      actual: component.date,
+      actual: component.date(),
       min: component.config().minDate,
       minString: '3/13/2021, 12:00:00 AM'
     });
@@ -137,7 +140,7 @@ describe('SiDateInputDirective', () => {
 
   it('should consider maxDate criteria with time', async () => {
     vi.spyOn(component.siDateInputDirective(), 'validate');
-    component.date = new Date('2024-03-12T13:13:13');
+    component.date.set(new Date('2024-03-12T13:13:13'));
     await updateConfig({
       showTime: true,
       showSeconds: true,
@@ -148,7 +151,7 @@ describe('SiDateInputDirective', () => {
     await fixture.whenStable();
 
     expect(component.validation().errors?.maxDate).toEqual({
-      actual: component.date,
+      actual: component.date(),
       max: component.config().maxDate,
       maxString: '3/12/2023, 1:13:12 PM'
     });
@@ -156,7 +159,7 @@ describe('SiDateInputDirective', () => {
 
   it('should consider maxDate criteria only date', async () => {
     vi.spyOn(component.siDateInputDirective(), 'validate');
-    component.date = new Date('2024-03-12');
+    component.date.set(new Date('2024-03-12'));
     await updateConfig({
       showTime: true,
       showSeconds: true,
@@ -167,7 +170,7 @@ describe('SiDateInputDirective', () => {
     await fixture.whenStable();
 
     expect(component.validation().errors?.maxDate).toEqual({
-      actual: component.date,
+      actual: component.date(),
       max: component.config().maxDate,
       maxString: '3/11/2023, 12:00:00 AM'
     });
@@ -192,8 +195,26 @@ describe('SiDateInputDirective', () => {
     expect((vi.mocked(spy).mock.lastCall![0]! as Date).getTime()).toBeNaN();
   });
 
+  it('should restore displayed value after manual entry when ngModel is reset programmatically', async () => {
+    await updateConfig({ showTime: true, dateTimeFormat: 'dd.MM.yyyy, HH:mm' });
+    component.date.set(getTestDate());
+    await fixture.whenStable();
+
+    expect(dateInput()).toHaveValue('12.03.2022, 05:30');
+
+    await userEvent.fill(dateInput(), '15.06.2023, 10:00');
+    await fixture.whenStable();
+
+    expect(dateInput()).toHaveValue('15.06.2023, 10:00');
+
+    component.date.set(new Date(2022, 2, 12, 5, 30));
+    await fixture.whenStable();
+
+    expect(dateInput()).toHaveValue('12.03.2022, 05:30');
+  });
+
   it('should update displayed value when config changes', async () => {
-    component.date = getTestDate();
+    component.date.set(getTestDate());
 
     await updateConfig({ showTime: true });
     fixture.detectChanges();

--- a/projects/element-ng/datepicker/si-date-input.directive.ts
+++ b/projects/element-ng/datepicker/si-date-input.directive.ts
@@ -7,7 +7,6 @@ import {
   booleanAttribute,
   computed,
   Directive,
-  HostListener,
   inject,
   input,
   LOCALE_ID,
@@ -58,7 +57,9 @@ import { DatepickerInputConfig, getDatepickerFormat } from './si-datepicker.mode
     '[attr.readonly]': 'readonly() || null',
     '[class.readonly]': 'readonly()',
     '[attr.aria-describedby]': 'errormessageId()',
-    '[value]': 'dateString()'
+    '[value]': 'dateString()',
+    '(input)': 'onInput($event)',
+    '(blur)': 'onBlur($event)'
   },
   exportAs: 'siDateInput'
 })
@@ -219,10 +220,14 @@ export class SiDateInputDirective
   /**
    * Handles `input` events on the input element.
    */
-  @HostListener('input', ['$event'])
   protected onInput(event: Event): void {
     const value = (event.target as HTMLInputElement).value;
     const parsedDate = parseDate(value, this.getFormat(), this.locale);
+
+    // Keep dateString in sync with the raw DOM value so that a subsequent
+    // writeValue() with the same formatted string still triggers the host
+    // [value] binding and overwrites any manually entered text.
+    this.dateString.set(value);
 
     // Is same date
     const hasChanged = !(parsedDate === this.date);
@@ -233,7 +238,7 @@ export class SiDateInputDirective
     }
   }
 
-  @HostListener('blur', ['$event']) protected onBlur(event: FocusEvent): void {
+  protected onBlur(event: FocusEvent): void {
     this.onTouched();
   }
 


### PR DESCRIPTION
Sync the input text with user edits so programmatic model updates replace it.

Fixes #2574

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2593/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2593/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2593/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2593/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2593/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2593/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2593/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2593/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2593/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2593/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
