### PR TITLE
feat(dashboards): add option to hide already added widgets from catalog

### DIFF
--- a/api-goldens/dashboards-ng/index.api.md
+++ b/api-goldens/dashboards-ng/index.api.md
@@ -197,6 +197,7 @@ export class SiFlexibleDashboardComponent implements OnInit, OnChanges, OnDestro
     readonly editable: _angular_core.ModelSignal<boolean>;
     readonly grid: _angular_core.Signal<SiGridComponent>;
     readonly heading: _angular_core.InputSignal<string | undefined>;
+    readonly hideAddedWidgetsFromCatalog: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly hideAddWidgetInstanceButton: _angular_core.InputSignal<boolean>;
     readonly hideEditButton: _angular_core.InputSignal<boolean>;
     readonly hideProgressIndicator: _angular_core.InputSignal<boolean>;

--- a/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.spec.ts
+++ b/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.spec.ts
@@ -16,9 +16,10 @@ import {
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MenuItem } from '@siemens/element-ng/common';
 import { SiLoadingSpinnerModule } from '@siemens/element-ng/loading-spinner';
-import { firstValueFrom, Observable, of, zip } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, Observable, of, zip } from 'rxjs';
+import { page } from 'vitest/browser';
 
-import { TestingModule } from '../../../test/testing.module';
+import { createTestingWidget, TestingModule } from '../../../test/testing.module';
 import {
   provideDashboardToolbarItems,
   SI_DASHBOARD_CONFIGURATION
@@ -80,6 +81,7 @@ export class GridComponent {
   readonly gridConfig = input<GridConfig>();
   readonly dashboardId = input<string>();
   readonly widgetCatalog = input<Widget[]>([]);
+  readonly visibleWidgetInstances$ = new BehaviorSubject<WidgetConfig[]>([]);
   readonly hideProgressIndicator = input(false);
   readonly widgetInstanceEditorDialogComponent =
     input<Type<SiWidgetInstanceEditorDialogComponent>>();
@@ -174,6 +176,27 @@ describe('SiFlexibleDashboardComponent', () => {
       expect(widgetConfig).toBeDefined();
       expect(widgetConfig.widgetId).toEqual('widgetId');
       vi.useRealTimers();
+    });
+
+    it('should keep added widgets in the catalog by default', async () => {
+      fixture.componentRef.setInput('widgetCatalog', [createTestingWidget('First', 'first')]);
+      grid.visibleWidgetInstances$.next([{ id: 'instance-1', widgetId: 'first' }]);
+
+      component.showWidgetCatalog();
+      await fixture.whenStable();
+
+      expect(page.getByRole('option').elements()).toHaveLength(1);
+    });
+
+    it('should hide added widgets from the catalog when configured', async () => {
+      fixture.componentRef.setInput('widgetCatalog', [createTestingWidget('First', 'first')]);
+      fixture.componentRef.setInput('hideAddedWidgetsFromCatalog', true);
+      grid.visibleWidgetInstances$.next([{ id: 'instance-1', widgetId: 'first' }]);
+
+      component.showWidgetCatalog();
+      await fixture.whenStable();
+
+      expect(page.getByRole('option').elements()).toHaveLength(0);
     });
 
     it('addWidgetAction action shall call showWidgetCatalog()', () => {

--- a/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.ts
+++ b/projects/dashboards-ng/src/components/flexible-dashboard/si-flexible-dashboard.component.ts
@@ -99,6 +99,15 @@ export class SiFlexibleDashboardComponent implements OnInit, OnChanges, OnDestro
   readonly widgetCatalog = input<Widget[]>([]);
 
   /**
+   * Whether widgets already added to the dashboard are hidden from the widget catalog.
+   *
+   * @defaultValue false
+   */
+  readonly hideAddedWidgetsFromCatalog = input(false, {
+    transform: booleanAttribute
+  });
+
+  /**
    * Option to remove the add widget instance button from the primary toolbar.
    *
    * @defaultValue false
@@ -296,7 +305,17 @@ export class SiFlexibleDashboardComponent implements OnInit, OnChanges, OnDestro
         })
       ]
     });
-    catalogRef.instance.widgetList.set(this.widgetCatalog());
+    const widgetCatalog = this.widgetCatalog();
+    if (this.hideAddedWidgetsFromCatalog()) {
+      const addedWidgetIds = new Set(
+        this.grid().visibleWidgetInstances$.value.map(widget => widget.widgetId)
+      );
+      catalogRef.instance.widgetList.set(
+        widgetCatalog.filter(widget => !addedWidgetIds.has(widget.id))
+      );
+    } else {
+      catalogRef.instance.widgetList.set(widgetCatalog);
+    }
   }
 
   protected onModified(event: boolean): void {


### PR DESCRIPTION
Add `hideAddedWidgetsFromCatalog` optional input to prevent already-added widget types from appearing in the catalog.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2694/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2694/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2694/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2694/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2694/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2694/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2694/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2694/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2694/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2694/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


