### PR TITLE
fixup(typography): add semibold typography tokens

### DIFF
--- a/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-body.component.scss
+++ b/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-body.component.scss
@@ -65,7 +65,7 @@
 }
 
 .si-weather-widget-location {
-  font-weight: variables.$si-font-weight-semibold;
+  font-weight: variables.$si-font-weight-sbold;
   color: variables.$si-sys-text-primary;
 }
 
@@ -80,7 +80,7 @@
 
 .si-weather-widget-range-max {
   color: variables.$si-sys-text-primary;
-  font-weight: variables.$si-font-weight-semibold;
+  font-weight: variables.$si-font-weight-sbold;
 }
 
 .si-weather-widget-metrics {
@@ -106,6 +106,6 @@
 
 .si-weather-widget-metric-value {
   color: variables.$si-sys-text-primary;
-  font-weight: variables.$si-font-weight-semibold;
+  font-weight: variables.$si-font-weight-sbold;
   text-align: end;
 }

--- a/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-forecast.component.scss
+++ b/projects/element-ng/dashboard/widgets/si-weather-widget/si-weather-widget-forecast.component.scss
@@ -27,7 +27,7 @@
 
 .si-weather-widget-forecast-range-max {
   color: variables.$si-sys-text-primary;
-  font-weight: variables.$si-font-weight-semibold;
+  font-weight: variables.$si-font-weight-sbold;
 }
 
 // Registered integer custom property used as the extras-track count. Registering

--- a/projects/element-ng/markdown/hightlighter/highlightjs/si-markdown-highlightjs.component.scss
+++ b/projects/element-ng/markdown/hightlighter/highlightjs/si-markdown-highlightjs.component.scss
@@ -103,7 +103,7 @@
 
   // Strong emphasis
   .hljs-strong {
-    font-weight: variables.$si-font-weight-semibold;
+    font-weight: variables.$si-font-weight-sbold;
   }
 
   // Code blocks and formulas

--- a/projects/element-theme/src/styles/bootstrap/_buttons.scss
+++ b/projects/element-theme/src/styles/bootstrap/_buttons.scss
@@ -19,7 +19,7 @@ button {
 :is(.btn, .btn-close) {
   --btn-icon-size: #{$btn-icon-font-size};
   --btn-font-size: #{bootstrap-variables.$btn-font-size};
-  --btn-font-weight: #{typography.$si-font-weight-semibold};
+  --btn-font-weight: #{typography.$si-font-weight-sbold};
   --btn-line-height: #{bootstrap-variables.$btn-line-height};
   --btn-padding-y: #{bootstrap-variables.$btn-padding-y};
   line-height: var(--btn-line-height);

--- a/projects/element-theme/src/styles/bootstrap/_type.scss
+++ b/projects/element-theme/src/styles/bootstrap/_type.scss
@@ -194,11 +194,27 @@ h6,
   );
 }
 
+.si-body-lg-sbold {
+  @include typography.si-font(
+    typography.$si-font-size-body-lg-sbold,
+    typography.$si-line-height-body-lg-sbold,
+    typography.$si-font-weight-body-lg-sbold
+  );
+}
+
 .si-body {
   @include typography.si-font(
     typography.$si-font-size-body,
     typography.$si-line-height-body,
     typography.$si-font-weight-body
+  );
+}
+
+.si-body-sbold {
+  @include typography.si-font(
+    typography.$si-font-size-body-sbold,
+    typography.$si-line-height-body-sbold,
+    typography.$si-font-weight-body-sbold
   );
 }
 
@@ -210,11 +226,27 @@ h6,
   );
 }
 
+.si-body-paragraph-sbold {
+  @include typography.si-font(
+    typography.$si-font-size-body-paragraph-sbold,
+    typography.$si-line-height-body-paragraph-sbold,
+    typography.$si-font-weight-body-paragraph-sbold
+  );
+}
+
 .si-body-sm {
   @include typography.si-font(
     typography.$si-font-size-body-sm,
     typography.$si-line-height-body-sm,
     typography.$si-font-weight-body-sm
+  );
+}
+
+.si-body-sm-sbold {
+  @include typography.si-font(
+    typography.$si-font-size-body-sm-sbold,
+    typography.$si-line-height-body-sm-sbold,
+    typography.$si-font-weight-body-sm-sbold
   );
 }
 
