### PR TITLE
build(semantic-release): link CVE references in changelog

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -36,7 +36,8 @@ export default {
       {
         preset: 'angular',
         parserOpts: {
-          noteKeywords: ['BREAKING CHANGE', 'NOTE', 'DEPRECATED']
+          noteKeywords: ['BREAKING CHANGE', 'NOTE', 'DEPRECATED'],
+          issuePrefixes: ['#', 'gh-', 'CVE-']
         },
         writerOpts
       }

--- a/tools/semantic-release/writer-opts.js
+++ b/tools/semantic-release/writer-opts.js
@@ -47,6 +47,10 @@ function transform(commit) {
   return {
     ...commit,
     notes: normalizedNotes,
+    references: commit.references.map(reference => ({
+      ...reference,
+      isCve: reference.prefix === 'CVE-'
+    })),
     type: visibleTypes[commit.type],
     shortHash
   };
@@ -68,9 +72,15 @@ function finalizeContext(context) {
   return context;
 }
 
+const commitPartial = `* {{#if scope}}**{{scope}}:** {{/if}}{{subject}}
+{{~#if @root.linkReferences}} ([{{shortHash}}]({{#if @root.repository}}{{@root.host}}/{{@root.owner}}/{{@root.repository}}{{else}}{{@root.repoUrl}}{{/if}}/commit/{{hash}})){{else}} {{shortHash}}{{/if}}
+{{~#if references}}, closes{{#each references}} {{#if isCve}}[{{prefix}}{{issue}}](https://nvd.nist.gov/vuln/detail/{{prefix}}{{issue}}){{else}}[{{prefix}}{{issue}}]({{#if @root.repository}}{{@root.host}}/{{#if repository}}{{owner}}/{{repository}}{{else}}{{@root.owner}}/{{@root.repository}}{{/if}}{{else}}{{@root.repoUrl}}{{/if}}/issues/{{issue}}){{/if}}{{/each}}{{/if}}
+`;
+
 export default {
   transform,
   finalizeContext,
+  commitPartial,
   commitGroupsSort(a, b) {
     return commitGroups.indexOf(a.title) - commitGroups.indexOf(b.title);
   },


### PR DESCRIPTION
Backport of #2632 to `release/48.x`.