### PR TITLE
build(gh-actions): disable automatic install for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           runtime: node@krypton
           cache: true
+          install: false # We need manual install, due to changed auto peer install.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist


### PR DESCRIPTION
## Summary

Disable the implicit dependency installation performed by `pnpm/setup` in the release job. The workflow already installs dependencies explicitly after configuring private registry authentication.

With pnpm 12, the implicit frozen install fails because the release job sets `PNPM_CONFIG_AUTO_INSTALL_PEERS=true`, while the committed lockfile records `autoInstallPeers: false`. Skipping the duplicate implicit install allows the existing `pnpm install --no-frozen-lockfile` step to handle the release-specific peer dependency configuration.

Failed release job: https://github.com/siemens/element/actions/runs/33669816355/job/100384877661

## Validation

- `pnpm exec prettier --check .github/workflows/release.yaml`
- `git diff --check`
- `actionlint .github/workflows/release.yaml`<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2691/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2691/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2691/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2691/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2691/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2691/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2691/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2691/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2691/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2691/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
