### PR TITLE
fix(dashboards): translate widget card heading aria label

### DIFF
--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.html
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.html
@@ -30,7 +30,7 @@
     [attr.tabindex]="editable() ? 0 : null"
     [attr.role]="editable() ? 'application' : null"
     [attr.aria-roledescription]="editable() ? 'widget' : null"
-    [attr.aria-label]="editable() ? widgetConfig().heading : null"
+    [attr.aria-label]="editable() ? (widgetConfig().heading | translate) : null"
     [attr.aria-description]="editable() ? (a11yWidgetDescription | translate) : null"
     [expandText]="labelExpand"
     [restoreText]="labelRestore"

--- a/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
+++ b/projects/dashboards-ng/src/components/widget-host/si-widget-host.component.spec.ts
@@ -13,6 +13,7 @@ import {
   SiActionDialogService
 } from '@siemens/element-ng/action-modal';
 import { MenuItemAction } from '@siemens/element-ng/menu';
+import { injectSiTranslateService } from '@siemens/element-translate-ng/translate';
 import { GridItemHTMLElement } from 'gridstack';
 import { firstValueFrom, Observable, Subject } from 'rxjs';
 import { page, userEvent } from 'vitest/browser';
@@ -261,6 +262,18 @@ describe('SiWidgetHostComponent', () => {
 
     it('should set tabindex on card when editable', () => {
       expect(cardEl.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('should use the translated heading as the card aria-label when editable', async () => {
+      const translateService = TestBed.runInInjectionContext(() => injectSiTranslateService());
+      vi.spyOn(translateService, 'translate').mockReturnValueOnce('Translated widget heading');
+      fixture.componentRef.setInput('widgetConfig', {
+        ...TEST_WIDGET_CONFIG_0,
+        heading: 'WIDGET.HEADING'
+      });
+      await fixture.whenStable();
+
+      expect(cardEl).toHaveAttribute('aria-label', 'Translated widget heading');
     });
 
     it('should not set tabindex on card when not editable', () => {


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2719/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2719/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2719/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2719/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2719/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2719/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2719/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2719/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2719/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2719/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
