### PR TITLE
fix: summary-chip and summary-widget layout

### DIFF
--- a/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item-side-panel--popover-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item-side-panel--popover-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d282247f1545b5e8a420eef98896cea20c6372f1b5ffa658493a9ca248d660d
-size 53599
+oid sha256:590049a85901d49a89ce625de64fbbce5cb6e6adc0c4899fe2e1dd78d60a4916
+size 53720

--- a/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item-side-panel--popover-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-notification-item.spec.ts-snapshots/si-notification-item--si-notification-item-side-panel--popover-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be8238c46fdf7687c69164808d1b709efbedc4b193680f354093b1c703a994d7
-size 50762
+oid sha256:d6a5f1cd0121cde772ccc35ba1bbd1e917cfcfe4252b3955660fd4a8311a09a3
+size 50822

--- a/playwright/snapshots/static.spec.ts-snapshots/si-summary-chip--si-summary-chip-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-summary-chip--si-summary-chip-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e80d0d69edf68fd6a281f2ddcfe46d11a0bcdd24d7af492a4780b46a6f7d11a
-size 27342
+oid sha256:4a4b7df867633c57dd7bec2594edd14ef413e6a3d8d9254161e5ee87e599b27b
+size 26197

--- a/playwright/snapshots/static.spec.ts-snapshots/si-summary-chip--si-summary-chip-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-summary-chip--si-summary-chip-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7901e489cdfb284ddb083344c33cc7d239efc661e0558197a2c4eae4f1b915ed
-size 26979
+oid sha256:9ebe1b09292556fabd94e93f008402fd80917561ff7183d1ed57e9b188f76a3d
+size 25968

--- a/playwright/snapshots/static.spec.ts-snapshots/si-summary-widget--si-summary-widget-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-summary-widget--si-summary-widget-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:41d0c5a1e72e50b04a70183873e7a1f70c2994284a04279d1b1246e3c1f3ca2b
-size 30631
+oid sha256:6b1cc61797ffc91cd619deed78ebf03f55dba368b14bec5ebf245d87442678fd
+size 30540

--- a/playwright/snapshots/static.spec.ts-snapshots/si-summary-widget--si-summary-widget-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-summary-widget--si-summary-widget-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a521ee43620ec95c72b75b5bdb94cb0caac46c86edca7b0573288add9aaf08c
-size 30734
+oid sha256:9d384549432b9a41ca3632c9467a56d68a2fe4ecef93b821a6e897ee3f9e5140
+size 30502

--- a/projects/element-ng/summary-chip/si-summary-chip.component.html
+++ b/projects/element-ng/summary-chip/si-summary-chip.component.html
@@ -24,6 +24,6 @@
     {{ label() | translate }}
   </div>
   @if (value) {
-    <div class="si-body fw-semibold">{{ value | translate }}</div>
+    <div class="si-body-sbold">{{ value | translate }}</div>
   }
 </div>

--- a/projects/element-ng/summary-chip/si-summary-chip.component.html
+++ b/projects/element-ng/summary-chip/si-summary-chip.component.html
@@ -24,6 +24,6 @@
     {{ label() | translate }}
   </div>
   @if (value) {
-    <div class="si-h5">{{ value | translate }}</div>
+    <div class="si-body fw-semibold">{{ value | translate }}</div>
   }
 </div>

--- a/projects/element-ng/summary-chip/si-summary-chip.component.spec.ts
+++ b/projects/element-ng/summary-chip/si-summary-chip.component.spec.ts
@@ -41,7 +41,7 @@ describe('SiSummaryChipComponent', () => {
     await fixture.whenStable();
 
     expect(element.querySelector('.si-body')).toHaveTextContent('test label');
-    expect(element.querySelector('.si-h5')).toHaveTextContent('42');
+    expect(element.querySelector('.fw-semibold')).toHaveTextContent('42');
     expect(element.querySelector('si-icon')).not.toBeInTheDocument();
   });
 

--- a/projects/element-ng/summary-chip/si-summary-chip.component.spec.ts
+++ b/projects/element-ng/summary-chip/si-summary-chip.component.spec.ts
@@ -41,7 +41,7 @@ describe('SiSummaryChipComponent', () => {
     await fixture.whenStable();
 
     expect(element.querySelector('.si-body')).toHaveTextContent('test label');
-    expect(element.querySelector('.fw-semibold')).toHaveTextContent('42');
+    expect(element.querySelector('.si-body-sbold')).toHaveTextContent('42');
     expect(element.querySelector('si-icon')).not.toBeInTheDocument();
   });
 

--- a/projects/element-ng/summary-widget/si-summary-widget.component.html
+++ b/projects/element-ng/summary-widget/si-summary-widget.component.html
@@ -13,7 +13,7 @@
 >
   @let actualIcon = statusIcon();
   @if (actualIcon.icon) {
-    <span class="icon icon-stack">
+    <span class="icon icon-stack mt-1">
       <si-icon [class]="actualIcon.color" [icon]="actualIcon.icon" />
       @if (actualIcon.stacked) {
         <si-icon [class]="actualIcon.stackedColor" [icon]="actualIcon.stacked" />
@@ -21,7 +21,7 @@
     </span>
   }
   <div class="d-flex flex-column py-2" [class.ps-2]="!actualIcon.icon">
-    <div class="si-h5">{{ value() | translate }}</div>
+    <div class="si-body-sbold">{{ value() | translate }}</div>
     <div class="si-body text-secondary">{{ label() | translate }}</div>
   </div>
 </div>

--- a/projects/element-ng/summary-widget/si-summary-widget.component.spec.ts
+++ b/projects/element-ng/summary-widget/si-summary-widget.component.spec.ts
@@ -44,7 +44,7 @@ describe('SiSummaryWidgetComponent', () => {
     await fixture.whenStable();
 
     expect(element.querySelector('.text-secondary')).toHaveTextContent('test label');
-    expect(element.querySelector('.si-h5')).toHaveTextContent('42');
+    expect(element.querySelector('.si-body-sbold')).toHaveTextContent('42');
     expect(element.querySelector('si-icon')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
Layout broke with the typography changes. This fixes it.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2639/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2639/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2639/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2639/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2639/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2639/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2639/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2639/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2639/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2639/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


