### PR TITLE
refactor(popover): create overlay with CDK directly

### DIFF
--- a/projects/element-ng/popover/si-popover.directive.ts
+++ b/projects/element-ng/popover/si-popover.directive.ts
@@ -18,8 +18,7 @@ import {
 } from '@angular/core';
 import {
   defaultConnectedOverlayScrollStrategy,
-  getOverlay,
-  getPositionStrategy,
+  isRTL,
   positions
 } from '@siemens/element-ng/common';
 import { TranslatableString } from '@siemens/element-translate-ng/translate-types';
@@ -45,7 +44,7 @@ export class SiPopoverDirective implements OnDestroy {
   readonly siPopover = input<TranslatableString | TemplateRef<unknown>>();
 
   /**
-   * The placement of the popover. One of 'top', 'start', end', 'bottom'
+   * The placement of the popover. One of 'top', 'start', 'end', 'bottom'
    *
    * @defaultValue 'auto'
    */
@@ -168,15 +167,18 @@ export class SiPopoverDirective implements OnDestroy {
   }
 
   private createOverlay(): OverlayRef {
-    const overlayRef = getOverlay(
-      this.elementRef,
-      this.overlay,
-      false,
-      this.placementInternal(),
-      false,
-      true,
-      this.scrollStrategy()
-    );
+    const positionStrategy = this.overlay
+      .position()
+      .flexibleConnectedTo(this.elementRef)
+      .withPush(false)
+      .withGrowAfterOpen(true)
+      .withFlexibleDimensions(false)
+      .withPositions(positions[this.placementInternal()]);
+    const overlayRef = this.overlay.create({
+      positionStrategy,
+      scrollStrategy: this.scrollStrategy(),
+      direction: isRTL() ? 'rtl' : 'ltr'
+    });
     overlayRef
       .detachments()
       .pipe(takeUntil(this.destroyer))
@@ -195,8 +197,8 @@ export class SiPopoverDirective implements OnDestroy {
           this.hide();
         }
       });
-    getPositionStrategy(overlayRef)
-      ?.positionChanges.pipe(takeUntil(this.destroyer))
+    positionStrategy.positionChanges
+      .pipe(takeUntil(this.destroyer))
       .subscribe(change => this.popoverRef?.instance.updateArrow(change, this.elementRef));
     return overlayRef;
   }


### PR DESCRIPTION
Create the popover overlay directly with Angular CDK and retain its typed flexible position strategy.

This removes the wrapper and unsafe strategy recovery while preserving direction, scrolling, outside-click, detach, and arrow behavior.

See #808<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2682/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2682/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2682/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2682/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2682/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2682/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2682/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2682/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2682/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2682/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



