### PR TITLE
fixup(forms): align items flex-start to avoid strecthing

### DIFF
--- a/projects/element-ng/form/si-form-item/si-form-item.component.html
+++ b/projects/element-ng/form/si-form-item/si-form-item.component.html
@@ -19,7 +19,7 @@
 <ng-template #labelTemplate>
   @if (label()) {
     <div
-      class="d-flex gap-2"
+      class="d-flex gap-2 align-items-start"
       [class.form-label]="!fieldControl()?.isFormCheck"
       [class.form-check-label]="fieldControl()?.isFormCheck"
     >


### PR DESCRIPTION
Align the form item label row to flex-start so the help button keeps its natural focus dimensions instead of stretching to the label height.\n\nThe targeted si-form-item component tests pass.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2605/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2605/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2605/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2605/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2605/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2605/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2605/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2605/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2605/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2605/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
