### PR TITLE
build(release): add release notes preview script

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,5 +1,7 @@
-import writerOpts from './tools/semantic-release/writer-opts.js';
-import { commitTypes, releaseRules } from './tools/semantic-release/config.js';
+import {
+  commitAnalyzerConfig,
+  releaseNotesGeneratorConfig
+} from './tools/semantic-release/config.js';
 
 const skipCommits = process.env.SKIP_COMMIT === 'true';
 
@@ -42,30 +44,8 @@ export default {
     }
   ],
   plugins: [
-    [
-      '@semantic-release/commit-analyzer',
-      {
-        preset: 'angular',
-        releaseRules,
-        parserOpts: {
-          noteKeywords: ['BREAKING CHANGE']
-        },
-        presetConfig: {
-          types: commitTypes
-        }
-      }
-    ],
-    [
-      '@semantic-release/release-notes-generator',
-      {
-        preset: 'angular',
-        parserOpts: {
-          noteKeywords: ['BREAKING CHANGE', 'NOTE', 'DEPRECATED'],
-          issuePrefixes: ['#', 'gh-', 'CVE-']
-        },
-        writerOpts
-      }
-    ],
+    ['@semantic-release/commit-analyzer', commitAnalyzerConfig],
+    ['@semantic-release/release-notes-generator', releaseNotesGeneratorConfig],
     ...(skipCommits ? [] : ['@semantic-release/changelog']),
     // All package.json where the version needs to be updated
     ...pnpmPackageRoots.map(pkgRoot => [

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -106,6 +106,20 @@ Run the unit tests using the corresponding pnpm script:
 pnpm run <module-name>:test
 ```
 
+## Previewing release notes
+
+To preview the release notes that semantic-release would generate from the
+currently checked-out branch, run:
+
+```shell
+node tools/semantic-release/preview.js
+```
+
+The script detects the current branch and prints the prospective release notes
+to standard output. It runs semantic-release in dry-run mode without prepare,
+publish, Git, or GitHub plugins, so it does not modify files, create tags, or
+publish a release.
+
 ## E2E Tests
 
 Our E2E tests are built with [Playwright](https://playwright.dev/).

--- a/tools/semantic-release/commit-config.js
+++ b/tools/semantic-release/commit-config.js
@@ -1,0 +1,42 @@
+// To reorder the types, simply change the order of the items
+export const commitTypes = [
+  { type: 'feat', section: 'Features' },
+  { type: 'fix', section: 'Bug Fixes' },
+  { type: 'perf', section: 'Performance Improvements' },
+  { type: 'revert', section: 'Reverts' },
+  { type: 'fixup', hidden: true },
+  { type: 'docs', hidden: true },
+  { type: 'style', hidden: true },
+  { type: 'refactor', hidden: true },
+  { type: 'test', hidden: true },
+  { type: 'build', hidden: true },
+  { type: 'ci', hidden: true },
+  { type: 'chore', hidden: true }
+];
+
+export const releaseRules = [
+  { breaking: true, release: 'major' },
+  { revert: true, release: 'patch' },
+  { type: 'feat', release: 'minor' },
+  { type: 'fix', release: 'patch' },
+  { type: 'perf', release: 'patch' }
+];
+
+// The angular preset does not parse the conventional commit `!` marker by default.
+export const parserOpts = {
+  headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
+  headerCorrespondence: ['type', 'scope', 'subject'],
+  breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+  // Require the uppercase `KEYWORD:` trailer form to avoid matching prose such as
+  // "Deprecated exports" or "note that" as separate release notes.
+  notesPattern: noteKeywords => new RegExp(`^[\\s*]*(${noteKeywords}):\\s+(.*)`)
+};
+
+// To reorder the notes, simply change the order of the items
+export const noteTitleMap = {
+  'NOTE': 'NOTES',
+  'BREAKING CHANGE': 'BREAKING CHANGES',
+  'DEPRECATED': 'DEPRECATIONS'
+};
+
+export const noteTitles = Object.values(noteTitleMap);

--- a/tools/semantic-release/config.js
+++ b/tools/semantic-release/config.js
@@ -1,32 +1,24 @@
-// To reorder the types, simply change the order of the items
-export const commitTypes = [
-  { type: 'feat', section: 'Features' },
-  { type: 'fix', section: 'Bug Fixes' },
-  { type: 'perf', section: 'Performance Improvements' },
-  { type: 'revert', section: 'Reverts' },
-  { type: 'fixup', hidden: true },
-  { type: 'docs', hidden: true },
-  { type: 'style', hidden: true },
-  { type: 'refactor', hidden: true },
-  { type: 'test', hidden: true },
-  { type: 'build', hidden: true },
-  { type: 'ci', hidden: true },
-  { type: 'chore', hidden: true }
-];
+import writerOpts from './writer-opts.js';
+import { commitTypes, parserOpts, releaseRules } from './commit-config.js';
 
-export const releaseRules = [
-  { breaking: true, release: 'major' },
-  { revert: true, release: 'patch' },
-  { type: 'feat', release: 'minor' },
-  { type: 'fix', release: 'patch' },
-  { type: 'perf', release: 'patch' }
-];
-
-// To reorder the notes, simply change the order of the items
-export const noteTitleMap = {
-  'NOTE': 'NOTES',
-  'BREAKING CHANGE': 'BREAKING CHANGES',
-  'DEPRECATED': 'DEPRECATIONS'
+export const commitAnalyzerConfig = {
+  preset: 'angular',
+  releaseRules,
+  parserOpts: {
+    ...parserOpts,
+    noteKeywords: ['BREAKING CHANGE']
+  },
+  presetConfig: {
+    types: commitTypes
+  }
 };
 
-export const noteTitles = Object.values(noteTitleMap);
+export const releaseNotesGeneratorConfig = {
+  preset: 'angular',
+  parserOpts: {
+    ...parserOpts,
+    noteKeywords: ['BREAKING CHANGE', 'NOTE', 'DEPRECATED'],
+    issuePrefixes: ['#', 'gh-', 'CVE-']
+  },
+  writerOpts
+};

--- a/tools/semantic-release/preview.js
+++ b/tools/semantic-release/preview.js
@@ -1,0 +1,45 @@
+import { execFileSync } from 'node:child_process';
+import { Writable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import semanticRelease from 'semantic-release';
+
+import { commitAnalyzerConfig, releaseNotesGeneratorConfig } from './config.js';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const branch = execFileSync('git', ['branch', '--show-current'], {
+  cwd: repositoryRoot,
+  encoding: 'utf8'
+}).trim();
+
+if (!branch) {
+  throw new Error('A checked-out Git branch is required to generate a release preview.');
+}
+
+const config = {
+  branches: [branch],
+  dryRun: true,
+  ci: false,
+  plugins: [
+    ['@semantic-release/commit-analyzer', commitAnalyzerConfig],
+    ['@semantic-release/release-notes-generator', releaseNotesGeneratorConfig]
+  ]
+};
+
+const silentOutput = new Writable({
+  write(_chunk, _encoding, callback) {
+    callback();
+  }
+});
+const result = await semanticRelease(config, {
+  cwd: repositoryRoot,
+  stdout: silentOutput,
+  stderr: process.stderr
+});
+
+if (result) {
+  process.stdout.write(result.nextRelease.notes);
+} else {
+  console.log('No release would be created from this branch.');
+}

--- a/tools/semantic-release/writer-opts.js
+++ b/tools/semantic-release/writer-opts.js
@@ -1,4 +1,4 @@
-import { noteTitleMap, noteTitles, commitTypes } from './config.js';
+import { commitTypes, noteTitleMap, noteTitles } from './commit-config.js';
 
 const COMMIT_HASH_LENGTH = 7;
 
@@ -21,7 +21,7 @@ function transform(commit) {
 
   const normalizedNotes = hasNotes
     ? commit.notes.map(note => ({
-        title: noteTitleMap[note.title],
+        title: noteTitleMap[note.title] ?? note.title,
         text: note.text.replace(/\n/g, '\n  ')
       }))
     : [];


### PR DESCRIPTION
## Summary

- add a read-only semantic-release script that previews release notes from any checked-out branch
- share commit-analyzer and release-notes-generator configuration between actual releases and previews
- correctly parse breaking commit headers and require explicit release-note trailer syntax
- document how to preview release notes locally

## Verification

- ran `node tools/semantic-release/preview.js`
- verified breaking features are grouped under Features and deprecation notes have valid headings
- ran Prettier and `git diff --check`
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2721/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2721/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2721/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2721/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2721/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2721/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2721/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2721/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2721/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2721/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
