### PR TITLE
feat(list-item): add list variants and improve examples

### DIFF
--- a/playwright/e2e/element-examples/static.spec.ts
+++ b/playwright/e2e/element-examples/static.spec.ts
@@ -30,6 +30,7 @@ test('links/links', ({ si }) => si.static());
 test('list-group/list-group', ({ si }) => si.static());
 test('list-item/list-item', ({ si }) => si.static());
 test('list-item/list-item-action', ({ si }) => si.static());
+test('list-item/list-variants', ({ si }) => si.static());
 test('list-item/list-item-unread', ({ si }) => si.static());
 test('shapes/shapes', ({ si }) => si.static());
 test('si-about/si-about-api', ({ si }) => si.static());

--- a/playwright/snapshots/static.spec.ts-snapshots/list-item--list-item-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/list-item--list-item-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98306c7ef57ebac3b7ead0cb3858b724baa406497db31ad3c3d5cd95fdee46f2
-size 44670
+oid sha256:0206cda3d43c50a296324e7ae79c69b97e9654a775897d5b74daa80e12776c77
+size 49766

--- a/playwright/snapshots/static.spec.ts-snapshots/list-item--list-item-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/list-item--list-item-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e973ec2ed2d8ad9cebc350d71c8cfbdfd630a11db0ed657cff222c915d272c83
-size 44009
+oid sha256:60efb4589c4b6a7b84062e709d19177d805b0f2360449ba22eb1f15ffe245e05
+size 49097

--- a/playwright/snapshots/static.spec.ts-snapshots/list-item--list-item.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/list-item--list-item.yaml
@@ -1,29 +1,36 @@
 - list:
   - listitem:
-    - time: /Today at \d+:\d+/
-    - heading "Conveyor belt inspection completed" [level=5]
-    - paragraph: /Routine inspection of conveyor belt CB-\d+ finished without issues\. All parameters within tolerance\./
-  - listitem:
-    - time: /Today at \d+:\d+/
-    - heading "Sensor calibration report available" [level=5]
-    - paragraph: Calibration of temperature sensors on production line 2 has been completed and documented.
-    - text: Production line 2
-    - link "View report":
-      - /url: "#"
-  - listitem:
-    - time: /Today at \d+:\d+/
-    - heading "Firmware update pending approval" [level=5]
+    - heading "HVAC Zone Controller Lobby" [level=5]
     - button "Options": 
-    - paragraph: Firmware v3.1.2 is ready for deployment. Review and approve to proceed with installation.
-    - group "Approval actions":
+  - listitem:
+    - checkbox /Select VAV box actuator Room \d+/
+    - heading /VAV box actuator Room \d+/ [level=5]
+  - listitem:
+    - heading /AHU-\d+ Supply Fan Fault/ [level=5]
+    - button "Options": 
+    - paragraph: Supply fan VFD reporting overcurrent fault. Airflow dropped below setpoint on floors 4–6.
+    - text: Building A 3 Critical
+  - listitem:
+    - heading "Scheduled Maintenance" [level=5]
+    - button "Options": 
+    - paragraph: Annual condenser coil cleaning and refrigerant level check. Assigned to Mike Torres, Facilities.
+    - group "Maintenance actions":
       - button "Approve"
       - button "Archive"
       - button "Delete"
   - listitem:
     - time: /Yesterday at \d+:\d+/
-    - heading "Motor drive fault detected" [level=5]
+    - text: Critical
+    - heading "Fire Damper Fault Zone B3" [level=5]
+    - paragraph: Smoke damper in return duct failed to close during test sequence. Manual inspection required before next occupancy cycle.
+  - listitem:
+    - time: /Today at \d+:\d+/
+    - status "plant in status critical"
+    - 'heading "Boiler #1 Pressure Drop Alert" [level=5]'
     - button "Options": 
