### PR TITLE
fixup(forms): use margin utility for form checks

### DIFF
--- a/docs/components/forms-inputs/checkbox.md
+++ b/docs/components/forms-inputs/checkbox.md
@@ -92,7 +92,7 @@ If a `si-form-item` component cannot be used, it is also possible to use
 the checkbox with native HTML elements only:
 
 ```html
-<div class="form-check">
+<div class="form-check mb-2">
   <input type="checkbox" id="check-id" class="form-check-input" />
   <label for="check-id" class="form-check-label">Checkbox</label>
 </div>

--- a/docs/components/forms-inputs/forms.md
+++ b/docs/components/forms-inputs/forms.md
@@ -352,7 +352,7 @@ Internally, a form field is basically structured like this:
 For checkboxes and radios, it uses `form-check` instead of the `form-control` class:
 
 ```html
-<div class="form-check">
+<div class="form-check mb-2">
   <input class="form-check-input" id="input" type="checkbox|radio" />
   <label class="form-check-label" for="input">Label</label>
 </div>

--- a/docs/components/forms-inputs/radio.md
+++ b/docs/components/forms-inputs/radio.md
@@ -97,7 +97,7 @@ If a `si-form-item` component cannot be used, it is also possible to use
 a radio button with native HTML elements only:
 
 ```html
-<div class="form-check">
+<div class="form-check mb-2">
   <input type="radio" id="check-id" class="form-check-input" />
   <label for="check-id" class="form-check-label">Radio button</label>
 </div>

--- a/docs/components/forms-inputs/switch.md
+++ b/docs/components/forms-inputs/switch.md
@@ -88,7 +88,7 @@ If a `si-form-item` component cannot be used, it is also possible to use
 a switch with native HTML elements only:
 
 ```html
-<div class="form-check form-switch">
+<div class="form-check mb-2 form-switch">
   <input type="checkbox" id="check-id" class="form-check-input" />
   <label for="check-id" class="form-check-label">Switch</label>
 </div>

