### PR TITLE
refactor(tooltip): create overlay with CDK directly

### DIFF
--- a/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
+++ b/projects/element-ng/tooltip/si-tooltip.directive.spec.ts
@@ -305,6 +305,17 @@ describe('SiTooltipDirective', () => {
         .element(page.getByRole('tooltip', { name: 'updated node tooltip' }))
         .toBeInTheDocument();
     });
+
+    it('should reposition on scroll by default', async () => {
+      const overlay = TestBed.inject(Overlay);
+      const reposition = vi.spyOn(overlay.scrollStrategies, 'reposition');
+
+      button.dispatchEvent(new FocusEvent('focus'));
+      await vi.advanceTimersByTimeAsync(0);
+      await fixture.whenStable();
+
+      expect(reposition).toHaveBeenCalledOnce();
+    });
   });
 
   describe('with scrollStrategy', () => {

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -2,7 +2,12 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import { Overlay, OverlayRef, ScrollStrategy } from '@angular/cdk/overlay';
+import {
+  FlexibleConnectedPositionStrategy,
+  Overlay,
+  OverlayRef,
+  ScrollStrategy
+} from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { isPlatformBrowser } from '@angular/common';
 import {
@@ -17,12 +22,7 @@ import {
   inputBinding,
   PLATFORM_ID
 } from '@angular/core';
-import {
-  getOverlay,
-  getOverlayPositions,
-  getPositionStrategy,
-  positions
-} from '@siemens/element-ng/common';
+import { isRTL, positions } from '@siemens/element-ng/common';
 import { fromEvent, Subject, Subscription, timer } from 'rxjs';
 import { delayWhen, filter, takeUntil } from 'rxjs/operators';
 
@@ -55,6 +55,7 @@ class BrowserTooltipRef {
   private isFocused = false;
   private isHovered = false;
   private overlayRef?: OverlayRef;
+  private positionStrategy?: FlexibleConnectedPositionStrategy;
   private positionSubscription?: Subscription;
   private canShowEffect?: EffectRef;
   private placementEffect?: EffectRef;
@@ -174,15 +175,20 @@ class BrowserTooltipRef {
   }
 
   private getOrCreateOverlay(): OverlayRef {
-    this.overlayRef ??= getOverlay(
-      this.config.element,
-      this.config.overlay,
-      false,
-      this.getPlacement(),
-      false,
-      true,
-      this.config.scrollStrategy?.()
-    );
+    if (!this.overlayRef) {
+      this.positionStrategy = this.config.overlay
+        .position()
+        .flexibleConnectedTo(this.config.element)
+        .withPush(false)
+        .withGrowAfterOpen(true)
+        .withFlexibleDimensions(false)
+        .withPositions(positions[this.getPlacement()]);
+      this.overlayRef = this.config.overlay.create({
+        positionStrategy: this.positionStrategy,
+        scrollStrategy: this.config.scrollStrategy?.(),
+        direction: isRTL() ? 'rtl' : 'ltr'
+      });
+    }
     return this.overlayRef;
   }
 
@@ -208,9 +214,8 @@ class BrowserTooltipRef {
     ]);
     const tooltipRef: ComponentRef<TooltipComponent> = overlayRef.attach(toolTipPortal);
 
-    const positionStrategy = getPositionStrategy(overlayRef);
     this.positionSubscription?.unsubscribe();
-    this.positionSubscription = positionStrategy?.positionChanges.subscribe(change =>
+    this.positionSubscription = this.positionStrategy?.positionChanges.subscribe(change =>
       tooltipRef.instance.updateTooltipPosition(change, this.config.element)
     );
   }
@@ -220,9 +225,8 @@ class BrowserTooltipRef {
   }
 
   private updatePlacement(placement: keyof typeof positions): void {
-    const positionStrategy = this.overlayRef && getPositionStrategy(this.overlayRef);
-    if (positionStrategy) {
-      positionStrategy.withPositions(getOverlayPositions(this.config.element, placement));
+    if (this.positionStrategy) {
+      this.positionStrategy.withPositions(positions[placement]);
       this.overlayRef?.updatePosition();
     }
   }

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -185,7 +185,8 @@ class BrowserTooltipRef {
         .withPositions(positions[this.getPlacement()]);
       this.overlayRef = this.config.overlay.create({
         positionStrategy: this.positionStrategy,
-        scrollStrategy: this.config.scrollStrategy?.(),
+        scrollStrategy:
+          this.config.scrollStrategy?.() ?? this.config.overlay.scrollStrategies.reposition(),
         direction: isRTL() ? 'rtl' : 'ltr'
       });
     }


### PR DESCRIPTION
Create tooltip overlays directly with Angular CDK and retain the typed flexible position strategy for dynamic placement updates.

Preserve reposition-on-scroll as the default for service callers that do not provide a custom strategy, with regression coverage.

See #808<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2683/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2683/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2683/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2683/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2683/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2683/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2683/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2683/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2683/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2683/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->



