### PR TITLE
docs(buttons): add selection buttons composition variants

### DIFF
--- a/docs/components/buttons-menus/button-group.md
+++ b/docs/components/buttons-menus/button-group.md
@@ -218,4 +218,41 @@ For selection-based button groups that represent different states or views, use 
 </div>
 ```
 
+**Composition variants**
+
+There are two ways to compose a selection button:
+
+**Input wrapped inside label** — nest the input directly inside a `<label>` element, removing the need for `for`/`id`.
+This variant is required for icon-only buttons to support and display **tooltips** correctly:
+
+```html
+<div class="btn-group" role="group" aria-label="Layout selection">
+  <label>
+    <input type="checkbox" class="btn-check" aria-label="One pane" siTooltip="One pane" checked />
+    <si-icon class="btn btn-icon icon" icon="element-layout-pane-1" />
+  </label>
+
+  <label>
+    <input type="checkbox" class="btn-check" aria-label="Two panes" siTooltip="Two panes" />
+    <si-icon class="btn btn-icon icon" icon="element-layout-pane-2" />
+  </label>
+</div>
+```
+
+**`for` / `id` linking** — place the input before the label and connect them via matching `for` and `id` attributes.
+This is the standard HTML pattern and works well for text labels:
+
+```html
+<div class="btn-group" role="group" aria-label="View selection">
+  <input type="radio" class="btn-check" name="view" id="view-day" checked />
+  <label class="btn" for="view-day">Day</label>
+
+  <input type="radio" class="btn-check" name="view" id="view-week" />
+  <label class="btn" for="view-week">Week</label>
+
+  <input type="radio" class="btn-check" name="view" id="view-month" />
+  <label class="btn" for="view-month">Month</label>
+</div>
+```
+
 <si-docs-component example="buttons/selection-buttons" height="350"></si-docs-component>

--- a/src/app/examples/buttons/selection-buttons.html
+++ b/src/app/examples/buttons/selection-buttons.html
@@ -40,7 +40,7 @@
         aria-label="One pane"
         checked
       />
-      <si-icon class="btn btn-icon" icon="element-layout-pane-1" />
+      <si-icon class="btn btn-icon icon" icon="element-layout-pane-1" />
     </label>
 
     <label>
@@ -51,7 +51,7 @@
         siTooltip="Two panes"
         aria-label="Two panes"
       />
-      <si-icon class="btn btn-icon" icon="element-layout-pane-2" />
+      <si-icon class="btn btn-icon icon" icon="element-layout-pane-2" />
     </label>
 
     <label>
@@ -62,7 +62,7 @@
         siTooltip="Three panes"
         aria-label="Three panes"
       />
-      <si-icon class="btn btn-icon" icon="element-layout-pane-3" />
+      <si-icon class="btn btn-icon icon" icon="element-layout-pane-3" />
     </label>
   </div>
 </div>
@@ -99,27 +99,27 @@
 <div class="btn-group mb-6" role="group" aria-label="Category filter">
   <label>
     <input type="checkbox" class="btn-check" siTooltip="Garden" aria-label="Garden" checked />
-    <si-icon class="btn btn-icon" icon="element-garden" />
+    <si-icon class="btn btn-icon icon" icon="element-garden" />
   </label>
 
   <label>
     <input type="checkbox" class="btn-check" siTooltip="Mobile" aria-label="Mobile" />
-    <si-icon class="btn btn-icon" icon="element-smartphone" />
+    <si-icon class="btn btn-icon icon" icon="element-smartphone" />
   </label>
 
   <label>
     <input type="checkbox" class="btn-check" siTooltip="Cloud" aria-label="Cloud" checked />
-    <si-icon class="btn btn-icon" icon="element-cloud" />
+    <si-icon class="btn btn-icon icon" icon="element-cloud" />
   </label>
 
   <label>
     <input type="checkbox" class="btn-check" siTooltip="AI" aria-label="AI" />
-    <si-icon class="btn btn-icon" icon="element-ai" />
+    <si-icon class="btn btn-icon icon" icon="element-ai" />
   </label>
 
   <label>
     <input type="checkbox" class="btn-check" siTooltip="Network" aria-label="Network" />
-    <si-icon class="btn btn-icon" icon="element-network" />
+    <si-icon class="btn btn-icon icon" icon="element-network" />
   </label>
 </div>
 
@@ -243,12 +243,12 @@
         siTooltip="Heating"
         aria-label="Heating"
       />
-      <si-icon class="btn btn-lg btn-icon" icon="element-sun" />
+      <si-icon class="btn btn-lg btn-icon icon" icon="element-sun" />
     </label>
 
     <label>
       <input type="radio" class="btn-check" name="btnradio7" siTooltip="Water" aria-label="Water" />
-      <si-icon class="btn btn-lg btn-icon" icon="element-water" />
+      <si-icon class="btn btn-lg btn-icon icon" icon="element-water" />
     </label>
 
     <label>
@@ -259,7 +259,7 @@
         siTooltip="Cooling"
         aria-label="Cooling"
       />
-      <si-icon class="btn btn-lg btn-icon" icon="element-cooling-state" />
+      <si-icon class="btn btn-lg btn-icon icon" icon="element-cooling-state" />
     </label>
   </div>
 
@@ -272,12 +272,12 @@
         siTooltip="Heating"
         aria-label="Heating"
       />
-      <si-icon class="btn btn-icon" icon="element-sun" />
+      <si-icon class="btn btn-icon icon" icon="element-sun" />
     </label>
 
     <label>
       <input type="radio" class="btn-check" name="btnradio8" siTooltip="Water" aria-label="Water" />
-      <si-icon class="btn btn-icon" icon="element-water" />
+      <si-icon class="btn btn-icon icon" icon="element-water" />
     </label>
 
     <label>
@@ -288,7 +288,7 @@
         siTooltip="Cooling"
         aria-label="Cooling"
       />
-      <si-icon class="btn btn-icon" icon="element-cooling-state" />
+      <si-icon class="btn btn-icon icon" icon="element-cooling-state" />
     </label>
   </div>
 
@@ -301,12 +301,12 @@
         siTooltip="Heating"
         aria-label="Heating"
       />
-      <si-icon class="btn btn-sm btn-icon" icon="element-sun" />
+      <si-icon class="btn btn-sm btn-icon icon" icon="element-sun" />
     </label>
 
     <label>
       <input type="radio" class="btn-check" name="btnradio9" siTooltip="Water" aria-label="Water" />
-      <si-icon class="btn btn-sm btn-icon" icon="element-water" />
+      <si-icon class="btn btn-sm btn-icon icon" icon="element-water" />
     </label>
 
     <label>
@@ -317,7 +317,7 @@
         siTooltip="Cooling"
         aria-label="Cooling"
       />
-      <si-icon class="btn btn-sm btn-icon" icon="element-cooling-state" />
+      <si-icon class="btn btn-sm btn-icon icon" icon="element-cooling-state" />
     </label>
   </div>
 </div>


### PR DESCRIPTION
Fixes #941

Rebased PR - https://github.com/siemens/element/pull/1561 as it got corrupted

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2598/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2598/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2598/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2598/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2598/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2598/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2598/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2598/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2598/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2598/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