--- a/projects/element-ng/date-range-filter/si-date-range-filter.component.html
+++ b/projects/element-ng/date-range-filter/si-date-range-filter.component.html
@@ -70,7 +70,7 @@
   }
 
   @if (advancedMode() || !hideAdvancedMode()) {
-    <label class="form-switch form-check ms-6">
+    <label class="form-switch form-check mb-2 ms-6">
       <input
         type="checkbox"
         class="form-check-input"
@@ -166,7 +166,7 @@
         />
       </si-calendar-button>
     </label>
-    <label class="ms-4 mt-5 text-nowrap form-check">
+    <label class="ms-4 mt-5 text-nowrap form-check mb-2">
       <input
         type="checkbox"
         class="form-check-input"

--- a/projects/element-ng/form/form-fieldset/si-form-fieldset.component.html
+++ b/projects/element-ng/form/form-fieldset/si-form-fieldset.component.html
@@ -3,7 +3,9 @@
   <ng-content select="[si-help-button]" />
 </div>
 <div>
-  <ng-content />
+  <div [class]="inline() ? '' : 'd-flex flex-column gap-2 mb-2'">
+    <ng-content />
+  </div>
   @if (hasOnlyRadios()) {
     <div class="invalid-feedback" [class.d-block]="touched()">
       @for (error of errors(); track error) {

--- a/projects/element-ng/formly/wrapper/si-formly-fieldset.component.html
+++ b/projects/element-ng/formly/wrapper/si-formly-fieldset.component.html
@@ -1,5 +1,7 @@
 <si-form-fieldset [label]="label!" [labelWidth]="labelWidth" [required]="props.required">
-  <ng-template #fieldComponent />
+  <div class="d-flex flex-column gap-2 mt-n2">
+    <ng-template #fieldComponent />
+  </div>
   <div class="invalid-feedback" [class.d-block]="showError">
     <formly-validation-message [field]="field" />
   </div>

--- a/projects/element-ng/formly/wrapper/si-formly-wrapper.component.html
+++ b/projects/element-ng/formly/wrapper/si-formly-wrapper.component.html
@@ -4,7 +4,12 @@
   [labelWidth]="labelWidth"
   [required]="props.required"
 >
-  <div class="w-100" siFormlyFormFieldProvider [field]="field">
+  <div
+    class="w-100"
+    siFormlyFormFieldProvider
+    [class.mb-2]="field.type === 'checkbox'"
+    [field]="field"
+  >
     <ng-template #fieldComponent />
     <div class="invalid-feedback" [class.d-block]="showError">
       <!-- This string is hard-coded in the bootstrap fields. -->

--- a/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.html
+++ b/projects/element-ng/tree-view/si-tree-view-item/si-tree-view-item.component.html
@@ -128,7 +128,7 @@
       }
       <ng-container
         [ngTemplateOutlet]="checkboxOrOption"
-        [ngTemplateOutletContext]="{ classNames: 'form-check' }"
+        [ngTemplateOutletContext]="{ classNames: 'form-check mb-2' }"
       />
 
       <p class="mb-0">{{ treeItem.label | translate }}</p>

--- a/projects/element-theme/src/styles/bootstrap/forms/_form-check.scss
+++ b/projects/element-theme/src/styles/bootstrap/forms/_form-check.scss
@@ -26,7 +26,6 @@ $form-check-label-start: calc($form-check-size + map.get(spacers.$spacers-inline
 .form-check {
   padding-block: map.get(spacers.$spacers-block, 1);
   padding-inline-start: calc($form-check-size + map.get(spacers.$spacers-inline, 4));
-  margin-block-end: map.get(spacers.$spacers-block, 2);
 
   @extend %form-check-spacing;
 
@@ -37,7 +36,6 @@ $form-check-label-start: calc($form-check-size + map.get(spacers.$spacers-inline
 
 .form-check-inline {
   display: inline-block;
-  margin-block-end: 0;
   margin-inline-end: variables.$form-check-inline-margin-end;
   @extend %form-check-spacing;
 }

--- a/src/app/examples/buttons/buttons.html
+++ b/src/app/examples/buttons/buttons.html
@@ -318,7 +318,7 @@
   </div>
 
   <div class="d-inline-block background-1 p-5 mt-auto rounded-3 e2e-ignore">
-    <div class="form-check form-switch">
+    <div class="form-check mb-2 form-switch">
       <input
         type="checkbox"
         class="form-check-input"

--- a/src/app/examples/custom-form-elements/radio.html
+++ b/src/app/examples/custom-form-elements/radio.html
@@ -24,7 +24,7 @@
     <div class="invalid-feedback">Example invalid feedback text</div>
     <div class="valid-feedback">Example valid feedback text</div>
   </div>
-  <div class="form-check">
+  <div class="form-check mb-2">
     <input
       type="radio"
       id="custom-radio-3"

--- a/src/app/examples/si-card/si-card.html
+++ b/src/app/examples/si-card/si-card.html
@@ -167,7 +167,7 @@
     </div>
   </div>
   <div class="mt-2 e2e-ignore">
-    <div class="form-check">
+    <div class="form-check mb-2">
       <input
         type="checkbox"
         class="form-check-input"
@@ -177,7 +177,7 @@
       />
       <label class="form-check-label" for="enable-primary-actions">Enable primary actions</label>
     </div>
-    <div class="form-check">
+    <div class="form-check mb-2">
       <input
         type="checkbox"
         class="form-check-input"

--- a/src/app/examples/si-charts/interactive/interactive.html
+++ b/src/app/examples/si-charts/interactive/interactive.html
@@ -68,7 +68,7 @@
       <div class="card-body">
         <div class="mb-5 row">
           <div class="col">
-            <div class="form-check form-switch">
+            <div class="form-check mb-2 form-switch">
               <input
                 class="form-check-input col-sm-2"
                 type="checkbox"
@@ -83,7 +83,7 @@
         </div>
         <div class="mb-5 row">
           <div class="col">
-            <div class="form-check form-switch">
+            <div class="form-check mb-2 form-switch">
               <input
                 class="form-check-input col-sm-2"
                 type="checkbox"
@@ -98,7 +98,7 @@
         </div>
         <div class="mb-5 row">
           <div class="col">
-            <div class="form-check form-switch">
+            <div class="form-check mb-2 form-switch">
               <input
                 class="form-check-input col-sm-2"
                 type="checkbox"
@@ -113,7 +113,7 @@
         </div>
         <div class="mb-5 row">
           <div class="col">
-            <div class="form-check form-switch">
+            <div class="form-check mb-2 form-switch">
               <input
                 class="form-check-input col-sm-2"
                 type="checkbox"

--- a/src/app/examples/si-circle-status/si-circle-status.html
+++ b/src/app/examples/si-circle-status/si-circle-status.html
@@ -104,7 +104,7 @@
   </div>
 
   <div class="mt-6 e2e-ignore">
-    <div class="form-check">
+    <div class="form-check mb-2">
       <input type="checkbox" class="form-check-input" id="no-selection" [(ngModel)]="pulsing" />
       <label class="form-check-label" for="no-selection"
         >Check to simulate pulsing indication.</label

--- a/src/app/examples/si-dashboard/si-weather-widget-configurable.html
+++ b/src/app/examples/si-dashboard/si-weather-widget-configurable.html
@@ -206,7 +206,7 @@
           </select>
         </div>
 
-        <div class="col-12 form-check ms-2">
+        <div class="col-12 form-check mb-2 ms-2">
           <input
             id="cfg-metrics"
             class="form-check-input"
@@ -217,7 +217,7 @@
           />
           <label class="form-check-label" for="cfg-metrics">Show additional data</label>
         </div>
-        <div class="col-12 form-check ms-2">
+        <div class="col-12 form-check mb-2 ms-2">
           <input
             id="cfg-forecast"
             class="form-check-input"
@@ -228,7 +228,7 @@
           />
           <label class="form-check-label" for="cfg-forecast">Show forecast</label>
         </div>
-        <div class="col-12 form-check ms-2">
+        <div class="col-12 form-check mb-2 ms-2">
           <input
             id="cfg-fcols"
             class="form-check-input"
@@ -241,7 +241,7 @@
             Show forecast extra columns (vertical, manual mode)
           </label>
         </div>
-        <div class="col-12 form-check ms-2">
+        <div class="col-12 form-check mb-2 ms-2">
           <input
             id="cfg-loading"
             class="form-check-input"

--- a/src/app/examples/si-filter-settings/si-filter-settings.component.html
+++ b/src/app/examples/si-filter-settings/si-filter-settings.component.html
@@ -18,7 +18,7 @@
           </select>
         </div>
         <div class="col-6">
-          <div class="form-check">
+          <div class="form-check mb-2">
             <input
               class="form-check-input"
               type="checkbox"
@@ -30,7 +30,7 @@
             <label class="form-check-label" for="disableCheck">Disable</label>
           </div>
           @if (showIcon !== undefined) {
-            <div class="form-check">
+            <div class="form-check mb-2">
               <input
                 class="form-check-input"
                 type="checkbox"
@@ -43,7 +43,7 @@
             </div>
           }
           @if (disableFreeTextSearch !== undefined) {
-            <div class="form-check">
+            <div class="form-check mb-2">
               <input
                 class="form-check-input"
                 type="checkbox"

--- a/src/app/examples/si-loading-spinner/si-loading-spinner-delay.html
+++ b/src/app/examples/si-loading-spinner/si-loading-spinner-delay.html
@@ -33,7 +33,7 @@
     />
     <label class="form-check-label" for="enable-initial-delay">Enable initial delay</label>
   </div>
-  <div class="form-check">
+  <div class="form-check mb-2">
     <input
       type="checkbox"
       class="form-check-input"

--- a/src/app/examples/si-slider/si-slider-icon.html
+++ b/src/app/examples/si-slider/si-slider-icon.html
@@ -31,7 +31,7 @@
   </div>
   <div class="mb-6 row">
     <div class="offset-sm-2 col-sm-10">
-      <label class="form-check">
+      <label class="form-check mb-2">
         <input type="checkbox" class="form-check-input" name="disabled" [(ngModel)]="disabled" />
         <span class="form-check-label">Disabled</span>
       </label>

--- a/src/app/examples/si-slider/si-slider.html
+++ b/src/app/examples/si-slider/si-slider.html
@@ -33,7 +33,7 @@
   </div>
   <div class="mb-6 row">
     <div class="offset-sm-2 col-sm-10">
-      <label class="form-check">
+      <label class="form-check mb-2">
         <input type="checkbox" class="form-check-input" name="disabled" [(ngModel)]="disabled" />
         <span class="form-check-label">Disabled</span>
       </label>

--- a/src/app/examples/si-switch/si-switch.html
+++ b/src/app/examples/si-switch/si-switch.html
@@ -2,7 +2,7 @@
   <div class="mb-6 row">
     <div class="col-sm-2 col-form-label">Power</div>
     <div class="col-sm-10">
-      <div class="form-check form-switch py-4">
+      <div class="form-check mb-2 form-switch py-4">
         <input type="checkbox" class="form-check-input" role="switch" id="switch4" />
         <label for="switch4" class="form-check-label">This one's enabled</label>
       </div>
@@ -12,7 +12,7 @@
   <div class="mb-6 row">
     <div class="col-sm-2 col-form-label">Disabled</div>
     <div class="col-sm-10">
-      <div class="form-check form-switch py-4">
+      <div class="form-check mb-2 form-switch py-4">
         <input type="checkbox" class="form-check-input" role="switch" id="switch5" disabled />
         <label for="switch5" class="form-check-label">This one's disabled in off state</label>
       </div>
@@ -22,7 +22,7 @@
   <div class="mb-6 row">
     <div class="col-sm-2 col-form-label">Disabled (on)</div>
     <div class="col-sm-10">
-      <div class="form-check form-switch py-4">
+      <div class="form-check mb-2 form-switch py-4">
         <input
           type="checkbox"
           class="form-check-input"

--- a/src/app/examples/si-tabs/si-tabs-legacy.html
+++ b/src/app/examples/si-tabs/si-tabs-legacy.html
@@ -18,7 +18,7 @@
   }
   <si-tab-legacy heading="Deselectable">
     <p class="mt-4">Uncheck to prevent switching to another tab.</p>
-    <label class="form-check">
+    <label class="form-check mb-2">
       <input type="checkbox" class="form-check-input" [(ngModel)]="deselectable" />
       <span class="form-check-label">Enable tab switching</span>
     </label>

--- a/src/app/examples/si-tabs/si-tabs.html
+++ b/src/app/examples/si-tabs/si-tabs.html
@@ -14,7 +14,7 @@
   }
   <si-tab heading="Deselectable" [canDeactivate]="canDeactivate">
     <p class="mt-4">Uncheck to prevent switching to another tab.</p>
-    <label class="form-check">
+    <label class="form-check mb-2">
       <input type="checkbox" class="form-check-input" [(ngModel)]="deselectable" />
       <span class="form-check-label">Enable tab switching</span>
     </label>
@@ -22,7 +22,7 @@
 </si-tabset>
 
 <div class="e2e-ignore">
-  <label class="form-check">
+  <label class="form-check mb-2">
     <input type="checkbox" class="form-check-input" [(ngModel)]="activable" />
     <span class="form-check-label">Allow Lobby tab activation</span>
   </label>

--- a/src/app/examples/si-wizard/si-wizard-cancel-button.html
+++ b/src/app/examples/si-wizard/si-wizard-cancel-button.html
@@ -10,7 +10,7 @@
   >
     <h1 class="text-center">Step 2</h1>
     <div class="text-center">
-      <label class="form-check">
+      <label class="form-check mb-2">
         <input type="checkbox" class="form-check-input" [(ngModel)]="stepIsValid" />
         <span class="form-check-label">Check, if the step 2 is valid.</span>
       </label>

--- a/src/app/examples/si-wizard/si-wizard-failed.html
+++ b/src/app/examples/si-wizard/si-wizard-failed.html
@@ -11,7 +11,7 @@
   >
     <h1 class="text-center">Step 2</h1>
     <div class="text-center">
-      <label class="form-check">
+      <label class="form-check mb-2">
         <input type="checkbox" class="form-check-input" [(ngModel)]="stepIsValid" />
         <span class="form-check-label">Check, if the step 2 is valid.</span>
       </label>

--- a/src/app/examples/si-wizard/si-wizard-input-validation.html
+++ b/src/app/examples/si-wizard/si-wizard-input-validation.html
@@ -14,7 +14,7 @@
         />
       }
 
-      <label class="form-check">
+      <label class="form-check mb-2">
         <input
           type="checkbox"
           class="form-check-input"

--- a/src/app/examples/si-wizard/si-wizard-numbered-steps.html
+++ b/src/app/examples/si-wizard/si-wizard-numbered-steps.html
@@ -17,7 +17,7 @@
       <div class="card d-flex flex-column h-100 p-6">
         <h1 class="text-center">{{ step }}</h1>
         <p>Content with full height</p>
-        <label class="form-check">
+        <label class="form-check mb-2">
           <input type="checkbox" class="form-check-input" [(ngModel)]="stepIsValid" />
           <span class="form-check-label">Check, if the step is valid.</span>
         </label>

--- a/src/app/examples/si-wizard/si-wizard-show-completion-page.html
+++ b/src/app/examples/si-wizard/si-wizard-show-completion-page.html
@@ -14,7 +14,7 @@
   >
     <h1 class="text-center">Step 2</h1>
     <div class="text-center">
-      <label class="form-check">
+      <label class="form-check mb-2">
         <input type="checkbox" class="form-check-input" [(ngModel)]="stepIsValid" />
         <span class="form-check-label">Check, if the step 2 is valid.</span>
       </label>

--- a/src/app/examples/si-wizard/si-wizard-vertical.html
+++ b/src/app/examples/si-wizard/si-wizard-vertical.html
@@ -11,7 +11,7 @@
     >
       <h1 class="text-center">Step 2</h1>
       <div class="text-center">
-        <label class="form-check">
+        <label class="form-check mb-2">
           <input type="checkbox" class="form-check-input" [(ngModel)]="stepIsValid" />
           <span class="form-check-label">Check, if the step 2 is valid.</span>
         </label>

--- a/src/app/examples/si-wizard/si-wizard.html
+++ b/src/app/examples/si-wizard/si-wizard.html
@@ -10,7 +10,7 @@
   >
     <h1 class="text-center">Step 2</h1>
     <div class="text-center">
-      <label class="form-check">
+      <label class="form-check mb-2">
         <input type="checkbox" class="form-check-input" [(ngModel)]="stepIsValid" />
         <span class="form-check-label">Check, if the step 2 is valid.</span>
       </label>


### PR DESCRIPTION
## Summary

- remove the built-in block-end margin from `.form-check`
- apply `mb-2` explicitly where form-check spacing is required
- preserve grouped Formly spacing through utility-based fieldset layout
- update the native form-control documentation examples

## Verification

- `pnpm lib:test --include='**/form/si-form.spec.ts' --no-watch`
- `pnpm lib:test --include='**/form/si-form-field/si-form-field.component.spec.ts' --no-watch`
- `AGENT=1 ./e2e-local.sh vrt playwright/e2e/element-examples/si-formly-dynamic-fields.spec.ts '--project=element-examples/*'`
- Element examples VRT run: 696 passed; unrelated MapLibre rendering failed in light and dark mode
- Prettier, Stylelint, and `git diff --check`

No snapshots were updated.
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2710/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2710/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2710/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2710/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2710/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2710/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2710/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2710/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2710/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2710/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

