### PR TITLE
fix(maps-ng): embed tooltip content as text instead of html

### DIFF
--- a/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.html
+++ b/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.html
@@ -1,5 +1,7 @@
 <div class="si-map-tooltip">
-  <div #content></div>
+  @for (label of tooltipLabels(); track $index) {
+    <div>{{ label }}</div>
+  }
   @if (hiddenEntries()) {
     <div>{{ moreText() | translate: { length: hiddenEntries() } }}</div>
   }

--- a/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.spec.ts
@@ -34,18 +34,18 @@ describe('SiMapTooltipComponent', () => {
 
   it('should display the tooltip from simple string value', () => {
     component.setTooltip(label);
+    fixture.detectChanges();
 
     const tooltip = fixture.debugElement.query(By.css('.si-map-tooltip'));
-    expect(tooltip.nativeElement.innerHTML).toContain('<div>Label X</div>');
+    expect(tooltip.nativeElement.textContent).toContain(label);
   });
 
   it('should display the tooltip from array of strings', () => {
     component.setTooltip(labels);
+    fixture.detectChanges();
 
     const tooltip = fixture.debugElement.query(By.css('.si-map-tooltip'));
-    expect(tooltip.nativeElement.innerHTML).toContain(
-      '<div>Label A</div><div>Label B</div><div>Label C</div>'
-    );
+    expect(tooltip.nativeElement.textContent).toContain(labels.join(''));
   });
 
   it('should render cropped tooltip if there are too many labels', () => {
@@ -58,7 +58,18 @@ describe('SiMapTooltipComponent', () => {
   it('should trim the label if too long', () => {
     const longLabel = 'This is too long label, which will be trimmed 50 ch';
     component.setTooltip(longLabel);
+    fixture.detectChanges();
     const tooltip = fixture.debugElement.query(By.css('.si-map-tooltip'));
-    expect(tooltip.nativeElement.innerHTML).toContain('...');
+    expect(tooltip.nativeElement.textContent).toContain('…');
+  });
+
+  it('should render untrusted label markup as text', () => {
+    const labelWithMarkup = '<img src=x onerror=alert(document.domain)>';
+    component.setTooltip(labelWithMarkup);
+    fixture.detectChanges();
+
+    const tooltip = fixture.debugElement.query(By.css('.si-map-tooltip'));
+    expect(tooltip.nativeElement.textContent).toContain(labelWithMarkup);
+    expect(tooltip.nativeElement.querySelector('img')).toBeNull();
   });
 });

--- a/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.ts
+++ b/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2025
  * SPDX-License-Identifier: MIT
  */
-import { Component, ElementRef, inject, input, signal, viewChild } from '@angular/core';
+import { Component, ElementRef, inject, input, signal } from '@angular/core';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
 import { TOOLTIP_FEATURES_TO_DISPLAY } from '../../models/constants';
@@ -15,8 +15,6 @@ import { TOOLTIP_FEATURES_TO_DISPLAY } from '../../models/constants';
   styleUrl: './si-map-tooltip.component.scss'
 })
 export class SiMapTooltipComponent {
-  protected readonly content = viewChild.required<ElementRef>('content');
-
   /**
    * Cutoff text for tooltips, when cluster combines more than 4 features
    *
@@ -41,6 +39,7 @@ export class SiMapTooltipComponent {
   }
 
   protected readonly hiddenEntries = signal(0);
+  protected readonly tooltipLabels = signal<string[]>([]);
   private readonly elementRef = inject(ElementRef);
 
   /**
@@ -51,37 +50,18 @@ export class SiMapTooltipComponent {
    * @param labels - array of strings or string itself
    */
   setTooltip(labels: string[] | string): void {
-    if (typeof labels === 'string') {
-      this.setContent(this.getLabelSnippet(labels));
-      this.hiddenEntries.set(0);
-      return;
-    }
-
-    const list: string[] = [];
-
-    if (labels.length > 1) {
-      const toDisplay = [...labels];
-      const rest = toDisplay.splice(
-        TOOLTIP_FEATURES_TO_DISPLAY,
-        toDisplay.length - TOOLTIP_FEATURES_TO_DISPLAY
-      );
-
-      toDisplay.forEach(feat => list.push(this.getLabelSnippet(feat)));
-      this.hiddenEntries.set(rest.length ?? 0);
-    }
-
-    this.setContent(list.join(''));
+    const labelList = typeof labels === 'string' ? [labels] : labels.length > 1 ? labels : [];
+    this.tooltipLabels.set(
+      labelList.slice(0, TOOLTIP_FEATURES_TO_DISPLAY).map(label => this.getLabelText(label))
+    );
+    this.hiddenEntries.set(Math.max(labelList.length - TOOLTIP_FEATURES_TO_DISPLAY, 0));
   }
 
-  private getLabelSnippet(label: string): string {
+  private getLabelText(label: string): string {
     if (this.maxLabelLength() != -1 && label.length > this.maxLabelLength()) {
-      return `<div>${label.substring(0, this.maxLabelLength())}...</div>`;
-    } else {
-      return `<div>${label}</div>`;
+      return `${label.substring(0, this.maxLabelLength())}…`;
     }
-  }
 
-  private setContent(tooltip: string): void {
-    this.content().nativeElement.innerHTML = tooltip;
+    return label;
   }
 }

--- a/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
@@ -84,6 +84,7 @@ describe('SiMapComponent', () => {
 
     fixture.detectChanges();
     component.showTooltipContent(mockFeature);
+    fixture.detectChanges();
     expect(component.showTooltipContent).toHaveBeenCalled();
     const tooltip = fixture.debugElement.query(By.directive(SiMapTooltipComponent));
     expect(tooltip.nativeElement.innerHTML).toContain('name');


### PR DESCRIPTION
Fixes CVE-2026-66155

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
