### PR TITLE
refactor(menu-bar): use btn-tertiary

### DIFF
--- a/projects/element-ng/content-action-bar/si-content-action-bar-toggle.component.ts
+++ b/projects/element-ng/content-action-bar/si-content-action-bar-toggle.component.ts
@@ -11,7 +11,7 @@ import { SiIconComponent } from '@siemens/element-ng/icon';
   imports: [SiIconComponent],
   templateUrl: './si-content-action-bar-toggle.component.html',
   styleUrl: '../menu/si-menu-item.component.scss',
-  host: { class: 'dropdown-item flex-grow-0 focus-inside' }
+  host: { class: 'btn btn-tertiary flex-grow-0 focus-inside' }
 })
 export class SiContentActionBarToggleComponent {
   /** Icon identifier rendered inside the toggle button. */

--- a/projects/element-ng/menu/si-menu-bar.directive.ts
+++ b/projects/element-ng/menu/si-menu-bar.directive.ts
@@ -9,8 +9,7 @@ import { Directive, inject, input } from '@angular/core';
   // eslint-disable-next-line @angular-eslint/directive-selector
   selector: 'si-menu-bar',
   host: {
-    class: 'd-inline-flex',
-    style: 'gap: 1px',
+    class: 'd-inline-flex btn-group',
     '[tabindex]': 'tabIndex'
   },
   hostDirectives: [CdkMenuBar, CdkTargetMenuAim]

--- a/projects/element-ng/menu/si-menu-item-base.directive.ts
+++ b/projects/element-ng/menu/si-menu-item-base.directive.ts
@@ -2,12 +2,14 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { booleanAttribute, computed, Directive, input } from '@angular/core';
+import { CDK_MENU } from '@angular/cdk/menu';
+import { booleanAttribute, computed, Directive, inject, input } from '@angular/core';
 
 @Directive({
   host: {
-    class: 'dropdown-item d-flex focus-inside',
-    '[class.disabled]': 'disabled()'
+    class: 'focus-inside',
+    '[class.disabled]': 'disabled()',
+    '[class]': 'isInBar ? "btn btn-tertiary" : "dropdown-item"'
   }
 })
 export abstract class SiMenuItemBase {
@@ -35,6 +37,8 @@ export abstract class SiMenuItemBase {
    * @defaultValue false
    */
   readonly disabled = input(false, { transform: booleanAttribute });
+
+  protected readonly isInBar = inject(CDK_MENU, { optional: true })?.orientation === 'horizontal';
 
   protected readonly badgeDotHasContent = computed(() => {
     return typeof this.iconBadgeDot() === 'string' || typeof this.iconBadgeDot() === 'number';

--- a/projects/element-ng/menu/si-menu-item.component.scss
+++ b/projects/element-ng/menu/si-menu-item.component.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '@siemens/element-theme/src/styles/variables/semantic-tokens';
 @use '@siemens/element-theme/src/styles/variables';
 @use '@siemens/element-theme/src/styles/variables/system-tokens';
 
@@ -20,22 +19,14 @@
 
 :host-context(si-menu-bar, si-content-action-bar) {
   :host {
-    border-radius: 0;
-
-    &:first-child {
-      border-start-start-radius: semantic-tokens.$element-button-radius;
-      border-end-start-radius: semantic-tokens.$element-button-radius;
-    }
-
-    &:last-child {
-      border-start-end-radius: semantic-tokens.$element-button-radius;
-      border-end-end-radius: semantic-tokens.$element-button-radius;
-    }
+    --btn-bg: #{system-tokens.$si-sys-background-1};
+    --btn-font-weight: #{variables.$si-font-weight-body};
+    min-inline-size: auto !important; // stylelint-disable-line declaration-no-important
   }
 
-  color: system-tokens.$si-sys-text-accent;
-  background: system-tokens.$si-sys-background-1;
-  padding-inline: map.get(variables.$spacers, 4);
+  .btn + :host {
+    margin-inline-start: 1px !important; // stylelint-disable-line declaration-no-important
+  }
 
   .item-wrapper {
     justify-content: center;
@@ -43,6 +34,7 @@
 
   .icon {
     margin-inline: 0;
+    margin-block: map.get(variables.$spacers, 1) * -1;
   }
 
   .item-end {
@@ -85,34 +77,8 @@
       ) !important; // stylelint-disable-line declaration-no-important
     }
   }
-
-  &:focus,
-  &.focus {
-    color: system-tokens.$si-sys-text-accent;
-    background: system-tokens.$si-sys-background-1;
-  }
-
-  &:hover,
-  &.hover {
-    color: system-tokens.$si-sys-text-on-accent-secondary-hover;
-    background: system-tokens.$si-sys-background-accent-secondary-hover;
-  }
-
-  &:active,
-  &.active,
-  &[aria-expanded='true'] {
-    color: system-tokens.$si-sys-text-on-accent-secondary-active;
-    background: system-tokens.$si-sys-background-accent-secondary-active;
-  }
-
-  &:disabled,
-  &.disabled {
-    opacity: variables.$element-action-disabled-opacity;
-    color: system-tokens.$si-sys-text-accent;
-    background: system-tokens.$si-sys-background-1;
-  }
 }
 
 :host-context(.card-outline) {
-  background: transparent;
+  background-color: transparent;
 }


### PR DESCRIPTION
Use the shared tertiary button styles for menu-bar items and content action bar toggles instead of maintaining component-specific interaction styles.

Apply button-group layout to menu bars and remove redundant hover, active, disabled, spacing, and border-radius rules.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2669/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2669/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2669/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2669/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2669/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2669/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2669/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2669/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2669/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2669/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->





