### PR TITLE
fixup(menu): prevent menu item content wrapping

### DIFF
--- a/projects/element-ng/menu/si-menu-item-checkbox.component.html
+++ b/projects/element-ng/menu/si-menu-item-checkbox.component.html
@@ -1,4 +1,4 @@
-<div class="item-wrapper">
+<div class="item-wrapper text-nowrap">
   @let iconValue = icon();
   @if (iconValue && !badgeDotHasContent()) {
     <si-icon class="icon" [class.badge-dot]="iconBadgeDot()" [icon]="iconValue" />

--- a/projects/element-ng/menu/si-menu-item-radio.component.html
+++ b/projects/element-ng/menu/si-menu-item-radio.component.html
@@ -1,4 +1,4 @@
-<div class="item-wrapper">
+<div class="item-wrapper text-nowrap">
   @let iconValue = icon();
   @if (iconValue && !badgeDotHasContent()) {
     <si-icon class="icon" [class.badge-dot]="iconBadgeDot()" [icon]="iconValue" />

--- a/projects/element-ng/menu/si-menu-item.component.html
+++ b/projects/element-ng/menu/si-menu-item.component.html
@@ -1,4 +1,4 @@
-<div class="item-wrapper">
+<div class="item-wrapper text-nowrap">
   @let iconValue = icon();
   @if (iconValue && !badgeDotHasContent()) {
     <si-icon class="icon" [class.badge-dot]="iconBadgeDot()" [icon]="iconValue" />


### PR DESCRIPTION
Prevent standard, checkbox, and radio menu item content from wrapping by applying the existing `text-nowrap` utility to their item wrappers. This covers both regular menus and menu bars.

Verified in the running `si-menu/si-menu` and `si-menu/si-menu-bar` examples.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2711/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2711/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2711/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2711/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2711/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2711/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2711/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2711/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2711/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2711/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
