### PR TITLE
docs: make version selector keyboard accessible

### DIFF
--- a/docs/_src/version-selector.css
+++ b/docs/_src/version-selector.css
@@ -1,22 +1,46 @@
-/* Open the docs version selector on click, not hover.
-   MkDocs Material shows `.md-version__list` on :hover / :focus-within. */
+/* Version selector: open on click/keyboard, not hover.
+   Overrides MkDocs Material's :hover / :focus-within open. */
+
+.md-version {
+  position: relative;
+  display: inline-block;
+  line-height: 1;
+}
 
 .md-version:hover .md-version__list,
 .md-version:focus-within .md-version__list {
   max-height: 0;
   opacity: 0;
+  visibility: hidden;
 }
 
 .md-version.md-version--open .md-version__list {
+  /* Below the button so a second click still hits the toggle. */
+  top: 100%;
+  inset-inline-end: 0;
+  inset-inline-start: auto;
+  z-index: 20;
   max-height: 10rem;
+  margin: 0;
+  overflow: auto;
   opacity: 1;
-  transition:
-    max-height 0ms,
-    opacity 0.25s;
+  visibility: visible;
+  pointer-events: auto;
+  background-color: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
 }
 
-@media (hover: none), (pointer: coarse) {
-  .md-version:hover .md-version__list {
-    animation: none;
-  }
+.md-version__list[hidden] {
+  display: none;
+}
+
+.md-version__current:focus-visible,
+.md-version__link:focus-visible {
+  outline: 2px solid var(--md-accent-fg-color);
+  outline-offset: 2px;
+}
+
+.md-version__link[aria-current='page'] {
+  font-weight: 700;
 }

--- a/docs/_src/version-selector.js
+++ b/docs/_src/version-selector.js
@@ -5,13 +5,13 @@
  * - Fetches versions.json from the root of the domain
  * - Supports absolute version URLs
  * - Preserves current page path when switching versions
- * - Opens the version menu on click (not hover)
+ * - Opens the version menu on click or keyboard, not hover
  * - Gracefully degrades if versions.json is not found (no errors, just no selector)
  *
  * If versions.json is not available (404), the page loads normally without the version selector.
  * No errors are thrown to ensure documentation remains accessible.
  *
- * Based on MkDocs Material's version selector implementation
+ * Based on MkDocs Material's version selector markup
  * https://github.com/squidfunk/mkdocs-material
  */
 
@@ -103,41 +103,70 @@
     const current = versions.find(v => v.version === currentVersion) || versions[0];
     const visibleVersions = versions.filter(v => !v.hidden);
 
-    const html = `<div class="md-version"><button type="button" class="md-version__current" aria-label="Select version" aria-expanded="false" aria-haspopup="true" aria-controls="md-version-list">${current.title}</button><ul id="md-version-list" class="md-version__list">${visibleVersions.map(version => `<li class="md-version__item"><a href="${buildVersionURL(version.version, currentVersion)}" class="md-version__link">${version.title}</a></li>`).join('')}</ul></div>`;
+    const items = visibleVersions
+      .map(version => {
+        const isCurrent = version.version === currentVersion;
+        const currentAttr = isCurrent ? ' aria-current="page"' : '';
+        const href = buildVersionURL(version.version, currentVersion);
+        return `<li class="md-version__item"><a href="${href}" class="md-version__link"${currentAttr}>${version.title}</a></li>`;
+      })
+      .join('');
 
-    return html;
+    return `<div class="md-version"><button type="button" class="md-version__current" aria-expanded="false" aria-controls="md-version-list">${current.title}</button><ul id="md-version-list" class="md-version__list" hidden>${items}</ul></div>`;
   }
 
   /**
-   * Open/close the version menu on click (Material CSS uses hover).
+   * Click/keyboard disclosure: no hover. Tab uses native link order.
    */
   function bindVersionSelector(versionEl) {
     const button = versionEl.querySelector('.md-version__current');
-    if (!button) {
+    const list = versionEl.querySelector('.md-version__list');
+    if (!button || !list) {
       return;
     }
 
     const setOpen = open => {
       versionEl.classList.toggle('md-version--open', open);
       button.setAttribute('aria-expanded', String(open));
+      list.hidden = !open;
     };
 
-    const isOpen = () => versionEl.classList.contains('md-version--open');
+    button.addEventListener('click', () => setOpen(list.hidden));
 
-    button.addEventListener('click', () => {
-      setOpen(!isOpen());
+    button.addEventListener('keydown', event => {
+      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+        return;
+      }
+      event.preventDefault();
+      setOpen(true);
+      requestAnimationFrame(() => {
+        (
+          list.querySelector('.md-version__link[aria-current="page"]') ||
+          list.querySelector('.md-version__link')
+        )?.focus();
+      });
     });
 
-    document.addEventListener('click', event => {
-      if (isOpen() && !versionEl.contains(event.target)) {
+    versionEl.addEventListener('keydown', event => {
+      if (event.key === 'Escape' && !list.hidden) {
+        event.preventDefault();
         setOpen(false);
+        button.focus();
       }
     });
 
-    document.addEventListener('keydown', event => {
-      if (event.key === 'Escape' && isOpen()) {
+    // Defer: Safari often reports relatedTarget as null on focusout.
+    versionEl.addEventListener('focusout', () => {
+      queueMicrotask(() => {
+        if (!versionEl.contains(document.activeElement)) {
+          setOpen(false);
+        }
+      });
+    });
+
+    document.addEventListener('pointerdown', event => {
+      if (!list.hidden && !versionEl.contains(event.target)) {
         setOpen(false);
-        button.focus();
       }
     });
   }


### PR DESCRIPTION
Follow-up to #2723. The click-only override also blocked the keyboard: Material opened the menu on `:hover` / `:focus-within`, and disabling that left no way to Tab into the list.

The version control is a small disclosure (not a combobox):

- Native button with `aria-expanded`, `aria-controls`, and `aria-label` (`Select version, current: …`)
- Real links in a `ul`, `hidden` when closed, `aria-current="page"` on the current version
- Click to toggle; hover does not open
- Tab through the links when open; ArrowUp/Down open and focus the current version; Escape closes and returns focus
- Close on `document` `focusin` (after focus has left) so Chrome does not hide the list while Tabbing, and Safari click is not cancelled by a null `relatedTarget`
- List sits flush under the button (`top: 100%`) so a second click still hits the toggle

Tested locally with `curl …/versions.json -o docs/versions.json` then `pnpm docs:serve`, in Chrome and Playwright WebKit. Real Safari still needs a Mac check.

Backports to v49 and v48 are intentionally not included yet.

<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2726/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2726/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2726/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2726/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2726/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2726/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2726/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2726/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2726/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2726/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->




