### PR TITLE
docs: open version selector on click

### DIFF
--- a/docs/_src/version-selector.css
+++ b/docs/_src/version-selector.css
@@ -1,0 +1,22 @@
+/* Open the docs version selector on click, not hover.
+   MkDocs Material shows `.md-version__list` on :hover / :focus-within. */
+
+.md-version:hover .md-version__list,
+.md-version:focus-within .md-version__list {
+  max-height: 0;
+  opacity: 0;
+}
+
+.md-version.md-version--open .md-version__list {
+  max-height: 10rem;
+  opacity: 1;
+  transition:
+    max-height 0ms,
+    opacity 0.25s;
+}
+
+@media (hover: none), (pointer: coarse) {
+  .md-version:hover .md-version__list {
+    animation: none;
+  }
+}

--- a/docs/_src/version-selector.js
+++ b/docs/_src/version-selector.js
@@ -5,6 +5,7 @@
  * - Fetches versions.json from the root of the domain
  * - Supports absolute version URLs
  * - Preserves current page path when switching versions
+ * - Opens the version menu on click (not hover)
  * - Gracefully degrades if versions.json is not found (no errors, just no selector)
  *
  * If versions.json is not available (404), the page loads normally without the version selector.
@@ -102,9 +103,43 @@
     const current = versions.find(v => v.version === currentVersion) || versions[0];
     const visibleVersions = versions.filter(v => !v.hidden);
 
-    const html = `<div class="md-version"><button class="md-version__current" aria-label="Select version">${current.title}</button><ul class="md-version__list">${visibleVersions.map(version => `<li class="md-version__item"><a href="${buildVersionURL(version.version, currentVersion)}" class="md-version__link">${version.title}</a></li>`).join('')}</ul></div>`;
+    const html = `<div class="md-version"><button type="button" class="md-version__current" aria-label="Select version" aria-expanded="false" aria-haspopup="true" aria-controls="md-version-list">${current.title}</button><ul id="md-version-list" class="md-version__list">${visibleVersions.map(version => `<li class="md-version__item"><a href="${buildVersionURL(version.version, currentVersion)}" class="md-version__link">${version.title}</a></li>`).join('')}</ul></div>`;
 
     return html;
+  }
+
+  /**
+   * Open/close the version menu on click (Material CSS uses hover).
+   */
+  function bindVersionSelector(versionEl) {
+    const button = versionEl.querySelector('.md-version__current');
+    if (!button) {
+      return;
+    }
+
+    const setOpen = open => {
+      versionEl.classList.toggle('md-version--open', open);
+      button.setAttribute('aria-expanded', String(open));
+    };
+
+    const isOpen = () => versionEl.classList.contains('md-version--open');
+
+    button.addEventListener('click', () => {
+      setOpen(!isOpen());
+    });
+
+    document.addEventListener('click', event => {
+      if (isOpen() && !versionEl.contains(event.target)) {
+        setOpen(false);
+      }
+    });
+
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape' && isOpen()) {
+        setOpen(false);
+        button.focus();
+      }
+    });
   }
 
   /**
@@ -152,6 +187,11 @@
 
         // Append to .md-header
         header.appendChild(topicWrapper);
+
+        const versionEl = topicWrapper.querySelector('.md-version');
+        if (versionEl) {
+          bindVersionSelector(versionEl);
+        }
       })
       .catch(error => {
         console.error('[Version Selector] Failed to load:', error.message);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -236,6 +236,7 @@ theme:
 extra_css:
   - '_src/dos-and-donts.css'
   - '_src/color-grid.css'
+  - '_src/version-selector.css'
 
 extra_javascript:
   - '//w3.siemens.com/ote/ote_config.js'


### PR DESCRIPTION
Disable MkDocs Material hover-open so the docs version menu only expands on click, and close it on outside click or Escape.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2723/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2723/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2723/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2723/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2723/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2723/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2723/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2723/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2723/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2723/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
