### PR TITLE
fix(filtered-search): prevent vertical stretching

### DIFF
--- a/projects/element-ng/filtered-search/si-filtered-search.component.scss
+++ b/projects/element-ng/filtered-search/si-filtered-search.component.scss
@@ -21,6 +21,7 @@ $filtered-search-criteria-margin: map.get(variables.$spacers-block, 2);
 
   display: flex;
   align-items: center;
+  block-size: fit-content;
   line-height: $filtered-search-line-height;
   // This is necessary to prevent the filtered-search from overflowing when it is used within the main-detail-layout
   min-inline-size: 0;


### PR DESCRIPTION
Set the filtered search host block size to `fit-content` so it keeps its intrinsic height instead of stretching vertically.

Tests were not run because this is a CSS-only change.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2715/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2715/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2715/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2715/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2715/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2715/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2715/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2715/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2715/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2715/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
