### PR TITLE
feat(datatable): support striped rows in ngx-datatable

### DIFF
--- a/docs/components/lists-tables-trees/ngx-datatable.md
+++ b/docs/components/lists-tables-trees/ngx-datatable.md
@@ -107,6 +107,20 @@ in your stylesheet:
 
 <si-docs-component example="datatable/datatable-footer" height="750"></si-docs-component>
 
+### Striped rows
+
+Add `table-striped` next to `table-element` on `<ngx-datatable>` to distinguish
+alternating body rows, like the [HTML table](html-table.md) variant of the same name.
+
+```html
+<ngx-datatable class="table-element table-striped">
+  <!-- Table content -->
+</ngx-datatable>
+```
+
+Striping is based on the row index, so it stays stable while scrolling virtualized rows.
+Hover, selection and focus states take precedence over the striping.
+
 ### Client-side paging, sorting and selection options
 
 - Use `class="table-element"` on `<ngx-datatable>`.

--- a/playwright/e2e/element-examples/datatable-tree.spec.ts
+++ b/playwright/e2e/element-examples/datatable-tree.spec.ts
@@ -18,6 +18,13 @@ test.describe('datatable', () => {
     await si.runVisualAndA11yTests('invalid-age');
   });
 
+  test(example + ' striped', async ({ page, si }) => {
+    await si.visitExample(example);
+    await page.getByLabel('Striped rows').check();
+    await expect(page.locator('ngx-datatable.table-striped')).toBeVisible();
+    await si.runVisualAndA11yTests('striped');
+  });
+
   const exampleTree = 'datatable/datatable-tree';
 
   test(exampleTree, async ({ page, si }) => {

--- a/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--striped-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--striped-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e023f14a52a0366ad1d82ed388ba34830a6bddb09bf5847dcc27e4bd9622f0d
+size 44635

--- a/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--striped-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--striped-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cb6cf99be628e982d167fe739d4d64e560f62067bb7821ef2568d260d57b64b
+size 43733

--- a/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--striped.yaml
+++ b/playwright/snapshots/datatable-tree.spec.ts-snapshots/datatable--datatable--striped.yaml
@@ -1,0 +1,130 @@
+- table:
+  - rowgroup:
+    - row "Status ID First Name Last Name Status Age Context options":
+      - columnheader "Status"
+      - columnheader "ID"
+      - columnheader "First Name"
+      - columnheader "Last Name"
+      - columnheader "Status"
+      - columnheader "Age"
+      - columnheader "Context options"
+  - rowgroup:
+    - row /plant status none 1 First 1 Last 1 \d+ Context menu/:
+      - cell "plant status none":
+        - status "plant status none"
+      - cell "1"
+      - cell "First 1"
+      - cell "Last 1"
+      - cell
+      - cell /\d+/:
+        - textbox "Age": /\d+/
+      - cell "Context menu":
+        - button "Context menu"
+    - row /plant status none 2 First 2 Last 2 \d+ Context menu/:
+      - cell "plant status none":
+        - status "plant status none"
+      - cell "2"
+      - cell "First 2"
+      - cell "Last 2"
+      - cell
+      - cell /\d+/:
+        - textbox "Age": /\d+/
+      - cell "Context menu":
+        - button "Context menu"
+    - row /plant status none 3 First 3 Last 3 \d+ Context menu/:
+      - cell "plant status none":
+        - status "plant status none"
+      - cell "3"
+      - cell "First 3"
+      - cell "Last 3"
+      - cell
+      - cell /\d+/:
+        - textbox "Age": /\d+/
+      - cell "Context menu":
+        - button "Context menu"
+    - row /plant in status info 4 First 4 Last 4 \d+ Context menu/:
+      - cell "plant in status info":
+        - status "plant in status info"
+      - cell "4"
+      - cell "First 4"
+      - cell "Last 4"
+      - cell
+      - cell /\d+/:
+        - textbox "Age": /\d+/
+      - cell "Context menu":
+        - button "Context menu"
+    - row /plant status none 5 First 5 Last 5 \d+ Context menu/:
+      - cell "plant status none":
+        - status "plant status none"
+      - cell "5"
+      - cell "First 5"
+      - cell "Last 5"
+      - cell
+      - cell /\d+/:
+        - textbox "Age": /\d+/
+      - cell "Context menu":
+        - button "Context menu"
+    - row /plant status none 6 First 6 Last 6 \d+ Context menu/:
+      - cell "plant status none":
+        - status "plant status none"
+      - cell "6"
+      - cell "First 6"
+      - cell "Last 6"
+      - cell
+      - cell /\d+/:
+        - textbox "Age": /\d+/
+      - cell "Context menu":
+        - button "Context menu"
+    - row /plant status none 7 First 7 Last 7 \d+ Context menu/:
+      - cell "plant status none":
+        - status "plant status none"
+      - cell "7"
+      - cell "First 7"
+      - cell "Last 7"
+      - cell
+      - cell /\d+/:
+        - textbox "Age": /\d+/
+      - cell "Context menu":
+        - button "Context menu"
+    - row /plant in status warning 8 First 8 Last 8 \d+ Context menu/:
+      - cell "plant in status warning":
+        - status "plant in status warning"
+      - cell "8"
+      - cell "First 8"
+      - cell "Last 8"
+      - cell
+      - cell /\d+/:
+        - textbox "Age": /\d+/
+      - cell "Context menu":
+        - button "Context menu"
+- navigation "Pagination":
+  - list:
+    - listitem:
+      - button "back" [disabled]
+    - listitem:
+      - button "1" [disabled]
+    - listitem:
+      - button "2"
+    - listitem:
+      - button "3"
+    - listitem:
+      - button "4"
+    - listitem:
+      - button "5"
+    - listitem: …
+    - listitem:
+      - button /\d+/
+    - listitem:
+      - button "forward"
+- text: Settings Selection type
+- combobox "Selection type":
+  - option "undefined"
+  - option "single"
+  - option "multi"
+  - option "multiClick" [selected]
+  - option "cell"
+  - option "checkbox"
+- checkbox "Enforce checkboxes"
+- text: Enforce checkboxes
+- checkbox "Striped rows" [checked]
+- text: Striped rows

--- a/projects/element-theme/src/styles/components/_datatable.scss
+++ b/projects/element-theme/src/styles/components/_datatable.scss
@@ -16,6 +16,7 @@ $datatable-header-color: system-tokens.$si-sys-text-primary !default;
 $datatable-footer-background-color: transparent !default;
 
 $datatable-summary-background-color: system-tokens.$si-sys-background-2 !default;
+$datatable-striped-background-color: variables.$table-striped-bg !default;
 
 $datatable-header-height: 40px !default;
 $datatable-cell-min-width: 40px !default;
@@ -54,6 +55,17 @@ $datatable-ghost-cell-strip-radius: 0 !default;
 
   &.table-custom {
     --si-datatable-row-min-height: 24px;
+  }
+
+  // Zebra striping, the counterpart of `.table-striped` for HTML tables.
+  // Interactive states are excluded so that hover, active and focus keep precedence.
+  &.table-striped {
+    .datatable-row-wrapper .datatable-body-row.datatable-row-odd:not(.active, :hover, :focus) {
+      &,
+      :is(.datatable-row-left, .datatable-row-right) {
+        background-color: $datatable-striped-background-color;
+      }
+    }
   }
 
   // any kind of selection: apply a row hover state

--- a/src/app/examples/datatable/datatable.html
+++ b/src/app/examples/datatable/datatable.html
@@ -4,6 +4,7 @@
     class="table-element"
     columnMode="force"
     siDatatableInteraction
+    [class.table-striped]="striped"
     [rows]="rows"
     [columns]="columns"
     [reorderable]="true"
@@ -50,7 +51,7 @@
             </select>
           </si-form-item>
         </div>
-        <div class="col-6">
+        <div class="col-4">
           <si-form-item label="Enforce checkboxes">
             <input
               class="form-check-input"
@@ -58,6 +59,11 @@
               [(ngModel)]="enforceCheckboxes"
               (ngModelChange)="selectionTypeChanged(!enforceCheckboxes)"
             />
+          </si-form-item>
+        </div>
+        <div class="col-4">
+          <si-form-item label="Striped rows">
+            <input class="form-check-input" type="checkbox" [(ngModel)]="striped" />
           </si-form-item>
         </div>
       </div>

--- a/src/app/examples/datatable/datatable.ts
+++ b/src/app/examples/datatable/datatable.ts
@@ -78,6 +78,7 @@ export class SampleComponent implements OnInit {
   selectionTypes: SelectionType[] = ['single', 'multi', 'multiClick', 'cell', 'checkbox'];
   nextStatusType = 0;
   enforceCheckboxes = false;
+  striped = false;
 
   constructor() {
     for (let i = 1; i <= 250; i++) {


### PR DESCRIPTION
Add `.table-striped` support to `ngx-datatable`, mirroring the HTML table variant of the same name. Striping uses the same `$table-striped-bg` token and is applied per row index, so it stays stable while scrolling virtualized rows. Hover, selection and focus states keep precedence.

Previously alternating row backgrounds were only available for plain HTML tables.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2678/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2678/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2678/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2678/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2678/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2678/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2678/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2678/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2678/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2678/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
