### PR TITLE
fix(tree-view): align items with and without folder state toggle

### DIFF
--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.html
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.html
@@ -19,7 +19,7 @@
         <ng-container
           [ngTemplateOutlet]="toggleTemplate"
           [ngTemplateOutletContext]="{
-            biggerPaddingStart: '-' + biggerPaddingStart,
+            biggerPaddingStart: negativeBiggerPaddingStart,
             paddingStart: paddingStart,
             toggleIcon: 'si-tree-view-item-dropdown-caret'
           }"

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.ts
@@ -192,19 +192,27 @@ export class SiTreeViewItemComponent implements OnInit, AfterViewInit, Focusable
 
   protected readonly deleteChildrenOnCollapse = this.treeViewComponent.deleteChildrenOnCollapse;
 
-  protected get paddingStart(): string {
+  private get indentation(): number {
     return this.siTreeViewService.groupedList
-      ? '0'
-      : this.indentLevel * this.siTreeViewService.childrenIndentation + 'px';
+      ? 0
+      : this.indentLevel * this.siTreeViewService.childrenIndentation;
   }
 
+  protected get paddingStart(): string {
+    return `${this.indentation}px`;
+  }
+
+  /** Indentation plus the space the start toggle occupies, so leaf items align with foldable ones. */
   protected get biggerPaddingStart(): string {
-    const basePadding = this.showFolderStateStart ? 24 : 0;
-    return (
-      (this.siTreeViewService.groupedList
-        ? basePadding
-        : this.indentLevel * this.siTreeViewService.childrenIndentation + basePadding) + 'px'
-    );
+    return this.showFolderStateStart
+      ? `calc(${this.indentation}px + var(--si-tree-view-icon-size))`
+      : `${this.indentation}px`;
+  }
+
+  protected get negativeBiggerPaddingStart(): string {
+    return this.showFolderStateStart
+      ? `calc(${-this.indentation}px - var(--si-tree-view-icon-size))`
+      : `${-this.indentation}px`;
   }
 
   protected get isGroupedItem(): boolean {


### PR DESCRIPTION
The start toggle slot was hardcoded to 24px while the toggle icon renders at `--si-tree-view-icon-size` (1.25rem). Leaf items were therefore indented 4px more than their foldable siblings on the same level. Reserve the actual icon size instead, so the slot also scales with the root font size and a custom icon size.

Closes #2550

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2618/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2618/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2618/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2618/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2618/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2618/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2618/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2618/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2618/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2618/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
