### PR TITLE
refactor(search-bar): remove tabbable input

### DIFF
--- a/api-goldens/element-ng/search-bar/index.api.md
+++ b/api-goldens/element-ng/search-bar/index.api.md
@@ -24,7 +24,6 @@ export class SiSearchBarComponent implements OnInit, OnDestroy, ControlValueAcce
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly searchChange: _angular_core.OutputEmitterRef<string>;
     readonly showIcon: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly tabbable: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly value: _angular_core.InputSignal<string | undefined>;
 }
 

--- a/projects/element-ng/schematics/migrations/data/symbol-removals.ts
+++ b/projects/element-ng/schematics/migrations/data/symbol-removals.ts
@@ -29,5 +29,10 @@ export const SYMBOL_REMOVALS_MIGRATION: SymbolRemovalInstruction[] = [
     module: /@siemens\/element-ng\/file-uploader/,
     elementSelector: 'si-file-dropzone',
     names: ['uploadTextFileSelect']
+  },
+  {
+    module: /@siemens\/element-ng\/search-bar/,
+    elementSelector: 'si-search-bar',
+    names: ['tabbable']
   }
 ];

--- a/projects/element-ng/schematics/ng-update/index.spec.ts
+++ b/projects/element-ng/schematics/ng-update/index.spec.ts
@@ -89,6 +89,36 @@ export const appConfig: ApplicationConfig = {
     expect(modifiedContent).toContain('providers: [provideZonelessChangeDetection()]');
   });
 
+  it('should remove the deprecated si-search-bar tabbable input', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/search.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-search',
+  template: \`<si-search-bar [tabbable]="false" placeholder="Search" />\`
+})
+export class SearchComponent {}`,
+      '/projects/app/src/external-search.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-external-search',
+  templateUrl: './search.component.html'
+})
+export class ExternalSearchComponent {}`,
+      '/projects/app/src/search.component.html': `<si-search-bar tabbable="false" />
+<div tabbable="false"></div>`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/search.component.ts');
+    const template = tree.readContent('/projects/app/src/search.component.html');
+
+    expect(component).not.toContain('tabbable');
+    expect(component).toContain('placeholder="Search"');
+    expect(template).not.toContain('si-search-bar tabbable');
+    expect(template).toContain('<div tabbable="false"></div>');
+  });
+
   it('should move literal split sizes to inline split parts', async () => {
     addTestFiles(appTree, {
       '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';

--- a/projects/element-ng/search-bar/si-search-bar.component.html
+++ b/projects/element-ng/search-bar/si-search-bar.component.html
@@ -12,7 +12,6 @@
     [class.icon-start]="showIcon()"
     [class.is-invalid]="isInvalid"
     [class.icon-end]="searchValue()"
-    [attr.tabindex]="tabbable() ? '' : '-1'"
     [attr.maxlength]="maxlength()"
     [readonly]="readonly()"
     (focus)="inFocus = true"

--- a/projects/element-ng/search-bar/si-search-bar.component.ts
+++ b/projects/element-ng/search-bar/si-search-bar.component.ts
@@ -69,12 +69,6 @@ export class SiSearchBarComponent implements OnInit, OnDestroy, ControlValueAcce
    * @defaultValue false
    */
   readonly showIcon = input(false, { transform: booleanAttribute });
-  /**
-   * Whether the search is tabbable or not.
-   *
-   * @defaultValue true
-   */
-  readonly tabbable = input(true, { transform: booleanAttribute });
 
   /**
    * Define search input content.


### PR DESCRIPTION
BREAKING CHANGE: removed the `tabbable` input of `si-search-bar`

Removed the `tabbable` input without any replacement. Remove the input from your templates:

```html
<!-- before -->
<si-search-bar [tabbable]="false" />

<!-- after -->
<si-search-bar />
```

The `migration-v51` schematic removes the input automatically.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2633/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2633/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2633/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2633/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2633/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2633/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2633/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2633/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2633/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2633/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
