### PR TITLE
fix(menu): mark expanded dropdown trigger as active

### DIFF
--- a/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu--dropdown-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu--dropdown-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d0c80c58afd619948fbaf08ab55394d9b6a2f3299d3d7e0993f552cc09a5d3e
-size 28295
+oid sha256:bd8fe0e0dabc4424adf6f6f1deec18722eccd1ffa63aa7233c1d2ee15b51c15c
+size 28474

--- a/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu--dropdown-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu--dropdown-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1331abf06422be3a6da354faedcac76228beadfb1d013e4d62f2e43192af754f
-size 28299
+oid sha256:4de76036ee2012c116919e24986a8121e614d547b4710dfe3a87c1a9e79badc3
+size 28478

--- a/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu-factory--dropdown-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu-factory--dropdown-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d0c80c58afd619948fbaf08ab55394d9b6a2f3299d3d7e0993f552cc09a5d3e
-size 28295
+oid sha256:bd8fe0e0dabc4424adf6f6f1deec18722eccd1ffa63aa7233c1d2ee15b51c15c
+size 28474

--- a/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu-factory--dropdown-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-menu.spec.ts-snapshots/si-menu--si-menu-factory--dropdown-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1331abf06422be3a6da354faedcac76228beadfb1d013e4d62f2e43192af754f
-size 28299
+oid sha256:4de76036ee2012c116919e24986a8121e614d547b4710dfe3a87c1a9e79badc3
+size 28478

--- a/projects/element-ng/menu/si-menu-item.component.scss
+++ b/projects/element-ng/menu/si-menu-item.component.scss
@@ -52,7 +52,7 @@
     transform: rotate(90deg);
   }
 
-  &[aria-expanded='true'] {
+  &.active {
     .item-end .submenu {
       transform: rotate(270deg);
     }

--- a/projects/element-ng/menu/si-menu-item.component.ts
+++ b/projects/element-ng/menu/si-menu-item.component.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
+import { CdkMenuItem, MENU_TRIGGER } from '@angular/cdk/menu';
 import { Component, inject } from '@angular/core';
 import { elementRight2 } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
@@ -14,6 +14,9 @@ import { SiMenuItemBase } from './si-menu-item-base.directive';
   imports: [SiIconComponent],
   templateUrl: './si-menu-item.component.html',
   styleUrl: './si-menu-item.component.scss',
+  host: {
+    '[class.active]': 'hasSubmenu && isExpanded'
+  },
   hostDirectives: [
     {
       directive: CdkMenuItem,
@@ -23,9 +26,13 @@ import { SiMenuItemBase } from './si-menu-item-base.directive';
   ]
 })
 export class SiMenuItemComponent extends SiMenuItemBase {
-  private menuTrigger = inject(CdkMenuTrigger, { optional: true, self: true });
+  private menuTrigger = inject(MENU_TRIGGER, { optional: true, self: true });
   protected readonly icons = addIcons({ elementRight2 });
   protected get hasSubmenu(): boolean {
     return !!this.menuTrigger?.menuTemplateRef;
+  }
+
+  protected get isExpanded(): boolean | undefined {
+    return this.menuTrigger?.isOpen();
   }
 }

--- a/projects/element-ng/menu/si-menu.spec.ts
+++ b/projects/element-ng/menu/si-menu.spec.ts
@@ -134,6 +134,7 @@ const withObjectType = <ItemType extends MenuItem, ComponentType extends { items
 
       const menu = await menuItem.getSubmenu();
       expect(await menu?.getItemTexts()).toEqual(['child1', 'child2']);
+      expect(await menuItem.isActive()).toBe(true);
     });
 
     it('should have icon', async () => {

--- a/projects/element-ng/menu/testing/si-menu.harness.ts
+++ b/projects/element-ng/menu/testing/si-menu.harness.ts
@@ -78,6 +78,10 @@ export class SiMenuItemHarness extends ComponentHarness {
     return (await this.getAttribute('aria-disabled')) === 'true';
   }
 
+  async isActive(): Promise<boolean> {
+    return (await this.host()).hasClass('active');
+  }
+
   async isCheckItem(): Promise<boolean> {
     return (await this.getAttribute('role')) === 'menuitemcheckbox';
   }


### PR DESCRIPTION
Mark menu items with an open submenu as active so dropdown triggers consistently expose their expanded visual state.

Use the CDK menu trigger token to support all trigger implementations and keep the submenu indicator synchronized with the open state.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2668/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2668/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2668/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2668/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2668/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2668/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2668/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2668/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2668/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2668/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


