### PR TITLE
feat(split)!: remove scale input in favour of unit

### DIFF
--- a/api-goldens/element-ng/split/index.api.md
+++ b/api-goldens/element-ng/split/index.api.md
@@ -31,9 +31,6 @@ export interface PartState {
 }
 
 // @public (undocumented)
-export type Scale = 'none' | 'auto';
-
-// @public (undocumented)
 export class SiSplitComponent {
     constructor();
     readonly gutterSize: _angular_core.InputSignal<number>;
@@ -64,7 +61,6 @@ export class SiSplitPartComponent {
     readonly heading: _angular_core.InputSignal<TranslatableString | undefined>;
     readonly minSize: _angular_core.InputSignalWithTransform<number, unknown>;
     readonly removeContentOnCollapse: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly scale: _angular_core.InputSignal<Scale>;
     readonly showHeader: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly size: _angular_core.InputSignalWithTransform<number, string | number>;
     readonly stateChange: _angular_core.OutputEmitterRef<PartState>;

--- a/docs/components/layout-navigation/split.md
+++ b/docs/components/layout-navigation/split.md
@@ -108,11 +108,17 @@ import { SiSplitComponent, SiSplitPartComponent } from '@siemens/element-ng/spli
 })
 ```
 
-### Horizontal split with auto scale
+### Sizing
+
+Each `si-split-part` requires a numeric `size` and a `unit`. Use `unit="fr"`
+for a part that should scale with the available space. Use `unit="px"` for a
+part that should keep a fixed size while the split container changes size.
+
+### Horizontal split with fractional sizing
 
 <si-docs-component example="si-split/si-split-auto"></si-docs-component>
 
-### Horizontal split with mixed scale (none/auto)
+### Horizontal split with mixed fixed and fractional sizing
 
 <si-docs-component example="si-split/si-split-mixed"></si-docs-component>
 

--- a/playwright/snapshots/static.spec.ts-snapshots/si-split--si-split-mixed-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-split--si-split-mixed-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbf0883178e2daacaa294fa9e372fb673ebdbae480e68ade665c2a6949ca7e7f
-size 10827
+oid sha256:f62221145bd32988095a07d97b921eda13ec38d7f683bee68a9edc61afb6f09b
+size 10825

--- a/playwright/snapshots/static.spec.ts-snapshots/si-split--si-split-mixed-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-split--si-split-mixed-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9cd4b6dda71f5bd6815eb004d6e143d8be03fff2fab13a81ef7bb72b2c45a6de
-size 10910
+oid sha256:6efc9474db03694c904e5648bb87db7c9655026c807c3c1e29c713eb3f4d9556
+size 10913

--- a/projects/element-ng/list-details/si-list-details.component.html
+++ b/projects/element-ng/list-details/si-list-details.component.html
@@ -6,7 +6,6 @@
     (sizesChange)="onSplitSizesChange($event)"
   >
     <si-split-part
-      scale="none"
       unit="fr"
       [size]="splitSizes()[0]"
       [showHeader]="false"
@@ -16,7 +15,6 @@
       <ng-container *ngTemplateOutlet="listTemplate" />
     </si-split-part>
     <si-split-part
-      scale="auto"
       unit="fr"
       [size]="splitSizes()[1]"
       [showHeader]="false"

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.html
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.html
@@ -8,7 +8,6 @@
       (sizesChange)="onSplitSizesChange($event)"
     >
       <si-split-part
-        scale="none"
         unit="fr"
         [size]="splitSizes[0]"
         [showHeader]="false"
@@ -18,7 +17,6 @@
         <ng-container *ngTemplateOutlet="mainTemplate" />
       </si-split-part>
       <si-split-part
-        scale="auto"
         unit="fr"
         [size]="splitSizes[1]"
         [showHeader]="false"

--- a/projects/element-ng/schematics/ng-update/index.spec.ts
+++ b/projects/element-ng/schematics/ng-update/index.spec.ts
@@ -754,6 +754,33 @@ export class SplitComponent {
     expect(template).not.toContain("=== 'none'");
   });
 
+  it('should keep dynamic scale mappings valid after their values are migrated', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+import { Scale } from '@siemens/element-ng/split';
+
+const defaultScale: Scale = 'none';
+
+@Component({
+  selector: 'app-split',
+  template: \`<si-split-part [scale]="assertedScale" />
+<si-split-part [scale]="inheritedScale" />\`
+})
+export class SplitComponent {
+  readonly assertedScale = 'none' as Scale;
+  readonly inheritedScale = defaultScale;
+}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain("const defaultScale: SplitUnit = 'px';");
+    expect(component).toContain("readonly assertedScale = 'px' as SplitUnit;");
+    expect(component).toContain(`[unit]="['none', 'px'].includes(assertedScale) ? 'px' : 'fr'"`);
+    expect(component).toContain(`[unit]="['none', 'px'].includes(inheritedScale) ? 'px' : 'fr'"`);
+  });
+
   it('should scope inline template bindings to their owning component', async () => {
     addTestFiles(appTree, {
       '/projects/app/src/owners.ts': `import { Component, signal } from '@angular/core';

