### PR TITLE
fix(maps-ng): embed tooltip content as text instead of html

### DIFF
--- a/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.html
+++ b/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.html
@@ -1,5 +1,7 @@
 <div class="si-map-tooltip">
-  <div #content></div>
+  @for (label of tooltipLabels(); track $index) {
+    <div>{{ label }}</div>
+  }
   @if (hiddenEntries()) {
     <div>{{ moreText() | translate: { length: hiddenEntries() } }}</div>
   }

--- a/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.spec.ts
@@ -30,25 +30,25 @@ describe('SiMapTooltipComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display the tooltip from simple string value', () => {
+  it('should display the tooltip from simple string value', async () => {
     component.setTooltip(label);
+    await fixture.whenStable();
 
     const tooltip = fixture.debugElement.query(By.css('.si-map-tooltip'));
-    expect(tooltip.nativeElement.innerHTML).toContain('<div>Label X</div>');
+    expect(tooltip.nativeElement.textContent).toContain(label);
   });
 
-  it('should display the tooltip from array of strings', () => {
+  it('should display the tooltip from array of strings', async () => {
     component.setTooltip(labels);
+    await fixture.whenStable();
 
     const tooltip = fixture.debugElement.query(By.css('.si-map-tooltip'));
-    expect(tooltip.nativeElement.innerHTML).toContain(
-      '<div>Label A</div><div>Label B</div><div>Label C</div>'
-    );
+    expect(tooltip.nativeElement.textContent).toContain(labels.join(''));
   });
 
-  it('should render cropped tooltip if there are too many labels', () => {
+  it('should render cropped tooltip if there are too many labels', async () => {
     component.setTooltip([...labels, ...labels]);
-    fixture.detectChanges();
+    await fixture.whenStable();
     const tooltip = fixture.debugElement.query(By.css('.si-map-tooltip'));
     expect(tooltip.nativeElement.innerHTML).toContain('+ 2 locations');
   });
@@ -56,7 +56,18 @@ describe('SiMapTooltipComponent', () => {
   it('should trim the label if too long', () => {
     const longLabel = 'This is too long label, which will be trimmed 50 ch';
     component.setTooltip(longLabel);
+    fixture.detectChanges();
     const tooltip = fixture.debugElement.query(By.css('.si-map-tooltip'));
-    expect(tooltip.nativeElement.innerHTML).toContain('…');
+    expect(tooltip.nativeElement.textContent).toContain('…');
+  });
+
+  it('should render untrusted label markup as text', () => {
+    const labelWithMarkup = '<img src=x onerror=alert(document.domain)>';
+    component.setTooltip(labelWithMarkup);
+    fixture.detectChanges();
+
+    const tooltip = fixture.debugElement.query(By.css('.si-map-tooltip'));
+    expect(tooltip.nativeElement.textContent).toContain(labelWithMarkup);
+    expect(tooltip.nativeElement.querySelector('img')).toBeNull();
   });
 });

--- a/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.ts
+++ b/projects/maps-ng/src/components/si-map/components/si-map-tooltip/si-map-tooltip.component.ts
@@ -8,8 +8,7 @@ import {
   ElementRef,
   inject,
   input,
-  signal,
-  viewChild
+  signal
 } from '@angular/core';
 import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
 
@@ -23,8 +22,6 @@ import { TOOLTIP_FEATURES_TO_DISPLAY } from '../../models/constants';
   changeDetection: ChangeDetectionStrategy.Eager
 })
 export class SiMapTooltipComponent {
-  protected readonly content = viewChild.required<ElementRef>('content');
-
   /**
    * Cutoff text for tooltips, when cluster combines more than 4 features
    *
@@ -49,6 +46,7 @@ export class SiMapTooltipComponent {
   }
 
   protected readonly hiddenEntries = signal(0);
+  protected readonly tooltipLabels = signal<string[]>([]);
   private readonly elementRef = inject(ElementRef);
 
   /**
@@ -59,37 +57,18 @@ export class SiMapTooltipComponent {
    * @param labels - array of strings or string itself
    */
   setTooltip(labels: string[] | string): void {
-    if (typeof labels === 'string') {
-      this.setContent(this.getLabelSnippet(labels));
-      this.hiddenEntries.set(0);
-      return;
-    }
-
-    const list: string[] = [];
-
-    if (labels.length > 1) {
-      const toDisplay = [...labels];
-      const rest = toDisplay.splice(
-        TOOLTIP_FEATURES_TO_DISPLAY,
-        toDisplay.length - TOOLTIP_FEATURES_TO_DISPLAY
-      );
-
-      toDisplay.forEach(feat => list.push(this.getLabelSnippet(feat)));
-      this.hiddenEntries.set(rest.length ?? 0);
-    }
-
-    this.setContent(list.join(''));
+    const labelList = typeof labels === 'string' ? [labels] : labels.length > 1 ? labels : [];
+    this.tooltipLabels.set(
+      labelList.slice(0, TOOLTIP_FEATURES_TO_DISPLAY).map(label => this.getLabelText(label))
+    );
+    this.hiddenEntries.set(Math.max(labelList.length - TOOLTIP_FEATURES_TO_DISPLAY, 0));
   }
 
-  private getLabelSnippet(label: string): string {
+  private getLabelText(label: string): string {
     if (this.maxLabelLength() != -1 && label.length > this.maxLabelLength()) {
-      return `<div>${label.substring(0, this.maxLabelLength())}…</div>`;
-    } else {
-      return `<div>${label}</div>`;
+      return `${label.substring(0, this.maxLabelLength())}…`;
     }
-  }
 
-  private setContent(tooltip: string): void {
-    this.content().nativeElement.innerHTML = tooltip;
+    return label;
   }
 }

--- a/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
+++ b/projects/maps-ng/src/components/si-map/si-map.component.spec.ts
@@ -81,14 +81,13 @@ describe('SiMapComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should define popup html and right overlay position when clustering is enabled', () => {
+  it('should define popup html and right overlay position when clustering is enabled', async () => {
     componentRef.setInput('displayTooltipOnHover', true);
     componentRef.setInput('cluster', true);
     component.isClicked = false;
     vi.spyOn(component, 'showTooltipContent');
-
-    fixture.detectChanges();
     component.showTooltipContent(mockFeature);
+    await fixture.whenStable();
     expect(component.showTooltipContent).toHaveBeenCalled();
     const tooltip = fixture.debugElement.query(By.directive(SiMapTooltipComponent));
     expect(tooltip.nativeElement.innerHTML).toContain('name');


### PR DESCRIPTION
Fixes CVE-2026-66155

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2628/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2628/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2628/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2628/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2628/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2628/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2628/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2628/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2628/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2628/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

