### PR TITLE
fix: don't use popover API for overlays

### DIFF
--- a/projects/element-ng/common/helpers/overlay-helper.ts
+++ b/projects/element-ng/common/helpers/overlay-helper.ts
@@ -81,6 +81,7 @@ export function makeOverlay(
   config.positionStrategy = positionStrategy;
   config.scrollStrategy = scrollStrategy ?? overlay.scrollStrategies.reposition();
   config.direction = isRTL() ? 'rtl' : 'ltr';
+  config.usePopover = false;
   if (hasBackdrop) {
     config.hasBackdrop = true;
     config.backdropClass = 'cdk-overlay-transparent-backdrop';

--- a/projects/element-ng/datepicker/si-datepicker-overlay.directive.ts
+++ b/projects/element-ng/datepicker/si-datepicker-overlay.directive.ts
@@ -234,6 +234,7 @@ export class SiDatepickerOverlayDirective implements OnDestroy {
     this.overlayRef = this.overlay.create({
       positionStrategy: this.overlay.position().global().centerHorizontally().centerVertically(),
       direction: isRTL() ? 'rtl' : 'ltr',
+      usePopover: false,
       hasBackdrop: true,
       scrollStrategy: this.scrollStrategy(),
       backdropClass: 'modal-backdrop'
@@ -251,6 +252,7 @@ export class SiDatepickerOverlayDirective implements OnDestroy {
         .withFlexibleDimensions(true)
         .withViewportMargin(4),
       direction: isRTL() ? 'rtl' : 'ltr',
+      usePopover: false,
       hasBackdrop: true,
       scrollStrategy: this.scrollStrategy(),
       backdropClass: 'cdk-overlay-transparent-backdrop'

--- a/projects/element-ng/header-dropdown/si-header-dropdown-trigger.directive.ts
+++ b/projects/element-ng/header-dropdown/si-header-dropdown-trigger.directive.ts
@@ -255,7 +255,8 @@ export class SiHeaderDropdownTriggerDirective implements OnChanges, OnInit, OnDe
                     offsetX: -4
                   }
                 ])
-        )
+        ),
+      usePopover: false
     });
     this.portal = new TemplatePortal(
       this.dropdown(),

--- a/projects/element-ng/modal/si-modal.service.ts
+++ b/projects/element-ng/modal/si-modal.service.ts
@@ -127,7 +127,8 @@ export class SiModalService {
 
     modalRef.overlayRef = this.overlay.create({
       positionStrategy: this.overlay.position().global().centerHorizontally().centerVertically(),
-      direction: isRTL() ? 'rtl' : 'ltr'
+      direction: isRTL() ? 'rtl' : 'ltr',
+      usePopover: false
     });
     const compPortal = new ComponentPortal(SiModalComponent, null, injector);
     // Ensure compatibility between Angular CDK 19 and 20 since constructor arguments have changed

--- a/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group-trigger.directive.ts
+++ b/projects/element-ng/navbar-vertical-next/si-navbar-vertical-next-group-trigger.directive.ts
@@ -131,7 +131,8 @@ export class SiNavbarVerticalNextGroupTriggerDirective {
       .withPositions([
         { originX: 'end', originY: 'top', overlayX: 'start', overlayY: 'top' },
         { originX: 'end', originY: 'bottom', overlayX: 'start', overlayY: 'bottom' }
-      ])
+      ]),
+    usePopover: false
   });
   private groupView?: EmbeddedViewRef<unknown>;
   private flyoutAnchorComponentRef?: ComponentRef<SiNavbarFlyoutAnchorComponent>;

--- a/projects/element-ng/navbar-vertical/si-navbar-vertical-group-trigger.directive.ts
+++ b/projects/element-ng/navbar-vertical/si-navbar-vertical-group-trigger.directive.ts
@@ -94,7 +94,8 @@ export class SiNavbarVerticalGroupTriggerDirective implements OnInit {
       .withPositions([
         { originX: 'end', originY: 'top', overlayX: 'start', overlayY: 'top' },
         { originX: 'end', originY: 'bottom', overlayX: 'start', overlayY: 'bottom' }
-      ])
+      ]),
+    usePopover: false
   });
   private groupView!: EmbeddedViewRef<unknown>;
   private flyoutAnchorComponentRef?: ComponentRef<SiNavbarFlyoutAnchorComponent>;

--- a/projects/element-ng/select/si-custom-select.directive.ts
+++ b/projects/element-ng/select/si-custom-select.directive.ts
@@ -264,7 +264,8 @@ export class SiCustomSelectDirective<T> implements ControlValueAccessor, SiFormI
       scrollStrategy: this.scrollStrategy(),
       backdropClass: 'cdk-overlay-transparent-backdrop',
       panelClass: ['dropdown-menu', 'show'],
-      minWidth: width + 2
+      minWidth: width + 2,
+      usePopover: false
     });
 
     const portal = new TemplatePortal(this.dropdownDirective()!.templateRef, this.viewContainerRef);

--- a/projects/element-ng/toast-notification/si-toast-notification.service.ts
+++ b/projects/element-ng/toast-notification/si-toast-notification.service.ts
@@ -162,7 +162,8 @@ export class SiToastNotificationService implements OnDestroy {
 
   private addToastDrawer(): void {
     this.overlayRef = this.overlay.create({
-      positionStrategy: this.overlay.position().global().end().bottom()
+      positionStrategy: this.overlay.position().global().end().bottom(),
+      usePopover: false
     });
     const portal = new ComponentPortal(
       SiToastNotificationDrawerComponent,

--- a/projects/element-ng/tour/si-tour.service.ts
+++ b/projects/element-ng/tour/si-tour.service.ts
@@ -249,7 +249,8 @@ export class SiTourService {
     // first the highlighter,
     const hlPortal = new ComponentPortal(SiTourHighlightComponent, undefined, componentInjector);
     this.overlayRefHighlight = this.overlay.create({
-      positionStrategy: this.overlay.position().global()
+      positionStrategy: this.overlay.position().global(),
+      usePopover: false
     });
     this.overlayRefHighlight.attach(hlPortal);
 
@@ -257,7 +258,8 @@ export class SiTourService {
     this.portal = new ComponentPortal(SiTourComponent, undefined, componentInjector);
     this.overlayRef = this.overlay.create({
       scrollStrategy: this.overlay.scrollStrategies.reposition(),
-      direction: isRTL() ? 'rtl' : 'ltr'
+      direction: isRTL() ? 'rtl' : 'ltr',
+      usePopover: false
     });
     this.overlayRef.attach(this.portal);
     // needs a subscriber, otherwise events will be ignored and the .backdrop CSS hack doesn't help

--- a/projects/element-ng/typeahead/si-typeahead.directive.ts
+++ b/projects/element-ng/typeahead/si-typeahead.directive.ts
@@ -514,7 +514,8 @@ export class SiTypeaheadDirective implements OnChanges, OnDestroy {
           .withPositions(SiTypeaheadDirective.overlayPositions),
         minWidth: this.typeaheadFullWidth()
           ? this.elementRef.nativeElement.getBoundingClientRect().width + 2 // 2px border
-          : 0
+          : 0,
+        usePopover: false
       };
 
       const scrollStrategy = this.typeaheadScrollStrategy();


### PR DESCRIPTION
See #2619

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2620/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2620/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2620/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2620/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2620/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2620/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2620/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2620/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2620/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2620/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
