### PR TITLE
refactor(select): use @angular/aria

### DIFF
--- a/api-goldens/element-ng/select/index.api.md
+++ b/api-goldens/element-ng/select/index.api.md
@@ -91,6 +91,7 @@ export class SiSelectComboboxValueComponent {
 
 // @public (undocumented)
 export class SiSelectComponent<T> implements SiFormItemControl {
+    constructor();
     readonly ariaLabel: _angular_core.InputSignal<string | null>;
     close(): void;
     readonly errormessageId: _angular_core.InputSignal<string>;

--- a/playwright/e2e/element-examples/si-select.spec.ts
+++ b/playwright/e2e/element-examples/si-select.spec.ts
@@ -54,7 +54,7 @@ test.describe('si-select', () => {
     const selectFormControlInput = page.getByRole('combobox', { name: 'FormControl' }).nth(1);
     await expect(selectFormControlInput).toBeFocused();
     await expect(selectFormControlInput).toHaveAttribute('aria-expanded', 'true');
-    await expect(formControlSelect.first()).toContainClass('active');
+    await expect(formControlSelect).toHaveAttribute('aria-expanded', 'true');
 
     await si.runVisualAndA11yTests('filter-opened');
     await selectFormControlInput.pressSequentially('Bad');
@@ -69,7 +69,7 @@ test.describe('si-select', () => {
     await formControlSelect.click();
     await expect(selectFormControlInput).toBeFocused();
     await expect(selectFormControlInput).toHaveAttribute('aria-expanded', 'true');
-    await expect(formControlSelect.first()).toContainClass('active');
+    await expect(formControlSelect).toHaveAttribute('aria-expanded', 'true');
 
     await selectFormControlInput.pressSequentially('no-value-found');
     await si.runVisualAndA11yTests('filter-no-value-found');
@@ -83,7 +83,7 @@ test.describe('si-select', () => {
       .nth(1);
     await expect(selectInputWithActions).toBeFocused();
     await expect(selectInputWithActions).toHaveAttribute('aria-expanded', 'true');
-    await expect(selectWithActions.first()).toContainClass('active');
+    await expect(selectWithActions.first()).toHaveAttribute('aria-expanded', 'true');
 
     await selectInputWithActions.pressSequentially('New option');
     await si.runVisualAndA11yTests('actions-search');

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--readonly.yaml
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--readonly.yaml
@@ -1,15 +1,15 @@
 - heading "Inline" [level=4]
-- textbox "Inline"
+- combobox "Inline" [disabled]: Fair
 - heading "FormControl" [level=4]
-- textbox "FormControl"
+- combobox "FormControl" [disabled]: Good
 - heading "Multi select" [level=4]
-- textbox "Multi select"
+- combobox "Multi select" [disabled]: Good , Fair
 - heading "Multi-select with groups" [level=4]
-- textbox "Multi-select with groups"
+- combobox "Multi-select with groups" [disabled]: Value 1.1 , Value 2.2
 - heading "Select with custom template" [level=4]
-- textbox "Select with custom template"
+- combobox "Select with custom template" [disabled]: Beer 2 (Alc.:7%)
 - heading "Select with actions" [level=4]
-- textbox "Select with actions"
+- combobox "Select with actions" [disabled]: Select an option
 - text: "Control panel Current value: fair"
 - checkbox "Readonly" [checked]
 - text: Readonly

--- a/projects/element-ng/select/select-input/si-select-input.component.ts
+++ b/projects/element-ng/select/select-input/si-select-input.component.ts
@@ -2,15 +2,8 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import {
-  booleanAttribute,
-  Component,
-  computed,
-  inject,
-  input,
-  output,
-  TemplateRef
-} from '@angular/core';
+import { Combobox } from '@angular/aria/combobox';
+import { booleanAttribute, Component, computed, inject, input, TemplateRef } from '@angular/core';
 import { elementDown2 } from '@siemens/element-icons';
 import { SiAutoCollapsableListModule } from '@siemens/element-ng/auto-collapsable-list';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
@@ -30,27 +23,10 @@ import { SelectOption } from '../si-select.types';
   templateUrl: './si-select-input.component.html',
   styleUrl: './si-select-input.component.scss',
   host: {
-    // In readonly mode, the select needs to be announced as a textbox.
-    // Otherwise, screen-reader won't announce the readonly state.
     class: 'select focus-none dropdown-toggle d-flex align-items-center ps-4',
-    'aria-autocomplete': 'none',
-    '[attr.role]': 'readonly() ? "textbox": "combobox"',
-    '[attr.aria-haspopup]': 'readonly() ? undefined : "listbox"',
-    '[attr.aria-expanded]': 'readonly() ? undefined : open()',
-    '[attr.aria-controls]': 'readonly() ? undefined : controls()',
-    '[attr.aria-readonly]': 'readonly()',
     '[attr.aria-labelledby]': 'labeledBy()',
-    '[attr.aria-disabled]': 'selectionStrategy.disabled()',
-    '[attr.tabindex]': 'selectionStrategy.disabled() ? "-1" : "0"',
     '[class.disabled]': 'selectionStrategy.disabled()',
-    '[class.active]': 'open()',
-    '(blur)': 'blur()',
-    '(click)': 'click($event)',
-    '(keydown.arrowDown)': 'click($event)',
-    '(keydown.alt.arrowDown)': 'click($event)',
-    '(keydown.arrowUp)': 'click($event)',
-    '(keydown.enter)': 'click($event)',
-    '(keydown.space)': 'click($event)'
+    '(blur)': 'blur()'
   }
 })
 export class SiSelectInputComponent<T> {
@@ -71,19 +47,9 @@ export class SiSelectInputComponent<T> {
    */
   readonly ariaLabel = input<string | null>(null);
   /**
-   * Whether the listbox is open.
-   *
-   * @defaultValue false
-   */
-  readonly open = input(false, { transform: booleanAttribute });
-  /**
    * Text shown when no option is selected.
    */
   readonly placeholder = input<TranslatableString>();
-  /**
-   * ID of the associated listbox.
-   */
-  readonly controls = input.required<string>();
   /**
    * Custom template for rendering selected options.
    */
@@ -100,10 +66,6 @@ export class SiSelectInputComponent<T> {
    */
   readonly readonly = input(false, { transform: booleanAttribute });
 
-  /**
-   * Emits when the user requests to open the listbox.
-   */
-  readonly openListbox = output<void>();
   protected readonly selectionStrategy = inject<SiSelectSelectionStrategy<T>>(
     SiSelectSelectionStrategy<T>
   );
@@ -112,14 +74,11 @@ export class SiSelectInputComponent<T> {
   protected readonly labeledBy = computed(() => `${this.baseId()}-aria-label ${this.labelledby()}`);
   protected readonly icons = addIcons({ elementDown2 });
 
+  private readonly ngCombobox = inject(Combobox);
+
   protected blur(): void {
-    if (!this.open()) {
+    if (!this.ngCombobox.expanded()) {
       this.selectionStrategy.onTouched();
     }
-  }
-
-  protected click(event?: Event): void {
-    event?.preventDefault();
-    this.openListbox.emit();
   }
 }

--- a/projects/element-ng/select/select-list/si-select-list.component.html
+++ b/projects/element-ng/select/select-list/si-select-list.component.html
@@ -1,11 +1,18 @@
 <div
-  cdkListbox
+  #listbox="ngListbox"
+  ngListbox
+  ngComboboxWidget
+  focusMode="activedescendant"
+  selectionMode="explicit"
   class="dropdown-menu-scroller focus-none"
+  [tabindex]="-1"
   [id]="baseId() + '-listbox'"
-  [cdkListboxMultiple]="selectionStrategy.allowMultiple"
-  [cdkListboxValue]="selectionStrategy.arrayValue()"
+  [multi]="selectionStrategy.allowMultiple"
+  [softDisabled]="false"
   [attr.aria-labelledby]="baseId() + '-aria-label' + ' ' + labelledby()"
-  (cdkListboxValueChange)="listBoxValueChange($event)"
+  [activeDescendant]="listbox.activeDescendant()"
+  [(value)]="selectedValues"
+  (valueChange)="listBoxValueChange($event)"
   (click)="closeOverlayIfSingle()"
   (keydown.enter)="closeOverlayIfSingle()"
   (keydown.space)="closeOverlayIfSingle()"
@@ -41,14 +48,14 @@
   }
   <ng-template #optionRowTemplate let-option siSelectOptionRowTemplate>
     <si-select-option-row
-      #cdkOption="cdkOption"
+      #ngOption="ngOption"
+      ngOption
+      [value]="option"
       [option]="option"
       [optionTemplate]="optionTemplate()"
-      [cdkOption]="option.value"
-      [cdkOptionDisabled]="!!option.disabled"
-      [cdkOptionTypeaheadLabel]="(option.typeaheadLabel | translate)!"
-      [class.active]="cdkOption.isActive()"
-      [selected]="cdkOption.isSelected()"
+      [disabled]="option.disabled"
+      [class.active]="ngOption.active()"
+      [selected]="ngOption.selected()"
     />
   </ng-template>
 </div>

--- a/projects/element-ng/select/select-list/si-select-list.component.ts
+++ b/projects/element-ng/select/select-list/si-select-list.component.ts
@@ -2,43 +2,47 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { CdkListbox, CdkOption, ListboxValueChangeEvent } from '@angular/cdk/listbox';
+import { ComboboxWidget } from '@angular/aria/combobox';
+import { Listbox, Option } from '@angular/aria/listbox';
 import { CommonModule } from '@angular/common';
-import { Component, ElementRef, OnInit, viewChild } from '@angular/core';
+import { Component, linkedSignal, OnInit, viewChild } from '@angular/core';
 import { SiTranslatePipe } from '@siemens/element-translate-ng/translate';
 
 import { SiSelectOptionRowComponent } from '../select-option/si-select-option-row.component';
 import { SiSelectGroupTemplateDirective } from '../si-select-group-template.directive';
 import { SiSelectOptionRowTemplateDirective } from '../si-select-option-row-template.directive';
+import { SelectOption } from '../si-select.types';
 import { SiSelectListBase } from './si-select-list.base';
 
 @Component({
   selector: 'si-select-list',
   imports: [
     CommonModule,
-    CdkListbox,
     SiTranslatePipe,
-    CdkOption,
     SiSelectOptionRowTemplateDirective,
     SiSelectGroupTemplateDirective,
-    SiSelectOptionRowComponent
+    SiSelectOptionRowComponent,
+    Listbox,
+    Option,
+    ComboboxWidget
   ],
   templateUrl: './si-select-list.component.html'
 })
 export class SiSelectListComponent<T> extends SiSelectListBase<T> implements OnInit {
-  private readonly listbox = viewChild.required<CdkListbox, ElementRef<HTMLUListElement>>(
-    CdkListbox,
-    {
-      read: ElementRef
+  /** @internal */
+  readonly listbox = viewChild.required('listbox', { read: Listbox });
+
+  protected listBoxValueChange(changeEvent: SelectOption<T>[]): void {
+    if (!this.selectionStrategy.allowMultiple && changeEvent.length === 0) {
+      return;
     }
-  );
-
-  override ngOnInit(): void {
-    super.ngOnInit();
-    setTimeout(() => this.listbox().nativeElement.focus());
+    const selectedOptions = this.rows()
+      .flatMap(row => (row.type === 'group' ? row.options : [row]))
+      .filter(option => changeEvent.includes(option));
+    this.selectionStrategy.updateFromUser(selectedOptions.map(option => option.value));
   }
 
-  protected listBoxValueChange(changeEvent: ListboxValueChangeEvent<T>): void {
-    this.selectionStrategy.updateFromUser(changeEvent.value.slice());
-  }
+  protected readonly selectedValues = linkedSignal<SelectOption<T>[]>(() => [
+    ...this.selectOptions.selectedRows()
+  ]);
 }

--- a/projects/element-ng/select/si-select-action.directive.ts
+++ b/projects/element-ng/select/si-select-action.directive.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { booleanAttribute, Directive, inject, input } from '@angular/core';
+import { booleanAttribute, Directive, ElementRef, inject, input } from '@angular/core';
 
 import { SiSelectComponent } from './si-select.component';
 
@@ -10,12 +10,14 @@ import { SiSelectComponent } from './si-select.component';
   selector: '[siSelectAction]',
   host: {
     class: 'mx-5 my-4',
-    '(click)': 'close()'
+    '(click)': 'close()',
+    '(focusout)': 'focusout($event)'
   },
   exportAs: 'si-select-action'
 })
 export class SiSelectActionDirective {
   private readonly select = inject(SiSelectComponent);
+  private readonly elementRef = inject(ElementRef);
   /**
    * Close the select drop down on click.
    * @defaultValue false
@@ -25,6 +27,19 @@ export class SiSelectActionDirective {
   protected close(): void {
     if (this.selectActionAutoClose()) {
       this.select.close();
+    }
+  }
+
+  protected focusout(event: FocusEvent): void {
+    // angular aria combobox will close the overlay on focusout which can happen if
+    // action is disabled after click, so we need to prevent the event from propagating
+    // if the select is disabled and auto close is false
+    if (
+      !this.selectActionAutoClose() &&
+      !event.relatedTarget &&
+      this.elementRef.nativeElement.disabled
+    ) {
+      event.stopPropagation();
     }
   }
 }

--- a/projects/element-ng/select/si-select.component.html
+++ b/projects/element-ng/select/si-select.component.html
@@ -1,50 +1,56 @@
 <si-select-input
-  #trigger="cdkOverlayOrigin"
+  #combobox="ngCombobox"
+  ngCombobox
   cdkOverlayOrigin
   [baseId]="id()"
   [labelledby]="labelledby()"
   [optionTemplate]="optionTemplate()"
   [ariaLabel]="ariaLabel()"
-  [controls]="id() + '-listbox'"
-  [open]="isOpen()"
   [placeholder]="placeholder()"
   [readonly]="readonly()"
+  [disabled]="selectionStrategy.disabled() || readonly()"
+  [softDisabled]="readonly()"
   [attr.aria-describedby]="errormessageId()"
-  (openListbox)="open()"
+  [(expanded)]="isOpen"
+  (expandedChange)="openChange.emit($event)"
 />
 
-<ng-template
-  cdkConnectedOverlay
-  cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
-  [cdkConnectedOverlayHasBackdrop]="true"
-  [cdkConnectedOverlayOrigin]="trigger"
-  [cdkConnectedOverlayOpen]="isOpen()"
-  [cdkConnectedOverlayScrollStrategy]="scrollStrategy()"
-  [cdkConnectedOverlayFlexibleDimensions]="true"
-  [cdkConnectedOverlayOffsetX]="-1"
-  [cdkConnectedOverlayMinWidth]="overlayWidth"
-  (backdropClick)="backdropClick()"
-  (detach)="close()"
->
-  @if (!hasFilter()) {
-    <si-select-list
-      [baseId]="id()"
-      [optionTemplate]="optionTemplate()"
-      [groupTemplate]="groupTemplate()"
-      [labelledby]="labelledby()"
-      [actionsTemplate]="actionsTemplate()"
-      (closeOverlay)="close()"
-    />
-  } @else {
-    <si-select-list-has-filter
-      [baseId]="id()"
-      [filterPlaceholder]="filterPlaceholder()"
-      [noResultsFoundLabel]="noResultsFoundLabel()"
-      [optionTemplate]="optionTemplate()"
-      [groupTemplate]="groupTemplate()"
-      [labelledby]="labelledby()"
-      [actionsTemplate]="actionsTemplate()"
-      (closeOverlay)="close()"
-    />
-  }
+<ng-template ngComboboxPopup [combobox]="combobox">
+  <ng-template
+    cdkConnectedOverlay
+    cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
+    [cdkConnectedOverlayHasBackdrop]="true"
+    [cdkConnectedOverlayOrigin]="combobox.element"
+    [cdkConnectedOverlayOpen]="isOpen()"
+    [cdkConnectedOverlayScrollStrategy]="scrollStrategy()"
+    [cdkConnectedOverlayFlexibleDimensions]="true"
+    [cdkConnectedOverlayOffsetX]="-1"
+    [cdkConnectedOverlayMinWidth]="overlayWidth()"
+    (backdropClick)="backdropClick()"
+    (detach)="close()"
+  >
+    @if (!hasFilter()) {
+      <si-select-list
+        ngComboboxWidget
+        [baseId]="id()"
+        [optionTemplate]="optionTemplate()"
+        [groupTemplate]="groupTemplate()"
+        [labelledby]="labelledby()"
+        [actionsTemplate]="actionsTemplate()"
+        (closeOverlay)="close()"
+      />
+    } @else {
+      <si-select-list-has-filter
+        ngComboboxWidget
+        [baseId]="id()"
+        [filterPlaceholder]="filterPlaceholder()"
+        [noResultsFoundLabel]="noResultsFoundLabel()"
+        [optionTemplate]="optionTemplate()"
+        [groupTemplate]="groupTemplate()"
+        [labelledby]="labelledby()"
+        [actionsTemplate]="actionsTemplate()"
+        (closeOverlay)="close()"
+      />
+    }
+  </ng-template>
 </ng-template>

--- a/projects/element-ng/select/si-select.component.ts
+++ b/projects/element-ng/select/si-select.component.ts
@@ -2,13 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { CdkOverlayOrigin, OverlayModule } from '@angular/cdk/overlay';
+import { Combobox, ComboboxPopup, ComboboxWidget } from '@angular/aria/combobox';
+import { OverlayModule } from '@angular/cdk/overlay';
 import {
+  afterRenderEffect,
   booleanAttribute,
   Component,
   computed,
   contentChild,
-  ElementRef,
   inject,
   input,
   output,
@@ -35,7 +36,10 @@ import { SelectGroup, SelectItem, SelectOption } from './si-select.types';
     OverlayModule,
     SiSelectInputComponent,
     SiSelectListComponent,
-    SiSelectListHasFilterComponent
+    SiSelectListHasFilterComponent,
+    ComboboxPopup,
+    Combobox,
+    ComboboxWidget
   ],
   templateUrl: './si-select.component.html',
   styleUrl: './si-select.component.scss',
@@ -126,13 +130,6 @@ export class SiSelectComponent<T> implements SiFormItemControl {
     { read: TemplateRef }
   );
 
-  private readonly trigger = viewChild.required<CdkOverlayOrigin, ElementRef<HTMLDivElement>>(
-    CdkOverlayOrigin,
-    {
-      read: ElementRef
-    }
-  );
-
   /** @internal */
   readonly labelledby = computed(() => this.labelledbyInput() ?? this.id() + '-label');
   /**
@@ -148,7 +145,12 @@ export class SiSelectComponent<T> implements SiFormItemControl {
   readonly errormessageId = input(`${this.id()}-errormessage`);
 
   protected rows: readonly SelectItem<T>[] = [];
-  protected overlayWidth = 0;
+  protected readonly overlayWidth = computed(() => {
+    if (this.isOpen()) {
+      return this.combobox().element.getBoundingClientRect().width + 2;
+    }
+    return 0;
+  });
   protected readonly selectionStrategy = inject(SiSelectSelectionStrategy<T>);
 
   private backdropClicked = false;
@@ -160,26 +162,32 @@ export class SiSelectComponent<T> implements SiFormItemControl {
    */
   readonly hasFilter = input(false, { transform: booleanAttribute });
 
+  private readonly combobox = viewChild.required(Combobox);
+  private readonly siSelectList = viewChild(SiSelectListComponent);
+  constructor() {
+    afterRenderEffect(() => {
+      if (this.combobox()?.expanded() === true) {
+        this.siSelectList()?.listbox()?.scrollActiveItemIntoView();
+      }
+    });
+  }
   /** Opens the `si-select`. */
   open(): void {
     if (this.readonly() || this.selectionStrategy.disabled()) {
       return;
     }
-    this.overlayWidth = this.trigger().nativeElement.getBoundingClientRect().width + 2; // 2px border
     this.isOpen.set(true);
-    this.openChange.emit(true);
   }
 
   /** Closes the `si-select`. */
   close(): void {
     this.isOpen.set(false);
     if (!this.backdropClicked) {
-      this.trigger().nativeElement.focus();
+      this.combobox().element.focus();
     } else {
       this.backdropClicked = false;
       this.selectionStrategy.onTouched();
     }
-    this.openChange.emit(false);
   }
 
   protected backdropClick(): void {

--- a/projects/element-ng/select/testing/si-select-list.harness.ts
+++ b/projects/element-ng/select/testing/si-select-list.harness.ts
@@ -7,7 +7,7 @@ import { HarnessPredicate, TestKey } from '@angular/cdk/testing';
 import { SiSelectListBaseHarness } from '../../select/testing/si-select-list-base.harness';
 
 export class SiSelectListHarness extends SiSelectListBaseHarness {
-  static hostSelector = '.cdk-listbox';
+  static hostSelector = '[ngListbox]';
 
   static with(id: string): HarnessPredicate<SiSelectListHarness> {
     return new HarnessPredicate(SiSelectListHarness, { selector: `#${CSS.escape(id)}` });

--- a/projects/element-ng/select/testing/si-select.harness.ts
+++ b/projects/element-ng/select/testing/si-select.harness.ts
@@ -21,8 +21,12 @@ export class SiSelectHarness extends ComponentHarness {
    * Clicks one or multiple items by their index. In the case of multi-select, this will toggle the selection state.
    */
   async clickItems(itemIndex: number | number[]): Promise<void> {
-    await this.open('click');
-    const list = await this.getList();
+    let list = await this.getList();
+    if (!list) {
+      await this.open('click');
+      list = await this.getList();
+    }
+
     for (const index of [itemIndex].flat()) {
       await list!.getItem(index).then(item => item.click());
     }
@@ -32,8 +36,11 @@ export class SiSelectHarness extends ComponentHarness {
    * Clicks one or multiple items by their text. In the case of multi-select, this will toggle the selection state.
    */
   async clickItemsByText(texts: string | string[]): Promise<void> {
-    await this.open('click');
-    const list = await this.getList();
+    let list = await this.getList();
+    if (!list) {
+      await this.open('click');
+      list = await this.getList();
+    }
 
     for (const text of [texts].flat()) {
       await list!.getItemByText(text).then(item => item.click());


### PR DESCRIPTION
replaces manual aria attributes binding with @angular/aria combobox primitives

related to #1070 , #2569

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2595/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2595/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2595/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2595/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2595/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2595/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2595/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2595/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2595/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2595/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->