-    - paragraph: /Drive unit DU-\d+ on packaging station reported overcurrent fault\. Manual reset required\./
-    - text: Fault log Critical
-    - button "Accept": 
-    - button "Deny": 
+    - paragraph: /System pressure fell below \d+ PSI threshold\. Possible leak in the north wing hydronic loop\. Technician dispatched\./
+    - text: Campus HQ 7 Urgent
+    - group "Fault actions":
+      - button "Approve"
+      - button "Archive"
+      - button "Delete"

--- a/playwright/snapshots/static.spec.ts-snapshots/list-item--list-variants-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/list-item--list-variants-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e2cd6ddfc3406f71fdcec55a648c546b71d13ce521bce1c5f879f7d7fd1980c
+size 49061

--- a/playwright/snapshots/static.spec.ts-snapshots/list-item--list-variants-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/list-item--list-variants-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc7d50e24fe2aa0b501ddef625a3729f21a4e8c1695a02841d9608b80a8ba8e2
+size 48163

--- a/playwright/snapshots/static.spec.ts-snapshots/list-item--list-variants.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/list-item--list-variants.yaml
@@ -1,0 +1,64 @@
+- heading "Ghost" [level=4]
+- list:
+  - listitem:
+    - heading "HVAC Zone Controller Lobby" [level=5]
+    - button "Options"
+  - listitem:
+    - heading "Lighting Controller Parking Garage" [level=5]
+    - button "Options"
+  - listitem:
+    - heading "Fire Alarm Panel East Wing" [level=5]
+    - button "Options"
+  - listitem:
+    - heading "Elevator Motor Room Sensor" [level=5]
+    - button "Options"
+- heading "With dividers" [level=4]
+- list:
+  - listitem:
+    - heading "HVAC Zone Controller Lobby" [level=5]
+    - button "Options"
+  - listitem:
+    - heading "Lighting Controller Parking Garage" [level=5]
+    - button "Options"
+  - listitem:
+    - heading "Fire Alarm Panel East Wing" [level=5]
+    - button "Options"
+  - listitem:
+    - heading "Elevator Motor Room Sensor" [level=5]
+    - button "Options"
+- heading "Filled" [level=4]
+- list:
+  - listitem:
+    - button "HVAC Zone Controller Lobby":
+      - heading "HVAC Zone Controller Lobby" [level=5]
+    - button "Options"
+  - listitem:
+    - button "Lighting Controller Parking Garage":
+      - heading "Lighting Controller Parking Garage" [level=5]
+    - button "Options"
+  - listitem:
+    - button "Fire Alarm Panel East Wing":
+      - heading "Fire Alarm Panel East Wing" [level=5]
+    - button "Options"
+  - listitem:
+    - button "Elevator Motor Room Sensor":
+      - heading "Elevator Motor Room Sensor" [level=5]
+    - button "Options"
+- heading "Outline" [level=4]
+- list:
+  - listitem:
+    - button "HVAC Zone Controller Lobby":
+      - heading "HVAC Zone Controller Lobby" [level=5]
+    - button "Options"
+  - listitem:
+    - button "Lighting Controller Parking Garage":
+      - heading "Lighting Controller Parking Garage" [level=5]
+    - button "Options"
+  - listitem:
+    - button "Fire Alarm Panel East Wing":
+      - heading "Fire Alarm Panel East Wing" [level=5]
+    - button "Options"
+  - listitem:
+    - button "Elevator Motor Room Sensor":
+      - heading "Elevator Motor Room Sensor" [level=5]
+    - button "Options"

--- a/projects/element-theme/src/styles/components/_list-item.scss
+++ b/projects/element-theme/src/styles/components/_list-item.scss
@@ -4,22 +4,46 @@
 
 @use 'sass:map';
 
