### PR TITLE
fix(result-details-list): ensure running state changes don't cause a …

### DIFF
--- a/projects/element-ng/result-details-list/si-result-details-list.component.html
+++ b/projects/element-ng/result-details-list/si-result-details-list.component.html
@@ -4,37 +4,35 @@
       class="position-relative d-flex align-items-center timeline px-6 py-5"
       [class.text-accent]="step.state === 'running'"
     >
-      @if (step.state === 'running') {
-        <si-loading-spinner class="me-4" />
-      } @else {
-        @if (step.icon) {
-          <si-icon class="me-4 icon" [icon]="step.icon" />
+      <div class="icon-stack icon me-4">
+        @if (step.state === 'running') {
+          <si-loading-spinner />
         } @else {
-          @switch (step.state) {
-            @case ('passed') {
-              <span class="me-4 icon icon-stack">
+          @if (step.icon) {
+            <si-icon [icon]="step.icon" />
+          } @else {
+            @switch (step.state) {
+              @case ('passed') {
                 <si-icon class="status-success" [icon]="icons.elementCircleFilled" />
                 <si-icon class="status-critical-contrast" [icon]="icons.elementStateTick" />
-              </span>
-            }
-            @case ('failed') {
-              <span class="me-4 icon icon-stack">
+              }
+              @case ('failed') {
                 <si-icon class="status-danger" [icon]="icons.elementCircleFilled" />
                 <si-icon
                   class="status-critical-contrast"
                   [icon]="icons.elementStateExclamationMark"
                 />
-              </span>
-            }
-            @case ('not-started') {
-              <si-icon class="me-4 icon" [icon]="icons.elementNotChecked" />
-            }
-            @default {
-              <si-icon class="me-4 icon" [icon]="icons.elementOutOfService" />
+              }
+              @case ('not-started') {
+                <si-icon [icon]="icons.elementNotChecked" />
+              }
+              @default {
+                <si-icon [icon]="icons.elementOutOfService" />
+              }
             }
           }
         }
-      }
+      </div>
 
       <div class="d-flex flex-column justify-content-center w-100 overflow-hidden">
         <div class="d-flex">

--- a/projects/element-ng/result-details-list/si-result-details-list.component.scss
+++ b/projects/element-ng/result-details-list/si-result-details-list.component.scss
@@ -7,6 +7,7 @@ $si-result-details-list-timeline-width: 1px;
 si-loading-spinner {
   --loading-spinner-size: #{variables.$si-icon-font-size};
   --loading-spinner-color: #{variables.$si-sys-text-accent};
+  line-height: 0;
 }
 
 .result-description {

--- a/src/app/examples/si-result-details-list/si-result-details-list-playground.html
+++ b/src/app/examples/si-result-details-list/si-result-details-list-playground.html
@@ -1,0 +1,13 @@
+<si-result-details-list class="d-block background-1" [steps]="steps()" />
+<div class="card mt-6 e2e-ignore">
+  <div class="card-header">Control panel</div>
+  <div class="card-body">
+    <div class="row">
+      <div class="col-sm-3">
+        <si-form-item label="Show progress" class="mb-0">
+          <input type="checkbox" class="form-check-input" [formControl]="progressState" />
+        </si-form-item>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/examples/si-result-details-list/si-result-details-list-playground.ts
+++ b/src/app/examples/si-result-details-list/si-result-details-list-playground.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, computed } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { SiFormItemComponent } from '@siemens/element-ng/form';
+import {
+  ResultDetailStep,
+  SiResultDetailsListComponent
+} from '@siemens/element-ng/result-details-list';
+
+@Component({
+  selector: 'app-sample',
+  imports: [ReactiveFormsModule, SiResultDetailsListComponent, SiFormItemComponent],
+  templateUrl: './si-result-details-list-playground.html',
+  host: { class: 'p-5' }
+})
+export class SampleComponent {
+  protected readonly steps = computed<ResultDetailStep[]>(() => [
+    {
+      description: 'Volume flow sensor',
+      state: 'passed',
+      detail: 'Additional detail about state'
+    },
+    {
+      description: 'Maximum differential pressure',
+      state: 'passed',
+      value: '4 kPa'
+    },
+    {
+      description: 'Maximum volume flow',
+      state: 'failed',
+      errorMessage: 'Cannot reach maximum volume flow',
+      value: '20 m³/h'
+    },
+    {
+      description: 'Nominal volume flow',
+      state: this.showProgress() ? 'running' : 'not-started'
+    },
+    {
+      description: 'Nominal differential pressure',
+      state: 'not-started'
+    },
+    {
+      description: 'A not supported step',
+      state: 'not-supported'
+    },
+    {
+      description: 'A step with a custom icon',
+      state: 'failed',
+      icon: 'element-lock'
+    }
+  ]);
+  readonly progressState = new FormControl<boolean>(true, { nonNullable: true });
+  readonly showProgress = toSignal(this.progressState.valueChanges, {
+    initialValue: this.progressState.value
+  });
+}


### PR DESCRIPTION
…layout shifts

See https://code.siemens.com/simpl/simpl-element/-/work_items/2728

**Problem:**

The `si-loading-spinner` use Angular `animate.leave` to fade out the spinner. In combination with the result-details-list this cause the problem that the spinner and the state icons are visible the same time when the user switch from `running` -> any other state.  

**Solution:**

We stack the icon means the two icons can be in the DOM at the same time but don't lead to a layout shift.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2706/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2706/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2706/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2706/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2706/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2706/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2706/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2706/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2706/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2706/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

