### PR TITLE
feat(split)!: remove scale input in favour of unit

### DIFF
--- a/api-goldens/element-ng/list-details/index.api.md
+++ b/api-goldens/element-ng/list-details/index.api.md
@@ -39,10 +39,12 @@ export class SiDetailsPaneHeaderComponent {
 // @public (undocumented)
 export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
     readonly detailsActive: _angular_core.ModelSignal<boolean>;
+    readonly detailsUnit: _angular_core.InputSignal<SplitUnit>;
     readonly disableResizing: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly expandBreakpoint: _angular_core.InputSignal<number>;
     // (undocumented)
     readonly hasLargeSize: _angular_core.Signal<boolean>;
+    readonly listUnit: _angular_core.InputSignal<SplitUnit>;
     readonly listWidth: _angular_core.ModelSignal<number>;
     readonly minDetailsSize: _angular_core.InputSignal<number>;
     readonly minListSize: _angular_core.InputSignal<number>;

--- a/api-goldens/element-ng/main-detail-container/index.api.md
+++ b/api-goldens/element-ng/main-detail-container/index.api.md
@@ -17,6 +17,7 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
     readonly detailsActive: _angular_core.ModelSignal<boolean>;
     readonly detailsBackButtonText: _angular_core.InputSignal<TranslatableString>;
     readonly detailsHeading: _angular_core.InputSignal<TranslatableString>;
+    readonly detailUnit: _angular_core.InputSignal<SplitUnit>;
     hasLargeSize: boolean;
     readonly hasLargeSizeChange: _angular_core.OutputEmitterRef<boolean>;
     readonly heading: _angular_core.InputSignal<TranslatableString>;
@@ -24,6 +25,7 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
     readonly largeLayoutBreakpoint: _angular_core.InputSignal<number>;
     readonly mainContainerClass: _angular_core.InputSignal<string>;
     readonly mainContainerWidth: _angular_core.ModelSignal<number | "default">;
+    readonly mainUnit: _angular_core.InputSignal<SplitUnit>;
     readonly minDetailSize: _angular_core.InputSignal<number>;
     readonly minMainSize: _angular_core.InputSignal<number>;
     readonly resizableParts: _angular_core.InputSignalWithTransform<boolean, unknown>;

--- a/api-goldens/element-ng/split/index.api.md
+++ b/api-goldens/element-ng/split/index.api.md
@@ -31,9 +31,6 @@ export interface PartState {
 }
 
 // @public (undocumented)
-export type Scale = 'none' | 'auto';
-
-// @public (undocumented)
 export class SiSplitComponent {
     constructor();
     readonly gutterSize: _angular_core.InputSignal<number>;
@@ -64,7 +61,6 @@ export class SiSplitPartComponent {
     readonly heading: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly minSize: _angular_core.InputSignalWithTransform<number, unknown>;
     readonly removeContentOnCollapse: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly scale: _angular_core.InputSignal<Scale>;
     readonly showHeader: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly size: _angular_core.InputSignalWithTransform<number, string | number>;
     readonly stateChange: _angular_core.OutputEmitterRef<PartState>;

--- a/docs/components/layout-navigation/list-details.md
+++ b/docs/components/layout-navigation/list-details.md
@@ -197,6 +197,16 @@ The `slot` attribute accepts one of the following values:
 - `details`: Details pane
 - `detailActions`: Content actions for the details pane
 
+When `resizableParts` is enabled, the underlying split parts use the
+`mainUnit` and `detailUnit` inputs. The main part uses `unit="px"` by default
+and the detail part uses `unit="fr"` by default. The `mainContainerWidth` value
+is interpreted using `mainUnit`; for example, `300` means `300px` with the
+default configuration. Use `mainUnit="fr"` and `detailUnit="fr"` to retain a
+relative split, where `mainContainerWidth` is the main part's fractional weight.
+
+When the component is not resizable, `mainContainerWidth` continues to be
+interpreted as a percentage for the static layout.
+
 <si-docs-component example="si-main-detail-container/si-main-detail-container" height="500"></si-docs-component>
 
 <si-docs-api component="SiMainDetailContainerComponent"></si-docs-api>

--- a/docs/components/layout-navigation/list-details.md
+++ b/docs/components/layout-navigation/list-details.md
@@ -148,6 +148,16 @@ Inside the `<si-details-pane>` the following child components can be used:
 
 It is highly advised to use at least the `<si-details-pane-header>` to show the back button in a responsive (mobile) view.
 
+When resizing is enabled, the underlying split parts use the `listUnit` and
+`detailsUnit` inputs. The list pane uses `unit="px"` by default and the details
+pane uses `unit="fr"` by default. Accordingly, `listWidth` defaults to `300`
+and represents pixels with the default configuration.
+
+Use `listUnit="fr"` and `detailsUnit="fr"` to retain a relative split, where
+`listWidth` is the list pane's fractional weight. When resizing is disabled,
+`listWidth` continues to control the static layout as a percentage. Values
+outside the percentage range use the standard 32/68 static layout.
+
 If the content may exceed the available space, the `overflow-auto` class should be applied
 to the body components or a child inside them.
 

--- a/docs/components/layout-navigation/split.md
+++ b/docs/components/layout-navigation/split.md
@@ -108,11 +108,17 @@ import { SiSplitComponent, SiSplitPartComponent } from '@siemens/element-ng/spli
 })
 ```
 
-### Horizontal split with auto scale
+### Sizing
+
+Each `si-split-part` requires a numeric `size` and a `unit`. Use `unit="fr"`
+for a part that should scale with the available space. Use `unit="px"` for a
+part that should keep a fixed size while the split container changes size.
+
+### Horizontal split with fractional sizing
 
 <si-docs-component example="si-split/si-split-auto"></si-docs-component>
 
-### Horizontal split with mixed scale (none/auto)
+### Horizontal split with mixed fixed and fractional sizing
 
 <si-docs-component example="si-split/si-split-mixed"></si-docs-component>
 

--- a/projects/element-ng/list-details/si-details-pane/si-details-pane.component.ts
+++ b/projects/element-ng/list-details/si-details-pane/si-details-pane.component.ts
@@ -19,7 +19,7 @@ import { SiListDetailsComponent } from '../si-list-details.component';
     '[class.details-active]': 'parent.detailsActive() && !parent.hasLargeSize()',
     '[attr.inert]': '!parent.hasLargeSize() && !parent.detailsActive() ? "" : null',
     '[style.flex-basis.%]':
-      'parent.hasLargeSize() && parent.disableResizing() ?  100 - parent.listWidth() : undefined'
+      'parent.hasLargeSize() && parent.disableResizing() ? 100 - parent.staticListWidth() : undefined'
   }
 })
 export class SiDetailsPaneComponent {

--- a/projects/element-ng/list-details/si-list-details.component.html
+++ b/projects/element-ng/list-details/si-list-details.component.html
@@ -6,7 +6,7 @@
     (sizesChange)="onSplitSizesChange($event)"
   >
     <si-split-part
-      unit="fr"
+      [unit]="listUnit()"
       [size]="splitSizes()[0]"
       [showHeader]="false"
       [minSize]="minListSize()"
@@ -15,7 +15,7 @@
       <ng-container *ngTemplateOutlet="listTemplate" />
     </si-split-part>
     <si-split-part
-      unit="fr"
+      [unit]="detailsUnit()"
       [size]="splitSizes()[1]"
       [showHeader]="false"
       [minSize]="minDetailsSize()"

--- a/projects/element-ng/list-details/si-list-details.component.html
+++ b/projects/element-ng/list-details/si-list-details.component.html
@@ -6,7 +6,6 @@
     (sizesChange)="onSplitSizesChange($event)"
   >
     <si-split-part
-      scale="none"
       unit="fr"
       [size]="splitSizes()[0]"
       [showHeader]="false"
@@ -16,7 +15,6 @@
       <ng-container *ngTemplateOutlet="listTemplate" />
     </si-split-part>
     <si-split-part
-      scale="auto"
       unit="fr"
       [size]="splitSizes()[1]"
       [showHeader]="false"

--- a/projects/element-ng/list-details/si-list-details.component.spec.ts
+++ b/projects/element-ng/list-details/si-list-details.component.spec.ts
@@ -14,6 +14,7 @@ import {
   ElementDimensions,
   ResizeObserverService
 } from '../resize-observer';
+import { SiSplitPartComponent, SplitUnit } from '../split';
 import { SiDetailsPaneBodyComponent } from './si-details-pane-body/si-details-pane-body.component';
 import { SiDetailsPaneFooterComponent } from './si-details-pane-footer/si-details-pane-footer.component';
 import { SiDetailsPaneHeaderComponent } from './si-details-pane-header/si-details-pane-header.component';
@@ -37,6 +38,9 @@ import { SiListPaneComponent } from './si-list-pane/si-list-pane.component';
       stateId="si-list-details-1"
       [expandBreakpoint]="expandBreakpoint"
       [disableResizing]="disableResizing()"
+      [listUnit]="listUnit()"
+      [detailsUnit]="detailsUnit()"
+      [listWidth]="listWidth()"
       [(detailsActive)]="detailsActive"
     >
       <si-list-pane>
@@ -62,6 +66,9 @@ class WrapperComponent {
   readonly listDetails = viewChild.required(SiListDetailsComponent);
   readonly hideBackButton = signal(false);
   readonly disableResizing = signal(true);
+  readonly listUnit = signal<SplitUnit>('px');
+  readonly detailsUnit = signal<SplitUnit>('fr');
+  readonly listWidth = signal(300);
   readonly expandBreakpoint = BOOTSTRAP_BREAKPOINTS.mdMinimum;
   readonly detailsActive = signal(false);
 }
@@ -166,6 +173,9 @@ describe('ListDetailsComponent', () => {
     });
 
     it('should change listWidth when split sizes change', async () => {
+      component.listUnit.set('fr');
+      component.detailsUnit.set('fr');
+      component.listWidth.set(32);
       component.disableResizing.set(false);
       await fixture.whenStable();
 
@@ -181,6 +191,60 @@ describe('ListDetailsComponent', () => {
       fixture.detectChanges();
       await fixture.whenStable();
       expect(component.listDetails().listWidth()).not.toBe(listWidth);
+    });
+
+    it('should use px for the list and fr for details by default', async () => {
+      component.disableResizing.set(false);
+      await fixture.whenStable();
+
+      const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+      expect(parts[0]!.componentInstance.unit()).toBe('px');
+      expect(parts[0]!.componentInstance.size()).toBe(300);
+      expect(parts[1]!.componentInstance.unit()).toBe('fr');
+      expect(parts[1]!.componentInstance.size()).toBe(1);
+    });
+
+    it('should preserve relative sizing when both units are fr', async () => {
+      component.listUnit.set('fr');
+      component.detailsUnit.set('fr');
+      component.listWidth.set(40);
+      component.disableResizing.set(false);
+      await fixture.whenStable();
+
+      const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+      expect(parts[0]!.componentInstance.size()).toBe(40);
+      expect(parts[1]!.componentInstance.size()).toBe(60);
+    });
+
+    it('should use minimum sizes when both panes are fixed', async () => {
+      component.listUnit.set('px');
+      component.detailsUnit.set('px');
+      component.listWidth.set(320);
+      component.disableResizing.set(false);
+      await fixture.whenStable();
+
+      const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+      expect(parts[0]!.componentInstance.size()).toBe(320);
+      expect(parts[1]!.componentInstance.size()).toBe(300);
+    });
+
+    it('should use one fr when the list is flexible and details are fixed', async () => {
+      component.listUnit.set('fr');
+      component.detailsUnit.set('px');
+      component.disableResizing.set(false);
+      await fixture.whenStable();
+
+      const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+      expect(parts[0]!.componentInstance.size()).toBe(1);
+      expect(parts[1]!.componentInstance.size()).toBe(300);
+    });
+
+    it('should keep percentage sizing for the static layout', async () => {
+      component.listWidth.set(300);
+      await fixture.whenStable();
+
+      expect(getListPane().style.flexBasis).toBe('32%');
+      expect(getDetailsPane().style.flexBasis).toBe('68%');
     });
 
     it('should unset detailsActive when back button is clicked', async () => {

--- a/projects/element-ng/list-details/si-list-details.component.ts
+++ b/projects/element-ng/list-details/si-list-details.component.ts
@@ -24,7 +24,7 @@ import {
   ElementDimensions,
   ResizeObserverService
 } from '@siemens/element-ng/resize-observer';
-import { SiSplitComponent, SiSplitPartComponent } from '@siemens/element-ng/split';
+import { SiSplitComponent, SiSplitPartComponent, SplitUnit } from '@siemens/element-ng/split';
 import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 
 @Component({
@@ -41,7 +41,7 @@ import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 })
 export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   private resizeSubs?: Subscription;
-  private elementRef = inject(ElementRef);
+  private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private resizeObserver = inject(ResizeObserverService);
   private readonly listDetailsContainer = viewChild.required<ElementRef>('listDetailsContainer');
   protected readonly animationsGloballyDisabled = areAnimationsDisabled();
@@ -79,11 +79,29 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   readonly disableResizing = input(false, { transform: booleanAttribute });
 
   /**
-   * The percentage width of the list view of the overall component width.
+   * Unit used for the list split part when resizing is enabled.
    *
-   * @defaultValue 32
+   * @defaultValue 'px'
    */
-  readonly listWidth = model<number>(32);
+  readonly listUnit = input<SplitUnit>('px');
+
+  /**
+   * Unit used for the details split part when resizing is enabled.
+   *
+   * @defaultValue 'fr'
+   */
+  readonly detailsUnit = input<SplitUnit>('fr');
+
+  /**
+   * The initial size of the list split part when resizing is enabled.
+   * The value uses {@link listUnit}. With `listUnit="fr"` and
+   * `detailsUnit="fr"`, the value is treated as a percentage-like fractional
+   * weight. In the static layout, numeric values continue to represent a
+   * percentage.
+   *
+   * @defaultValue 300
+   */
+  readonly listWidth = model<number>(300);
 
   /**
    * Sets the minimal width of the list component in pixel.
@@ -105,10 +123,28 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
    */
   readonly stateId = input<string>();
 
-  protected readonly splitSizes = computed<[number, number]>(() => [
-    this.listWidth(),
-    100 - this.listWidth()
-  ]);
+  /** @internal */
+  readonly staticListWidth = computed(() => {
+    const listWidth = this.listWidth();
+    return listWidth >= 0 && listWidth <= 100 ? listWidth : 32;
+  });
+
+  protected readonly splitSizes = computed<[number, number]>(() => {
+    const listWidth = this.listWidth();
+    if (this.listUnit() === 'fr' && this.detailsUnit() === 'fr') {
+      const relativeListWidth = listWidth >= 0 && listWidth <= 100 ? listWidth : 32;
+      return [relativeListWidth, 100 - relativeListWidth];
+    }
+
+    const listSize =
+      this.listUnit() === 'fr'
+        ? this.detailsUnit() === 'px'
+          ? 1
+          : this.getRelativeListWidth()
+        : listWidth;
+    const detailsSize = this.detailsUnit() === 'px' ? this.minDetailsSize() : 1;
+    return [listSize, detailsSize];
+  });
 
   protected readonly listStateId = computed(() => {
     const stateId = this.stateId();
@@ -168,7 +204,28 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   private readonly resizeDimensions = signal<ElementDimensions | undefined>(undefined);
 
   protected onSplitSizesChange(sizes: number[]): void {
-    this.listWidth.set(sizes[0]);
+    if (this.listUnit() === 'px') {
+      this.listWidth.set(this.getListSizePx(sizes[0]));
+    } else {
+      this.listWidth.set(sizes[0]);
+    }
+  }
+
+  private getRelativeListWidth(): number {
+    const listWidth = this.listWidth();
+    return listWidth >= 0 && listWidth <= 100 ? listWidth : 32;
+  }
+
+  private getListSizePx(fallbackPercentage: number): number {
+    const listPart = this.elementRef.nativeElement.querySelector<HTMLElement>('si-split-part');
+    const listWidth = listPart?.getBoundingClientRect().width;
+    if (listWidth) {
+      return listWidth;
+    }
+
+    const split = this.elementRef.nativeElement.querySelector<HTMLElement>('si-split');
+    const splitWidth = split?.getBoundingClientRect().width;
+    return splitWidth ? (splitWidth * fallbackPercentage) / 100 : fallbackPercentage;
   }
 
   /** @internal */

--- a/projects/element-ng/list-details/si-list-pane/si-list-pane.component.ts
+++ b/projects/element-ng/list-details/si-list-pane/si-list-pane.component.ts
@@ -17,7 +17,7 @@ import { SiListDetailsComponent } from '../si-list-details.component';
     '[attr.inert]': '!parent.hasLargeSize() && parent.detailsActive() ? "" : null',
     '[attr.tabindex]': '-1',
     '[style.flex-basis.%]':
-      'parent.hasLargeSize() && parent.disableResizing() ? parent.listWidth() : undefined'
+      'parent.hasLargeSize() && parent.disableResizing() ? parent.staticListWidth() : undefined'
   }
 })
 export class SiListPaneComponent {

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.html
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.html
@@ -8,7 +8,7 @@
       (sizesChange)="onSplitSizesChange($event)"
     >
       <si-split-part
-        unit="fr"
+        [unit]="mainUnit()"
         [size]="splitSizes[0]"
         [showHeader]="false"
         [minSize]="minMainSize()"
@@ -17,7 +17,7 @@
         <ng-container *ngTemplateOutlet="mainTemplate" />
       </si-split-part>
       <si-split-part
-        unit="fr"
+        [unit]="detailUnit()"
         [size]="splitSizes[1]"
         [showHeader]="false"
         [minSize]="minDetailSize()"

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.html
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.html
@@ -8,7 +8,6 @@
       (sizesChange)="onSplitSizesChange($event)"
     >
       <si-split-part
-        scale="none"
         unit="fr"
         [size]="splitSizes[0]"
         [showHeader]="false"
@@ -18,7 +17,6 @@
         <ng-container *ngTemplateOutlet="mainTemplate" />
       </si-split-part>
       <si-split-part
-        scale="auto"
         unit="fr"
         [size]="splitSizes[1]"
         [showHeader]="false"

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
@@ -13,6 +13,7 @@ import {
   ElementDimensions,
   ResizeObserverService
 } from '../resize-observer';
+import { SiSplitPartComponent, SplitUnit } from '../split';
 import { SiMainDetailContainerComponent } from './si-main-detail-container.component';
 
 @Component({
@@ -27,6 +28,9 @@ import { SiMainDetailContainerComponent } from './si-main-detail-container.compo
       [hideBackButton]="hideBackButton()"
       [largeLayoutBreakpoint]="largeLayoutBreakpoint"
       [resizableParts]="resizableParts()"
+      [mainUnit]="mainUnit()"
+      [detailUnit]="detailUnit()"
+      [mainContainerWidth]="mainContainerWidth()"
       [(detailsActive)]="detailsActive"
       (hasLargeSizeChange)="hasLargeSizeChanged($event)"
       (mainContainerWidthChange)="mainContainerWidthChanged($event)"
@@ -47,6 +51,9 @@ class WrapperComponent {
   readonly detailsHeading = signal('details-heading');
   readonly hideBackButton = signal(false);
   readonly resizableParts = signal(false);
+  readonly mainUnit = signal<SplitUnit>('px');
+  readonly detailUnit = signal<SplitUnit>('fr');
+  readonly mainContainerWidth = signal<number | 'default'>('default');
   largeLayoutBreakpoint = BOOTSTRAP_BREAKPOINTS.mdMinimum;
   readonly detailsActive = signal(false);
 
@@ -125,6 +132,49 @@ describe('MainDetailContainerComponent', () => {
 
     expect(htmlElement.querySelector('si-split')).toBeInTheDocument();
     expect(htmlElement.querySelectorAll('si-split-part')).toHaveLength(2);
+  });
+
+  it('should use px for the main part and fr for the detail part by default', async () => {
+    component.resizableParts.set(true);
+    await fixture.whenStable();
+
+    const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+    expect(parts[0]!.componentInstance.unit()).toBe('px');
+    expect(parts[0]!.componentInstance.size()).toBe(300);
+    expect(parts[1]!.componentInstance.unit()).toBe('fr');
+    expect(parts[1]!.componentInstance.size()).toBe(1);
+  });
+
+  it('should keep the existing relative split when both units are fr', async () => {
+    component.mainUnit.set('fr');
+    component.detailUnit.set('fr');
+    component.mainContainerWidth.set(40);
+    component.resizableParts.set(true);
+    await fixture.whenStable();
+
+    const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+    expect(parts[0]!.componentInstance.size()).toBe(40);
+    expect(parts[1]!.componentInstance.size()).toBe(60);
+  });
+
+  it('should use minimum sizes for fixed parts and one fr for a flexible detail part', async () => {
+    component.mainContainerWidth.set(320);
+    component.mainUnit.set('px');
+    component.detailUnit.set('px');
+    component.resizableParts.set(true);
+    await fixture.whenStable();
+
+    const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+    expect(parts[0]!.componentInstance.size()).toBe(320);
+    expect(parts[1]!.componentInstance.size()).toBe(300);
+  });
+
+  it('should keep the standard static layout for a px-sized main part', async () => {
+    component.mainContainerWidth.set(320);
+    await fixture.whenStable();
+
+    expect(getMainContainer().style.maxInlineSize).toBe('');
+    expect(getDetailContainer().style.maxInlineSize).toBe('');
   });
 
   it('should hide the heading component when heading input text is empty', async () => {

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
@@ -27,7 +27,7 @@ import {
   ElementDimensions,
   ResizeObserverService
 } from '@siemens/element-ng/resize-observer';
-import { SiSplitComponent, SiSplitPartComponent } from '@siemens/element-ng/split';
+import { SiSplitComponent, SiSplitPartComponent, SplitUnit } from '@siemens/element-ng/split';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { timer } from 'rxjs';
 
@@ -52,7 +52,7 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
   protected readonly icons = addIcons({ elementBack });
 
   private readonly animationDuration = 500;
-  private readonly elementRef = inject(ElementRef);
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly resizeObserver = inject(ResizeObserverService);
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly destroyRef = inject(DestroyRef);
@@ -162,10 +162,26 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
   readonly detailContainerClass = input('pb-6');
 
   /**
-   * The percentage width of the main container from the overall component width.
-   * Can be a number or `'default'`, which is 32% when {@link resizableParts} is active, otherwise 50%.
+   * Unit used for the main split part when {@link resizableParts} is enabled.
    *
-   * @defaultValue 'default'
+   * @defaultValue 'px'
+   */
+  readonly mainUnit = input<SplitUnit>('px');
+
+  /**
+   * Unit used for the detail split part when {@link resizableParts} is enabled.
+   *
+   * @defaultValue 'fr'
+   */
+  readonly detailUnit = input<SplitUnit>('fr');
+
+  /**
+   * The initial size of the main split part when {@link resizableParts} is enabled.
+   * The value uses {@link mainUnit}. With `mainUnit="fr"` and `detailUnit="fr"`,
+   * the value is treated as a percentage-like fractional weight. In the static
+   * layout, numeric values continue to represent a percentage.
+   *
+   * @defaultValue 'default', which uses {@link minMainSize} for `px`, `32` for two `fr` parts, and `1` otherwise.
    */
   readonly mainContainerWidth = model<number | 'default'>('default');
   /**
@@ -194,17 +210,22 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
 
   private readonly actualMainContainerWidth = computed(() => {
     const mainContainerWidth = this.mainContainerWidth();
-    return mainContainerWidth === 'default'
-      ? this.resizableParts()
-        ? 32
-        : 50
-      : mainContainerWidth;
+    if (mainContainerWidth !== 'default') {
+      return mainContainerWidth;
+    }
+
+    if (!this.resizableParts()) {
+      return 50;
+    }
+
+    if (this.mainUnit() === 'px') {
+      return this.minMainSize();
+    }
+
+    return this.detailUnit() === 'fr' ? 32 : 1;
   });
 
-  protected splitSizes: [number, number] = [
-    this.actualMainContainerWidth(),
-    100 - this.actualMainContainerWidth()
-  ];
+  protected splitSizes: [number, number] = this.getSplitSizes();
   // The max size to limit the main container in the static flex layout (if less than 50%), otherwise not set.
   protected maxMainSize: string = this.getMaxSize(0);
   // The max size to limit the detail container in the static flex layout (if less than 50%), otherwise not set.
@@ -229,8 +250,15 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
       this.updateDetailsFocusable();
       this.doAnimation(changes.detailsActive.currentValue);
     }
-    if (changes.mainContainerWidth || changes.resizableParts) {
-      this.splitSizes = [this.actualMainContainerWidth(), 100 - this.actualMainContainerWidth()];
+    if (
+      changes.mainContainerWidth ||
+      changes.resizableParts ||
+      changes.mainUnit ||
+      changes.detailUnit ||
+      changes.minMainSize ||
+      changes.minDetailSize
+    ) {
+      this.splitSizes = this.getSplitSizes();
       this.maxMainSize = this.getMaxSize(0);
       this.maxDetailSize = this.getMaxSize(1);
     }
@@ -244,7 +272,11 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
   }
 
   protected onSplitSizesChange(sizes: number[]): void {
-    this.mainContainerWidth.set(sizes[0]);
+    if (this.mainUnit() === 'px') {
+      this.mainContainerWidth.set(this.getMainSizePx(sizes[0]));
+    } else {
+      this.mainContainerWidth.set(sizes[0]);
+    }
   }
 
   protected detailsBackClicked(): void {
@@ -256,12 +288,45 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
    * Get the max size to limit in the static flex layout (if less than 50%), otherwise not set
    */
   private getMaxSize(part: 0 | 1): string {
-    return this.resizableParts() ||
-      this.mainContainerWidth() === 'default' ||
+    const mainContainerWidth = this.mainContainerWidth();
+    if (
+      this.resizableParts() ||
+      mainContainerWidth === 'default' ||
       !this.hasLargeSize ||
-      this.splitSizes[part] > 50
-      ? ''
-      : this.splitSizes[part] + '%';
+      mainContainerWidth < 0 ||
+      mainContainerWidth > 100
+    ) {
+      return '';
+    }
+
+    const size = part === 0 ? mainContainerWidth : 100 - mainContainerWidth;
+    return size > 50 ? '' : size + '%';
+  }
+
+  private getSplitSizes(): [number, number] {
+    if (!this.resizableParts()) {
+      const mainSize = this.actualMainContainerWidth();
+      return mainSize >= 0 && mainSize <= 100 ? [mainSize, 100 - mainSize] : [50, 50];
+    }
+
+    const mainSize = this.actualMainContainerWidth();
+    if (this.mainUnit() === 'fr' && this.detailUnit() === 'fr') {
+      return mainSize >= 0 && mainSize <= 100 ? [mainSize, 100 - mainSize] : [32, 68];
+    }
+
+    return [mainSize, this.detailUnit() === 'px' ? this.minDetailSize() : 1];
+  }
+
+  private getMainSizePx(fallbackPercentage: number): number {
+    const mainPart = this.elementRef.nativeElement.querySelector<HTMLElement>('si-split-part');
+    const mainWidth = mainPart?.getBoundingClientRect().width;
+    if (mainWidth) {
+      return mainWidth;
+    }
+
+    const split = this.elementRef.nativeElement.querySelector<HTMLElement>('si-split');
+    const splitWidth = split?.getBoundingClientRect().width;
+    return splitWidth ? (splitWidth * fallbackPercentage) / 100 : fallbackPercentage;
   }
 
   private determineLayout(dimensions: ElementDimensions): void {

--- a/projects/element-ng/schematics/ng-update/index.spec.ts
+++ b/projects/element-ng/schematics/ng-update/index.spec.ts
@@ -589,4 +589,126 @@ export class SplitComponent {}`
 })
 export class SplitComponent {}`);
   });
+
+  it('should migrate split scale inputs to units in inline templates', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  template: \`<si-split>
+  <si-split-part scale="auto" size="1">Flexible</si-split-part>
+  <si-split-part scale="none" size="240">Fixed</si-split-part>
+  <si-split-part scale="auto" size="2" unit="px">Explicit unit</si-split-part>
+</si-split>\`
+})
+export class SplitComponent {}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain('<si-split-part unit="fr" size="1"');
+    expect(component).toContain('<si-split-part unit="px" size="240"');
+    expect(component).toContain('<si-split-part size="2" unit="px"');
+    expect(component).not.toContain('scale=');
+  });
+
+  it('should migrate dynamic split scale bindings in external templates', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  templateUrl: './split.component.html'
+})
+export class SplitComponent {
+  readonly scale = 'auto';
+  getScale(): string {
+    return this.scale;
+  }
+}`,
+      '/projects/app/src/split.component.html': `<si-split>
+  <si-split-part [scale]="scale" size="1">Flexible</si-split-part>
+  <si-split-part [scale]="getScale()" size="240">Dynamic</si-split-part>
+</si-split>`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const template = tree.readContent('/projects/app/src/split.component.html');
+
+    expect(template).toContain(`<si-split-part [unit]="(scale) === 'none' ? 'px' : 'fr'" size="1"`);
+    expect(template).toContain(
+      `<si-split-part [unit]="(getScale()) === 'none' ? 'px' : 'fr'" size="240"`
+    );
+    expect(template).not.toContain('[scale]');
+  });
+
+  it('should preserve scale-derived units when migrating split sizes', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  template: \`<si-split [sizes]="[20, 80]">
+  <si-split-part scale="none">Fixed</si-split-part>
+  <si-split-part scale="auto">Flexible</si-split-part>
+</si-split>\`
+})
+export class SplitComponent {}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain('<si-split-part unit="px" size="20"');
+    expect(component).toContain('<si-split-part unit="fr" size="80"');
+    expect(component).not.toContain('[sizes]');
+    expect(component).not.toContain('scale=');
+  });
+
+  it('should migrate Scale type imports and literals', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+import { Scale } from '@siemens/element-ng/split';
+
+@Component({
+  selector: 'app-split',
+  template: ''
+})
+export class SplitComponent {
+  readonly scale: Scale = 'auto';
+}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain("import { SplitUnit } from '@siemens/element-ng/split';");
+    expect(component).toContain("readonly scale: SplitUnit = 'fr';");
+    expect(component).not.toContain('Scale');
+  });
+
+  it('should retain an existing SplitUnit import when removing Scale', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+import { Scale, SplitUnit } from '@siemens/element-ng/split';
+
+@Component({
+  selector: 'app-split',
+  template: ''
+})
+export class SplitComponent {
+  readonly scale: Scale = 'none';
+  readonly unit: SplitUnit = 'px';
+}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain("import { SplitUnit } from '@siemens/element-ng/split';");
+    expect(component).toContain("readonly scale: SplitUnit = 'px';");
+    expect(component).not.toContain('Scale');
+  });
 });

--- a/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
@@ -1,0 +1,429 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Rule, SchematicContext, Tree, UpdateRecorder } from '@angular-devkit/schematics';
+import type { Attribute } from '@angular/compiler';
+import { dirname, join } from 'path/posix';
+import ts from 'typescript';
+
+import { removeImportSpecifiers } from '../migrations/utilities/import-removal.js';
+import {
+  discoverSourceFiles,
+  findElement,
+  getInlineTemplates,
+  getTemplateUrl
+} from '../utils/index.js';
+
+const splitImportPath = /^@(siemens|simpl)\/element-ng\/split(?:\/index)?$/;
+const scaleAttributeNames = ['scale', '[scale]', 'bind-scale'];
+const unitAttributeNames = ['unit', '[unit]', 'bind-unit'];
+
+export const splitScaleMigrationRule = (options: { path: string }): Rule => {
+  return async (tree: Tree, context: SchematicContext) => {
+    const processedTemplates = new Set<string>();
+
+    for await (const discoveredSourceFile of discoverSourceFiles(tree, context, options.path)) {
+      const { path: filePath, sourceFile } = discoveredSourceFile;
+      const recorder = tree.beginUpdate(filePath);
+
+      migrateScaleTypes(sourceFile, recorder);
+      for (const template of getInlineTemplates(sourceFile)) {
+        migrateScaleTemplate(
+          sourceFile.text.substring(template.getStart() + 1, template.getEnd() - 1),
+          template.getStart() + 1,
+          recorder
+        );
+      }
+      tree.commitUpdate(recorder);
+
+      for (const templateUrl of getTemplateUrl(sourceFile)) {
+        const templatePath = join(dirname(filePath), templateUrl);
+        if (processedTemplates.has(templatePath) || !tree.exists(templatePath)) {
+          continue;
+        }
+
+        processedTemplates.add(templatePath);
+        const templateRecorder = tree.beginUpdate(templatePath);
+        migrateScaleTemplate(tree.read(templatePath)!.toString('utf-8'), 0, templateRecorder);
+        tree.commitUpdate(templateRecorder);
+      }
+    }
+
+    return tree;
+  };
+};
+
+const migrateScaleTemplate = (template: string, offset: number, recorder: UpdateRecorder): void => {
+  findElement(template, element => element.name === 'si-split-part').forEach(element => {
+    const scale = element.attrs.find(attribute => scaleAttributeNames.includes(attribute.name));
+    if (!scale) {
+      return;
+    }
+
+    const hasUnit = element.attrs.some(attribute => unitAttributeNames.includes(attribute.name));
+    if (hasUnit) {
+      removeAttribute(template, scale, offset, recorder);
+      return;
+    }
+
+    replaceAttribute(scale, getUnitAttribute(scale), offset, recorder);
+  });
+};
+
+const getUnitAttribute = (attribute: Attribute): string => {
+  if (attribute.name === 'scale') {
+    const interpolation = /^\s*{{([\s\S]*)}}\s*$/.exec(attribute.value);
+    if (interpolation) {
+      return formatBoundAttribute('unit', getUnitExpression(interpolation[1]!.trim()));
+    }
+
+    return `unit="${getScaleUnit(attribute.value)}"`;
+  }
+
+  const expression = getExpression(attribute.value);
+  if (expression && ts.isStringLiteral(expression)) {
+    return `unit="${getScaleUnit(expression.text)}"`;
+  }
+
+  return formatBoundAttribute('unit', getUnitExpression(attribute.value));
+};
+
+const getScaleUnit = (value: string): 'px' | 'fr' => (value.trim() === 'none' ? 'px' : 'fr');
+
+const getUnitExpression = (expression: string): string => {
+  const value = expression.trim();
+  return `(${value}) === 'none' ? 'px' : 'fr'`;
+};
+
+const formatBoundAttribute = (name: string, expression: string): string => {
+  const quote = expression.includes('"') && !expression.includes("'") ? "'" : '"';
+  const escapedExpression =
+    quote === '"' ? expression.replaceAll('"', '&quot;') : expression.replaceAll("'", '&#39;');
+  return `[${name}]=${quote}${escapedExpression}${quote}`;
+};
+
+const replaceAttribute = (
+  attribute: Attribute,
+  replacement: string,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  const start = attribute.sourceSpan.start.offset + offset;
+  recorder.remove(start, attribute.sourceSpan.end.offset - attribute.sourceSpan.start.offset);
+  recorder.insertLeft(start, replacement);
+};
+
+const removeAttribute = (
+  template: string,
+  attribute: Attribute,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  const start = attribute.sourceSpan.start.offset;
+  const end = attribute.sourceSpan.end.offset;
+  const lineStart = template.lastIndexOf('\n', start - 1) + 1;
+  const lineEnd = template.indexOf('\n', end);
+  const endOfLine = lineEnd === -1 ? template.length : lineEnd;
+
+  if (
+    template.slice(lineStart, start).trim() === '' &&
+    template.slice(end, endOfLine).trim() === ''
+  ) {
+    const removeEnd = lineEnd === -1 ? endOfLine : lineEnd + 1;
+    recorder.remove(lineStart + offset, removeEnd - lineStart);
+    return;
+  }
+
+  const removeStart = start > 0 && /\s/.test(template[start - 1]!) ? start - 1 : start;
+  recorder.remove(removeStart + offset, end - removeStart);
+};
+
+const migrateScaleTypes = (sourceFile: ts.SourceFile, recorder: UpdateRecorder): void => {
+  const scaleImports = sourceFile.statements.flatMap(statement => {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      !splitImportPath.test(statement.moduleSpecifier.text)
+    ) {
+      return [];
+    }
+
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
+      return [];
+    }
+
+    return namedBindings.elements
+      .filter(element => (element.propertyName?.text ?? element.name.text) === 'Scale')
+      .map(element => ({ declaration: statement, element }));
+  });
+
+  if (!scaleImports.length) {
+    return;
+  }
+
+  const scaleTypeNames = new Set(scaleImports.map(({ element }) => element.name.text));
+  collectScaleTypeAliases(sourceFile, scaleTypeNames);
+
+  const replacements = new Map<string, string>();
+  const importEdits: { start: number; width: number; replacement?: string }[] = [];
+  const existingUnit = findSplitUnitImport(sourceFile);
+
+  for (const { declaration, element } of scaleImports) {
+    if (existingUnit) {
+      replacements.set(element.name.text, existingUnit.name.text);
+      const edit = removeImportSpecifiers(sourceFile, declaration, [element]);
+      importEdits.push({
+        start: edit.start,
+        width: edit.width,
+        replacement: edit.newNode
+          ? ts.createPrinter().printNode(ts.EmitHint.Unspecified, edit.newNode, sourceFile)
+          : undefined
+      });
+      continue;
+    }
+
+    if (element.propertyName) {
+      importEdits.push({
+        start: element.propertyName.getStart(sourceFile),
+        width: element.propertyName.getWidth(sourceFile),
+        replacement: 'SplitUnit'
+      });
+      continue;
+    }
+
+    importEdits.push({
+      start: element.name.getStart(sourceFile),
+      width: element.name.getWidth(sourceFile),
+      replacement: 'SplitUnit'
+    });
+    replacements.set(element.name.text, 'SplitUnit');
+  }
+
+  for (const edit of importEdits) {
+    recorder.remove(edit.start, edit.width);
+    if (edit.replacement) {
+      recorder.insertLeft(edit.start, edit.replacement);
+    }
+  }
+
+  replaceScaleIdentifiers(sourceFile, replacements, recorder);
+  replaceScaleLiterals(sourceFile, scaleTypeNames, recorder);
+};
+
+const findSplitUnitImport = (sourceFile: ts.SourceFile): ts.ImportSpecifier | undefined => {
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      !splitImportPath.test(statement.moduleSpecifier.text)
+    ) {
+      continue;
+    }
+
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
+      continue;
+    }
+
+    const unit = namedBindings.elements.find(
+      element => (element.propertyName?.text ?? element.name.text) === 'SplitUnit'
+    );
+    if (unit) {
+      return unit;
+    }
+  }
+
+  return undefined;
+};
+
+const collectScaleTypeAliases = (sourceFile: ts.SourceFile, names: Set<string>): void => {
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const statement of sourceFile.statements) {
+      if (
+        ts.isTypeAliasDeclaration(statement) &&
+        typeContainsScale(statement.type, names) &&
+        !names.has(statement.name.text)
+      ) {
+        names.add(statement.name.text);
+        changed = true;
+      }
+    }
+  }
+};
+
+const typeContainsScale = (type: ts.TypeNode, names: Set<string>): boolean => {
+  let contains = false;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isTypeReferenceNode(node) &&
+      ts.isIdentifier(node.typeName) &&
+      names.has(node.typeName.text)
+    ) {
+      contains = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(type);
+  return contains;
+};
+
+const replaceScaleIdentifiers = (
+  sourceFile: ts.SourceFile,
+  replacements: Map<string, string>,
+  recorder: UpdateRecorder
+): void => {
+  if (!replacements.size) {
+    return;
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      return;
+    }
+
+    if (ts.isIdentifier(node)) {
+      const replacement = replacements.get(node.text);
+      if (replacement) {
+        recorder.remove(node.getStart(sourceFile), node.getWidth(sourceFile));
+        recorder.insertLeft(node.getStart(sourceFile), replacement);
+        return;
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  sourceFile.statements.forEach(statement => visit(statement));
+};
+
+const replaceScaleLiterals = (
+  sourceFile: ts.SourceFile,
+  scaleTypeNames: Set<string>,
+  recorder: UpdateRecorder
+): void => {
+  const typedNames = new Set<string>();
+  const literals = new Set<ts.StringLiteral>();
+
+  const collectLiterals = (node: ts.Node): void => {
+    if (ts.isStringLiteral(node) && (node.text === 'auto' || node.text === 'none')) {
+      literals.add(node);
+      return;
+    }
+    ts.forEachChild(node, collectLiterals);
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      if (node.type && typeContainsScale(node.type, scaleTypeNames)) {
+        typedNames.add(node.name.text);
+        if (node.initializer) {
+          collectLiterals(node.initializer);
+        }
+      }
+
+      if (
+        node.initializer &&
+        ts.isCallExpression(node.initializer) &&
+        node.initializer.typeArguments?.some(type => typeContainsScale(type, scaleTypeNames))
+      ) {
+        typedNames.add(node.name.text);
+        collectLiterals(node.initializer);
+      }
+    }
+
+    if (ts.isPropertyDeclaration(node) && ts.isIdentifier(node.name)) {
+      if (node.type && typeContainsScale(node.type, scaleTypeNames)) {
+        typedNames.add(node.name.text);
+        if (node.initializer) {
+          collectLiterals(node.initializer);
+        }
+      }
+    }
+
+    if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+      if (node.type && typeContainsScale(node.type, scaleTypeNames)) {
+        typedNames.add(node.name.text);
+      }
+    }
+
+    const isFunctionWithBody =
+      ts.isFunctionDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node);
+    if (isFunctionWithBody && node.type && typeContainsScale(node.type, scaleTypeNames)) {
+      if (node.body) {
+        const collectReturns = (child: ts.Node): void => {
+          if (ts.isReturnStatement(child) && child.expression) {
+            collectLiterals(child.expression);
+          }
+          ts.forEachChild(child, collectReturns);
+        };
+        collectReturns(node.body);
+      }
+    }
+
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      const root = getRootIdentifier(node.left);
+      if (root && typedNames.has(root)) {
+        collectLiterals(node.right);
+      }
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      (node.expression.name.text === 'set' || node.expression.name.text === 'update') &&
+      typedNames.has(getRootIdentifier(node.expression.expression) ?? '')
+    ) {
+      node.arguments.forEach(collectLiterals);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  sourceFile.statements.filter(statement => !ts.isImportDeclaration(statement)).forEach(visit);
+
+  literals.forEach(literal => {
+    const replacement = literal.text === 'auto' ? 'fr' : 'px';
+    const start = literal.getStart(sourceFile) + 1;
+    recorder.remove(start, literal.getWidth(sourceFile) - 2);
+    recorder.insertLeft(start, replacement);
+  });
+};
+
+const getRootIdentifier = (node: ts.Expression): string | undefined => {
+  if (ts.isIdentifier(node)) {
+    return node.text;
+  }
+
+  if (ts.isPropertyAccessExpression(node)) {
+    return node.name.text;
+  }
+
+  return undefined;
+};
+
+const getExpression = (value: string): ts.Expression | undefined => {
+  const statement = ts.createSourceFile(
+    'split-scale-expression.ts',
+    `const value = ${value};`,
+    ts.ScriptTarget.Latest,
+    true
+  ).statements[0];
+
+  if (!statement || !ts.isVariableStatement(statement)) {
+    return undefined;
+  }
+
+  return statement.declarationList.declarations[0]?.initializer;
+};

--- a/projects/element-ng/schematics/ng-update/migrate-split-sizes.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-sizes.ts
@@ -69,9 +69,13 @@ const migrateSplitSizes = (template: string, offset: number, recorder: UpdateRec
         return;
       }
 
+      const hasUnit = parts[index]!.attrs.some(attribute =>
+        ['unit', '[unit]', 'bind-unit'].includes(attribute.name)
+      );
+      const unitAttribute = hasUnit ? '' : ' unit="fr"';
       const sizeAttribute = literalSizes
-        ? ` size="${literalSizes[index]}" unit="fr"`
-        : ` [size]="${getIndexedSizeExpression(sizes.value, index)}" unit="fr"`;
+        ? ` size="${literalSizes[index]}"${unitAttribute}`
+        : ` [size]="${getIndexedSizeExpression(sizes.value, index)}"${unitAttribute}`;
       const startTag = part.startSourceSpan.toString();
       const insertOffset = part.startSourceSpan.end.offset - (startTag.endsWith('/>') ? 2 : 1);
       recorder.insertLeft(insertOffset + offset, sizeAttribute);
@@ -138,7 +142,7 @@ const migrateMissingSplitUnit = (
 ): void => {
   findElement(template, element => element.name === 'si-split-part').forEach(part => {
     const hasSize = part.attrs.some(a => a.name === 'size' || a.name === '[size]');
-    const hasUnit = part.attrs.some(a => a.name === 'unit' || a.name === '[unit]');
+    const hasUnit = part.attrs.some(a => ['unit', '[unit]', 'bind-unit'].includes(a.name));
 
     if (!hasSize || hasUnit) {
       return;

--- a/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
@@ -12,6 +12,7 @@ import { contentFormatterMigrationRule } from './migrate-content-formatter.js';
 import { markdownRendererMigrationRule } from './migrate-markdown-renderer.js';
 import { spacerMigrationRule } from './migrate-spacers.js';
 import { splitCollapseMigrationRule } from './migrate-split-collapse.js';
+import { splitScaleMigrationRule } from './migrate-split-scale.js';
 import { splitSizesMigrationRule } from './migrate-split-sizes.js';
 
 export const migrateToV51 = (): Rule => {
@@ -22,6 +23,7 @@ export const migrateToV51 = (): Rule => {
     return chain([
       elementMigrationRule(options, migrationData),
       missingTranslateMigrationRule(options),
+      splitScaleMigrationRule(options),
       splitSizesMigrationRule(options),
       splitCollapseMigrationRule(options),
       contentFormatterMigrationRule(options),

--- a/projects/element-ng/split/si-split-part.component.ts
+++ b/projects/element-ng/split/si-split-part.component.ts
@@ -22,14 +22,7 @@ import { elementDoubleRight } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
-import {
-  Action,
-  CollapseTo,
-  PartState,
-  Scale,
-  SplitOrientation,
-  SplitUnit
-} from './si-split.interfaces';
+import { Action, CollapseTo, PartState, SplitOrientation, SplitUnit } from './si-split.interfaces';
 
 @Component({
   selector: 'si-split-part',
@@ -97,14 +90,6 @@ export class SiSplitPartComponent {
    * @defaultValue false
    */
   readonly removeContentOnCollapse = input(false, { transform: booleanAttribute });
-
-  /**
-   * Defines the behavior of the split part during scaling.
-   * E.g. when set to `none`, the spit part will keep its current size even when the parent container grows or shrinks.
-   *
-   * @defaultValue 'auto'
-   */
-  readonly scale = input<Scale>('auto');
 
   /**
    * Defines if the header of the split part is visible. Default is true.

--- a/projects/element-ng/split/si-split.component.spec.ts
+++ b/projects/element-ng/split/si-split.component.spec.ts
@@ -7,7 +7,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideSiUiState, SI_UI_STATE_SERVICE, UIStateStorage } from '@siemens/element-ng/common';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
 
-import { CollapseTo, PartState, Scale, SiSplitModule, SplitOrientation, SplitUnit } from './index';
+import { CollapseTo, PartState, SiSplitModule, SplitOrientation, SplitUnit } from './index';
 import { SiSplitPartComponent } from './si-split-part.component';
 import { SiSplitComponent as TestComponent } from './si-split.component';
 
@@ -49,7 +49,6 @@ class SynchronousMockStore implements UIStateStorage {
           [actions]="[]"
           [collapseToMinSize]="collapseToMinSize1()"
           [minSize]="minSize1()"
-          [scale]="scale1()"
           [size]="size1()"
           [unit]="unit1()"
           (collapseChanged)="collapseChanged1($event)"
@@ -69,7 +68,6 @@ class SynchronousMockStore implements UIStateStorage {
           [collapsible]="collapsible2()"
           [collapseToMinSize]="false"
           [minSize]="0"
-          [scale]="scale2()"
           [size]="size2()"
           [unit]="unit2()"
           [collapseOthers]="collapseOthers2()"
@@ -91,7 +89,6 @@ class SynchronousMockStore implements UIStateStorage {
             [collapsible]="collapsible3()"
             [collapseToMinSize]="false"
             [minSize]="minSize3()"
-            [scale]="scale3()"
             [size]="size3()"
             [unit]="unit3()"
             (collapseChanged)="collapseChanged3($event)"
@@ -115,18 +112,15 @@ class WrapperComponent {
   readonly splitPart1 = viewChild.required('splitPart1', { read: ElementRef });
   readonly collapseToMinSize1 = signal(false);
   readonly minSize1 = signal(0);
-  readonly scale1 = signal<Scale>('auto');
   readonly size1 = signal(0);
   readonly unit1 = signal<SplitUnit>('px');
   readonly splitPart2 = viewChild.required('splitPart2', { read: ElementRef });
   readonly collapsible2 = signal<CollapseTo>('to-start');
-  readonly scale2 = signal<Scale>('auto');
   readonly size2 = signal(0);
   readonly unit2 = signal<SplitUnit>('px');
   readonly splitPart3 = viewChild.required('splitPart3', { read: ElementRef });
   readonly collapsible3 = signal<CollapseTo>('to-start');
   readonly minSize3 = signal(0);
-  readonly scale3 = signal<Scale>('auto');
   readonly size3 = signal(0);
   readonly unit3 = signal<SplitUnit>('px');
   readonly showPart3 = signal(true);
@@ -639,9 +633,6 @@ describe('SiSplitComponent', () => {
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         wrapperComponent.minSize3.set(100);
-        wrapperComponent.scale1.set('none');
-        wrapperComponent.scale2.set('auto');
-        wrapperComponent.scale3.set('none');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
@@ -803,9 +794,6 @@ describe('SiSplitComponent', () => {
         wrapperComponent.orientation.set('vertical');
         wrapperComponent.setSizes([200, 150, 150], 'px');
         wrapperComponent.minSize1.set(100);
-        wrapperComponent.scale1.set('none');
-        wrapperComponent.scale2.set('auto');
-        wrapperComponent.scale3.set('none');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
@@ -820,12 +808,9 @@ describe('SiSplitComponent', () => {
         expect(wrapperComponent.measureSize3()).toBeCloseTo(150, 0);
       });
 
-      it('should display with set sizes and gutter size after changes with scale none', async () => {
+      it('should update configured pixel sizes after changes', async () => {
         wrapperComponent.orientation.set('vertical');
         wrapperComponent.setSizes([100, 300, 100], 'px');
-        wrapperComponent.scale1.set('none');
-        wrapperComponent.scale2.set('none');
-        wrapperComponent.scale3.set('none');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(100, 0);

--- a/projects/element-ng/split/si-split.interfaces.ts
+++ b/projects/element-ng/split/si-split.interfaces.ts
@@ -7,8 +7,6 @@ type CollapseTo = 'to-start' | 'to-end';
 type SplitOrientation = 'horizontal' | 'vertical';
 type SplitUnit = 'px' | 'fr';
 
-type Scale = 'none' | 'auto';
-
 interface Action {
   iconClass: string;
   tooltip: string;
@@ -20,4 +18,4 @@ interface PartState {
   size?: number;
 }
 
-export type { Action, CollapseTo, PartState, Scale, SplitOrientation, SplitUnit };
+export type { Action, CollapseTo, PartState, SplitOrientation, SplitUnit };

--- a/src/app/examples/si-list-details/si-list-details-router.html
+++ b/src/app/examples/si-list-details/si-list-details-router.html
@@ -2,6 +2,8 @@
   #container
   stateId="si-list-details-demo"
   class="p-6 px-md-9"
+  listUnit="fr"
+  detailsUnit="fr"
   [expandBreakpoint]="expandBreakpoint"
   [disableResizing]="disableResizing"
   [listWidth]="50"

--- a/src/app/examples/si-list-details/si-list-details.html
+++ b/src/app/examples/si-list-details/si-list-details.html
@@ -2,6 +2,8 @@
   #container
   stateId="si-list-details-demo"
   class="p-6 px-md-9"
+  listUnit="fr"
+  detailsUnit="fr"
   [expandBreakpoint]="expandBreakpoint"
   [disableResizing]="disableResizing"
   [listWidth]="50"

--- a/src/app/examples/si-main-detail-container/si-main-detail-container-block.html
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container-block.html
@@ -1,6 +1,8 @@
 <si-main-detail-container
   style="height: 500px"
   stateId="si-main-detail-demo"
+  mainUnit="fr"
+  detailUnit="fr"
   [style.maxWidth.px]="containerMaxWidth ? containerMaxWidth : null"
   [largeLayoutBreakpoint]="largeLayoutBreakpoint"
   [heading]="heading"

--- a/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.html
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.html
@@ -4,6 +4,8 @@
   detailsHeading="Details"
   resizableParts="true"
   truncateHeading="true"
+  mainUnit="fr"
+  detailUnit="fr"
   [largeLayoutBreakpoint]="largeLayoutBreakpoint"
   [mainContainerWidth]="50"
   [minMainSize]="200"

--- a/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.ts
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.ts
@@ -88,7 +88,7 @@ export class SampleComponent {
     this.logEvent(this.selectedEntities);
   }
 
-  onSplitChange(containerWidth: number | string): void {
+  onSplitChange(containerWidth: number | 'default'): void {
     this.logEvent(`Main width is ${containerWidth}%.`);
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     this.table().recalculate();

--- a/src/app/examples/si-main-detail-container/si-main-detail-container.html
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container.html
@@ -1,5 +1,7 @@
 <si-main-detail-container
   stateId="si-main-detail-demo"
+  mainUnit="fr"
+  detailUnit="fr"
   [style.maxWidth.px]="containerMaxWidth ? containerMaxWidth : null"
   [largeLayoutBreakpoint]="largeLayoutBreakpoint"
   [heading]="heading"

--- a/src/app/examples/si-main-detail-container/si-main-detail-container.ts
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container.ts
@@ -168,7 +168,7 @@ export class SampleComponent {
     });
   }
 
-  onSplitChange(containerWidth: number | string): void {
+  onSplitChange(containerWidth: number | 'default'): void {
     this.logEvent(`Main width is ${containerWidth}%.`);
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     this.table().recalculate();

--- a/src/app/examples/si-split/si-split-mixed.html
+++ b/src/app/examples/si-split/si-split-mixed.html
@@ -3,10 +3,9 @@
     heading="Filters"
     stateId="filters"
     collapsible="to-start"
-    scale="none"
     class="background-1"
-    size="20"
-    unit="fr"
+    size="200"
+    unit="px"
     [actions]="[
       { iconClass: 'element-edit', click: logEvent, tooltip: 'edit' },
       { iconClass: 'element-delete', click: logEvent, tooltip: 'delete' }
@@ -16,31 +15,22 @@
     <p class="p-4 text-secondary">Split Part #1</p>
   </si-split-part>
 
-  <si-split-part
-    heading="Employees"
-    stateId="employees"
-    scale="auto"
-    class="background-1"
-    size="60"
-    unit="fr"
-  >
+  <si-split-part heading="Employees" stateId="employees" class="background-1" size="1" unit="fr">
     <si-split orientation="vertical" stateId="vertical-split">
       <si-split-part
-        scale="none"
         stateId="middle-top"
         class="background-1"
-        size="40"
-        unit="fr"
+        size="100"
+        unit="px"
         [showHeader]="false"
         (stateChange)="logEvent(format('middle', $event))"
       >
         <p class="p-4 text-secondary">Split Part #2.1</p>
       </si-split-part>
       <si-split-part
-        scale="auto"
         stateId="middle-bottom"
         class="background-1"
-        size="60"
+        size="1"
         unit="fr"
         [showHeader]="false"
       >
@@ -53,10 +43,9 @@
     heading="Details"
     stateId="details"
     collapsible="to-end"
-    scale="none"
     class="background-1"
-    size="20"
-    unit="fr"
+    size="200"
+    unit="px"
     (stateChange)="logEvent(format('right', $event))"
   >
     <p class="p-4 text-secondary">Split Part #3</p>


### PR DESCRIPTION
BREAKING CHANGE: The `scale` input and exported `Scale` type have been removed from `si-split-part`.

Use `unit="fr"` for split parts that scale with the available space and `unit="px"` for split parts that keep a fixed size.

Before:

```html
<si-split>
  <si-split-part scale="auto">
    Flexible content
  </si-split-part>
  <si-split-part scale="none">
    Fixed content
  </si-split-part>
</si-split>
```

After:

```html
<si-split>
  <si-split-part size="1" unit="fr">
    Flexible content
  </si-split-part>
  <si-split-part size="240" unit="px">
    Fixed content
  </si-split-part>
</si-split>
```

Replace typed Scale values with SplitUnit, mapping 'auto' to 'fr' and 'none' to 'px'. The v51 ng-update schematic applies this migration automatically.

feat(main-detail-container): support configurable split 

Add `mainUnit` and `detailUnit` inputs to configure the units of the
underlying split parts.

The main part defaults to `px` and the detail part defaults to `fr`.
When resizing is enabled, `mainContainerWidth` is interpreted using
`mainUnit`. Use `mainUnit="fr"` and `detailUnit="fr"` to retain a
relative split. Static layouts continue to interpret
`mainContainerWidth` as a percentage.

feat(list-details)!: support configurable pane 

BREAKING CHANGE: Resizable list-details panes now use explicit sizing units.

The list pane defaults to `px`, the details pane defaults to `fr`, and
`listWidth` now defaults to `300`. In resizable layouts, numeric
`listWidth` values are interpreted using `listUnit`.

Before:

```html
<si-list-details [listWidth]="50" />

<! -- After, using the new fixed-list default: -->
<si-list-details [listWidth]="300" />
```

```html
<!-- To retain the previous relative layout: -->
<si-list-details
  [listWidth]="50"
  listUnit="fr"
  detailsUnit="fr"
/>
```
Static, non-resizable layouts continue to interpret listWidth as a
percentage.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2724/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2724/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2724/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2724/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2724/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2724/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2724/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2724/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2724/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2724/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