@@ -235,11 +267,27 @@ h6,
   );
 }
 
+.si-display-xl-sbold {
+  @include typography.si-font(
+    typography.$si-font-size-display-xl-sbold,
+    typography.$si-line-height-display-xl-sbold,
+    typography.$si-font-weight-display-xl-sbold
+  );
+}
+
 .si-display-xxl {
   @include typography.si-font(
     typography.$si-font-size-display-xxl,
     typography.$si-line-height-display-xxl,
     typography.$si-font-weight-display-xxl
+  );
+}
+
+.si-display-xxl-sbold {
+  @include typography.si-font(
+    typography.$si-font-size-display-xxl-sbold,
+    typography.$si-line-height-display-xxl-sbold,
+    typography.$si-font-weight-display-xxl-sbold
   );
 }
 
@@ -252,12 +300,28 @@ h6,
   );
 }
 
+.si-display-lg-sbold {
+  @include typography.si-font(
+    typography.$si-font-size-display-lg-sbold,
+    typography.$si-line-height-display-lg-sbold,
+    typography.$si-font-weight-display-lg-sbold
+  );
+}
+
 .si-display-bold,
 .display-3 {
   @include typography.si-font(
     typography.$si-font-size-display-bold,
     typography.$si-line-height-display-bold,
     typography.$si-font-weight-display-bold
+  );
+}
+
+.si-display-sbold {
+  @include typography.si-font(
+    typography.$si-font-size-display-sbold,
+    typography.$si-line-height-display-sbold,
+    typography.$si-font-weight-display-sbold
   );
 }
 

--- a/projects/element-theme/src/styles/bootstrap/_variables.scss
+++ b/projects/element-theme/src/styles/bootstrap/_variables.scss
@@ -169,7 +169,7 @@ $font-weight-lighter: typography.$si-font-weight-lighter;
 $font-weight-light: typography.$si-font-weight-light;
 $font-weight-normal: typography.$si-font-weight-normal;
 $font-weight-medium: typography.$si-font-weight-medium;
-$font-weight-semibold: typography.$si-font-weight-semibold;
+$font-weight-semibold: typography.$si-font-weight-sbold;
 $font-weight-bold: typography.$si-font-weight-bold;
 $font-weight-bolder: typography.$si-font-weight-bolder;
 
@@ -198,7 +198,7 @@ $font-sizes: (
 $headings-margin-bottom: spacers.$spacer * 0.5 !default;
 $headings-font-family: null !default;
 $headings-font-style: null !default;
-$headings-font-weight: typography.$si-font-weight-semibold !default;
+$headings-font-weight: typography.$si-font-weight-sbold !default;
 $headings-line-height: 1.2 !default;
 $headings-color: system-tokens.$si-sys-text-primary !default;
 

--- a/projects/element-theme/src/styles/bootstrap/mixins/_badge-text.scss
+++ b/projects/element-theme/src/styles/bootstrap/mixins/_badge-text.scss
@@ -12,6 +12,6 @@
   padding-block: 0;
   padding-inline: map.get(spacers.$spacers, 2);
   font-family: variables.$font-family-sans-serif;
-  font-weight: typography.$si-font-weight-semibold;
+  font-weight: typography.$si-font-weight-sbold;
   text-align: center;
 }