+.list,
 ul:has(.list-item),
 ol:has(.list-item) {
+  display: flex;
+  flex-direction: column;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
+.list {
+  &.list-divider > li:not(:last-child) {
+    border-block-end: 1px solid variables.$si-sys-border-4;
+  }
+
+  &.list-filled,
+  &.list-outline {
+    gap: map.get(variables.$spacers, 4);
+  }
+
+  &.list-filled .list-item {
+    background-color: variables.$si-sys-background-1;
+    border-radius: variables.$element-radius-2;
+  }
+
+  &.list-outline .list-item {
+    border: 1px solid variables.$si-sys-border-4;
+    border-radius: variables.$element-radius-2;
+  }
+}
+
 .list-item {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto auto 1fr auto;
   grid-template-areas:
-    '.         timestamp     timestamp'
-    'indicator title         action'
-    '.         description   description'
-    '.         metadata      metadata'
-    '.         quick-actions quick-actions';
+    '.     .         timestamp     timestamp'
+    'check indicator title         action'
+    '.     .         description   description'
+    '.     .         metadata      metadata'
+    '.     .         quick-actions quick-actions';
   padding-block: map.get(variables.$spacers, 4);
   padding-inline: map.get(variables.$spacers, 6);
 
@@ -30,7 +54,13 @@ ol:has(.list-item) {
   );
 
   > * {
-    grid-column: 2 / -1;
+    grid-column: 3 / -1;
+  }
+
+  .list-item-check {
+    grid-area: check;
+    align-self: center;
+    margin-inline-end: map.get(variables.$spacers, 4);
   }
 
   .list-item-indicator {

--- a/src/app/examples/list-item/list-item.html
+++ b/src/app/examples/list-item/list-item.html
@@ -1,30 +1,30 @@
 <ul>
   <li class="list-item">
-    <si-circle-status class="list-item-indicator" status="success" [icon]="icons.elementPlant" />
-    <time class="list-item-timestamp" datetime="14:20">Today at 14:20</time>
-    <h5 class="list-item-title">Conveyor belt inspection completed</h5>
-    <p class="list-item-description"
-      >Routine inspection of conveyor belt CB-04 finished without issues. All parameters within
-      tolerance.</p
-    >
-  </li>
-
-  <li class="list-item">
-    <time class="list-item-timestamp" datetime="11:45">Today at 11:45</time>
-    <h5 class="list-item-title">Sensor calibration report available</h5>
-    <p class="list-item-description"
-      >Calibration of temperature sensors on production line 2 has been completed and documented.</p
-    >
-    <div class="list-item-metadata">
-      <span>Production line 2</span>
-      <div class="list-item-metadata-divider"></div>
-      <a href="#">View report</a>
+    <si-icon class="list-item-indicator icon" [icon]="icons.elementAhuPlant" />
+    <h5 class="list-item-title">HVAC Zone Controller Lobby</h5>
+    <div class="list-item-primary-action">
+      <button
+        type="button"
+        class="btn btn-icon btn-tertiary-ghost element-options-vertical"
+        aria-label="Options"
+        [cdkMenuTriggerFor]="contextMenu"
+      ></button>
     </div>
   </li>
 
   <li class="list-item">
-    <time class="list-item-timestamp" datetime="09:30">Today at 09:30</time>
-    <h5 class="list-item-title">Firmware update pending approval</h5>
+    <input
+      type="checkbox"
+      class="form-check-input list-item-check"
+      aria-label="Select VAV box actuator Room 312"
+    />
+    <si-icon class="list-item-indicator icon" [icon]="icons.elementSpecialObject" />
+    <h5 class="list-item-title">VAV box actuator Room 312</h5>
+  </li>
+
+  <li class="list-item">
+    <si-icon class="list-item-indicator icon" [icon]="icons.elementSpecialObject" />
+    <h5 class="list-item-title">AHU-03 Supply Fan Fault</h5>
     <div class="list-item-primary-action">
       <button
         type="button"
@@ -34,15 +34,48 @@
       ></button>
     </div>
     <p class="list-item-description"
-      >Firmware v3.1.2 is ready for deployment. Review and approve to proceed with installation.</p
+      >Supply fan VFD reporting overcurrent fault. Airflow dropped below setpoint on floors 4–6.</p
+    >
+    <div class="list-item-metadata">
+      <span>Building A</span>
+      <div class="list-item-metadata-divider"></div>
+      <div class="d-inline-flex align-items-center gap-1">
+        <si-icon class="icon-sm" [icon]="icons.elementDocument" />
+        <span>3</span>
+      </div>
+      <div class="list-item-metadata-divider"></div>
+      <span>Critical</span>
+    </div>
+  </li>
+
+  <li class="list-item">
+    <si-avatar
+      class="list-item-indicator"
+      size="small"
+      icon="element-user"
+      altText="Assigned technician"
+      color="5"
+    />
+    <h5 class="list-item-title">Scheduled Maintenance</h5>
+    <div class="list-item-primary-action">
+      <button
+        type="button"
+        class="btn btn-icon btn-tertiary-ghost element-options-vertical"
+        aria-label="Options"
+        [cdkMenuTriggerFor]="contextMenu"
+      ></button>
+    </div>
+    <p class="list-item-description"
+      >Annual condenser coil cleaning and refrigerant level check. Assigned to Mike Torres,
+      Facilities.</p
     >
     <div class="list-item-quick-actions">
-      <div class="btn-group" role="group" aria-label="Approval actions">
+      <div class="btn-group" role="group" aria-label="Maintenance actions">
         <button
           type="button"
           class="btn btn-icon btn-tertiary-ghost"
           aria-label="Approve"
-          (click)="logEvent('Approve firmware update')"
+          (click)="logEvent('Approve maintenance task')"
         >
           <si-icon class="icon" [icon]="icons.elementCheckboxChecked" />
         </button>
@@ -50,7 +83,7 @@
           type="button"
           class="btn btn-icon btn-tertiary-ghost"
           aria-label="Archive"
-          (click)="logEvent('Archive firmware update')"
+          (click)="logEvent('Archive maintenance task')"
         >
           <si-icon class="icon" [icon]="icons.elementArchive" />
         </button>
@@ -58,7 +91,7 @@
           type="button"
           class="btn btn-icon btn-tertiary-ghost"
           aria-label="Delete"
-          (click)="logEvent('Delete firmware update')"
+          (click)="logEvent('Delete maintenance task')"
         >
           <si-icon class="icon" [icon]="icons.elementDelete" />
         </button>
@@ -67,9 +100,19 @@
   </li>
 
   <li class="list-item">
-    <si-status-icon class="list-item-indicator icon" status="danger" />
-    <time class="list-item-timestamp" datetime="16:05">Yesterday at 16:05</time>
-    <h5 class="list-item-title">Motor drive fault detected</h5>
+    <time class="list-item-timestamp" datetime="16:30">Yesterday at 16:30</time>
+    <si-status-icon class="list-item-indicator si-h3" status="critical" />
+    <h5 class="list-item-title">Fire Damper Fault Zone B3</h5>
+    <p class="list-item-description"
+      >Smoke damper in return duct failed to close during test sequence. Manual inspection required
+      before next occupancy cycle.</p
+    >
+  </li>
+
+  <li class="list-item">
+    <time class="list-item-timestamp" datetime="09:12">Today at 09:12</time>
+    <si-circle-status status="critical" icon="element-plant" class="list-item-indicator icon" />
+    <h5 class="list-item-title">Boiler #1 Pressure Drop Alert</h5>
     <div class="list-item-primary-action">
       <button
         type="button"
@@ -79,27 +122,46 @@
       ></button>
     </div>
     <p class="list-item-description"
-      >Drive unit DU-07 on packaging station reported overcurrent fault. Manual reset required.</p
+      >System pressure fell below 12 PSI threshold. Possible leak in the north wing hydronic loop.
+      Technician dispatched.</p
     >
     <div class="list-item-metadata">
+      <span>Campus HQ</span>
+      <div class="list-item-metadata-divider"></div>
       <div class="d-inline-flex align-items-center gap-1">
         <si-icon class="icon-sm" [icon]="icons.elementDocument" />
-        <span>Fault log</span>
+        <span>7</span>
       </div>
       <div class="list-item-metadata-divider"></div>
-      <span class="badge bg-critical">Critical</span>
+      <span>Urgent</span>
     </div>
     <div class="list-item-quick-actions">
-      <button
-        type="button"
-        class="btn btn-icon btn-primary element-ok"
-        aria-label="Accept"
-      ></button>
-      <button
-        type="button"
-        class="btn btn-icon btn-danger element-cancel"
-        aria-label="Deny"
-      ></button>
+      <div class="btn-group" role="group" aria-label="Fault actions">
+        <button
+          type="button"
+          class="btn btn-icon btn-tertiary-ghost"
+          aria-label="Approve"
+          (click)="logEvent('Approve fault resolution')"
+        >
+          <si-icon class="icon" [icon]="icons.elementCheckboxChecked" />
+        </button>
+        <button
+          type="button"
+          class="btn btn-icon btn-tertiary-ghost"
+          aria-label="Archive"
+          (click)="logEvent('Archive fault resolution')"
+        >
+          <si-icon class="icon" [icon]="icons.elementArchive" />
+        </button>
+        <button
+          type="button"
+          class="btn btn-icon btn-tertiary-ghost"
+          aria-label="Delete"
+          (click)="logEvent('Delete fault resolution')"
+        >
+          <si-icon class="icon" [icon]="icons.elementDelete" />
+        </button>
+      </div>
     </div>
   </li>
 </ul>

--- a/src/app/examples/list-item/list-item.ts
+++ b/src/app/examples/list-item/list-item.ts
@@ -9,8 +9,10 @@ import {
   elementCheckboxChecked,
   elementDelete,
   elementDocument,
-  elementPlant
+  elementAhuPlant,
+  elementSpecialObject
 } from '@siemens/element-icons';
+import { SiAvatarComponent } from '@siemens/element-ng/avatar';
 import { SiCircleStatusComponent } from '@siemens/element-ng/circle-status';
 import { addIcons, SiIconComponent, SiStatusIconComponent } from '@siemens/element-ng/icon';
 import { type MenuItem, SiMenuFactoryComponent } from '@siemens/element-ng/menu';
@@ -21,9 +23,10 @@ import { LOG_EVENT } from '@siemens/live-preview';
   imports: [
     SiIconComponent,
     SiMenuFactoryComponent,
+    SiAvatarComponent,
     SiCircleStatusComponent,
-    CdkMenuTrigger,
-    SiStatusIconComponent
+    SiStatusIconComponent,
+    CdkMenuTrigger
   ],
   templateUrl: './list-item.html',
   host: { class: 'p-5' }
@@ -32,11 +35,12 @@ export class SampleComponent {
   logEvent = inject(LOG_EVENT);
 
   icons = addIcons({
-    elementCheckboxChecked,
     elementArchive,
+    elementCheckboxChecked,
     elementDelete,
     elementDocument,
-    elementPlant
+    elementAhuPlant,
+    elementSpecialObject
   });
 
   items: MenuItem[] = [

--- a/src/app/examples/list-item/list-variants.html
+++ b/src/app/examples/list-item/list-variants.html
@@ -1,0 +1,78 @@
+<div class="d-flex flex-column gap-10">
+  <div class="d-flex flex-wrap gap-10">
+    <div class="flex-grow-1">
+      <h4 class="mb-4">Ghost</h4>
+      <ul class="list">
+        @for (item of items; track item.title) {
+          <li class="list-item">
+            <si-icon class="list-item-indicator icon" [icon]="item.icon" />
+            <h5 class="list-item-title">{{ item.title }}</h5>
+            <div class="list-item-primary-action">
+              <button type="button" class="btn btn-icon btn-tertiary-ghost" aria-label="Options">
+                <si-icon [icon]="icons.elementOptionsVertical" />
+              </button>
+            </div>
+          </li>
+        }
+      </ul>
+    </div>
+
+    <div class="flex-grow-1">
+      <h4 class="mb-4">With dividers</h4>
+      <ul class="list list-divider">
+        @for (item of items; track item.title) {
+          <li class="list-item">
+            <si-icon class="list-item-indicator icon" [icon]="item.icon" />
+            <h5 class="list-item-title">{{ item.title }}</h5>
+            <div class="list-item-primary-action">
+              <button type="button" class="btn btn-icon btn-tertiary-ghost" aria-label="Options">
+                <si-icon [icon]="icons.elementOptionsVertical" />
+              </button>
+            </div>
+          </li>
+        }
+      </ul>
+    </div>
+  </div>
+  <div class="d-flex flex-wrap gap-10">
+    <div class="flex-grow-1">
+      <h4 class="mb-4">Filled</h4>
+      <ul class="list list-filled">
+        @for (item of items; track item.title) {
+          <li class="position-relative">
+            <button type="button" class="list-item list-item-action" (click)="logEvent(item.title)">
+              <si-icon class="list-item-indicator icon" [icon]="item.icon" />
+              <h5 class="list-item-title">{{ item.title }}</h5>
+              <span class="list-item-primary-action btn btn-icon" aria-hidden="true"></span>
+            </button>
+            <div class="position-absolute top-50 end-0 translate-middle-y me-6">
+              <button type="button" class="btn btn-icon btn-tertiary-ghost" aria-label="Options">
+                <si-icon [icon]="icons.elementOptionsVertical" />
+              </button>
+            </div>
+          </li>
+        }
+      </ul>
+    </div>
+
+    <div class="flex-grow-1">
+      <h4 class="mb-4">Outline</h4>
+      <ul class="list list-outline">
+        @for (item of items; track item.title) {
+          <li class="position-relative">
+            <button type="button" class="list-item list-item-action" (click)="logEvent(item.title)">
+              <si-icon class="list-item-indicator icon" [icon]="item.icon" />
+              <h5 class="list-item-title">{{ item.title }}</h5>
+              <span class="list-item-primary-action btn btn-icon" aria-hidden="true"></span>
+            </button>
+            <div class="position-absolute top-50 end-0 translate-middle-y me-6">
+              <button type="button" class="btn btn-icon btn-tertiary-ghost" aria-label="Options">
+                <si-icon [icon]="icons.elementOptionsVertical" />
+              </button>
+            </div>
+          </li>
+        }
+      </ul>
+    </div>
+  </div>
+</div>

--- a/src/app/examples/list-item/list-variants.ts
+++ b/src/app/examples/list-item/list-variants.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, inject } from '@angular/core';
+import {
+  elementAhuPlant,
+  elementLightOn,
+  elementFireSensor,
+  elementElevator,
+  elementOptionsVertical
+} from '@siemens/element-icons';
+import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
+import { LOG_EVENT } from '@siemens/live-preview';
+
+@Component({
+  selector: 'app-sample',
+  imports: [SiIconComponent],
+  templateUrl: './list-variants.html',
+  host: { class: 'p-5' }
+})
+export class SampleComponent {
+  logEvent = inject(LOG_EVENT);
+
+  icons = addIcons({
+    elementAhuPlant,
+    elementLightOn,
+    elementFireSensor,
+    elementElevator,
+    elementOptionsVertical
+  });
+
+  readonly items = [
+    {
+      icon: this.icons.elementAhuPlant,
+      title: 'HVAC Zone Controller Lobby'
+    },
+    {
+      icon: this.icons.elementLightOn,
+      title: 'Lighting Controller Parking Garage'
+    },
+    {
+      icon: this.icons.elementFireSensor,
+      title: 'Fire Alarm Panel East Wing'
+    },
+    {
+      icon: this.icons.elementElevator,
+      title: 'Elevator Motor Room Sensor'
+    }
+  ];
+}


### PR DESCRIPTION
- Add ghost, divider, filled and outline list styles to element-theme
- Add new list-variants example.

Closes #2634

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2674/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2674/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2674/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2674/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2674/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2674/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2674/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2674/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2674/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2674/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->








