### PR TITLE
feat(maplibre): provide cluster visualization via si-cluster-source

### DIFF
--- a/api-goldens/element-ng/maplibre/index.api.md
+++ b/api-goldens/element-ng/maplibre/index.api.md
@@ -4,9 +4,24 @@
 
 ```ts
 
-import * as i0 from '@angular/core';
+import * as _angular_core from '@angular/core';
+import * as geojson from 'geojson';
 import { Signal } from '@angular/core';
 import { StyleSpecification } from 'maplibre-gl';
+
+// @public
+export type ClusterColors = 'status' | 'element' | Record<number, string>;
+
+// @public
+export type ClusterPoint = GeoJSON.Feature<GeoJSON.Point, GeoJSON.GeoJsonProperties>;
+
+// @public
+export interface ClusterSegment {
+    // (undocumented)
+    color: string;
+    // (undocumented)
+    property: string;
+}
 
 // @public
 export const injectSiMapStyle: (key: string) => Signal<StyleSpecification>;
@@ -14,12 +29,25 @@ export const injectSiMapStyle: (key: string) => Signal<StyleSpecification>;
 // @public
 export const injectSiMapTranslations: () => Signal<Record<string, string>>;
 
-// @public (undocumented)
-export type MarkerStatus = 'default' | 'unknown' | 'success' | 'info' | 'warning' | 'danger' | 'caution' | 'critical';
+// @public
+export type MarkerStatus = ExtendedStatusType | 'default';
+
+// @public
+export class SiClusterSourceComponent {
+    readonly clusterClick: _angular_core.OutputEmitterRef<ClusterPoint>;
+    readonly clusterMaxZoom: _angular_core.InputSignal<number | undefined>;
+    readonly clusterMinPoints: _angular_core.InputSignal<number>;
+    readonly clusterRadius: _angular_core.InputSignal<number>;
+    readonly data: _angular_core.InputSignal<geojson.FeatureCollection<geojson.Point, geojson.GeoJsonProperties>>;
+    readonly groupColors: _angular_core.InputSignal<ClusterColors>;
+    readonly groupProperty: _angular_core.InputSignal<string>;
+    readonly sourceId: _angular_core.InputSignal<string>;
+    readonly statusProperty: _angular_core.InputSignal<string | undefined>;
+}
 
 // @public (undocumented)
 export class SiStatusMarkerComponent {
-    readonly status: i0.InputSignal<MarkerStatus>;
+    readonly status: _angular_core.InputSignal<MarkerStatus>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/playwright/e2e/element-examples/maplibre.spec.ts
+++ b/playwright/e2e/element-examples/maplibre.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { expect, test } from '../../support/test-helpers';
+
+test('maplibre/maplibre-cluster', ({ si }) =>
+  si.static({
+    skipAriaSnapshot: true,
+    waitCallback: async page => {
+      const markers = page.locator('si-cluster-marker .cluster-marker');
+      await markers.first().waitFor({ state: 'visible' });
+
+      await expect
+        .poll(async () => {
+          const gradients = await markers.evaluateAll(elements =>
+            elements.map(element => element.style.getPropertyValue('--si-cluster-gradient'))
+          );
+          const gradientText = gradients.join('\n');
+          return {
+            caution: gradientText.includes('var(--si-sys-background-caution)'),
+            danger: gradientText.includes('var(--si-sys-background-danger)'),
+            success: gradientText.includes('var(--si-sys-background-success)')
+          };
+        })
+        .toEqual({ caution: true, danger: true, success: true });
+    }
+  }));

--- a/playwright/snapshots/maplibre.spec.ts-snapshots/maplibre--maplibre-cluster-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/maplibre.spec.ts-snapshots/maplibre--maplibre-cluster-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25e829b2a5d79ad152e6741cdb47d5b98bc820583be4089dcdf7fae283d98767
+size 18386

--- a/playwright/snapshots/maplibre.spec.ts-snapshots/maplibre--maplibre-cluster-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/maplibre.spec.ts-snapshots/maplibre--maplibre-cluster-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee939430e9babfae9ae36f4abf666c6d56289cabd732ec96f0a3e1f34c64e8c0
+size 17965

--- a/projects/element-ng/maplibre/cluster-types.ts
+++ b/projects/element-ng/maplibre/cluster-types.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+/** A point feature consumed by the clustered MapLibre source. */
+export type ClusterPoint = GeoJSON.Feature<GeoJSON.Point, GeoJSON.GeoJsonProperties>;
+
+/**
+ * Built-in group palette or exact colors indexed by positive group ID. The `'status'` palette is
+ * the four-color palette used for numeric groups; it is separate from status-based bucketing.
+ */
+export type ClusterColors = 'status' | 'element' | Record<number, string>;
+
+/** A rendered color segment and its generated cluster-property name. */
+export interface ClusterSegment {
+  // The color used to render the segment.
+  color: string;
+  // The generated cluster property name to count the points for this segment.
+  property: string;
+}

--- a/projects/element-ng/maplibre/cluster.utils.spec.ts
+++ b/projects/element-ng/maplibre/cluster.utils.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { createClusterConfiguration, createClusterGradient } from './cluster.utils';
+
+const clusterFeature = (properties: GeoJSON.GeoJsonProperties): GeoJSON.Feature<GeoJSON.Point> => ({
+  type: 'Feature',
+  geometry: { type: 'Point', coordinates: [8, 47] },
+  properties
+});
+
+describe('cluster utils', () => {
+  it('generates fixed four-color status group palette for positive group IDs', () => {
+    const configuration = createClusterConfiguration('status', 'group');
+
+    expect(configuration.segments).toHaveLength(4);
+    expect(configuration.segments[0]).toEqual({
+      color: 'var(--si-sys-background-information)',
+      property: 'si_group_0'
+    });
+    expect(configuration.clusterProperties.si_group_0).toEqual([
+      '+',
+      [
+        'case',
+        [
+          'all',
+          ['>', ['to-number', ['get', 'group'], 0], 0],
+          ['==', ['%', ['-', ['to-number', ['get', 'group'], 0], 1], 4], 0]
+        ],
+        1,
+        0
+      ]
+    ]);
+  });
+
+  it('generates exact buckets for custom group colors', () => {
+    const configuration = createClusterConfiguration(
+      { 3: 'blue', 1: 'red', 0: 'ignored' },
+      'category'
+    );
+
+    expect(configuration.segments).toEqual([
+      { color: 'red', property: 'si_group_1' },
+      { color: 'blue', property: 'si_group_3' }
+    ]);
+    expect(configuration.clusterProperties).toMatchObject({
+      si_group_1: ['+', ['case', ['==', ['to-number', ['get', 'category'], 0], 1], 1, 0]],
+      si_group_3: ['+', ['case', ['==', ['to-number', ['get', 'category'], 0], 3], 1, 0]]
+    });
+  });
+
+  it('creates a conic gradient and includes ungrouped points as a neutral segment', () => {
+    const gradient = createClusterGradient(
+      clusterFeature({ point_count: 10, si_group_0: 6, si_group_1: 2 }),
+      [
+        { color: 'red', property: 'si_group_0' },
+        { color: 'blue', property: 'si_group_1' }
+      ]
+    );
+
+    expect(gradient).toContain('conic-gradient(from -90deg');
+    expect(gradient).toContain('red');
+    expect(gradient).toContain('blue');
+    expect(gradient).toContain('var(--si-sys-background-accent)');
+    expect(gradient).toContain('var(--si-sys-background-1)');
+  });
+
+  it('uses a neutral color when a cluster has no configured group', () => {
+    expect(createClusterGradient(clusterFeature({ point_count: 2 }), [])).toBe(
+      'conic-gradient(from -90deg, var(--si-sys-background-accent) 0deg 360deg)'
+    );
+  });
+
+  it('does not add status buckets unless a status property is configured', () => {
+    const configuration = createClusterConfiguration('status', 'group');
+
+    expect(configuration.segments).toHaveLength(4);
+    expect(configuration.clusterProperties.si_status_caution).toBeUndefined();
+  });
+
+  it('generates fixed status buckets for an explicit top-level property', () => {
+    const configuration = createClusterConfiguration('status', 'group', 'status');
+
+    expect(configuration.segments).toHaveLength(12);
+    expect(configuration.segments.slice(4)).toEqual([
+      { color: 'var(--si-sys-background-information)', property: 'si_status_info' },
+      { color: 'var(--si-sys-background-success)', property: 'si_status_success' },
+      { color: 'var(--si-sys-background-warning)', property: 'si_status_warning' },
+      { color: 'var(--si-sys-background-danger)', property: 'si_status_danger' },
+      { color: 'var(--si-sys-background-caution)', property: 'si_status_caution' },
+      { color: 'var(--si-sys-background-critical)', property: 'si_status_critical' },
+      { color: 'var(--si-sys-background-accent)', property: 'si_status_default' },
+      { color: 'var(--si-sys-background-neutral)', property: 'si_status_unknown' }
+    ]);
+    expect(configuration.clusterProperties.si_status_caution).toEqual([
+      '+',
+      [
+        'case',
+        [
+          'all',
+          ['==', ['to-number', ['get', 'group'], 0], 0],
+          ['==', ['get', 'status'], 'caution']
+        ],
+        1,
+        0
+      ]
+    ]);
+  });
+
+  it('mixes group, status and ungrouped segments in the gradient', () => {
+    const gradient = createClusterGradient(
+      clusterFeature({
+        point_count: 5,
+        si_group_0: 1,
+        si_status_caution: 2
+      }),
+      [
+        { color: 'red', property: 'si_group_0' },
+        { color: 'yellow', property: 'si_status_caution' }
+      ]
+    );
+
+    expect(gradient).toContain('red');
+    expect(gradient).toContain('yellow');
+    expect(gradient).toContain('var(--si-sys-background-accent)');
+  });
+});

--- a/projects/element-ng/maplibre/cluster.utils.ts
+++ b/projects/element-ng/maplibre/cluster.utils.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import type { ClusterColors, ClusterPoint, ClusterSegment } from './cluster-types';
+import type { MarkerStatus } from './marker-types';
+
+type ClusterProperties = Record<string, ['+', unknown]>;
+
+const MARKER_STATUS_COLORS = {
+  info: 'var(--si-sys-background-information)',
+  success: 'var(--si-sys-background-success)',
+  warning: 'var(--si-sys-background-warning)',
+  danger: 'var(--si-sys-background-danger)',
+  caution: 'var(--si-sys-background-caution)',
+  critical: 'var(--si-sys-background-critical)',
+  default: 'var(--si-sys-background-accent)',
+  unknown: 'var(--si-sys-background-neutral)'
+} satisfies Record<MarkerStatus, string>;
+
+// Keep the four-color status palette stable for numeric group IDs.
+const GROUP_STATUS_COLORS = [
+  MARKER_STATUS_COLORS.info,
+  MARKER_STATUS_COLORS.success,
+  MARKER_STATUS_COLORS.warning,
+  MARKER_STATUS_COLORS.danger
+];
+const ELEMENT_COLORS = [
+  'var(--si-sys-data-sequential-red-2)',
+  'var(--si-sys-data-sequential-orange-4)',
+  'var(--si-sys-background-caution)',
+  'var(--si-sys-data-sequential-green-2)',
+  'var(--si-sys-background-information)',
+  'var(--si-sys-data-categorial-1)',
+  'var(--si-sys-data-categorial-17)'
+];
+const UNGROUPED_COLOR = 'var(--si-sys-background-accent)';
+const SEPARATOR_COLOR = 'var(--si-sys-background-1)';
+const CHART_FRAGMENTS = 20;
+const SEPARATOR_DEGREES = 2;
+
+interface ClusterBucket extends ClusterSegment {
+  mapExpression: unknown;
+}
+
+/** @internal */
+export interface ClusterConfiguration {
+  clusterProperties: ClusterProperties;
+  segments: readonly ClusterSegment[];
+}
+
+/** @internal */
+export const createClusterConfiguration = (
+  groupColors: ClusterColors,
+  groupProperty: string,
+  statusProperty?: string
+): ClusterConfiguration => {
+  const group = ['to-number', ['get', groupProperty], 0];
+  let buckets: ClusterBucket[];
+
+  if (typeof groupColors === 'string') {
+    const colors = groupColors === 'status' ? GROUP_STATUS_COLORS : ELEMENT_COLORS;
+    buckets = colors.map((color, index) => ({
+      color,
+      mapExpression: [
+        'case',
+        ['all', ['>', group, 0], ['==', ['%', ['-', group, 1], colors.length], index]],
+        1,
+        0
+      ],
+      property: `si_group_${index}`
+    }));
+  } else {
+    buckets = Object.entries(groupColors)
+      .map(([groupId, color]) => ({ color, groupId: Number(groupId) }))
+      .filter(bucket => Number.isInteger(bucket.groupId) && bucket.groupId > 0)
+      .sort((a, b) => a.groupId - b.groupId)
+      .map(bucket => ({
+        color: bucket.color,
+        mapExpression: ['case', ['==', group, bucket.groupId], 1, 0],
+        property: `si_group_${bucket.groupId}`
+      }));
+  }
+
+  if (statusProperty !== undefined) {
+    for (const [status, color] of Object.entries(MARKER_STATUS_COLORS)) {
+      buckets.push({
+        color,
+        mapExpression: [
+          'case',
+          ['all', ['==', group, 0], ['==', ['get', statusProperty], status]],
+          1,
+          0
+        ],
+        property: `si_status_${status}`
+      });
+    }
+  }
+
+  return {
+    clusterProperties: Object.fromEntries(
+      buckets.map(bucket => [bucket.property, ['+', bucket.mapExpression]])
+    ),
+    segments: buckets.map(({ color, property }) => ({ color, property }))
+  };
+};
+
+/** @internal */
+export const createClusterGradient = (
+  feature: ClusterPoint,
+  configuredSegments: readonly ClusterSegment[]
+): string => {
+  const count = getNumberProperty(feature, 'point_count');
+  const segments = configuredSegments
+    .map(segment => ({
+      color: segment.color,
+      count: getNumberProperty(feature, segment.property)
+    }))
+    .filter(segment => segment.count > 0);
+  const groupedCount = segments.reduce((sum, segment) => sum + segment.count, 0);
+  if (groupedCount < count) {
+    segments.push({ color: UNGROUPED_COLOR, count: count - groupedCount });
+  }
+  if (!segments.length) {
+    return UNGROUPED_COLOR;
+  }
+
+  const fragmentSize = count / CHART_FRAGMENTS;
+  const weightedSegments = segments.map(segment => ({
+    ...segment,
+    weight: Math.max(1, segment.count / fragmentSize)
+  }));
+  const totalWeight = weightedSegments.reduce((sum, segment) => sum + segment.weight, 0);
+  const separator =
+    weightedSegments.length > 1 ? Math.min(SEPARATOR_DEGREES, 180 / totalWeight) : 0;
+  let position = 0;
+  const stops: string[] = [];
+  for (const segment of weightedSegments) {
+    const start = position;
+    position += (segment.weight / totalWeight) * 360;
+    if (separator) {
+      stops.push(
+        `${SEPARATOR_COLOR} ${start}deg ${start + separator / 2}deg`,
+        `${segment.color} ${start + separator / 2}deg ${position - separator / 2}deg`,
+        `${SEPARATOR_COLOR} ${position - separator / 2}deg ${position}deg`
+      );
+    } else {
+      stops.push(`${segment.color} ${start}deg ${position}deg`);
+    }
+  }
+  return `conic-gradient(from -90deg, ${stops.join(', ')})`;
+};
+
+const getNumberProperty = (feature: ClusterPoint, property: string): number => {
+  const value = feature.properties?.[property];
+  return typeof value === 'number' ? value : Number(value) || 0;
+};

--- a/projects/element-ng/maplibre/index.ts
+++ b/projects/element-ng/maplibre/index.ts
@@ -2,6 +2,9 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
+export * from './cluster-types';
+export * from './marker-types';
 export * from './si-maplibre-style';
+export * from './si-cluster-source.component';
 export * from './si-maplibre-translate';
 export * from './si-status-marker.component';

--- a/projects/element-ng/maplibre/marker-types.ts
+++ b/projects/element-ng/maplibre/marker-types.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import type { ExtendedStatusType } from '@siemens/element-ng/common';
+
+/** Status values supported by status markers and cluster status segments. */
+export type MarkerStatus = ExtendedStatusType | 'default';

--- a/projects/element-ng/maplibre/si-cluster-marker.component.html
+++ b/projects/element-ng/maplibre/si-cluster-marker.component.html
@@ -1,0 +1,9 @@
+<button
+  type="button"
+  class="cluster-marker"
+  [attr.aria-label]="clusterLabel | translate: { count: count() }"
+  [style.--si-cluster-gradient]="gradient()"
+  (click)="onClick($event)"
+>
+  <span class="cluster-count" aria-hidden="true">{{ countLabel() }}</span>
+</button>

--- a/projects/element-ng/maplibre/si-cluster-marker.component.scss
+++ b/projects/element-ng/maplibre/si-cluster-marker.component.scss
@@ -1,0 +1,40 @@
+@use '@siemens/element-theme/src/styles/variables';
+
+:host {
+  display: block;
+}
+
+.cluster-marker {
+  position: relative;
+  display: flex;
+  inline-size: 46px;
+  block-size: 46px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 3px solid variables.$si-sys-background-1;
+  border-radius: 50%;
+  background: var(--si-cluster-gradient);
+  color: variables.$si-sys-text-primary;
+  cursor: pointer;
+
+  &::before {
+    position: absolute;
+    inset: 20%;
+    border-radius: 50%;
+    background: variables.$si-sys-background-1;
+    content: '';
+  }
+
+  &:focus-visible {
+    @include variables.make-outline-focus();
+  }
+}
+
+.cluster-count {
+  position: relative;
+  font-family: variables.$si-font-family;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+}

--- a/projects/element-ng/maplibre/si-cluster-marker.component.spec.ts
+++ b/projects/element-ng/maplibre/si-cluster-marker.component.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { inputBinding, outputBinding, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ClusterPoint, ClusterSegment } from './cluster-types';
+import { SiClusterMarkerComponent as TestComponent } from './si-cluster-marker.component';
+
+describe('SiClusterMarkerComponent', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let element: HTMLElement;
+  let feature: ReturnType<typeof signal<ClusterPoint>>;
+  const markerClick = vi.fn();
+  const segments: ClusterSegment[] = [
+    { color: 'red', property: 'si_group_0' },
+    { color: 'blue', property: 'si_group_1' }
+  ];
+
+  beforeEach(() => {
+    feature = signal({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [8, 47] },
+      properties: { cluster_id: 1, point_count: 120, si_group_0: 90, si_group_1: 30 }
+    });
+    markerClick.mockClear();
+    fixture = TestBed.createComponent(TestComponent, {
+      bindings: [
+        inputBinding('feature', feature),
+        inputBinding('segments', () => segments),
+        outputBinding('markerClick', markerClick)
+      ]
+    });
+    element = fixture.nativeElement;
+    fixture.detectChanges();
+  });
+
+  it('renders the capped count and accessible label', () => {
+    const marker = element.querySelector('button')!;
+
+    expect(marker).toHaveTextContent('99+');
+    expect(marker).toHaveAttribute('aria-label', 'Cluster with 120 locations');
+  });
+
+  it('renders the group proportions as a CSS conic gradient', () => {
+    const gradient = element
+      .querySelector<HTMLElement>('button')!
+      .style.getPropertyValue('--si-cluster-gradient');
+
+    expect(gradient).toContain('conic-gradient');
+    expect(gradient).toContain('red');
+    expect(gradient).toContain('blue');
+  });
+
+  it('emits a click and stops propagation', () => {
+    const marker = element.querySelector<HTMLButtonElement>('button')!;
+    const parentClick = vi.fn();
+    marker.parentElement!.addEventListener('click', parentClick);
+
+    marker.click();
+
+    expect(markerClick).toHaveBeenCalledOnce();
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it('renders counts up to 99 without abbreviation', async () => {
+    feature.set({
+      ...feature(),
+      properties: { ...feature().properties, point_count: 99 }
+    });
+    await fixture.whenStable();
+
+    expect(element.querySelector('button')).toHaveTextContent('99');
+  });
+});

--- a/projects/element-ng/maplibre/si-cluster-marker.component.ts
+++ b/projects/element-ng/maplibre/si-cluster-marker.component.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, computed, input, output } from '@angular/core';
+import { SiTranslatePipe, t } from '@siemens/element-translate-ng/translate';
+
+import { ClusterPoint, ClusterSegment } from './cluster-types';
+import { createClusterGradient } from './cluster.utils';
+
+/**
+ * Renders an interactive marker for a MapLibre cluster.
+ *
+ * The marker displays the total number of clustered points and visualizes their group distribution
+ * as colored segments. It is created internally by `SiClusterSourceComponent`.
+ *
+ * @internal
+ */
+@Component({
+  selector: 'si-cluster-marker',
+  imports: [SiTranslatePipe],
+  templateUrl: './si-cluster-marker.component.html',
+  styleUrl: './si-cluster-marker.component.scss'
+})
+export class SiClusterMarkerComponent {
+  /** Cluster feature represented by this marker. */
+  readonly feature = input.required<ClusterPoint>();
+
+  /** Colored segments that represent the grouped points in the cluster. */
+  readonly segments = input.required<readonly ClusterSegment[]>();
+
+  /** Emits when the marker is activated. */
+  readonly markerClick = output<void>();
+
+  protected readonly count = computed(() => Number(this.feature().properties?.point_count) || 0);
+  protected readonly countLabel = computed(() => (this.count() > 99 ? '99+' : `${this.count()}`));
+  protected readonly clusterLabel = t(
+    () => $localize`:@@SI_MAP_CLUSTER.LABEL:Cluster with {{count}} locations`
+  );
+
+  protected readonly gradient = computed(() =>
+    createClusterGradient(this.feature(), this.segments())
+  );
+
+  protected onClick(event: MouseEvent): void {
+    event.stopPropagation();
+    this.markerClick.emit();
+  }
+}

--- a/projects/element-ng/maplibre/si-cluster-source.component.html
+++ b/projects/element-ng/maplibre/si-cluster-source.component.html
@@ -1,0 +1,22 @@
+<mgl-geojson-source
+  #source
+  [id]="sourceId()"
+  [data]="data()"
+  [cluster]="true"
+  [clusterRadius]="clusterRadius()"
+  [clusterMaxZoom]="clusterMaxZoom()"
+  [clusterMinPoints]="clusterMinPoints()"
+  [clusterProperties]="clusterConfiguration().clusterProperties"
+/>
+
+<mgl-markers-for-clusters [source]="sourceId()">
+  <ng-template let-feature mglClusterPoint>
+    <si-cluster-marker
+      [feature]="feature"
+      [segments]="clusterConfiguration().segments"
+      (markerClick)="selectCluster(feature)"
+    />
+  </ng-template>
+</mgl-markers-for-clusters>
+
+<ng-content select="si-cluster-popover,[siClusterPopoverOutlet]" />

--- a/projects/element-ng/maplibre/si-cluster-source.component.ts
+++ b/projects/element-ng/maplibre/si-cluster-source.component.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, computed, input, output, signal } from '@angular/core';
+import {
+  ClusterPointDirective,
+  GeoJSONSourceComponent,
+  MarkersForClustersComponent
+} from '@maplibre/ngx-maplibre-gl';
+
+import type { ClusterColors, ClusterPoint } from './cluster-types';
+import { createClusterConfiguration } from './cluster.utils';
+import { SiClusterMarkerComponent } from './si-cluster-marker.component';
+
+const EMPTY_DATA: GeoJSON.FeatureCollection<GeoJSON.Point> = {
+  type: 'FeatureCollection',
+  features: []
+};
+
+/**
+ * Adds a clustered GeoJSON source to a MapLibre map and renders interactive cluster markers.
+ *
+ * Cluster markers display the number of contained points and their distribution by group. Status
+ * segments can be enabled for ungrouped points by providing `statusProperty`. Render individual,
+ * unclustered points separately with `mgl-markers-for-clusters` using the same source ID.
+ * Positive numeric groups always take precedence over status segments. Status segments apply only
+ * when the normalized group value is zero; points without a matching group or status use the
+ * ungrouped color.
+ *
+ * @example Basic usage
+ * ```html
+ * <mgl-map [mapStyle]="mapStyle()">
+ *   <si-cluster-source
+ *     sourceId="locations"
+ *     statusProperty="status"
+ *     [data]="locations"
+ *     (clusterClick)="onClusterClick($event)"
+ *   />
+ *
+ *   <mgl-markers-for-clusters source="locations">
+ *     <ng-template let-feature mglPoint>
+ *       <si-status-marker
+ *         [status]="feature.properties?.status"
+ *       />
+ *     </ng-template>
+ *   </mgl-markers-for-clusters>
+ * </mgl-map>
+ * ```
+ *
+ * @experimental
+ */
+@Component({
+  selector: 'si-cluster-source',
+  imports: [
+    ClusterPointDirective,
+    GeoJSONSourceComponent,
+    MarkersForClustersComponent,
+    SiClusterMarkerComponent
+  ],
+  templateUrl: './si-cluster-source.component.html'
+})
+export class SiClusterSourceComponent {
+  /** ID used to register the generated GeoJSON source in MapLibre. */
+  readonly sourceId = input.required<string>();
+  /**
+   * Point feature collection to cluster.
+   * @defaultValue EMPTY_DATA
+   */
+  readonly data = input<GeoJSON.FeatureCollection<GeoJSON.Point>>(EMPTY_DATA);
+  /**
+   * Feature property containing the positive numeric group ID.
+   * @defaultValue 'group'
+   */
+  readonly groupProperty = input('group');
+  /**
+   * Built-in palette or exact colors indexed by group ID. The built-in `'status'` palette contains
+   * four colors for numeric groups and is separate from status-based bucketing.
+   * @defaultValue 'status'
+   */
+  readonly groupColors = input<ClusterColors>('status');
+  /**
+   * Top-level feature property containing a {@link MarkerStatus} value. Status bucketing is
+   * disabled by default and only applies when the normalized group value is zero. Missing or
+   * unsupported status values, and groups that do not match a configured bucket, use the ungrouped
+   * color. Built-in colors match `SiStatusMarkerComponent`, with `default` using accent and
+   * `unknown` using neutral.
+   * @defaultValue undefined
+   * @see https://maplibre.org/maplibre-style-spec/sources/#clusterproperties
+   */
+  readonly statusProperty = input<string | undefined>();
+  /**
+   * Cluster radius in pixels.
+   * @defaultValue 50
+   */
+  readonly clusterRadius = input(50);
+  /**
+   * Maximum zoom at which points are clustered.
+   * @defaultValue undefined
+   */
+  readonly clusterMaxZoom = input<number | undefined>(undefined);
+  /**
+   * Minimum number of points required to form a cluster.
+   * @defaultValue 2
+   */
+  readonly clusterMinPoints = input(2);
+
+  /** Emits when a cluster marker is activated. */
+  readonly clusterClick = output<ClusterPoint>();
+
+  protected readonly clusterConfiguration = computed(() =>
+    createClusterConfiguration(this.groupColors(), this.groupProperty(), this.statusProperty())
+  );
+  /** Stores selection for the projected cluster-popover integration. */
+  protected readonly selectedCluster = signal<ClusterPoint | undefined>(undefined);
+
+  protected async selectCluster(feature: ClusterPoint): Promise<void> {
+    this.clusterClick.emit(feature);
+    this.selectedCluster.set({ ...feature, geometry: feature.geometry });
+  }
+}

--- a/projects/element-ng/maplibre/si-status-marker.component.scss
+++ b/projects/element-ng/maplibre/si-status-marker.component.scss
@@ -8,7 +8,7 @@
   cursor: pointer;
 
   &[data-status='default'] {
-    color: variables.$element-ui-0;
+    color: variables.$si-sys-background-accent;
   }
 
   &[data-status='success'] {

--- a/projects/element-ng/maplibre/si-status-marker.component.ts
+++ b/projects/element-ng/maplibre/si-status-marker.component.ts
@@ -4,8 +4,7 @@
  */
 import { Component, input } from '@angular/core';
 
-export type MarkerStatus =
-  'default' | 'unknown' | 'success' | 'info' | 'warning' | 'danger' | 'caution' | 'critical';
+import type { MarkerStatus } from './marker-types';
 
 @Component({
   selector: 'si-status-marker',
@@ -13,7 +12,7 @@ export type MarkerStatus =
   styleUrl: './si-status-marker.component.scss',
   host: {
     class: 'si-status-marker',
-    '[attr.data-status]': 'status()'
+    '[attr.data-status]': 'status() ?? "default"'
   }
 })
 export class SiStatusMarkerComponent {

--- a/projects/element-ng/translate/si-translatable-keys.interface.ts
+++ b/projects/element-ng/translate/si-translatable-keys.interface.ts
@@ -209,6 +209,7 @@ export interface SiTranslatableKeys {
   'SI_MAP.WINDOWS_HELP'?: string;
   'SI_MAP.ZOOM_IN'?: string;
   'SI_MAP.ZOOM_OUT'?: string;
+  'SI_MAP_CLUSTER.LABEL'?: string;
   'SI_MARKDOWN.COPIED_CODE'?: string;
   'SI_MARKDOWN.COPY_CODE'?: string;
   'SI_MARKDOWN.COPY_TABLE_AS_CSV'?: string;

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -16,6 +16,7 @@ import {
   provideAppInitializer,
   ɵLocaleDataIndex
 } from '@angular/core';
+import { provideMaplibreWorker } from '@maplibre/ngx-maplibre-gl/config';
 import { provideFormlyCore } from '@ngx-formly/core';
 import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
 import { provideSiAgGridConfig } from '@siemens/element-ng/ag-grid';
@@ -166,6 +167,7 @@ export const APP_CONFIG: ApplicationConfig = {
       extras: {
         resetFieldOnHide: false
       }
-    })
+    }),
+    provideMaplibreWorker('assets/maplibre/maplibre-gl-worker.mjs')
   ]
 };

--- a/src/app/examples/maplibre/maplibre-cluster.html
+++ b/src/app/examples/maplibre/maplibre-cluster.html
@@ -1,0 +1,30 @@
+<mgl-map
+  class="h-100"
+  [attributionControl]="false"
+  [locale]="mapTranslations()"
+  [mapStyle]="mapStyle()"
+  [center]="[8.0, 47.1]"
+  [canvasContextAttributes]="{ preserveDrawingBuffer: true }"
+  [zoom]="4"
+  (mapError)="onError($event)"
+>
+  <mgl-control mglFullscreen />
+  <mgl-control mglGlobe position="top-right" />
+  <mgl-control mglScale unit="metric" position="top-right" />
+  <mgl-control mglAttribution position="bottom-left" />
+  <mgl-control mglNavigation position="bottom-right" />
+  <mgl-control mglGeolocate position="bottom-right" (geolocate)="onGeolocate($event)" />
+
+  <si-cluster-source
+    sourceId="cluster-source"
+    statusProperty="status"
+    [data]="geoJson"
+    (clusterClick)="selectCluster($event)"
+  />
+
+  <mgl-markers-for-clusters source="cluster-source">
+    <ng-template let-feature mglPoint>
+      <si-status-marker [status]="feature.properties?.status" />
+    </ng-template>
+  </mgl-markers-for-clusters>
+</mgl-map>

--- a/src/app/examples/maplibre/maplibre-cluster.ts
+++ b/src/app/examples/maplibre/maplibre-cluster.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, inject } from '@angular/core';
+import {
+  AttributionControlDirective,
+  ControlComponent,
+  EventData,
+  FullscreenControlDirective,
+  GeolocateControlDirective,
+  GlobeControlDirective,
+  MapComponent,
+  MarkersForClustersComponent,
+  NavigationControlDirective,
+  PointDirective,
+  Position,
+  ScaleControlDirective
+} from '@maplibre/ngx-maplibre-gl';
+import {
+  injectSiMapStyle,
+  injectSiMapTranslations,
+  ClusterPoint,
+  SiClusterSourceComponent,
+  SiStatusMarkerComponent
+} from '@siemens/element-ng/maplibre';
+import { LOG_EVENT } from '@siemens/live-preview';
+import { MapPoint } from '@siemens/maps-ng';
+
+import { environment } from '../../../environments/environment';
+import { mockPoints } from '../../mocks/points.mock';
+
+const buildGeoJSON = (points: MapPoint[]): GeoJSON.FeatureCollection<GeoJSON.Point> => ({
+  type: 'FeatureCollection',
+  features: points.map(point => ({
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [point.lon, point.lat]
+    },
+    properties: {
+      description: point.description,
+      group: point.group,
+      marker: point.marker?.type ?? 'default',
+      name: point.name,
+      status: point.marker?.status
+    }
+  }))
+});
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    AttributionControlDirective,
+    ControlComponent,
+    FullscreenControlDirective,
+    GeolocateControlDirective,
+    GlobeControlDirective,
+    MapComponent,
+    MarkersForClustersComponent,
+    NavigationControlDirective,
+    PointDirective,
+    ScaleControlDirective,
+    SiClusterSourceComponent,
+    SiStatusMarkerComponent
+  ],
+  templateUrl: './maplibre-cluster.html',
+  host: {
+    class: 'h-100 d-flex flex-column p-5'
+  }
+})
+export class SampleComponent {
+  protected readonly logEvent = inject(LOG_EVENT);
+  protected readonly mapStyle = injectSiMapStyle(environment.maptilerKey);
+  protected readonly mapTranslations = injectSiMapTranslations();
+
+  protected readonly geoJson = buildGeoJSON(mockPoints);
+
+  protected selectCluster(feature: ClusterPoint): void {
+    this.logEvent('cluster click', feature.properties);
+  }
+
+  protected onError(event: ErrorEvent & EventData): void {
+    if (event.error.message) {
+      this.logEvent('map error', event.error.message);
+    } else {
+      this.logEvent('map error', event.error);
+    }
+  }
+
+  protected onGeolocate(position: Position): void {
+    this.logEvent('geolocate', position);
+  }
+}

--- a/src/app/examples/maplibre/maplibre.html
+++ b/src/app/examples/maplibre/maplibre.html
@@ -20,7 +20,7 @@
       These markers are slow compared to a Layer of symbol because they're not rendered using WebGL.
     -->
     <mgl-marker #marker [feature]="point">
-      <si-status-marker [status]="point.properties.status" [ariaLabel]="point.properties.name" />
+      <si-status-marker [status]="point.properties.status" />
     </mgl-marker>
     <mgl-popup [marker]="marker">
       <dl class="mb-0">


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2641/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2641/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2641/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2641/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2641/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2641/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2641/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2641/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2641/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2641/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


