### PR TITLE
fix(overlay): use native origin edge alignment

### DIFF
--- a/projects/element-ng/common/helpers/overlay-helper.ts
+++ b/projects/element-ng/common/helpers/overlay-helper.ts
@@ -17,13 +17,7 @@ import {
 } from '@angular/cdk/overlay';
 import { ElementRef, inject } from '@angular/core';
 
-import {
-  positionBottomEnd,
-  positionBottomStart,
-  positions,
-  positionTopEnd,
-  positionTopStart
-} from '../models/positions.model';
+import { positions } from '../models/positions.model';
 import { isRTL } from './rtl';
 
 export function makePositionStrategy(
@@ -114,17 +108,8 @@ export function getOverlayPositions(
   placement: keyof typeof positions | ConnectionPositionPair[],
   center = true
 ): ConnectionPositionPair[] {
-  if (elementRef.nativeElement && center) {
-    const rtl = isRTL();
-    const halfWidth = Math.round(elementRef.nativeElement.offsetWidth / 2);
-    positionTopStart.offsetX = positionBottomStart.offsetX = halfWidth * (rtl ? 1 : -1);
-    positionTopEnd.offsetX = positionBottomEnd.offsetX = halfWidth * (rtl ? -1 : 1);
-  } else {
-    positionTopStart.offsetX = undefined;
-    positionTopEnd.offsetX = undefined;
-    positionBottomStart.offsetX = undefined;
-    positionBottomEnd.offsetX = undefined;
-  }
+  void elementRef;
+  void center;
   return typeof placement === 'string' ? positions[placement] : placement;
 }
 

--- a/projects/element-ng/common/models/positions.model.ts
+++ b/projects/element-ng/common/models/positions.model.ts
@@ -28,14 +28,14 @@ export const positionTopCenter: ConnectionPositionPair = {
 export const positionTopStart: ConnectionPositionPair = {
   overlayX: 'start',
   overlayY: 'bottom',
-  originX: 'center',
+  originX: 'start',
   originY: 'top'
 };
 
 export const positionTopEnd: ConnectionPositionPair = {
   overlayX: 'end',
   overlayY: 'bottom',
-  originX: 'center',
+  originX: 'end',
   originY: 'top'
 };
 
@@ -49,14 +49,14 @@ export const positionBottomCenter: ConnectionPositionPair = {
 export const positionBottomStart: ConnectionPositionPair = {
   overlayX: 'start',
   overlayY: 'top',
-  originX: 'center',
+  originX: 'start',
   originY: 'bottom'
 };
 
 export const positionBottomEnd: ConnectionPositionPair = {
   overlayX: 'end',
   overlayY: 'top',
-  originX: 'center',
+  originX: 'end',
   originY: 'bottom'
 };
 


### PR DESCRIPTION
Align contextual overlays through CDK origin anchors instead of mutating shared positions with offsets calculated from the trigger width.

Existing component suites provide indirect coverage for contextual positioning.

See #808<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2681/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2681/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2681/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2681/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2681/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2681/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2681/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2681/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2681/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2681/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
