### PR TITLE
docs: use version-relative links to sibling apps and pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,12 +25,12 @@ which implement the Element design system. The components are developed in the
 
 ## Playground
 
-Open our [demo playground](https://element.siemens.io/element-examples/#/overview)
+Open our <a href="element-examples/#/overview">demo playground</a>
 to see examples for all our components.
 
 ## Flexible dashboard demo
 
-Open our [flexible dashboard demo](https://element.siemens.io/dashboards-demo/).
+Open our <a href="dashboards-demo/">flexible dashboard demo</a>.
 
 ## Figma design assets
 

--- a/docs/components/charts/index.md
+++ b/docs/components/charts/index.md
@@ -40,7 +40,7 @@ available.
 There is also a [generic chart](generic-chart.md) which provides full
 flexibility by supporting all ECharts options.
 
-More examples can be found in our [playground](https://element.siemens.io/element-examples/#/overview?q=si-charts)
+More examples can be found in our <a href="../../element-examples/#/overview?q=si-charts">playground</a>
 by filtering for `si-charts`.
 
 ### Axis and labels

--- a/docs/components/dashboards/flexible-dashboards.md
+++ b/docs/components/dashboards/flexible-dashboards.md
@@ -81,9 +81,9 @@ The flexible dashboards are based on [gridstack.js](http://gridstackjs.com).
 See [README](https://github.com/siemens/element/blob/main/projects/dashboards-ng/README.md) for details
 about including to your app.
 
-<iframe class="component-preview" src="https://element.siemens.io/dashboards-demo/#/dashboard" height="991px" width="100%" allowfullscreen="true"></iframe>
+<iframe class="component-preview" src="../../../dashboards-demo/#/dashboard" height="991px" width="100%" allowfullscreen="true"></iframe>
 
-Direct [Link](https://element.siemens.io/dashboards-demo/#/dashboard) to dashboard demo.
+Direct <a href="../../../dashboards-demo/#/dashboard">Link</a> to dashboard demo.
 
 <si-docs-api component="SiFlexibleDashboardComponent" package="@siemens/dashboards-ng" hideImplicitlyPublic="true"></si-docs-api>
 

--- a/docs/components/maps/maps.md
+++ b/docs/components/maps/maps.md
@@ -47,7 +47,7 @@ information.
 A _Map pin_ is used to represent a single location.
 If needed, _Map pins_ can also be used to represent different status.
 Avoid mixing the
-[Status color palette](https://element.siemens.io/fundamentals/colors/ui-colors/#status)
+[Status color palette](../../fundamentals/colors/ui-colors.md#status)
 with the default color.
 
 ![Map Pin](images/map-pin.png)

--- a/docs/fundamentals/localization.md
+++ b/docs/fundamentals/localization.md
@@ -158,7 +158,7 @@ Element provides the possibility to override text keys on a global level. This c
 text keys that are used multiple times within an application but have most likely the same value. This is usually the case
 for static labels like `Close`, `Ok`, ...
 
-All keys that can be overridden can be found [here.](https://element.siemens.io/api/element-ng/types/SiTranslatableKeys)
+All keys that can be overridden can be found <a href="../../api/element-ng/types/SiTranslatableKeys">here.</a>
 
 The overriding of text keys is available for every framework except `@angular/localize` due to technical limitations.
 

--- a/docs/update-guides/update-v49.md
+++ b/docs/update-guides/update-v49.md
@@ -56,7 +56,7 @@ As the icons now have a reduced built-in margin, spacings must be adjusted:
 
 Remove the `@angular/animations` package and `@angular/platform-browser/animations` imports
 if your app never uses the `animations` property in their `@Component` metadata.
-See our [Motion animation](https://element.siemens.io/architecture/motion-animation/) chapter for more details.
+See our [Motion animation](../architecture/motion-animation.md) chapter for more details.
 
 Compile and test your application. Consult the [changelog](https://github.com/siemens/element/releases/tag/v49.0.0) for more changes.
 


### PR DESCRIPTION
﻿Backport of #2597 to `release/49.x`.

Several docs pages linked to `https://element.siemens.io/...` with absolute URLs. Those always resolve to the latest documentation, so a user browsing the versioned site at `/v49/` was silently taken out of that version, for example when opening the playground or the flexible dashboard demo from the start page.

This replaces those absolute links with relative ones so they stay within the version that is currently being served.

- Internal docs pages use regular markdown links, which MkDocs resolves and validates.
- The sibling apps (`element-examples`, `dashboards-demo`, `api`) live outside the docs tree, so they use raw HTML anchors. Markdown links there would fail the `--strict` build since MkDocs cannot resolve targets it does not own.

Pages touched: start page, charts overview, flexible dashboards (iframe and link), maps, localization, and the v49 update guide.

The cherry-pick applied cleanly, so this is identical to the change on `main`, which was verified there with a full `mkdocs build --strict` run.
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2612/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2612/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2612/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2612/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-79%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2612/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2612/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2612/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2612/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2612/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2612/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
