### PR TITLE
fix(ag-grid): restore pinned row shadows

### DIFF
--- a/playwright/snapshots/static.spec.ts-snapshots/ag-grid--ag-grid-row-pinning-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/ag-grid--ag-grid-row-pinning-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:19f758952563f5b0dee75cc1b2200387e1a77953524e500d13f46bbdbfde26aa
-size 52181
+oid sha256:7379f21f9e62057be2f6f274e9b2211c69ba9bde8f7ca400ac5a21dc99e3d75f
+size 52548

--- a/playwright/snapshots/static.spec.ts-snapshots/ag-grid--ag-grid-row-pinning-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/ag-grid--ag-grid-row-pinning-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a974f4c226f23f0ca15c8e01a2757f3c61b2754b8de340a98fec5b016549846
-size 47681
+oid sha256:527833a6113f875f575ca93e18519bf68e16e6267efbe7cff6e7ffef62131d56
+size 48000

--- a/projects/element-ng/ag-grid/parts/pinning-style.part.ts
+++ b/projects/element-ng/ag-grid/parts/pinning-style.part.ts
@@ -7,26 +7,22 @@ import { createPart, type Part } from 'ag-grid-community';
 
 /**
  * Creates a pinning style part for the Element AG Grid theme.
- * This part applies box shadow styling to floating top and bottom rows.
+ * This part applies box shadow styling to pinned top and bottom rows.
  *
  * @returns A part that defines pinning styles for the Element AG Grid theme.
  */
 export const elementPinningStyle: Part = createPart({
   css: `
-  .ag-floating-top {
+  .ag-grid-pinned-top-rows-container {
     box-shadow:
       0 0 8px var(--element-box-shadow-color-1),
       0 8px 8px var(--element-box-shadow-color-2);
-    z-index: 1;
-    position: relative;
   }
 
-  .ag-floating-bottom {
+  .ag-grid-pinned-bottom-rows-container {
     box-shadow:
       0 0 8px var(--element-box-shadow-color-1),
       0 -8px 8px var(--element-box-shadow-color-2);
-    z-index: 1;
-    position: relative;
   }
 `
 });


### PR DESCRIPTION
## Summary

Restore shadows on AG Grid pinned top and bottom rows by targeting the container classes rendered by current AG Grid versions.

The previous selectors no longer matched the generated DOM. The fix keeps the existing `--element-box-shadow-color-1` and `--element-box-shadow-color-2` tokens and directional shadow values. It also preserves AG Grid's native sticky positioning and stacking order.

## Validation

- Prettier
- ESLint
- `git diff --check`
- Verified the row-pinning example in the live preview: the pinned top container resolves the expected shadow and remains `position: sticky`
- `pnpm lib:test --no-watch` ran without observed failures but exceeded the 120-second harness timeout before completing
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2696/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2696/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2696/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2696/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2696/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2696/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2696/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2696/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2696/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2696/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