--- a/projects/element-theme/src/styles/components/_markdown.scss
+++ b/projects/element-theme/src/styles/components/_markdown.scss
@@ -10,7 +10,7 @@
   line-height: variables.$si-line-height-body-paragraph;
 
   strong {
-    font-weight: variables.$si-font-weight-semibold;
+    font-weight: variables.$si-font-weight-sbold;
   }
 
   :is(ul, ol) {

--- a/projects/element-theme/src/styles/variables/_typography.scss
+++ b/projects/element-theme/src/styles/variables/_typography.scss
@@ -22,7 +22,9 @@ $si-font-weight-lighter: lighter !default;
 $si-font-weight-light: 300 !default;
 $si-font-weight-normal: 400 !default;
 $si-font-weight-medium: 500 !default;
-$si-font-weight-semibold: 600 !default;
+$si-font-weight-sbold: 600 !default;
+// DEPRECATED: Use $si-font-weight-sbold instead.
+$si-font-weight-semibold: $si-font-weight-sbold !default;
 $si-font-weight-bold: 700 !default;
 $si-font-weight-bolder: bolder !default;
 $si-font-weight-black: 900 !default;
@@ -37,15 +39,15 @@ $si-font-weight-h1: $si-font-weight-normal;
 
 $si-font-size-h2: px-to-rem(24px);
 $si-line-height-h2: px-to-ratio($si-font-size-h2, 32px);
-$si-font-weight-h2: $si-font-weight-semibold;
+$si-font-weight-h2: $si-font-weight-sbold;
 
 $si-font-size-h3: px-to-rem(20px);
 $si-line-height-h3: px-to-ratio($si-font-size-h3, 24px);
-$si-font-weight-h3: $si-font-weight-semibold;
+$si-font-weight-h3: $si-font-weight-sbold;
 
 $si-font-size-h4: px-to-rem(16px);
 $si-line-height-h4: px-to-ratio($si-font-size-h4, 20px);
-$si-font-weight-h4: $si-font-weight-semibold;
+$si-font-weight-h4: $si-font-weight-sbold;
 
 $si-font-size-h4-bold: px-to-rem(16px);
 $si-line-height-h4-bold: px-to-ratio($si-font-size-h4-bold, 20px);
@@ -53,7 +55,7 @@ $si-font-weight-h4-bold: $si-font-weight-bold;
 
 $si-font-size-h5: px-to-rem(14px);
 $si-line-height-h5: px-to-ratio($si-font-size-h5, 20px);
-$si-font-weight-h5: $si-font-weight-semibold;
+$si-font-weight-h5: $si-font-weight-sbold;
 
 $si-font-size-h5-bold: px-to-rem(14px);
 $si-line-height-h5-bold: px-to-ratio($si-font-size-h5-bold, 20px);
@@ -61,7 +63,7 @@ $si-font-weight-h5-bold: $si-font-weight-bold;
 
 $si-font-size-h6: px-to-rem(12px);
 $si-line-height-h6: px-to-ratio($si-font-size-h6, 16px);
-$si-font-weight-h6: $si-font-weight-semibold;
+$si-font-weight-h6: $si-font-weight-sbold;
 
 $si-font-size-body-lg: px-to-rem(16px);
 $si-line-height-body-lg: px-to-ratio($si-font-size-body-lg, 20px);
@@ -69,20 +71,36 @@ $si-font-weight-body-lg: $si-font-weight-normal;
 
 $si-font-size-body-lg-bold: px-to-rem(16px);
 $si-line-height-body-lg-bold: px-to-ratio($si-font-size-body-lg-bold, 20px);
-$si-font-weight-body-lg-bold: $si-font-weight-semibold;
+$si-font-weight-body-lg-bold: $si-font-weight-sbold;
+
+$si-font-size-body-lg-sbold: $si-font-size-body-lg;
+$si-line-height-body-lg-sbold: $si-line-height-body-lg;
+$si-font-weight-body-lg-sbold: $si-font-weight-sbold;
 
 $si-font-size-body: px-to-rem(14px);
 $si-line-height-body: px-to-ratio($si-font-size-body, 16px);
 $si-line-height-body-rem: px-to-rem(16px);
 $si-font-weight-body: $si-font-weight-normal;
 
+$si-font-size-body-sbold: $si-font-size-body;
+$si-line-height-body-sbold: $si-line-height-body;
+$si-font-weight-body-sbold: $si-font-weight-sbold;
+
 $si-font-size-body-paragraph: px-to-rem(14px);
 $si-line-height-body-paragraph: px-to-ratio($si-font-size-body-paragraph, 20px);
 $si-font-weight-body-paragraph: $si-font-weight-normal;
 
+$si-font-size-body-paragraph-sbold: $si-font-size-body-paragraph;
+$si-line-height-body-paragraph-sbold: $si-line-height-body-paragraph;
+$si-font-weight-body-paragraph-sbold: $si-font-weight-sbold;
+
 $si-font-size-body-sm: px-to-rem(12px);
 $si-line-height-body-sm: px-to-ratio($si-font-size-body-sm, 16px);
 $si-font-weight-body-sm: $si-font-weight-normal;
+
+$si-font-size-body-sm-sbold: $si-font-size-body-sm;
+$si-line-height-body-sm-sbold: $si-line-height-body-sm;
+$si-font-weight-body-sm-sbold: $si-font-weight-sbold;
 
 $si-font-size-caption: $si-font-size-body-sm;
 $si-line-height-caption: $si-line-height-body-sm;
@@ -92,13 +110,25 @@ $si-font-size-display-xxl: px-to-rem(58px);
 $si-line-height-display-xxl: px-to-ratio($si-font-size-display-xxl, 72px);
 $si-font-weight-display-xxl: $si-font-weight-normal;
 
+$si-font-size-display-xxl-sbold: $si-font-size-display-xxl;
+$si-line-height-display-xxl-sbold: $si-line-height-display-xxl;
+$si-font-weight-display-xxl-sbold: $si-font-weight-sbold;
+
 $si-font-size-display-xl: px-to-rem(48px);
 $si-line-height-display-xl: px-to-ratio($si-font-size-display-xl, 64px);
 $si-font-weight-display-xl: $si-font-weight-normal;
 
+$si-font-size-display-xl-sbold: $si-font-size-display-xl;
+$si-line-height-display-xl-sbold: $si-line-height-display-xl;
+$si-font-weight-display-xl-sbold: $si-font-weight-sbold;
+
 $si-font-size-display-lg: px-to-rem(40px);
 $si-line-height-display-lg: px-to-ratio($si-font-size-display-lg, 52px);
 $si-font-weight-display-lg: $si-font-weight-normal;
+
+$si-font-size-display-lg-sbold: $si-font-size-display-lg;
+$si-line-height-display-lg-sbold: $si-line-height-display-lg;
+$si-font-weight-display-lg-sbold: $si-font-weight-sbold;
 
 $si-font-size-display-bold: $si-font-size-display-lg;
 $si-line-height-display-bold: $si-line-height-display-lg;
@@ -107,6 +137,10 @@ $si-font-weight-display-bold: $si-font-weight-bold;
 $si-font-size-display: px-to-rem(32px);
 $si-line-height-display: px-to-ratio($si-font-size-display, 40px);
 $si-font-weight-display: $si-font-weight-normal;
+
+$si-font-size-display-sbold: $si-font-size-display;
+$si-line-height-display-sbold: $si-line-height-display;
+$si-font-weight-display-sbold: $si-font-weight-sbold;
 
 $si-font-size-code-sm: px-to-rem(12px);
 $si-line-height-code-sm: px-to-ratio($si-font-size-code-sm, 16px);

--- a/projects/live-preview/styles/_variables.scss
+++ b/projects/live-preview/styles/_variables.scss
@@ -2,7 +2,7 @@
 
 $font-family-monospace: Menlo, 'Ubuntu Mono', 'Liberation Mono', Consolas, Courier, monospace;
 
-$live-preview-font-weight-semibold: variables.$si-font-weight-semibold;
+$live-preview-font-weight-semibold: variables.$si-font-weight-sbold;
 
 $live-preview-alert-color: variables.$si-sys-text-on-danger;
 $live-preview-alert-background-color: variables.$si-sys-background-danger;


### PR DESCRIPTION
Add the missing semibold body and display typography Sass variables and utility classes to align Element Theme with @siemens-ux/design-tokens.\n\nValidation: pnpm exec stylelint projects/element-theme/src/styles/variables/_typography.scss projects/element-theme/src/styles/bootstrap/_type.scss<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2643/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2643/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2643/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2643/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2643/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2643/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2643/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2643/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2643/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2643/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


