### PR TITLE
build(gh-actions): set environments for jobs

### DIFF
--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -13,6 +13,7 @@ jobs:
       MAPTILER_KEY: ${{ secrets.MAPTILER_KEY }}
 
   publish-documentation:
+    environment: github-pages
     runs-on: ubuntu-24.04
     permissions:
       pages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ jobs:
       MAPTILER_KEY: ${{ secrets.MAPTILER_KEY }}
 
   publish:
+    environment: release
     runs-on: ubuntu-24.04
     needs:
       - build-and-test


### PR DESCRIPTION
Backports the release-environment configuration to `release/47.x`.

Sets the `release` environment for the package publish job and `github-pages` for documentation publishing, matching the newer release branches.