### PR TITLE
fixup(datatable): restore frozen column shadow

### DIFF
--- a/projects/element-theme/src/styles/components/_datatable.scss
+++ b/projects/element-theme/src/styles/components/_datatable.scss
@@ -105,6 +105,24 @@ $datatable-ghost-cell-strip-radius: 0 !default;
     }
   }
 
+  &.scroll-horz {
+    .datatable-row-left {
+      .datatable-body-cell:last-child,
+      .datatable-header-cell:last-child {
+        box-shadow: system-tokens.$si-sys-effects-shadow-3;
+        clip-path: inset(0 -8px 0 0);
+      }
+    }
+
+    .datatable-row-right {
+      .datatable-body-cell:first-child,
+      .datatable-header-cell:first-child {
+        box-shadow: system-tokens.$si-sys-effects-shadow-3;
+        clip-path: inset(0 0 0 -8px);
+      }
+    }
+  }
+
   // 'checkbox' selection
   :is(.datatable-header-cell, .datatable-body-cell) {
     label.datatable-checkbox {
@@ -185,24 +203,6 @@ $datatable-ghost-cell-strip-radius: 0 !default;
         }
       }
     }
-
-    .horizontal-overflow {
-      .datatable-row-left {
-        .datatable-body-cell:last-child,
-        .datatable-header-cell:last-child {
-          box-shadow: 0 0 8px system-tokens.$si-sys-effects-shadow-1;
-          clip-path: inset(0 -8px 0 0);
-        }
-      }
-
-      .datatable-row-right {
-        .datatable-body-cell:first-child,
-        .datatable-header-cell:first-child {
-          box-shadow: 0 0 8px system-tokens.$si-sys-effects-shadow-1;
-          clip-path: inset(0 0 0 -8px);
-        }
-      }
-    }
   }
 
   // Header Styles
@@ -239,7 +239,6 @@ $datatable-ghost-cell-strip-radius: 0 !default;
 
     :is(.datatable-row-left, .datatable-row-right) {
       background-color: variables.$table-bg;
-      display: flex;
 
       .datatable-header-cell {
         flex-shrink: 0;


### PR DESCRIPTION
Restore frozen-column shadows after the internal horizontal-overflow class was removed. Use the official datatable root scroll class and the system shadow token directly.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2604/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2604/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2604/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2604/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2604/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2604/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2604/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2604/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2604/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2604/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

