### PR TITLE
test(carousel): stabilize snapshot navigation

### DIFF
--- a/playwright/e2e/element-examples/carousel.spec.ts
+++ b/playwright/e2e/element-examples/carousel.spec.ts
@@ -23,6 +23,18 @@ test.describe('si-carousel', () => {
     );
   };
 
+  // Carousel navigation uses a requestAnimationFrame loop, which is not exposed
+  // through document.getAnimations(). In snapshot-update mode Playwright can
+  // therefore capture the page while the viewport is still scrolling. The
+  // component removes its temporary inline scroll behavior once that loop has
+  // settled, giving the test a deterministic completion signal.
+  const waitForNavigationToSettle = async (page: Page): Promise<void> => {
+    const viewport = page.locator('si-carousel .carousel-viewport');
+    await expect
+      .poll(() => viewport.evaluate(element => element.style.scrollSnapType))
+      .toBe('');
+  };
+
   test(example, async ({ page, si }) => {
     await si.visitExample(example, false);
     await expect(page.locator('si-carousel')).toBeVisible();
@@ -55,6 +67,7 @@ test.describe('si-carousel', () => {
     for (let i = 0; i < 5; i++) {
       await nextButton.click();
     }
+    await waitForNavigationToSettle(page);
     await expect(page.locator('button[aria-label^="Slide 6 of"] span').first()).toHaveClass(
       /active/
     );
@@ -64,6 +77,7 @@ test.describe('si-carousel', () => {
     for (let i = 0; i < 3; i++) {
       await nextButton.click();
     }
+    await waitForNavigationToSettle(page);
     await expect(page.locator('button[aria-label^="Slide 9 of"] span').first()).toHaveClass(
       /active/
     );


### PR DESCRIPTION
Wait for requestAnimationFrame-driven carousel scrolling to settle before capturing navigated slides. This prevents snapshot updates from capturing the carousel mid-scroll.

## Verification

- `AGENT=1 ./e2e-local.sh update carousel.spec.ts '--project=element-examples/*'` (10 passed)<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2695/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2695/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2695/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2695/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2695/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2695/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2695/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2695/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2695/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2695/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
