### PR TITLE
fix(password-toggle): use ghost tertiary button

### DIFF
--- a/playwright/snapshots/password-strength.spec.ts-snapshots/input-fields--password--visibility-toggle-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/password-strength.spec.ts-snapshots/input-fields--password--visibility-toggle-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cbe4919d5939e7b72b824924caaaf2d679b91c768e413c19f37c94dd5e43d463
-size 17952
+oid sha256:0ec0b4515be0faba1581ab467db25c77469b036f1a994c4049c6972f5f104fa1
+size 17946

--- a/playwright/snapshots/password-strength.spec.ts-snapshots/input-fields--password--visibility-toggle-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/password-strength.spec.ts-snapshots/input-fields--password--visibility-toggle-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0a75538afd914f8822b2a8b9abc67e184c174138e66afe5fe97d144012861ab4
-size 17819
+oid sha256:474bfbb4a119e7debd0b6134a1e715f16843d02b4353b66ad035ff3709e1e441
+size 17804

--- a/projects/element-ng/password-toggle/si-password-toggle.component.html
+++ b/projects/element-ng/password-toggle/si-password-toggle.component.html
@@ -3,7 +3,7 @@
   <div class="form-control-actions">
     <button
       type="button"
-      class="btn btn-tertiary btn-icon btn-sm text-body password-visibility-icon"
+      class="btn btn-tertiary-ghost btn-icon btn-sm password-visibility-icon"
       [attr.aria-label]="(showPassword() ? hideLabel() : showLabel()) | translate"
       (click)="toggle()"
     >


### PR DESCRIPTION
Use the ghost tertiary button variant for the password visibility toggle so it no longer applies the body text color.\n\nUpdate the affected light and dark visual-regression snapshots.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2651/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2651/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2651/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2651/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2651/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2651/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2651/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2651/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2651/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2651/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