--- a/projects/element-ng/schematics/ng-update/index.spec.ts
+++ b/projects/element-ng/schematics/ng-update/index.spec.ts
@@ -614,6 +614,46 @@ export class SplitComponent {}`
     expect(component).not.toContain('scale=');
   });
 
+  it('should warn when static scale and unit inputs conflict', async () => {
+    const logSpy = vi.fn();
+    runner.logger.subscribe(logSpy);
+
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  template: \`<si-split>
+  <si-split-part unit="fr" scale="none">Fixed conflict</si-split-part>
+  <si-split-part unit="px" scale="auto">Flexible conflict</si-split-part>
+  <si-split-part unit="fr" scale="auto">Matching</si-split-part>
+  <si-split-part [unit]="unit" [scale]="scale">Dynamic</si-split-part>
+</si-split>\`
+})
+export class SplitComponent {
+  readonly unit = 'fr';
+  readonly scale = 'auto';
+}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toMatch(/<si-split-part unit="fr"[^>]*>Fixed conflict<\/si-split-part>/);
+    expect(component).toMatch(/<si-split-part unit="px"[^>]*>Flexible conflict<\/si-split-part>/);
+    expect(component).toMatch(/<si-split-part unit="fr"[^>]*>Matching<\/si-split-part>/);
+    expect(component).toMatch(/<si-split-part \[unit\]="unit"[^>]*>Dynamic<\/si-split-part>/);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'warn',
+        message: expect.stringContaining('projects/app/src/split.component.ts')
+      })
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('conflicting scale and unit') })
+    );
+  });
+
   it('should migrate dynamic split scale bindings in external templates', async () => {
     addTestFiles(appTree, {
       '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';

--- a/projects/element-ng/schematics/ng-update/index.spec.ts
+++ b/projects/element-ng/schematics/ng-update/index.spec.ts
@@ -589,4 +589,327 @@ export class SplitComponent {}`
 })
 export class SplitComponent {}`);
   });
+
+  it('should migrate split scale inputs to units in inline templates', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  template: \`<si-split>
+  <si-split-part scale="auto" size="1">Flexible</si-split-part>
+  <si-split-part scale="none" size="240">Fixed</si-split-part>
+  <si-split-part scale="auto" size="2" unit="px">Explicit unit</si-split-part>
+</si-split>\`
+})
+export class SplitComponent {}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain('<si-split-part unit="fr" size="1"');
+    expect(component).toContain('<si-split-part unit="px" size="240"');
+    expect(component).toContain('<si-split-part size="2" unit="px"');
+    expect(component).not.toContain('scale=');
+  });
+
+  it('should migrate dynamic split scale bindings in external templates', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  templateUrl: './split.component.html'
+})
+export class SplitComponent {
+  readonly scale = 'auto';
+  getScale(): string {
+    return this.scale;
+  }
+}`,
+      '/projects/app/src/split.component.html': `<si-split>
+  <si-split-part [scale]="scale" size="1">Flexible</si-split-part>
+  <si-split-part [scale]="getScale()" size="240">Dynamic</si-split-part>
+</si-split>`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const template = tree.readContent('/projects/app/src/split.component.html');
+
+    expect(template).toContain(`<si-split-part [unit]="(scale) === 'none' ? 'px' : 'fr'" size="1"`);
+    expect(template).toContain(
+      `<si-split-part [unit]="(getScale()) === 'none' ? 'px' : 'fr'" size="240"`
+    );
+    expect(template).not.toContain('[scale]');
+  });
+
+  it('should preserve scale-derived units when migrating split sizes', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-split',
+  template: \`<si-split [sizes]="[20, 80]">
+  <si-split-part scale="none">Fixed</si-split-part>
+  <si-split-part scale="auto">Flexible</si-split-part>
+</si-split>\`
+})
+export class SplitComponent {}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain('<si-split-part unit="px" size="20"');
+    expect(component).toContain('<si-split-part unit="fr" size="80"');
+    expect(component).not.toContain('[sizes]');
+    expect(component).not.toContain('scale=');
+  });
+
+  it('should migrate Scale type imports and literals', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+import { Scale } from '@siemens/element-ng/split';
+
+@Component({
+  selector: 'app-split',
+  template: ''
+})
+export class SplitComponent {
+  readonly scale: Scale = 'auto';
+}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain("import { SplitUnit } from '@siemens/element-ng/split';");
+    expect(component).toContain("readonly scale: SplitUnit = 'fr';");
+    expect(component).not.toContain('Scale');
+  });
+
+  it('should retain an existing SplitUnit import when removing Scale', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+import { Scale, SplitUnit } from '@siemens/element-ng/split';
+
+@Component({
+  selector: 'app-split',
+  template: ''
+})
+export class SplitComponent {
+  readonly scale: Scale = 'none';
+  readonly unit: SplitUnit = 'px';
+}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain("import { SplitUnit } from '@siemens/element-ng/split';");
+    expect(component).toContain("readonly scale: SplitUnit = 'px';");
+    expect(component).not.toContain('Scale');
+  });
+
+  it('should bind typed scale members directly as units', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+import { Scale } from '@siemens/element-ng/split';
+
+@Component({
+  selector: 'app-split',
+  templateUrl: './split.component.html'
+})
+export class SplitComponent {
+  readonly scale: Scale = 'none';
+
+  getScale(): Scale {
+    return this.scale;
+  }
+}`,
+      '/projects/app/src/split.component.html': `<si-split>
+  <si-split-part [scale]="scale" size="240">Property</si-split-part>
+  <si-split-part [scale]="getScale()" size="240">Method</si-split-part>
+</si-split>`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const template = tree.readContent('/projects/app/src/split.component.html');
+
+    expect(template).toContain('<si-split-part [unit]="scale" size="240"');
+    expect(template).toContain('<si-split-part [unit]="getScale()" size="240"');
+    expect(template).not.toContain("=== 'none'");
+  });
+
+  it('should scope inline template bindings to their owning component', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/owners.ts': `import { Component, signal } from '@angular/core';
+import { Scale } from '@siemens/element-ng/split';
+
+const localScale: Scale = 'none';
+@Component({ template: \`<si-split-part [scale]="scale()" /><si-split-part [scale]="this.scale()" />\` })
+export class TypedComponent {
+  readonly scale = signal<Scale>('none');
+}
+@Component({ template: \`<si-split-part [scale]="scale" /><si-split-part [scale]="localScale" />\` })
+export class UntypedComponent {
+  scale = 'none';
+  localScale = 'none';
+  method() {
+    const scale: Scale = 'none';
+    return scale;
+  }
+}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const source = tree.readContent('/projects/app/src/owners.ts');
+
+    expect(source).toContain('[unit]="scale()"');
+    expect(source).toContain('[unit]="this.scale()"');
+    expect(source).toContain(`[unit]="(scale) === 'none' ? 'px' : 'fr'"`);
+    expect(source).toContain(`[unit]="(localScale) === 'none' ? 'px' : 'fr'"`);
+  });
+
+  it('should not treat an unrelated object property as a migrated component member', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/object-owner.ts': `import { Component } from '@angular/core';
+import { Scale } from '@siemens/element-ng/split';
+@Component({ template: \`<si-split-part [scale]="config.scale" />\` })
+export class ObjectOwner {
+  scale: Scale = 'none';
+  config = { scale: 'none' };
+}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+
+    expect(tree.readContent('/projects/app/src/object-owner.ts')).toContain(
+      `[unit]="(config.scale) === 'none' ? 'px' : 'fr'"`
+    );
+  });
+
+  it.each([false, true])(
+    'should handle shared template owners regardless of order (reversed: %s)',
+    async reversed => {
+      const typed = `import { Component } from '@angular/core';
+import { Scale } from '@siemens/element-ng/split';
+@Component({ templateUrl: './shared.html' })
+export class TypedOwner { scale: Scale = 'none'; }`;
+      const untyped = `import { Component } from '@angular/core';
+@Component({ templateUrl: './shared.html' })
+export class UntypedOwner { scale = 'none'; }`;
+      addTestFiles(appTree, {
+        '/projects/app/src/first-owner.ts': reversed ? untyped : typed,
+        '/projects/app/src/second-owner.ts': reversed ? typed : untyped,
+        '/projects/app/src/shared.html': `<si-split-part [scale]="scale" />
+<si-split-part scale="{{scale}}" />
+<si-split-part scale="none" />`
+      });
+
+      const tree = await runner.runSchematic('migration-v51', {}, appTree);
+      const template = tree.readContent('/projects/app/src/shared.html');
+
+      expect(
+        template.match(/\[unit\]="\['none', 'px'\]\.includes\(scale\) \? 'px' : 'fr'"/g)
+      ).toHaveLength(2);
+      expect(template).toContain('unit="px"');
+      expect(template).not.toContain('scale=');
+    }
+  );
+
+  it('should keep direct bindings when shared template owners agree', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/shared-owners.ts': `import { Component } from '@angular/core';
+import { Scale } from '@siemens/element-ng/split';
+@Component({ templateUrl: './agreed.html' })
+export class FirstOwner { scale: Scale = 'none'; }
+@Component({ templateUrl: './agreed.html' })
+export class SecondOwner { scale: Scale = 'auto'; }`,
+      '/projects/app/src/agreed.html': '<si-split-part [scale]="scale" />'
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+
+    expect(tree.readContent('/projects/app/src/agreed.html')).toContain('[unit]="scale"');
+  });
+
+  it('should migrate Scale literals in class-field generic initializers', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component, signal } from '@angular/core';
+import { Scale } from '@siemens/element-ng/split';
+
+@Component({
+  selector: 'app-split',
+  template: ''
+})
+export class SplitComponent {
+  readonly scale = signal<Scale>('auto');
+}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain("readonly scale = signal<SplitUnit>('fr');");
+  });
+
+  it('should only migrate Scale-typed object properties', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+import { Scale } from '@siemens/element-ng/split';
+
+interface Config {
+  Scale: string;
+  scale: Scale;
+  objectFit: 'none' | 'contain';
+}
+
+const config: Config = {
+  scale: 'auto',
+  objectFit: 'none'
+};
+
+@Component({
+  selector: 'app-split',
+  template: ''
+})
+export class SplitComponent {
+  readonly config = config;
+}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain('Scale: string;');
+    expect(component).toContain('scale: SplitUnit;');
+    expect(component).toContain("scale: 'fr',");
+    expect(component).toContain("objectFit: 'none'");
+  });
+
+  it('should not rename unrelated Scale property names', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
+import { Scale } from '@siemens/element-ng/split';
+
+interface Config {
+  Scale: string;
+  split: Scale;
+}
+
+@Component({
+  selector: 'app-split',
+  template: ''
+})
+export class SplitComponent {}`
+    });
+
+    const tree = await runner.runSchematic('migration-v51', {}, appTree);
+    const component = tree.readContent('/projects/app/src/split.component.ts');
+
+    expect(component).toContain('Scale: string;');
+    expect(component).toContain('split: SplitUnit;');
+  });
 });

--- a/projects/element-ng/schematics/ng-update/index.spec.ts
+++ b/projects/element-ng/schematics/ng-update/index.spec.ts
@@ -644,7 +644,10 @@ export class SplitComponent {
     expect(template).not.toContain('[scale]');
   });
 
-  it('should preserve scale-derived units when migrating split sizes', async () => {
+  it('should preserve relative split sizes and warn about manual fixed sizing', async () => {
+    const logSpy = vi.fn();
+    runner.logger.subscribe(logSpy);
+
     addTestFiles(appTree, {
       '/projects/app/src/split.component.ts': `import { Component } from '@angular/core';
 
@@ -661,10 +664,19 @@ export class SplitComponent {}`
     const tree = await runner.runSchematic('migration-v51', {}, appTree);
     const component = tree.readContent('/projects/app/src/split.component.ts');
 
-    expect(component).toContain('<si-split-part unit="px" size="20"');
+    expect(component).toContain('<si-split-part unit="fr" size="20"');
     expect(component).toContain('<si-split-part unit="fr" size="80"');
     expect(component).not.toContain('[sizes]');
     expect(component).not.toContain('scale=');
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'warn',
+        message: expect.stringContaining('projects/app/src/split.component.ts')
+      })
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('scale="none"') })
+    );
   });
 
   it('should migrate Scale type imports and literals', async () => {

--- a/projects/element-ng/schematics/ng-update/index.spec.ts
+++ b/projects/element-ng/schematics/ng-update/index.spec.ts
@@ -677,9 +677,11 @@ export class SplitComponent {
     const tree = await runner.runSchematic('migration-v51', {}, appTree);
     const template = tree.readContent('/projects/app/src/split.component.html');
 
-    expect(template).toContain(`<si-split-part [unit]="(scale) === 'none' ? 'px' : 'fr'" size="1"`);
     expect(template).toContain(
-      `<si-split-part [unit]="(getScale()) === 'none' ? 'px' : 'fr'" size="240"`
+      `<si-split-part [unit]="['none', 'px'].includes(scale) ? 'px' : 'fr'" size="1"`
+    );
+    expect(template).toContain(
+      `<si-split-part [unit]="['none', 'px'].includes(getScale()) ? 'px' : 'fr'" size="240"`
     );
     expect(template).not.toContain('[scale]');
   });
@@ -847,8 +849,8 @@ export class UntypedComponent {
 
     expect(source).toContain('[unit]="scale()"');
     expect(source).toContain('[unit]="this.scale()"');
-    expect(source).toContain(`[unit]="(scale) === 'none' ? 'px' : 'fr'"`);
-    expect(source).toContain(`[unit]="(localScale) === 'none' ? 'px' : 'fr'"`);
+    expect(source).toContain(`[unit]="['none', 'px'].includes(scale) ? 'px' : 'fr'"`);
+    expect(source).toContain(`[unit]="['none', 'px'].includes(localScale) ? 'px' : 'fr'"`);
   });
 
   it('should not treat an unrelated object property as a migrated component member', async () => {
@@ -865,7 +867,7 @@ export class ObjectOwner {
     const tree = await runner.runSchematic('migration-v51', {}, appTree);
 
     expect(tree.readContent('/projects/app/src/object-owner.ts')).toContain(
-      `[unit]="(config.scale) === 'none' ? 'px' : 'fr'"`
+      `[unit]="['none', 'px'].includes(config.scale) ? 'px' : 'fr'"`
     );
   });
 

--- a/projects/element-ng/schematics/ng-update/migrate-split-collapse.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-collapse.ts
@@ -11,8 +11,12 @@ import ts from 'typescript';
 import {
   discoverSourceFiles,
   findElement,
+  formatBoundAttribute,
   getInlineTemplates,
-  getTemplateUrl
+  getTemplateUrl,
+  insertAttribute,
+  removeAttribute,
+  replaceAttribute
 } from '../utils/index.js';
 
 const collapseValues = new Map([
@@ -204,61 +208,6 @@ const getShowCollapseButtonExpression = (attribute: Attribute): string => {
 
 const getBooleanAttributeCondition = (expression: string): string =>
   `![false, null, undefined, 'false'].includes($any(${expression}))`;
-
-const formatBoundAttribute = (name: string, expression: string): string => {
-  const quote = expression.includes('"') && !expression.includes("'") ? "'" : '"';
-  const escapedExpression =
-    quote === '"' ? expression.replaceAll('"', '&quot;') : expression.replaceAll("'", '&#39;');
-  return `[${name}]=${quote}${escapedExpression}${quote}`;
-};
-
-const replaceAttribute = (
-  attribute: Attribute,
-  replacement: string,
-  offset: number,
-  recorder: UpdateRecorder
-): void => {
-  const start = attribute.sourceSpan.start.offset + offset;
-  recorder.remove(start, attribute.sourceSpan.end.offset - attribute.sourceSpan.start.offset);
-  recorder.insertLeft(start, replacement);
-};
-
-const insertAttribute = (
-  template: string,
-  element: Element,
-  attribute: string,
-  offset: number,
-  recorder: UpdateRecorder
-): void => {
-  const selfClosing = element.startSourceSpan.toString().endsWith('/>');
-  const insertOffset = element.startSourceSpan.end.offset - (selfClosing ? 2 : 1);
-  const prefix = /\s/.test(template[insertOffset - 1]) ? '' : ' ';
-  recorder.insertLeft(insertOffset + offset, `${prefix}${attribute}${selfClosing ? ' ' : ''}`);
-};
-
-const removeAttribute = (
-  template: string,
-  attribute: { sourceSpan: { start: { offset: number }; end: { offset: number } } },
-  offset: number,
-  recorder: UpdateRecorder
-): void => {
-  const start = attribute.sourceSpan.start.offset;
-  const end = attribute.sourceSpan.end.offset;
-  const lineStart = template.lastIndexOf('\n', start - 1) + 1;
-  const lineEnd = template.indexOf('\n', end);
-  const endOfLine = lineEnd === -1 ? template.length : lineEnd;
-  if (
-    template.slice(lineStart, start).trim() === '' &&
-    template.slice(end, endOfLine).trim() === ''
-  ) {
-    const removeEnd = lineEnd === -1 ? endOfLine : lineEnd + 1;
-    recorder.remove(lineStart + offset, removeEnd - lineStart);
-    return;
-  }
-
-  const removeStart = start > 0 && /\s/.test(template[start - 1]) ? start - 1 : start;
-  recorder.remove(removeStart + offset, attribute.sourceSpan.end.offset - removeStart);
-};
 
 const getStringLiteral = (value: string): string | undefined => {
   const initializer = getExpression(value);

--- a/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
@@ -27,6 +27,7 @@ export const splitScaleMigrationRule = (options: { path: string }): Rule => {
   return async (tree: Tree, context: SchematicContext) => {
     const externalTemplates = new Map<string, Set<string>[]>();
     const manualSizeMigrationPaths = new Set<string>();
+    const conflictingUnitPaths = new Set<string>();
 
     for await (const discoveredSourceFile of discoverSourceFiles(tree, context, options.path)) {
       const { path: filePath, sourceFile } = discoveredSourceFile;
@@ -44,14 +45,17 @@ export const splitScaleMigrationRule = (options: { path: string }): Rule => {
       for (const template of getComponentTemplates(sourceFile)) {
         const scaleMemberNames = collectScaleMemberNames(template.component, scaleTypeNames);
         if (template.kind === 'inline') {
-          const requiresManualSizeMigration = migrateScaleTemplate(
+          const result = migrateScaleTemplate(
             sourceFile.text.substring(template.node.getStart() + 1, template.node.getEnd() - 1),
             template.node.getStart() + 1,
             recorder,
             [scaleMemberNames]
           );
-          if (requiresManualSizeMigration) {
+          if (result.requiresManualSizeMigration) {
             manualSizeMigrationPaths.add(filePath);
+          }
+          if (result.hasConflictingUnit) {
+            conflictingUnitPaths.add(filePath);
           }
         } else {
           const templatePath = join(dirname(filePath), template.url);
@@ -69,14 +73,12 @@ export const splitScaleMigrationRule = (options: { path: string }): Rule => {
         continue;
       }
       const recorder = tree.beginUpdate(templatePath);
-      const requiresManualSizeMigration = migrateScaleTemplate(
-        tree.readText(templatePath),
-        0,
-        recorder,
-        owners
-      );
-      if (requiresManualSizeMigration) {
+      const result = migrateScaleTemplate(tree.readText(templatePath), 0, recorder, owners);
+      if (result.requiresManualSizeMigration) {
         manualSizeMigrationPaths.add(templatePath);
+      }
+      if (result.hasConflictingUnit) {
+        conflictingUnitPaths.add(templatePath);
       }
       tree.commitUpdate(recorder);
     }
@@ -85,6 +87,17 @@ export const splitScaleMigrationRule = (options: { path: string }): Rule => {
       context.logger.warn(
         `The following files contain si-split-part elements with scale="none" whose relative size was supplied by [sizes]. Their relative size is preserved with unit="fr" because a pixel size cannot be inferred. Set size and unit="px" manually:\n${[
           ...manualSizeMigrationPaths
+        ]
+          .sort()
+          .map(path => `- ${path}`)
+          .join('\n')}`
+      );
+    }
+
+    if (conflictingUnitPaths.size) {
+      context.logger.warn(
+        `The following files contain si-split-part elements with conflicting scale and unit values. The existing unit was preserved and scale removed. Review these parts manually:\n${[
+          ...conflictingUnitPaths
         ]
           .sort()
           .map(path => `- ${path}`)
@@ -101,7 +114,7 @@ const migrateScaleTemplate = (
   offset: number,
   recorder: UpdateRecorder,
   owners: Set<string>[]
-): boolean => {
+): { requiresManualSizeMigration: boolean; hasConflictingUnit: boolean } => {
   const elements = findElement(
     template,
     element => element.name === 'si-split' || element.name === 'si-split-part'
@@ -124,6 +137,7 @@ const migrateScaleTemplate = (
   }
 
   let requiresManualSizeMigration = false;
+  let hasConflictingUnit = false;
   elements.forEach(element => {
     if (element.name !== 'si-split-part') {
       return;
@@ -134,8 +148,9 @@ const migrateScaleTemplate = (
       return;
     }
 
-    const hasUnit = element.attrs.some(attribute => unitAttributeNames.includes(attribute.name));
-    if (hasUnit) {
+    const unit = element.attrs.find(attribute => unitAttributeNames.includes(attribute.name));
+    if (unit) {
+      hasConflictingUnit ||= hasConflictingStaticUnit(scale, unit);
       removeAttribute(template, scale, offset, recorder);
       return;
     }
@@ -165,7 +180,19 @@ const migrateScaleTemplate = (
     replaceAttribute(scale, replacement, offset, recorder);
   });
 
-  return requiresManualSizeMigration;
+  return { requiresManualSizeMigration, hasConflictingUnit };
+};
+
+const hasConflictingStaticUnit = (scale: Attribute, unit: Attribute): boolean => {
+  const scaleValue = scale.value.trim();
+  const unitValue = unit.value.trim();
+  return (
+    scale.name === 'scale' &&
+    unit.name === 'unit' &&
+    (scaleValue === 'auto' || scaleValue === 'none') &&
+    (unitValue === 'fr' || unitValue === 'px') &&
+    getScaleUnit(scaleValue) !== unitValue
+  );
 };
 
 const getUnitAttribute = (attribute: Attribute, scaleMemberNames: Set<string>): string => {

--- a/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
@@ -1,0 +1,653 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Rule, SchematicContext, Tree, UpdateRecorder } from '@angular-devkit/schematics';
+import type { Attribute } from '@angular/compiler';
+import { dirname, join } from 'path/posix';
+import ts from 'typescript';
+
+import { removeImportSpecifiers } from '../migrations/utilities/import-removal.js';
+import {
+  discoverSourceFiles,
+  findElement,
+  formatBoundAttribute,
+  getComponentTemplates,
+  getImportSpecifiers,
+  removeAttribute,
+  replaceAttribute
+} from '../utils/index.js';
+
+const splitImportPath = /^@(siemens|simpl)\/element-ng\/split(?:\/index)?$/;
+const scaleAttributeNames = ['scale', '[scale]', 'bind-scale'];
+const unitAttributeNames = ['unit', '[unit]', 'bind-unit'];
+
+export const splitScaleMigrationRule = (options: { path: string }): Rule => {
+  return async (tree: Tree, context: SchematicContext) => {
+    const externalTemplates = new Map<string, Set<string>[]>();
+
+    for await (const discoveredSourceFile of discoverSourceFiles(tree, context, options.path)) {
+      const { path: filePath, sourceFile } = discoveredSourceFile;
+      const scaleImports = getScaleImports(sourceFile);
+      const scaleTypeNames = getScaleTypeNames(sourceFile, scaleImports);
+      const recorder = tree.beginUpdate(filePath);
+
+      migrateScaleTypes(
+        sourceFile,
+        recorder,
+        scaleImports,
+        scaleTypeNames,
+        discoveredSourceFile.typeChecker
+      );
+      for (const template of getComponentTemplates(sourceFile)) {
+        const scaleMemberNames = collectScaleMemberNames(template.component, scaleTypeNames);
+        if (template.kind === 'inline') {
+          migrateScaleTemplate(
+            sourceFile.text.substring(template.node.getStart() + 1, template.node.getEnd() - 1),
+            template.node.getStart() + 1,
+            recorder,
+            [scaleMemberNames]
+          );
+        } else {
+          const templatePath = join(dirname(filePath), template.url);
+          const owners = externalTemplates.get(templatePath) ?? [];
+          owners.push(scaleMemberNames);
+          externalTemplates.set(templatePath, owners);
+        }
+      }
+      tree.commitUpdate(recorder);
+    }
+
+    // A shared template must be migrated using all of its component contexts.
+    for (const [templatePath, owners] of externalTemplates) {
+      if (!tree.exists(templatePath)) {
+        continue;
+      }
+      const recorder = tree.beginUpdate(templatePath);
+      migrateScaleTemplate(tree.readText(templatePath), 0, recorder, owners);
+      tree.commitUpdate(recorder);
+    }
+
+    return tree;
+  };
+};
+
+const migrateScaleTemplate = (
+  template: string,
+  offset: number,
+  recorder: UpdateRecorder,
+  owners: Set<string>[]
+): void => {
+  findElement(template, element => element.name === 'si-split-part').forEach(element => {
+    const scale = element.attrs.find(attribute => scaleAttributeNames.includes(attribute.name));
+    if (!scale) {
+      return;
+    }
+
+    const hasUnit = element.attrs.some(attribute => unitAttributeNames.includes(attribute.name));
+    if (hasUnit) {
+      removeAttribute(template, scale, offset, recorder);
+      return;
+    }
+
+    const replacements = new Set(owners.map(names => getUnitAttribute(scale, names)));
+    let replacement = replacements.values().next().value!;
+    if (replacements.size > 1) {
+      const expression =
+        scale.name === 'scale'
+          ? /^\s*{{([\s\S]*)}}\s*$/.exec(scale.value)![1]!.trim()
+          : scale.value;
+      replacement = formatBoundAttribute(
+        'unit',
+        `['none', 'px'].includes(${expression}) ? 'px' : 'fr'`
+      );
+    }
+    replaceAttribute(scale, replacement, offset, recorder);
+  });
+};
+
+const getUnitAttribute = (attribute: Attribute, scaleMemberNames: Set<string>): string => {
+  if (attribute.name === 'scale') {
+    const interpolation = /^\s*{{([\s\S]*)}}\s*$/.exec(attribute.value);
+    if (interpolation) {
+      const expression = interpolation[1]!.trim();
+      return formatUnitBinding(expression, scaleMemberNames, getExpression(expression));
+    }
+
+    return `unit="${getScaleUnit(attribute.value)}"`;
+  }
+
+  const expression = getExpression(attribute.value);
+  if (expression && ts.isStringLiteral(expression)) {
+    return `unit="${getScaleUnit(expression.text)}"`;
+  }
+
+  return formatUnitBinding(attribute.value, scaleMemberNames, expression);
+};
+
+const getScaleUnit = (value: string): 'px' | 'fr' => (value.trim() === 'none' ? 'px' : 'fr');
+
+const getUnitExpression = (expression: string): string => {
+  const value = expression.trim();
+  return `(${value}) === 'none' ? 'px' : 'fr'`;
+};
+
+const formatUnitBinding = (
+  expression: string,
+  scaleMemberNames: Set<string>,
+  parsedExpression: ts.Expression | undefined
+): string => {
+  const typedExpression = getTypedScaleExpression(parsedExpression, scaleMemberNames);
+  const mappedExpression = getMappedScaleExpression(expression, parsedExpression);
+  const value = typedExpression ?? mappedExpression ?? getUnitExpression(expression);
+  return formatBoundAttribute('unit', value);
+};
+
+interface ScaleImport {
+  declaration: ts.ImportDeclaration;
+  element: ts.ImportSpecifier;
+}
+
+const getScaleImports = (sourceFile: ts.SourceFile): ScaleImport[] => {
+  const importedSpecifiers = new Set(getImportSpecifiers(sourceFile, splitImportPath, 'Scale'));
+
+  return sourceFile.statements.flatMap(statement => {
+    if (!ts.isImportDeclaration(statement)) {
+      return [];
+    }
+
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
+      return [];
+    }
+
+    return namedBindings.elements
+      .filter(element => importedSpecifiers.has(element))
+      .map(element => ({ declaration: statement, element }));
+  });
+};
+
+const getScaleTypeNames = (sourceFile: ts.SourceFile, scaleImports: ScaleImport[]): Set<string> => {
+  const names = new Set(scaleImports.map(({ element }) => element.name.text));
+  collectScaleTypeAliases(sourceFile, names);
+  return names;
+};
+
+const collectScaleMemberNames = (
+  component: ts.ClassDeclaration,
+  scaleTypeNames: Set<string>
+): Set<string> => {
+  const names = new Set<string>();
+  for (const node of component.members) {
+    if (
+      ts.canHaveModifiers(node) &&
+      ts.getModifiers(node)?.some(modifier => modifier.kind === ts.SyntaxKind.StaticKeyword)
+    ) {
+      continue;
+    }
+    if (
+      ts.isPropertyDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      (isScaleType(node.type, scaleTypeNames) ||
+        isScaleInitializer(node.initializer, scaleTypeNames))
+    ) {
+      names.add(node.name.text);
+    }
+
+    if (
+      (ts.isMethodDeclaration(node) || ts.isGetAccessorDeclaration(node)) &&
+      node.name &&
+      ts.isIdentifier(node.name) &&
+      isScaleType(node.type, scaleTypeNames)
+    ) {
+      names.add(node.name.text);
+    }
+
+    if (
+      ts.isPropertyDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer)) &&
+      isScaleType(node.initializer.type, scaleTypeNames)
+    ) {
+      names.add(node.name.text);
+    }
+  }
+  return names;
+};
+
+const isScaleInitializer = (
+  initializer: ts.Expression | undefined,
+  scaleTypeNames: Set<string>
+): boolean => {
+  if (!initializer || !ts.isCallExpression(initializer)) {
+    return false;
+  }
+
+  return (
+    initializer.typeArguments?.some(typeArgument => isScaleType(typeArgument, scaleTypeNames)) ===
+    true
+  );
+};
+
+const migrateScaleTypes = (
+  sourceFile: ts.SourceFile,
+  recorder: UpdateRecorder,
+  scaleImports: ScaleImport[],
+  scaleTypeNames: Set<string>,
+  typeChecker: ts.TypeChecker
+): void => {
+  if (!scaleImports.length) {
+    return;
+  }
+
+  const replacements = new Map<string, string>();
+  const importEdits: { start: number; width: number; replacement?: string }[] = [];
+  const existingUnit = getImportSpecifiers(sourceFile, splitImportPath, 'SplitUnit')[0];
+
+  for (const importDeclaration of new Set(scaleImports.map(({ declaration }) => declaration))) {
+    const imports = scaleImports.filter(item => item.declaration === importDeclaration);
+
+    if (existingUnit) {
+      imports.forEach(({ element }) => replacements.set(element.name.text, existingUnit.name.text));
+      const edit = removeImportSpecifiers(
+        sourceFile,
+        importDeclaration,
+        imports.map(({ element }) => element)
+      );
+      importEdits.push({
+        start: edit.start,
+        width: edit.width,
+        replacement: edit.newNode
+          ? ts.createPrinter().printNode(ts.EmitHint.Unspecified, edit.newNode, sourceFile)
+          : undefined
+      });
+      continue;
+    }
+
+    for (const { element } of imports) {
+      if (element.propertyName) {
+        importEdits.push({
+          start: element.propertyName.getStart(sourceFile),
+          width: element.propertyName.getWidth(sourceFile),
+          replacement: 'SplitUnit'
+        });
+        continue;
+      }
+
+      importEdits.push({
+        start: element.name.getStart(sourceFile),
+        width: element.name.getWidth(sourceFile),
+        replacement: 'SplitUnit'
+      });
+      replacements.set(element.name.text, 'SplitUnit');
+    }
+  }
+
+  for (const edit of importEdits) {
+    recorder.remove(edit.start, edit.width);
+    if (edit.replacement) {
+      recorder.insertLeft(edit.start, edit.replacement);
+    }
+  }
+
+  replaceScaleIdentifiers(sourceFile, replacements, recorder);
+  replaceScaleLiterals(sourceFile, scaleTypeNames, typeChecker, recorder);
+};
+
+const collectScaleTypeAliases = (sourceFile: ts.SourceFile, names: Set<string>): void => {
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const statement of sourceFile.statements) {
+      if (
+        ts.isTypeAliasDeclaration(statement) &&
+        isScaleType(statement.type, names) &&
+        !names.has(statement.name.text)
+      ) {
+        names.add(statement.name.text);
+        changed = true;
+      }
+    }
+  }
+};
+
+const isScaleType = (type: ts.TypeNode | undefined, names: Set<string>): boolean => {
+  if (!type) {
+    return false;
+  }
+
+  if (ts.isTypeReferenceNode(type)) {
+    return ts.isIdentifier(type.typeName) && names.has(type.typeName.text);
+  }
+
+  if (ts.isParenthesizedTypeNode(type)) {
+    return isScaleType(type.type, names);
+  }
+
+  if (ts.isUnionTypeNode(type) || ts.isIntersectionTypeNode(type)) {
+    return type.types.some(member => isScaleType(member, names));
+  }
+
+  return false;
+};
+
+const replaceScaleIdentifiers = (
+  sourceFile: ts.SourceFile,
+  replacements: Map<string, string>,
+  recorder: UpdateRecorder
+): void => {
+  if (!replacements.size) {
+    return;
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      return;
+    }
+
+    if (ts.isIdentifier(node) && isScaleTypeReference(node)) {
+      const replacement = replacements.get(node.text);
+      if (replacement) {
+        recorder.remove(node.getStart(sourceFile), node.getWidth(sourceFile));
+        recorder.insertLeft(node.getStart(sourceFile), replacement);
+        return;
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  sourceFile.statements.forEach(statement => visit(statement));
+};
+
+const isScaleTypeReference = (node: ts.Identifier): boolean => {
+  const parent = node.parent;
+
+  if (ts.isTypeReferenceNode(parent)) {
+    return parent.typeName === node;
+  }
+
+  if (ts.isExpressionWithTypeArguments(parent)) {
+    return parent.expression === node;
+  }
+
+  if (ts.isTypeQueryNode(parent)) {
+    return parent.exprName === node;
+  }
+
+  if (ts.isExportSpecifier(parent)) {
+    return !parent.propertyName || parent.propertyName === node;
+  }
+
+  return false;
+};
+
+const replaceScaleLiterals = (
+  sourceFile: ts.SourceFile,
+  scaleTypeNames: Set<string>,
+  typeChecker: ts.TypeChecker,
+  recorder: UpdateRecorder
+): void => {
+  const typedNames = new Set<string>();
+  const literals = new Set<ts.StringLiteral>();
+
+  const collectLiterals = (node: ts.Node | undefined): void => {
+    if (!node) {
+      return;
+    }
+
+    if (ts.isStringLiteral(node) && isScaleLiteral(node)) {
+      literals.add(node);
+      return;
+    }
+
+    if (ts.isParenthesizedExpression(node)) {
+      collectLiterals(node.expression);
+      return;
+    }
+
+    if (
+      ts.isAsExpression(node) ||
+      ts.isTypeAssertionExpression(node) ||
+      ts.isNonNullExpression(node)
+    ) {
+      collectLiterals(node.expression);
+      return;
+    }
+
+    if (ts.isConditionalExpression(node)) {
+      collectLiterals(node.whenTrue);
+      collectLiterals(node.whenFalse);
+      return;
+    }
+
+    if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+      collectLiterals(node.body);
+      return;
+    }
+
+    if (ts.isObjectLiteralExpression(node)) {
+      node.properties.forEach(property => {
+        if (!ts.isPropertyAssignment(property)) {
+          return;
+        }
+
+        const contextualType = typeChecker.getContextualType(property.initializer);
+        if (isScaleCheckerType(contextualType, scaleTypeNames)) {
+          collectLiterals(property.initializer);
+        }
+      });
+    }
+  };
+
+  const collectContextualLiterals = (node: ts.Node): void => {
+    if (
+      ts.isStringLiteral(node) &&
+      isScaleLiteral(node) &&
+      isScaleCheckerType(typeChecker.getContextualType(node), scaleTypeNames)
+    ) {
+      literals.add(node);
+    }
+    ts.forEachChild(node, collectContextualLiterals);
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)) &&
+      ts.isIdentifier(node.name)
+    ) {
+      const hasScaleType = isScaleType(node.type, scaleTypeNames);
+      const scaleInitializer =
+        node.initializer && ts.isCallExpression(node.initializer) ? node.initializer : undefined;
+      const hasScaleInitializer =
+        !!scaleInitializer && isScaleInitializer(scaleInitializer, scaleTypeNames);
+
+      if (hasScaleType || hasScaleInitializer) {
+        typedNames.add(node.name.text);
+        if (hasScaleInitializer) {
+          collectLiterals(scaleInitializer.arguments[0]);
+        } else {
+          collectLiterals(node.initializer);
+        }
+      }
+    }
+
+    if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+      if (isScaleType(node.type, scaleTypeNames)) {
+        typedNames.add(node.name.text);
+        collectLiterals(node.initializer);
+      }
+    }
+
+    const isFunctionWithBody =
+      ts.isFunctionDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node);
+    if (isFunctionWithBody && isScaleType(node.type, scaleTypeNames)) {
+      if (node.body) {
+        const collectReturns = (child: ts.Node): void => {
+          if (ts.isReturnStatement(child) && child.expression) {
+            collectLiterals(child.expression);
+          }
+          ts.forEachChild(child, collectReturns);
+        };
+        collectReturns(node.body);
+      }
+    }
+
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      const root = getRootIdentifier(node.left);
+      if (root && typedNames.has(root)) {
+        collectLiterals(node.right);
+      }
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      (node.expression.name.text === 'set' || node.expression.name.text === 'update') &&
+      typedNames.has(getRootIdentifier(node.expression.expression) ?? '')
+    ) {
+      node.arguments.forEach(collectLiterals);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  sourceFile.statements.filter(statement => !ts.isImportDeclaration(statement)).forEach(visit);
+  sourceFile.statements
+    .filter(statement => !ts.isImportDeclaration(statement))
+    .forEach(collectContextualLiterals);
+
+  literals.forEach(literal => {
+    const replacement = literal.text === 'auto' ? 'fr' : 'px';
+    const start = literal.getStart(sourceFile) + 1;
+    recorder.remove(start, literal.getWidth(sourceFile) - 2);
+    recorder.insertLeft(start, replacement);
+  });
+};
+
+const isScaleLiteral = (node: ts.StringLiteral): boolean =>
+  node.text === 'auto' || node.text === 'none';
+
+const isScaleCheckerType = (type: ts.Type | undefined, names: Set<string>): boolean => {
+  if (!type) {
+    return false;
+  }
+
+  if (type.isUnionOrIntersection()) {
+    return type.types.some(member => isScaleCheckerType(member, names));
+  }
+
+  return names.has(type.aliasSymbol?.name ?? '') || names.has(type.symbol?.name ?? '');
+};
+
+const getTypedScaleExpression = (
+  expression: ts.Expression | undefined,
+  scaleMemberNames: Set<string>
+): string | undefined => {
+  return expression && isTypedScaleExpression(expression, scaleMemberNames)
+    ? expression.getText()
+    : undefined;
+};
+
+const isTypedScaleExpression = (
+  expression: ts.Expression,
+  scaleMemberNames: Set<string>
+): boolean => {
+  if (ts.isIdentifier(expression)) {
+    return scaleMemberNames.has(expression.text);
+  }
+
+  if (ts.isPropertyAccessExpression(expression)) {
+    return (
+      expression.expression.kind === ts.SyntaxKind.ThisKeyword &&
+      scaleMemberNames.has(expression.name.text)
+    );
+  }
+
+  if (ts.isCallExpression(expression)) {
+    return isTypedScaleExpression(expression.expression, scaleMemberNames);
+  }
+
+  if (ts.isParenthesizedExpression(expression)) {
+    return isTypedScaleExpression(expression.expression, scaleMemberNames);
+  }
+
+  return false;
+};
+
+const getMappedScaleExpression = (
+  expression: string,
+  initializer: ts.Expression | undefined
+): string | undefined => {
+  if (!initializer || !ts.isConditionalExpression(initializer)) {
+    return undefined;
+  }
+
+  const replacements: { start: number; end: number; value: string }[] = [];
+  const source = initializer.getSourceFile();
+  const collect = (node: ts.Node): void => {
+    if (ts.isStringLiteral(node) && isScaleLiteral(node)) {
+      replacements.push({
+        start: node.getStart(source) + 1,
+        end: node.getEnd() - 1,
+        value: node.text === 'none' ? 'px' : 'fr'
+      });
+      return;
+    }
+
+    if (ts.isConditionalExpression(node)) {
+      collect(node.whenTrue);
+      collect(node.whenFalse);
+    }
+  };
+
+  collect(initializer);
+  if (!replacements.length) {
+    return undefined;
+  }
+
+  return replacements
+    .sort((first, second) => second.start - first.start)
+    .reduce((value, replacement) => {
+      const offset = initializer.getStart(source) - expression.indexOf(expression.trim());
+      return (
+        value.slice(0, replacement.start - offset) +
+        replacement.value +
+        value.slice(replacement.end - offset)
+      );
+    }, expression);
+};
+
+const getRootIdentifier = (node: ts.Expression): string | undefined => {
+  if (ts.isIdentifier(node)) {
+    return node.text;
+  }
+
+  if (ts.isPropertyAccessExpression(node)) {
+    return node.name.text;
+  }
+
+  return undefined;
+};
+
+const getExpression = (value: string): ts.Expression | undefined => {
+  const statement = ts.createSourceFile(
+    'split-scale-expression.ts',
+    `const value = ${value};`,
+    ts.ScriptTarget.Latest,
+    true
+  ).statements[0];
+
+  if (!statement || !ts.isVariableStatement(statement)) {
+    return undefined;
+  }
+
+  return statement.declarationList.declarations[0]?.initializer;
+};

--- a/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
@@ -191,7 +191,7 @@ const getScaleUnit = (value: string): 'px' | 'fr' => (value.trim() === 'none' ? 
 
 const getUnitExpression = (expression: string): string => {
   const value = expression.trim();
-  return `(${value}) === 'none' ? 'px' : 'fr'`;
+  return `['none', 'px'].includes(${value}) ? 'px' : 'fr'`;
 };
 
 const formatUnitBinding = (

--- a/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
@@ -4,7 +4,7 @@
  */
 
 import { Rule, SchematicContext, Tree, UpdateRecorder } from '@angular-devkit/schematics';
-import type { Attribute } from '@angular/compiler';
+import { Element, type Attribute } from '@angular/compiler';
 import { dirname, join } from 'path/posix';
 import ts from 'typescript';
 
@@ -26,6 +26,7 @@ const unitAttributeNames = ['unit', '[unit]', 'bind-unit'];
 export const splitScaleMigrationRule = (options: { path: string }): Rule => {
   return async (tree: Tree, context: SchematicContext) => {
     const externalTemplates = new Map<string, Set<string>[]>();
+    const manualSizeMigrationPaths = new Set<string>();
 
     for await (const discoveredSourceFile of discoverSourceFiles(tree, context, options.path)) {
       const { path: filePath, sourceFile } = discoveredSourceFile;
@@ -43,12 +44,15 @@ export const splitScaleMigrationRule = (options: { path: string }): Rule => {
       for (const template of getComponentTemplates(sourceFile)) {
         const scaleMemberNames = collectScaleMemberNames(template.component, scaleTypeNames);
         if (template.kind === 'inline') {
-          migrateScaleTemplate(
+          const requiresManualSizeMigration = migrateScaleTemplate(
             sourceFile.text.substring(template.node.getStart() + 1, template.node.getEnd() - 1),
             template.node.getStart() + 1,
             recorder,
             [scaleMemberNames]
           );
+          if (requiresManualSizeMigration) {
+            manualSizeMigrationPaths.add(filePath);
+          }
         } else {
           const templatePath = join(dirname(filePath), template.url);
           const owners = externalTemplates.get(templatePath) ?? [];
@@ -65,8 +69,27 @@ export const splitScaleMigrationRule = (options: { path: string }): Rule => {
         continue;
       }
       const recorder = tree.beginUpdate(templatePath);
-      migrateScaleTemplate(tree.readText(templatePath), 0, recorder, owners);
+      const requiresManualSizeMigration = migrateScaleTemplate(
+        tree.readText(templatePath),
+        0,
+        recorder,
+        owners
+      );
+      if (requiresManualSizeMigration) {
+        manualSizeMigrationPaths.add(templatePath);
+      }
       tree.commitUpdate(recorder);
+    }
+
+    if (manualSizeMigrationPaths.size) {
+      context.logger.warn(
+        `The following files contain si-split-part elements with scale="none" whose relative size was supplied by [sizes]. Their relative size is preserved with unit="fr" because a pixel size cannot be inferred. Set size and unit="px" manually:\n${[
+          ...manualSizeMigrationPaths
+        ]
+          .sort()
+          .map(path => `- ${path}`)
+          .join('\n')}`
+      );
     }
 
     return tree;
@@ -78,8 +101,34 @@ const migrateScaleTemplate = (
   offset: number,
   recorder: UpdateRecorder,
   owners: Set<string>[]
-): void => {
-  findElement(template, element => element.name === 'si-split-part').forEach(element => {
+): boolean => {
+  const elements = findElement(
+    template,
+    element => element.name === 'si-split' || element.name === 'si-split-part'
+  );
+  const partsWithRelativeSizes = new Set<Element>();
+  for (const split of elements) {
+    if (split.name !== 'si-split' || !split.attrs.some(attribute => attribute.name === '[sizes]')) {
+      continue;
+    }
+
+    for (const child of split.children) {
+      if (
+        child instanceof Element &&
+        child.name === 'si-split-part' &&
+        !child.attrs.some(attribute => attribute.name === 'size' || attribute.name === '[size]')
+      ) {
+        partsWithRelativeSizes.add(child);
+      }
+    }
+  }
+
+  let requiresManualSizeMigration = false;
+  elements.forEach(element => {
+    if (element.name !== 'si-split-part') {
+      return;
+    }
+
     const scale = element.attrs.find(attribute => scaleAttributeNames.includes(attribute.name));
     if (!scale) {
       return;
@@ -91,20 +140,32 @@ const migrateScaleTemplate = (
       return;
     }
 
-    const replacements = new Set(owners.map(names => getUnitAttribute(scale, names)));
-    let replacement = replacements.values().next().value!;
-    if (replacements.size > 1) {
-      const expression =
-        scale.name === 'scale'
-          ? /^\s*{{([\s\S]*)}}\s*$/.exec(scale.value)![1]!.trim()
-          : scale.value;
-      replacement = formatBoundAttribute(
-        'unit',
-        `['none', 'px'].includes(${expression}) ? 'px' : 'fr'`
-      );
+    let replacement: string;
+    if (
+      partsWithRelativeSizes.has(element) &&
+      scale.name === 'scale' &&
+      scale.value.trim() === 'none'
+    ) {
+      replacement = 'unit="fr"';
+      requiresManualSizeMigration = true;
+    } else {
+      const replacements = new Set(owners.map(names => getUnitAttribute(scale, names)));
+      replacement = replacements.values().next().value!;
+      if (replacements.size > 1) {
+        const expression =
+          scale.name === 'scale'
+            ? /^\s*{{([\s\S]*)}}\s*$/.exec(scale.value)![1]!.trim()
+            : scale.value;
+        replacement = formatBoundAttribute(
+          'unit',
+          `['none', 'px'].includes(${expression}) ? 'px' : 'fr'`
+        );
+      }
     }
     replaceAttribute(scale, replacement, offset, recorder);
   });
+
+  return requiresManualSizeMigration;
 };
 
 const getUnitAttribute = (attribute: Attribute, scaleMemberNames: Set<string>): string => {

--- a/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
@@ -164,13 +164,11 @@ const migrateScaleTemplate = (
       replacement = 'unit="fr"';
       requiresManualSizeMigration = true;
     } else {
-      const replacements = new Set(owners.map(names => getUnitAttribute(scale, names)));
+      const expression =
+        scale.name === 'scale' ? getInterpolationExpression(scale.value) : scale.value;
+      const replacements = new Set(owners.map(names => getUnitAttribute(scale, names, expression)));
       replacement = replacements.values().next().value!;
-      if (replacements.size > 1) {
-        const expression =
-          scale.name === 'scale'
-            ? /^\s*{{([\s\S]*)}}\s*$/.exec(scale.value)![1]!.trim()
-            : scale.value;
+      if (replacements.size > 1 && expression !== undefined) {
         replacement = formatBoundAttribute(
           'unit',
           `['none', 'px'].includes(${expression}) ? 'px' : 'fr'`
@@ -195,23 +193,28 @@ const hasConflictingStaticUnit = (scale: Attribute, unit: Attribute): boolean =>
   );
 };
 
-const getUnitAttribute = (attribute: Attribute, scaleMemberNames: Set<string>): string => {
+const getInterpolationExpression = (value: string): string | undefined =>
+  /^\s*{{([\s\S]*)}}\s*$/.exec(value)?.[1]?.trim();
+
+const getUnitAttribute = (
+  attribute: Attribute,
+  scaleMemberNames: Set<string>,
+  expression: string | undefined
+): string => {
   if (attribute.name === 'scale') {
-    const interpolation = /^\s*{{([\s\S]*)}}\s*$/.exec(attribute.value);
-    if (interpolation) {
-      const expression = interpolation[1]!.trim();
+    if (expression !== undefined) {
       return formatUnitBinding(expression, scaleMemberNames, getExpression(expression));
     }
 
     return `unit="${getScaleUnit(attribute.value)}"`;
   }
 
-  const expression = getExpression(attribute.value);
-  if (expression && ts.isStringLiteral(expression)) {
-    return `unit="${getScaleUnit(expression.text)}"`;
+  const parsedExpression = getExpression(attribute.value);
+  if (parsedExpression && ts.isStringLiteral(parsedExpression)) {
+    return `unit="${getScaleUnit(parsedExpression.text)}"`;
   }
 
-  return formatUnitBinding(attribute.value, scaleMemberNames, expression);
+  return formatUnitBinding(attribute.value, scaleMemberNames, parsedExpression);
 };
 
 const getScaleUnit = (value: string): 'px' | 'fr' => (value.trim() === 'none' ? 'px' : 'fr');

--- a/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-scale.ts
@@ -704,14 +704,15 @@ const getMappedScaleExpression = (
     return undefined;
   }
 
+  const leadingWhitespaceLength = expression.length - expression.trimStart().length;
+  const syntheticSourcePrefixLength = initializer.getStart(source) - leadingWhitespaceLength;
   return replacements
     .sort((first, second) => second.start - first.start)
     .reduce((value, replacement) => {
-      const offset = initializer.getStart(source) - expression.indexOf(expression.trim());
       return (
-        value.slice(0, replacement.start - offset) +
+        value.slice(0, replacement.start - syntheticSourcePrefixLength) +
         replacement.value +
-        value.slice(replacement.end - offset)
+        value.slice(replacement.end - syntheticSourcePrefixLength)
       );
     }, expression);
 };

--- a/projects/element-ng/schematics/ng-update/migrate-split-sizes.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-split-sizes.ts
@@ -69,9 +69,13 @@ const migrateSplitSizes = (template: string, offset: number, recorder: UpdateRec
         return;
       }
 
+      const hasUnit = parts[index]!.attrs.some(attribute =>
+        ['unit', '[unit]', 'bind-unit'].includes(attribute.name)
+      );
+      const unitAttribute = hasUnit ? '' : ' unit="fr"';
       const sizeAttribute = literalSizes
-        ? ` size="${literalSizes[index]}" unit="fr"`
-        : ` [size]="${getIndexedSizeExpression(sizes.value, index)}" unit="fr"`;
+        ? ` size="${literalSizes[index]}"${unitAttribute}`
+        : ` [size]="${getIndexedSizeExpression(sizes.value, index)}"${unitAttribute}`;
       const startTag = part.startSourceSpan.toString();
       const insertOffset = part.startSourceSpan.end.offset - (startTag.endsWith('/>') ? 2 : 1);
       recorder.insertLeft(insertOffset + offset, sizeAttribute);
@@ -138,7 +142,7 @@ const migrateMissingSplitUnit = (
 ): void => {
   findElement(template, element => element.name === 'si-split-part').forEach(part => {
     const hasSize = part.attrs.some(a => a.name === 'size' || a.name === '[size]');
-    const hasUnit = part.attrs.some(a => a.name === 'unit' || a.name === '[unit]');
+    const hasUnit = part.attrs.some(a => ['unit', '[unit]', 'bind-unit'].includes(a.name));
 
     if (!hasSize || hasUnit) {
       return;

--- a/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
@@ -12,6 +12,7 @@ import { contentFormatterMigrationRule } from './migrate-content-formatter.js';
 import { markdownRendererMigrationRule } from './migrate-markdown-renderer.js';
 import { spacerMigrationRule } from './migrate-spacers.js';
 import { splitCollapseMigrationRule } from './migrate-split-collapse.js';
+import { splitScaleMigrationRule } from './migrate-split-scale.js';
 import { splitSizesMigrationRule } from './migrate-split-sizes.js';
 
 export const migrateToV51 = (): Rule => {
@@ -22,6 +23,7 @@ export const migrateToV51 = (): Rule => {
     return chain([
       elementMigrationRule(options, migrationData),
       missingTranslateMigrationRule(options),
+      splitScaleMigrationRule(options),
       splitSizesMigrationRule(options),
       splitCollapseMigrationRule(options),
       contentFormatterMigrationRule(options),

--- a/projects/element-ng/schematics/utils/index.ts
+++ b/projects/element-ng/schematics/utils/index.ts
@@ -7,5 +7,6 @@ export * from './project-utils.js';
 export * from './ts-compiler-host.js';
 export * from './schematics-file-system.js';
 export * from './template-utils.js';
+export * from './template-edit-utils.js';
 export * from './testing.js';
 export * from './ts-utils.js';

--- a/projects/element-ng/schematics/utils/template-edit-utils.ts
+++ b/projects/element-ng/schematics/utils/template-edit-utils.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+import { UpdateRecorder } from '@angular-devkit/schematics';
+import type { Attribute, Element } from '@angular/compiler';
+
+export const formatBoundAttribute = (name: string, expression: string): string => {
+  const quote = expression.includes('"') && !expression.includes("'") ? "'" : '"';
+  const escapedExpression =
+    quote === '"' ? expression.replaceAll('"', '&quot;') : expression.replaceAll("'", '&#39;');
+  return `[${name}]=${quote}${escapedExpression}${quote}`;
+};
+
+export const replaceAttribute = (
+  attribute: Pick<Attribute, 'sourceSpan'>,
+  replacement: string,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  const start = attribute.sourceSpan.start.offset + offset;
+  recorder.remove(start, attribute.sourceSpan.end.offset - attribute.sourceSpan.start.offset);
+  recorder.insertLeft(start, replacement);
+};
+
+export const insertAttribute = (
+  template: string,
+  element: Element,
+  attribute: string,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  const selfClosing = element.startSourceSpan.toString().endsWith('/>');
+  const insertOffset = element.startSourceSpan.end.offset - (selfClosing ? 2 : 1);
+  const prefix = /\s/.test(template[insertOffset - 1] ?? '') ? '' : ' ';
+  recorder.insertLeft(insertOffset + offset, `${prefix}${attribute}${selfClosing ? ' ' : ''}`);
+};
+
+export const removeAttribute = (
+  template: string,
+  attribute: Pick<Attribute, 'sourceSpan'>,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  const start = attribute.sourceSpan.start.offset;
+  const end = attribute.sourceSpan.end.offset;
+  const lineStart = template.lastIndexOf('\n', start - 1) + 1;
+  const lineEnd = template.indexOf('\n', end);
+  const endOfLine = lineEnd === -1 ? template.length : lineEnd;
+
+  if (
+    template.slice(lineStart, start).trim() === '' &&
+    template.slice(end, endOfLine).trim() === ''
+  ) {
+    const removeEnd = lineEnd === -1 ? endOfLine : lineEnd + 1;
+    recorder.remove(lineStart + offset, removeEnd - lineStart);
+    return;
+  }
+
+  const removeStart = start > 0 && /\s/.test(template[start - 1] ?? '') ? start - 1 : start;
+  recorder.remove(removeStart + offset, end - removeStart);
+};

--- a/projects/element-ng/schematics/utils/template-utils.spec.ts
+++ b/projects/element-ng/schematics/utils/template-utils.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+import ts from 'typescript';
+
+import { getComponentTemplates, getInlineTemplates, getTemplateUrl } from './template-utils.js';
+
+describe('component template discovery', () => {
+  it('associates inline and external templates with their owning classes', () => {
+    const source = ts.createSourceFile(
+      'components.ts',
+      `@Component({ template: '<first />' })
+class First {}
+@Component({ templateUrl: './second.html' })
+class Second {}
+@Component({ template: \`<third />\` })
+class Third {}`,
+      ts.ScriptTarget.Latest,
+      true
+    );
+    const components = source.statements.filter(ts.isClassDeclaration);
+    const templates = getComponentTemplates(source);
+
+    expect(templates).toHaveLength(3);
+    expect(templates[0].component).toBe(components[0]);
+    expect(templates[1]).toMatchObject({
+      component: components[1],
+      kind: 'external',
+      url: './second.html'
+    });
+    expect(templates[2].component).toBe(components[2]);
+    expect(getInlineTemplates(source).map(node => node.text)).toEqual(['<first />', '<third />']);
+    expect(getTemplateUrl(source)).toEqual(['./second.html']);
+  });
+
+  it('retains both owners of a shared external template', () => {
+    const source = ts.createSourceFile(
+      'shared.ts',
+      `@Component({ templateUrl: './shared.html' })
+class First {}
+@Component({ templateUrl: './shared.html' })
+class Second {}`,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const templates = getComponentTemplates(source);
+
+    expect(templates.map(template => template.component.name?.text)).toEqual(['First', 'Second']);
+    expect(getTemplateUrl(source)).toEqual(['./shared.html', './shared.html']);
+  });
+
+  it('ignores other decorators and non-literal or missing metadata', () => {
+    const source = ts.createSourceFile(
+      'ignored.ts',
+      `@Directive({ template: '<ignored />' })
+class DirectiveClass {}
+@Component()
+class MissingMetadata {}
+@Component(metadata)
+class DynamicMetadata {}
+@Component({ template: template, templateUrl: url })
+class DynamicTemplate {}`,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    expect(getComponentTemplates(source)).toEqual([]);
+  });
+});

--- a/projects/element-ng/schematics/utils/template-utils.ts
+++ b/projects/element-ng/schematics/utils/template-utils.ts
@@ -2,73 +2,71 @@
  * Copyright (c) Siemens 2016 - 2026
  * SPDX-License-Identifier: MIT
  */
-import ts, { NoSubstitutionTemplateLiteral, PropertyAssignment, StringLiteral } from 'typescript';
+import ts from 'typescript';
+
+export type ComponentTemplate =
+  | {
+      component: ts.ClassDeclaration;
+      kind: 'inline';
+      node: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral;
+    }
+  | {
+      component: ts.ClassDeclaration;
+      kind: 'external';
+      url: string;
+    };
+
+export const getComponentTemplates = (source: ts.SourceFile): ComponentTemplate[] => {
+  const templates: ComponentTemplate[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isClassDeclaration(node)) {
+      for (const decorator of ts.getDecorators(node) ?? []) {
+        const call = decorator.expression;
+        if (
+          !ts.isCallExpression(call) ||
+          !ts.isIdentifier(call.expression) ||
+          call.expression.text !== 'Component'
+        ) {
+          continue;
+        }
+
+        const metadata = call.arguments[0];
+        if (!metadata || !ts.isObjectLiteralExpression(metadata)) {
+          continue;
+        }
+
+        for (const property of metadata.properties) {
+          if (!ts.isPropertyAssignment(property) || !ts.isIdentifier(property.name)) {
+            continue;
+          }
+
+          const value = property.initializer;
+          if (
+            property.name.text === 'template' &&
+            (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value))
+          ) {
+            templates.push({ component: node, kind: 'inline', node: value });
+          } else if (property.name.text === 'templateUrl' && ts.isStringLiteral(value)) {
+            templates.push({ component: node, kind: 'external', url: value.text });
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
+  return templates;
+};
 
 export const getInlineTemplates = (
   source: ts.SourceFile
-): (NoSubstitutionTemplateLiteral | StringLiteral)[] => {
-  const templateNodes: (NoSubstitutionTemplateLiteral | StringLiteral)[] = [];
-  const componentDecoratorVisitor = (node: ts.Node): void => {
-    if (
-      ts.isDecorator(node) &&
-      ts.isCallExpression(node.expression) &&
-      ts.isIdentifier(node.expression.expression) &&
-      node.expression.expression.text === 'Component'
-    ) {
-      const arg = node.expression.arguments[0];
-      if (ts.isObjectLiteralExpression(arg)) {
-        const template = arg.properties.find(
-          property =>
-            ts.isPropertyAssignment(property) &&
-            ts.isIdentifier(property.name) &&
-            property.name.text === 'template'
-        ) as PropertyAssignment;
-        const initializer = template?.initializer;
-        if (
-          initializer &&
-          (ts.isNoSubstitutionTemplateLiteral(initializer) || ts.isStringLiteral(initializer))
-        ) {
-          templateNodes.push(initializer);
-        }
-      }
-    } else {
-      node.forEachChild(componentDecoratorVisitor);
-    }
-  };
+): (ts.NoSubstitutionTemplateLiteral | ts.StringLiteral)[] =>
+  getComponentTemplates(source).flatMap(template =>
+    template.kind === 'inline' ? [template.node] : []
+  );
 
-  source.forEachChild(componentDecoratorVisitor);
-
-  return templateNodes;
-};
-
-export const getTemplateUrl = (source: ts.SourceFile): string[] => {
-  const templateUrls: string[] = [];
-  const componentDecoratorVisitor = (node: ts.Node): void => {
-    if (
-      ts.isDecorator(node) &&
-      ts.isCallExpression(node.expression) &&
-      ts.isIdentifier(node.expression.expression) &&
-      node.expression.expression.text === 'Component'
-    ) {
-      const arg = node.expression.arguments[0];
-      if (ts.isObjectLiteralExpression(arg)) {
-        const template = arg.properties.find(
-          property =>
-            ts.isPropertyAssignment(property) &&
-            ts.isIdentifier(property.name) &&
-            property.name.text === 'templateUrl'
-        ) as PropertyAssignment;
-        const initializer = template?.initializer;
-        if (initializer && ts.isStringLiteral(initializer)) {
-          templateUrls.push(initializer.text);
-        }
-      }
-    } else {
-      node.forEachChild(componentDecoratorVisitor);
-    }
-  };
-
-  source.forEachChild(componentDecoratorVisitor);
-
-  return templateUrls;
-};
+export const getTemplateUrl = (source: ts.SourceFile): string[] =>
+  getComponentTemplates(source).flatMap(template =>
+    template.kind === 'external' ? [template.url] : []
+  );

--- a/projects/element-ng/split/si-split-part.component.ts
+++ b/projects/element-ng/split/si-split-part.component.ts
@@ -22,14 +22,7 @@ import { elementDoubleRight } from '@siemens/element-icons';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 
-import {
-  Action,
-  CollapseTo,
-  PartState,
-  Scale,
-  SplitOrientation,
-  SplitUnit
-} from './si-split.interfaces';
+import { Action, CollapseTo, PartState, SplitOrientation, SplitUnit } from './si-split.interfaces';
 
 @Component({
   selector: 'si-split-part',
@@ -97,14 +90,6 @@ export class SiSplitPartComponent {
    * @defaultValue false
    */
   readonly removeContentOnCollapse = input(false, { transform: booleanAttribute });
-
-  /**
-   * Defines the behavior of the split part during scaling.
-   * E.g. when set to `none`, the spit part will keep its current size even when the parent container grows or shrinks.
-   *
-   * @defaultValue 'auto'
-   */
-  readonly scale = input<Scale>('auto');
 
   /**
    * Defines if the header of the split part is visible. Default is true.

--- a/projects/element-ng/split/si-split.component.spec.ts
+++ b/projects/element-ng/split/si-split.component.spec.ts
@@ -7,7 +7,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideSiUiState, SI_UI_STATE_SERVICE, UIStateStorage } from '@siemens/element-ng/common';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
 
-import { CollapseTo, PartState, Scale, SiSplitModule, SplitOrientation, SplitUnit } from './index';
+import { CollapseTo, PartState, SiSplitModule, SplitOrientation, SplitUnit } from './index';
 import { SiSplitPartComponent } from './si-split-part.component';
 import { SiSplitComponent as TestComponent } from './si-split.component';
 
@@ -49,7 +49,6 @@ class SynchronousMockStore implements UIStateStorage {
           [actions]="[]"
           [collapseToMinSize]="collapseToMinSize1()"
           [minSize]="minSize1()"
-          [scale]="scale1()"
           [size]="size1()"
           [unit]="unit1()"
           (collapseChanged)="collapseChanged1($event)"
@@ -69,7 +68,6 @@ class SynchronousMockStore implements UIStateStorage {
           [collapsible]="collapsible2()"
           [collapseToMinSize]="false"
           [minSize]="0"
-          [scale]="scale2()"
           [size]="size2()"
           [unit]="unit2()"
           [collapseOthers]="collapseOthers2()"
@@ -91,7 +89,6 @@ class SynchronousMockStore implements UIStateStorage {
             [collapsible]="collapsible3()"
             [collapseToMinSize]="false"
             [minSize]="minSize3()"
-            [scale]="scale3()"
             [size]="size3()"
             [unit]="unit3()"
             (collapseChanged)="collapseChanged3($event)"
@@ -115,18 +112,15 @@ class WrapperComponent {
   readonly splitPart1 = viewChild.required('splitPart1', { read: ElementRef });
   readonly collapseToMinSize1 = signal(false);
   readonly minSize1 = signal(0);
-  readonly scale1 = signal<Scale>('auto');
   readonly size1 = signal(0);
   readonly unit1 = signal<SplitUnit>('px');
   readonly splitPart2 = viewChild.required('splitPart2', { read: ElementRef });
   readonly collapsible2 = signal<CollapseTo>('to-start');
-  readonly scale2 = signal<Scale>('auto');
   readonly size2 = signal(0);
   readonly unit2 = signal<SplitUnit>('px');
   readonly splitPart3 = viewChild.required('splitPart3', { read: ElementRef });
   readonly collapsible3 = signal<CollapseTo>('to-start');
   readonly minSize3 = signal(0);
-  readonly scale3 = signal<Scale>('auto');
   readonly size3 = signal(0);
   readonly unit3 = signal<SplitUnit>('px');
   readonly showPart3 = signal(true);
@@ -639,9 +633,6 @@ describe('SiSplitComponent', () => {
         wrapperComponent.gutterSize.set(32);
         wrapperComponent.containerWidth.set(564);
         wrapperComponent.minSize3.set(100);
-        wrapperComponent.scale1.set('none');
-        wrapperComponent.scale2.set('auto');
-        wrapperComponent.scale3.set('none');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
@@ -803,9 +794,6 @@ describe('SiSplitComponent', () => {
         wrapperComponent.orientation.set('vertical');
         wrapperComponent.setSizes([200, 150, 150], 'px');
         wrapperComponent.minSize1.set(100);
-        wrapperComponent.scale1.set('none');
-        wrapperComponent.scale2.set('auto');
-        wrapperComponent.scale3.set('none');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
@@ -820,12 +808,9 @@ describe('SiSplitComponent', () => {
         expect(wrapperComponent.measureSize3()).toBeCloseTo(150, 0);
       });
 
-      it('should display with set sizes and gutter size after changes with scale none', async () => {
+      it('should update configured pixel sizes after changes', async () => {
         wrapperComponent.orientation.set('vertical');
         wrapperComponent.setSizes([100, 300, 100], 'px');
-        wrapperComponent.scale1.set('none');
-        wrapperComponent.scale2.set('none');
-        wrapperComponent.scale3.set('none');
         await fixture.whenStable();
 
         expect(wrapperComponent.measureSize1()).toBeCloseTo(100, 0);

--- a/projects/element-ng/split/si-split.component.spec.ts
+++ b/projects/element-ng/split/si-split.component.spec.ts
@@ -6,6 +6,7 @@ import { Component, ElementRef, Injectable, signal, viewChild } from '@angular/c
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideSiUiState, SI_UI_STATE_SERVICE, UIStateStorage } from '@siemens/element-ng/common';
 import { runOnPushChangeDetection } from '@siemens/element-ng/test-helpers';
+import { Mock } from 'vitest';
 
 import { CollapseTo, PartState, SiSplitModule, SplitOrientation, SplitUnit } from './index';
 import { SiSplitPartComponent } from './si-split-part.component';
@@ -329,6 +330,14 @@ describe('SiSplitComponent', () => {
   };
 
   describe('using ui state service', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     describe('without SiUIStateService', () => {
       setup();
 
@@ -337,6 +346,7 @@ describe('SiSplitComponent', () => {
         wrapperComponent = fixture.componentInstance;
         element = fixture.nativeElement;
         wrapperComponent.setSizes([20, 60, 20], 'fr');
+        vi.runAllTimers();
         await fixture.whenStable();
       });
 
@@ -364,6 +374,7 @@ describe('SiSplitComponent', () => {
           wrapperComponent = fixture.componentInstance;
           element = fixture.nativeElement;
           wrapperComponent.setSizes([20, 60, 20], 'fr');
+          vi.runAllTimers();
           await fixture.whenStable();
         });
 
@@ -382,8 +393,8 @@ describe('SiSplitComponent', () => {
         });
 
         it('should save ui state', async () => {
-          // cannot use jasmine.clock here
-          await new Promise(resolve => setTimeout(resolve));
+          vi.runAllTimers();
+          await fixture.whenStable();
           wrapperComponent.splitPart().toggleCollapse();
           const uiStateMock =
             await TestBed.inject(SI_UI_STATE_SERVICE).load<Record<string, any>>('split-test');
@@ -396,30 +407,39 @@ describe('SiSplitComponent', () => {
       });
 
       describe('with SiUIStateService and persisted state', () => {
-        beforeEach(() => {
+        let sizesSpy: Mock<(sizes: number[]) => void>;
+
+        beforeEach(async () => {
+          sizesSpy = vi.fn();
           const store = TestBed.inject(SI_UI_STATE_SERVICE);
-          store.save('split-test', {
-            one: { initialSize: 20, initialUnit: 'fr', size: 40, expanded: true },
-            two: { initialSize: 60, initialUnit: 'fr', size: 40, expanded: true },
-            three: { initialSize: 20, initialUnit: 'fr', size: 20, expanded: true }
+          await store.save('split-test', {
+            one: { initialSize: 99, initialUnit: 'fr', size: 40, expanded: true },
+            two: { initialSize: 99, initialUnit: 'fr', size: 40, expanded: true },
+            three: { initialSize: 99, initialUnit: 'fr', size: 20, expanded: true }
           });
 
           fixture = TestBed.createComponent(WrapperComponent);
           wrapperComponent = fixture.componentInstance;
+          wrapperComponent.split().sizesChange.subscribe(sizesSpy);
           wrapperComponent.setSizes([20, 60, 20], 'fr');
           // We need this here to run checks after async tasks completed.
           fixture.autoDetectChanges();
           element = fixture.nativeElement;
         });
 
-        it('should load and configure split parts', async () => {
-          // cannot use jasmine.clock here
-          await new Promise(resolve => setTimeout(resolve));
+        it('should load and configure split parts even if initialSize does not match part size', async () => {
+          vi.runAllTimers();
           await fixture.whenStable();
           expect(wrapperComponent.measureSize1()).toBeCloseTo(200, 0);
           expect(wrapperComponent.measureSize2()).toBeCloseTo(200, 0);
           expect(wrapperComponent.measureSize3()).toBeCloseTo(100, 0);
           expect(wrapperComponent.split().orientation()).toEqual('horizontal');
+        });
+
+        it('should emit sizesChange on restore', async () => {
+          vi.runAllTimers();
+          await fixture.whenStable();
+          expect(sizesSpy).toHaveBeenCalled();
         });
       });
     });

--- a/projects/element-ng/split/si-split.component.ts
+++ b/projects/element-ng/split/si-split.component.ts
@@ -203,7 +203,6 @@ export class SiSplitComponent {
     const startPosition = this.getPosition(event);
     const minDelta = -1 * (beforeSize - gutter.before.minSize());
     const maxDelta = afterSize - afterPart.minSize();
-    const containerSize = this.measureContainerSize();
     event.preventDefault(); // prevents text-selection
 
     this.ngZone.runOutsideAngular(() => {
@@ -254,15 +253,20 @@ export class SiSplitComponent {
                 this.gridTemplateColumns()
               );
             }
-            this.ngZone.run(() =>
-              this.sizesChange.emit(
-                this.parts().map(part => (part.actualSize() * 100) / containerSize)
-              )
-            );
+            this.emitSizesChange();
           },
           complete: () => this.saveUIState()
         });
     });
+  }
+
+  private emitSizesChange(): void {
+    const containerSize = this.measureContainerSize();
+    if (containerSize > 0) {
+      this.ngZone.run(() =>
+        this.sizesChange.emit(this.parts().map(part => (part.actualSize() * 100) / containerSize))
+      );
+    }
   }
 
   private measureContainerSize(): number {
@@ -318,16 +322,16 @@ export class SiSplitComponent {
         return;
       }
 
+      let restored = false;
       this.parts()
         .filter(part => part.stateId())
         .map(part => ({ part, state: uiState[part.stateId()!] }))
         .filter(
           (item): item is { part: SiSplitPartComponent; state: SplitPartState } =>
-            !!item.state &&
-            item.state.initialSize === item.part.size() &&
-            item.state.initialUnit === item.part.unit()
+            !!item.state && item.state.initialUnit === item.part.unit()
         )
         .forEach(({ part, state }) => {
+          restored = true;
           if (part.unit() === 'px') {
             part.expandedSize.set(state.size);
           } else {
@@ -335,7 +339,12 @@ export class SiSplitComponent {
           }
           part.collapsedState.set(!state.expanded);
         });
-      setTimeout(() => this.refreshAllPartSizes());
+      setTimeout(() => {
+        this.refreshAllPartSizes();
+        if (restored) {
+          this.emitSizesChange();
+        }
+      });
     });
   }
 }

--- a/projects/element-ng/split/si-split.interfaces.ts
+++ b/projects/element-ng/split/si-split.interfaces.ts
@@ -7,8 +7,6 @@ type CollapseTo = 'to-start' | 'to-end';
 type SplitOrientation = 'horizontal' | 'vertical';
 type SplitUnit = 'px' | 'fr';
 
-type Scale = 'none' | 'auto';
-
 interface Action {
   iconClass: string;
   tooltip: string;
@@ -20,4 +18,4 @@ interface PartState {
   size?: number;
 }
 
-export type { Action, CollapseTo, PartState, Scale, SplitOrientation, SplitUnit };
+export type { Action, CollapseTo, PartState, SplitOrientation, SplitUnit };

--- a/src/app/examples/si-split/si-split-mixed.html
+++ b/src/app/examples/si-split/si-split-mixed.html
@@ -3,10 +3,9 @@
     heading="Filters"
     stateId="filters"
     collapsible="to-start"
-    scale="none"
     class="background-1"
-    size="20"
-    unit="fr"
+    size="200"
+    unit="px"
     [actions]="[
       { iconClass: 'element-edit', click: logEvent, tooltip: 'edit' },
       { iconClass: 'element-delete', click: logEvent, tooltip: 'delete' }
@@ -16,31 +15,22 @@
     <p class="p-4 text-secondary">Split Part #1</p>
   </si-split-part>
 
-  <si-split-part
-    heading="Employees"
-    stateId="employees"
-    scale="auto"
-    class="background-1"
-    size="60"
-    unit="fr"
-  >
+  <si-split-part heading="Employees" stateId="employees" class="background-1" size="1" unit="fr">
     <si-split orientation="vertical" stateId="vertical-split">
       <si-split-part
-        scale="none"
         stateId="middle-top"
         class="background-1"
-        size="40"
-        unit="fr"
+        size="100"
+        unit="px"
         [showHeader]="false"
         (stateChange)="logEvent(format('middle', $event))"
       >
         <p class="p-4 text-secondary">Split Part #2.1</p>
       </si-split-part>
       <si-split-part
-        scale="auto"
         stateId="middle-bottom"
         class="background-1"
-        size="60"
+        size="1"
         unit="fr"
         [showHeader]="false"
       >
@@ -53,10 +43,9 @@
     heading="Details"
     stateId="details"
     collapsible="to-end"
-    scale="none"
     class="background-1"
-    size="20"
-    unit="fr"
+    size="200"
+    unit="px"
     (stateChange)="logEvent(format('right', $event))"
   >
     <p class="p-4 text-secondary">Split Part #3</p>


### PR DESCRIPTION
BREAKING CHANGE: The `scale` input and exported `Scale` type have been removed from `si-split-part`.

Use `unit="fr"` for split parts that scale with the available space and
`unit="px"` for split parts that keep a fixed size.

Before:

```html
<si-split>
  <si-split-part scale="auto">
    Flexible content
  </si-split-part>
  <si-split-part scale="none">
    Fixed content
  </si-split-part>
</si-split>
```

After:

```html
<si-split>
  <si-split-part size="1" unit="fr">
    Flexible content
  </si-split-part>
  <si-split-part size="240" unit="px">
    Fixed content
  </si-split-part>
</si-split>
```

Replace typed Scale values with SplitUnit, mapping 'auto' to 'fr'
and 'none' to 'px'.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. --><!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2727/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2727/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2727/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2727/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2727/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2727/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2727/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2727/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2727/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2727/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->







