### PR TITLE
feat(main-detail-container)!: support configurable split unit for main part

### DIFF
--- a/api-goldens/element-ng/main-detail-container/index.api.md
+++ b/api-goldens/element-ng/main-detail-container/index.api.md
@@ -24,6 +24,7 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
     readonly largeLayoutBreakpoint: _angular_core.InputSignal<number>;
     readonly mainContainerClass: _angular_core.InputSignal<string>;
     readonly mainContainerWidth: _angular_core.ModelSignal<number | "default">;
+    readonly mainContainerWidthUnit: _angular_core.InputSignal<SplitUnit>;
     readonly minDetailSize: _angular_core.InputSignal<number>;
     readonly minMainSize: _angular_core.InputSignal<number>;
     readonly resizableParts: _angular_core.InputSignalWithTransform<boolean, unknown>;

--- a/docs/components/layout-navigation/list-details.md
+++ b/docs/components/layout-navigation/list-details.md
@@ -197,6 +197,15 @@ The `slot` attribute accepts one of the following values:
 - `details`: Details pane
 - `detailActions`: Content actions for the details pane
 
+When `resizableParts` is enabled, the main split part uses the `mainContainerWidthUnit`
+input (`unit="px"` by default), while the detail part always uses `unit="fr"`.
+The `mainContainerWidth` value is interpreted using `mainContainerWidthUnit`; for example,
+`300` means `300px` with the default configuration. Use `mainContainerWidthUnit="fr"` to
+retain a relative split, where `mainContainerWidth` is the main part's fractional weight.
+
+When the component is not resizable, `mainContainerWidth` continues to be
+interpreted as a percentage for the static layout.
+
 <si-docs-component example="si-main-detail-container/si-main-detail-container" height="500"></si-docs-component>
 
 <si-docs-api component="SiMainDetailContainerComponent"></si-docs-api>

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.html
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.html
@@ -2,13 +2,15 @@
   <div class="main-detail-layout d-flex flex-column" [class]="containerClass()">
     <ng-container *ngTemplateOutlet="headingTemplate" />
     <si-split
+      #splitComponent
       class="w-100 flex-grow-1"
       orientation="horizontal"
       [stateId]="stateId()"
       (sizesChange)="onSplitSizesChange($event)"
     >
       <si-split-part
-        unit="fr"
+        #mainSplitPart
+        [unit]="mainContainerWidthUnit()"
         [size]="splitSizes[0]"
         [showHeader]="false"
         [minSize]="minMainSize()"

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.html
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.html
@@ -2,7 +2,7 @@
   <div class="main-detail-layout d-flex flex-column" [class]="containerClass()">
     <ng-container *ngTemplateOutlet="headingTemplate" />
     <si-split
-      #splitComponent
+      #splitElement
       class="w-100 flex-grow-1"
       orientation="horizontal"
       [stateId]="stateId()"

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
@@ -157,6 +157,7 @@ describe('MainDetailContainerComponent', () => {
   });
 
   it('should update mainContainerWidth in pixels when split sizes change with px unit', async () => {
+    vi.useRealTimers();
     const widthSpy = vi.spyOn(component, 'mainContainerWidthChanged');
     component.resizableParts.set(true);
     await fixture.whenStable();
@@ -166,12 +167,13 @@ describe('MainDetailContainerComponent', () => {
 
     const split = debugElement.query(By.directive(SiSplitComponent));
     split.componentInstance.sizesChange.emit([38.5, 61.5]);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(widthSpy).toHaveBeenCalledWith(385);
   });
 
   it('should calculate pixel size from split width when mainSplitPart expandedSize is unavailable', async () => {
+    vi.useRealTimers();
     const widthSpy = vi.spyOn(component, 'mainContainerWidthChanged');
     component.resizableParts.set(true);
     await fixture.whenStable();
@@ -182,12 +184,13 @@ describe('MainDetailContainerComponent', () => {
     const split = debugElement.query(By.directive(SiSplitComponent));
     const splitWidth = split.nativeElement.getBoundingClientRect().width;
     split.componentInstance.sizesChange.emit([30, 70]);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(widthSpy).toHaveBeenCalledWith(Math.round((splitWidth * 30) / 100));
   });
 
   it('should fallback to minMainSize when split width is 0 and expandedSize is unavailable', async () => {
+    vi.useRealTimers();
     const widthSpy = vi.spyOn(component, 'mainContainerWidthChanged');
     component.resizableParts.set(true);
     await fixture.whenStable();
@@ -198,12 +201,13 @@ describe('MainDetailContainerComponent', () => {
     const split = debugElement.query(By.directive(SiSplitComponent));
     vi.spyOn(split.nativeElement, 'getBoundingClientRect').mockReturnValue({ width: 0 } as DOMRect);
     split.componentInstance.sizesChange.emit([30, 70]);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(widthSpy).toHaveBeenCalledWith(300);
   });
 
   it('should update mainContainerWidth as percentage when split sizes change with fr unit', async () => {
+    vi.useRealTimers();
     const widthSpy = vi.spyOn(component, 'mainContainerWidthChanged');
     component.mainContainerWidthUnit.set('fr');
     component.resizableParts.set(true);
@@ -211,12 +215,12 @@ describe('MainDetailContainerComponent', () => {
 
     const split = debugElement.query(By.directive(SiSplitComponent));
     split.componentInstance.sizesChange.emit([42, 58]);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(widthSpy).toHaveBeenCalledWith(42);
   });
 
-  it('should keep the standard static layout for a px-sized main part', async () => {
+  it('should not apply max sizes when mainContainerWidth is outside 0-100', async () => {
     component.mainContainerWidth.set(320);
     await fixture.whenStable();
 

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.spec.ts
@@ -13,6 +13,7 @@ import {
   ElementDimensions,
   ResizeObserverService
 } from '../resize-observer';
+import { SiSplitComponent, SiSplitPartComponent, SplitUnit } from '../split';
 import { SiMainDetailContainerComponent } from './si-main-detail-container.component';
 
 @Component({
@@ -27,6 +28,8 @@ import { SiMainDetailContainerComponent } from './si-main-detail-container.compo
       [hideBackButton]="hideBackButton()"
       [largeLayoutBreakpoint]="largeLayoutBreakpoint"
       [resizableParts]="resizableParts()"
+      [mainContainerWidthUnit]="mainContainerWidthUnit()"
+      [mainContainerWidth]="mainContainerWidth()"
       [(detailsActive)]="detailsActive"
       (hasLargeSizeChange)="hasLargeSizeChanged($event)"
       (mainContainerWidthChange)="mainContainerWidthChanged($event)"
@@ -47,6 +50,8 @@ class WrapperComponent {
   readonly detailsHeading = signal('details-heading');
   readonly hideBackButton = signal(false);
   readonly resizableParts = signal(false);
+  readonly mainContainerWidthUnit = signal<SplitUnit>('px');
+  readonly mainContainerWidth = signal<number | 'default'>('default');
   largeLayoutBreakpoint = BOOTSTRAP_BREAKPOINTS.mdMinimum;
   readonly detailsActive = signal(false);
 
@@ -125,6 +130,98 @@ describe('MainDetailContainerComponent', () => {
 
     expect(htmlElement.querySelector('si-split')).toBeInTheDocument();
     expect(htmlElement.querySelectorAll('si-split-part')).toHaveLength(2);
+  });
+
+  it('should use px for the main part and fr for the detail part by default', async () => {
+    component.resizableParts.set(true);
+    await fixture.whenStable();
+
+    const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+    expect(parts[0]!.componentInstance.unit()).toBe('px');
+    expect(parts[0]!.componentInstance.size()).toBe(300);
+    expect(parts[1]!.componentInstance.unit()).toBe('fr');
+    expect(parts[1]!.componentInstance.size()).toBe(1);
+  });
+
+  it('should keep the existing relative split when mainContainerWidthUnit is fr', async () => {
+    component.mainContainerWidthUnit.set('fr');
+    component.mainContainerWidth.set(40);
+    component.resizableParts.set(true);
+    await fixture.whenStable();
+
+    const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+    expect(parts[0]!.componentInstance.unit()).toBe('fr');
+    expect(parts[0]!.componentInstance.size()).toBe(40);
+    expect(parts[1]!.componentInstance.unit()).toBe('fr');
+    expect(parts[1]!.componentInstance.size()).toBe(60);
+  });
+
+  it('should update mainContainerWidth in pixels when split sizes change with px unit', async () => {
+    const widthSpy = vi.spyOn(component, 'mainContainerWidthChanged');
+    component.resizableParts.set(true);
+    await fixture.whenStable();
+
+    const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+    parts[0]!.componentInstance.expandedSize.set(385.4);
+
+    const split = debugElement.query(By.directive(SiSplitComponent));
+    split.componentInstance.sizesChange.emit([38.5, 61.5]);
+    fixture.detectChanges();
+
+    expect(widthSpy).toHaveBeenCalledWith(385);
+  });
+
+  it('should calculate pixel size from split width when mainSplitPart expandedSize is unavailable', async () => {
+    const widthSpy = vi.spyOn(component, 'mainContainerWidthChanged');
+    component.resizableParts.set(true);
+    await fixture.whenStable();
+
+    const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+    parts[0]!.componentInstance.expandedSize.set(undefined);
+
+    const split = debugElement.query(By.directive(SiSplitComponent));
+    const splitWidth = split.nativeElement.getBoundingClientRect().width;
+    split.componentInstance.sizesChange.emit([30, 70]);
+    fixture.detectChanges();
+
+    expect(widthSpy).toHaveBeenCalledWith(Math.round((splitWidth * 30) / 100));
+  });
+
+  it('should fallback to minMainSize when split width is 0 and expandedSize is unavailable', async () => {
+    const widthSpy = vi.spyOn(component, 'mainContainerWidthChanged');
+    component.resizableParts.set(true);
+    await fixture.whenStable();
+
+    const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+    parts[0]!.componentInstance.expandedSize.set(undefined);
+
+    const split = debugElement.query(By.directive(SiSplitComponent));
+    vi.spyOn(split.nativeElement, 'getBoundingClientRect').mockReturnValue({ width: 0 } as DOMRect);
+    split.componentInstance.sizesChange.emit([30, 70]);
+    fixture.detectChanges();
+
+    expect(widthSpy).toHaveBeenCalledWith(300);
+  });
+
+  it('should update mainContainerWidth as percentage when split sizes change with fr unit', async () => {
+    const widthSpy = vi.spyOn(component, 'mainContainerWidthChanged');
+    component.mainContainerWidthUnit.set('fr');
+    component.resizableParts.set(true);
+    await fixture.whenStable();
+
+    const split = debugElement.query(By.directive(SiSplitComponent));
+    split.componentInstance.sizesChange.emit([42, 58]);
+    fixture.detectChanges();
+
+    expect(widthSpy).toHaveBeenCalledWith(42);
+  });
+
+  it('should keep the standard static layout for a px-sized main part', async () => {
+    component.mainContainerWidth.set(320);
+    await fixture.whenStable();
+
+    expect(getMainContainer().style.maxInlineSize).toBe('');
+    expect(getDetailContainer().style.maxInlineSize).toBe('');
   });
 
   it('should hide the heading component when heading input text is empty', async () => {

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
@@ -57,7 +57,7 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
   private readonly resizeObserver = inject(ResizeObserverService);
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly splitComponent = viewChild('splitComponent', { read: ElementRef });
+  private readonly splitElement = viewChild('splitElement', { read: ElementRef });
   private readonly mainSplitPart = viewChild('mainSplitPart', { read: SiSplitPartComponent });
 
   /**
@@ -317,7 +317,7 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
       return Math.round(mainPartSize);
     }
 
-    const splitWidth = this.splitComponent()?.nativeElement.getBoundingClientRect().width;
+    const splitWidth = this.splitElement()?.nativeElement.getBoundingClientRect().width;
     return splitWidth ? Math.round((splitWidth * fallbackPercentage) / 100) : this.minMainSize();
   }
 

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
@@ -174,8 +174,12 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
   /**
    * The size of the main container. When {@link resizableParts} is enabled,
    * the value is interpreted using {@link mainContainerWidthUnit} and updates as the splitter is moved.
-   * With `mainContainerWidthUnit="fr"`, the value is treated as a percentage-like fractional weight.
-   * In the static layout, numeric values represent a percentage.
+    * With `mainContainerWidthUnit="fr"`, numeric values must be from `0` to `100` (inclusive).
+    * The main and detail fractional weights are the value and `100 - value`;
+    * out-of-range values fall back to `32` and `68`.
+    * In the static layout, numeric values represent a percentage from `0` to `100`
+    * (inclusive); out-of-range values leave both containers without max-size constraints.
+    * Pixel widths are not limited to the `0` to `100` range.
    *
    * @defaultValue 'default', which uses {@link minMainSize} for `px` and `32` for `fr`.
    */
@@ -303,6 +307,7 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
       return mainSize >= 0 && mainSize <= 100 ? [mainSize, 100 - mainSize] : [32, 68];
     }
 
+    // The main size is in pixels; the detail part fills the remaining space with 1fr.
     return [mainSize, 1];
   }
 

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
@@ -17,7 +17,8 @@ import {
   OnInit,
   output,
   signal,
-  SimpleChanges
+  SimpleChanges,
+  viewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { elementBack } from '@siemens/element-icons';
@@ -27,7 +28,7 @@ import {
   ElementDimensions,
   ResizeObserverService
 } from '@siemens/element-ng/resize-observer';
-import { SiSplitComponent, SiSplitPartComponent } from '@siemens/element-ng/split';
+import { SiSplitComponent, SiSplitPartComponent, SplitUnit } from '@siemens/element-ng/split';
 import { SiTranslatePipe, t, TranslatableString } from '@siemens/element-translate-ng/translate';
 import { timer } from 'rxjs';
 
@@ -52,10 +53,12 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
   protected readonly icons = addIcons({ elementBack });
 
   private readonly animationDuration = 500;
-  private readonly elementRef = inject(ElementRef);
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly resizeObserver = inject(ResizeObserverService);
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly splitComponent = viewChild('splitComponent', { read: ElementRef });
+  private readonly mainSplitPart = viewChild('mainSplitPart', { read: SiSplitPartComponent });
 
   /**
    * A numeric value defining the minimum width in px, which the container needs
@@ -162,10 +165,19 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
   readonly detailContainerClass = input('pb-6');
 
   /**
-   * The percentage width of the main container from the overall component width.
-   * Can be a number or `'default'`, which is 32% when {@link resizableParts} is active, otherwise 50%.
+   * Unit used for the main split part when {@link resizableParts} is enabled.
    *
-   * @defaultValue 'default'
+   * @defaultValue 'px'
+   */
+  readonly mainContainerWidthUnit = input<SplitUnit>('px');
+
+  /**
+   * The size of the main container. When {@link resizableParts} is enabled,
+   * the value is interpreted using {@link mainContainerWidthUnit} and updates as the splitter is moved.
+   * With `mainContainerWidthUnit="fr"`, the value is treated as a percentage-like fractional weight.
+   * In the static layout, numeric values represent a percentage.
+   *
+   * @defaultValue 'default', which uses {@link minMainSize} for `px` and `32` for `fr`.
    */
   readonly mainContainerWidth = model<number | 'default'>('default');
   /**
@@ -194,17 +206,18 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
 
   private readonly actualMainContainerWidth = computed(() => {
     const mainContainerWidth = this.mainContainerWidth();
-    return mainContainerWidth === 'default'
-      ? this.resizableParts()
-        ? 32
-        : 50
-      : mainContainerWidth;
+    if (mainContainerWidth !== 'default') {
+      return mainContainerWidth;
+    }
+
+    if (!this.resizableParts()) {
+      return 50;
+    }
+
+    return this.mainContainerWidthUnit() === 'px' ? this.minMainSize() : 32;
   });
 
-  protected splitSizes: [number, number] = [
-    this.actualMainContainerWidth(),
-    100 - this.actualMainContainerWidth()
-  ];
+  protected splitSizes: [number, number] = this.getSplitSizes();
   // The max size to limit the main container in the static flex layout (if less than 50%), otherwise not set.
   protected maxMainSize: string = this.getMaxSize(0);
   // The max size to limit the detail container in the static flex layout (if less than 50%), otherwise not set.
@@ -229,8 +242,14 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
       this.updateDetailsFocusable();
       this.doAnimation(changes.detailsActive.currentValue);
     }
-    if (changes.mainContainerWidth || changes.resizableParts) {
-      this.splitSizes = [this.actualMainContainerWidth(), 100 - this.actualMainContainerWidth()];
+    if (
+      changes.mainContainerWidth ||
+      changes.resizableParts ||
+      changes.mainContainerWidthUnit ||
+      changes.minMainSize ||
+      changes.minDetailSize
+    ) {
+      this.splitSizes = this.getSplitSizes();
       this.maxMainSize = this.getMaxSize(0);
       this.maxDetailSize = this.getMaxSize(1);
     }
@@ -244,7 +263,11 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
   }
 
   protected onSplitSizesChange(sizes: number[]): void {
-    this.mainContainerWidth.set(sizes[0]);
+    if (this.mainContainerWidthUnit() === 'px') {
+      this.mainContainerWidth.set(this.getMainSizePx(sizes[0]));
+    } else {
+      this.mainContainerWidth.set(sizes[0]);
+    }
   }
 
   protected detailsBackClicked(): void {
@@ -256,12 +279,42 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
    * Get the max size to limit in the static flex layout (if less than 50%), otherwise not set
    */
   private getMaxSize(part: 0 | 1): string {
-    return this.resizableParts() ||
-      this.mainContainerWidth() === 'default' ||
+    const mainContainerWidth = this.mainContainerWidth();
+    if (
+      this.resizableParts() ||
+      mainContainerWidth === 'default' ||
       !this.hasLargeSize ||
-      this.splitSizes[part] > 50
-      ? ''
-      : this.splitSizes[part] + '%';
+      mainContainerWidth < 0 ||
+      mainContainerWidth > 100
+    ) {
+      return '';
+    }
+
+    const size = part === 0 ? mainContainerWidth : 100 - mainContainerWidth;
+    return size > 50 ? '' : size + '%';
+  }
+
+  private getSplitSizes(): [number, number] {
+    const mainSize = this.actualMainContainerWidth();
+    if (!this.resizableParts()) {
+      return mainSize >= 0 && mainSize <= 100 ? [mainSize, 100 - mainSize] : [50, 50];
+    }
+
+    if (this.mainContainerWidthUnit() === 'fr') {
+      return mainSize >= 0 && mainSize <= 100 ? [mainSize, 100 - mainSize] : [32, 68];
+    }
+
+    return [mainSize, 1];
+  }
+
+  private getMainSizePx(fallbackPercentage: number): number {
+    const mainPartSize = this.mainSplitPart()?.expandedSize();
+    if (mainPartSize !== undefined) {
+      return Math.round(mainPartSize);
+    }
+
+    const splitWidth = this.splitComponent()?.nativeElement.getBoundingClientRect().width;
+    return splitWidth ? Math.round((splitWidth * fallbackPercentage) / 100) : this.minMainSize();
   }
 
   private determineLayout(dimensions: ElementDimensions): void {

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
@@ -174,14 +174,17 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
   /**
    * The size of the main container. When {@link resizableParts} is enabled,
    * the value is interpreted using {@link mainContainerWidthUnit} and updates as the splitter is moved.
-    * With `mainContainerWidthUnit="fr"`, numeric values must be from `0` to `100` (inclusive).
-    * The main and detail fractional weights are the value and `100 - value`;
-    * out-of-range values fall back to `32` and `68`.
-    * In the static layout, numeric values represent a percentage from `0` to `100`
-    * (inclusive); out-of-range values leave both containers without max-size constraints.
-    * Pixel widths are not limited to the `0` to `100` range.
+   * With `mainContainerWidthUnit="fr"`, numeric values must be from `0` to `100` (inclusive).
+   * The main and detail fractional weights are the value and `100 - value`;
+   * out-of-range values fall back to `32` and `68`.
+   * In the static layout, numeric values represent a percentage from `0` to `100`
+   * (inclusive); out-of-range values leave both containers without max-size constraints.
+   * Pixel widths are not limited to the `0` to `100` range.
    *
-   * @defaultValue 'default', which uses {@link minMainSize} for `px` and `32` for `fr`.
+   * With `'default'`, resizable pixel layouts use {@link minMainSize}, resizable fractional
+   * layouts use main and detail weights of `32` and `68`, and static layouts use `50%`.
+   *
+   * @defaultValue 'default'
    */
   readonly mainContainerWidth = model<number | 'default'>('default');
   /**

--- a/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
+++ b/projects/element-ng/main-detail-container/si-main-detail-container.component.ts
@@ -246,8 +246,7 @@ export class SiMainDetailContainerComponent implements OnInit, OnChanges {
       changes.mainContainerWidth ||
       changes.resizableParts ||
       changes.mainContainerWidthUnit ||
-      changes.minMainSize ||
-      changes.minDetailSize
+      changes.minMainSize
     ) {
       this.splitSizes = this.getSplitSizes();
       this.maxMainSize = this.getMaxSize(0);

--- a/projects/element-ng/schematics/ng-update/migrate-main-detail-units.spec.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-main-detail-units.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+import { callRule, Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+import { addTestFiles, createTestApp } from '../utils/index.js';
+import { mainDetailUnitsMigrationRule } from './migrate-main-detail-units.js';
+
+const collectionPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../migration.json');
+
+describe('main detail units migration', () => {
+  let runner: SchematicTestRunner;
+  let appTree: Tree;
+
+  beforeEach(async () => {
+    runner = new SchematicTestRunner('migration-v51', collectionPath);
+    appTree = await createTestApp(runner, { style: 'scss' });
+  });
+
+  const runMigration = async (): Promise<Tree> => {
+    const context = runner.engine.createContext(
+      runner.engine.createSchematic('migration-v51', runner.engine.createCollection(collectionPath))
+    );
+    const tree = await callRule(
+      mainDetailUnitsMigrationRule({ path: 'projects/app/src' }),
+      appTree,
+      context
+    ).toPromise();
+
+    if (!tree) {
+      throw new Error('mainDetailUnitsMigrationRule returned undefined');
+    }
+
+    return tree;
+  };
+
+  it('should add mainContainerWidthUnit="fr" to resizable containers in inline templates', async () => {
+    const initialContent = `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  template: \`<si-main-detail-container resizableParts [mainContainerWidth]="40">
+    <div slot="mainData">Main</div>
+    <div slot="details">Details</div>
+  </si-main-detail-container>\`
+})
+export class TestComponent {}`;
+
+    addTestFiles(appTree, {
+      '/projects/app/src/test.component.ts': initialContent
+    });
+
+    const tree = await runMigration();
+
+    expect(tree.readContent('/projects/app/src/test.component.ts')).toBe(
+      `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  template: \`<si-main-detail-container resizableParts [mainContainerWidth]="40" mainContainerWidthUnit="fr">
+    <div slot="mainData">Main</div>
+    <div slot="details">Details</div>
+  </si-main-detail-container>\`
+})
+export class TestComponent {}`
+    );
+  });
+
+  it('should add mainContainerWidthUnit="fr" to resizable containers in external templates', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/test.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  templateUrl: './test.component.html'
+})
+export class TestComponent {}`,
+      '/projects/app/src/test.component.html': `<si-main-detail-container [resizableParts]="true" [mainContainerWidth]="32">
+  <div slot="mainData">Main</div>
+  <div slot="details">Details</div>
+</si-main-detail-container>`
+    });
+
+    const tree = await runMigration();
+
+    expect(tree.readContent('/projects/app/src/test.component.html')).toBe(
+      `<si-main-detail-container [resizableParts]="true" [mainContainerWidth]="32" mainContainerWidthUnit="fr">
+  <div slot="mainData">Main</div>
+  <div slot="details">Details</div>
+</si-main-detail-container>`
+    );
+  });
+
+  it('should not modify containers without resizableParts', async () => {
+    const template = `<si-main-detail-container [mainContainerWidth]="50">
+  <div slot="mainData">Main</div>
+  <div slot="details">Details</div>
+</si-main-detail-container>`;
+
+    addTestFiles(appTree, {
+      '/projects/app/src/test.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  templateUrl: './test.component.html'
+})
+export class TestComponent {}`,
+      '/projects/app/src/test.component.html': template
+    });
+
+    const tree = await runMigration();
+
+    expect(tree.readContent('/projects/app/src/test.component.html')).toBe(template);
+  });
+
+  it('should not modify containers when resizableParts is explicitly false', async () => {
+    const template = `<si-main-detail-container resizableParts="false" [mainContainerWidth]="50">
+  <div slot="mainData">Main</div>
+  <div slot="details">Details</div>
+</si-main-detail-container>`;
+
+    addTestFiles(appTree, {
+      '/projects/app/src/test.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  templateUrl: './test.component.html'
+})
+export class TestComponent {}`,
+      '/projects/app/src/test.component.html': template
+    });
+
+    const tree = await runMigration();
+
+    expect(tree.readContent('/projects/app/src/test.component.html')).toBe(template);
+  });
+
+  it('should not overwrite existing mainContainerWidthUnit', async () => {
+    const template = `<si-main-detail-container resizableParts mainContainerWidthUnit="px">
+  <div slot="mainData">Main</div>
+  <div slot="details">Details</div>
+</si-main-detail-container>`;
+
+    addTestFiles(appTree, {
+      '/projects/app/src/test.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  templateUrl: './test.component.html'
+})
+export class TestComponent {}`,
+      '/projects/app/src/test.component.html': template
+    });
+
+    const tree = await runMigration();
+
+    expect(tree.readContent('/projects/app/src/test.component.html')).toBe(template);
+  });
+});

--- a/projects/element-ng/schematics/ng-update/migrate-main-detail-units.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-main-detail-units.ts
@@ -12,7 +12,8 @@ import {
   discoverSourceFiles,
   findElement,
   getInlineTemplates,
-  getTemplateUrl
+  getTemplateUrl,
+  insertAttribute
 } from '../utils/index.js';
 
 const resizableAttributeNames = ['resizableParts', '[resizableParts]', 'bind-resizableParts'];
@@ -94,19 +95,6 @@ const migrateMainDetailContainerElement = (
   }
 
   insertAttribute(template, element, 'mainContainerWidthUnit="fr"', offset, recorder);
-};
-
-const insertAttribute = (
-  template: string,
-  element: Element,
-  attribute: string,
-  offset: number,
-  recorder: UpdateRecorder
-): void => {
-  const selfClosing = element.startSourceSpan.toString().endsWith('/>');
-  const insertOffset = element.startSourceSpan.end.offset - (selfClosing ? 2 : 1);
-  const prefix = /\s/.test(template[insertOffset - 1] ?? '') ? '' : ' ';
-  recorder.insertLeft(insertOffset + offset, `${prefix}${attribute}${selfClosing ? ' ' : ''}`);
 };
 
 const getStaticBooleanValue = (attribute: Attribute): boolean | undefined => {

--- a/projects/element-ng/schematics/ng-update/migrate-main-detail-units.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-main-detail-units.ts
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Rule, SchematicContext, Tree, UpdateRecorder } from '@angular-devkit/schematics';
+import type { Attribute, Element } from '@angular/compiler';
+import { dirname, join } from 'path/posix';
+import ts from 'typescript';
+
+import {
+  discoverSourceFiles,
+  findElement,
+  getInlineTemplates,
+  getTemplateUrl
+} from '../utils/index.js';
+
+const resizableAttributeNames = ['resizableParts', '[resizableParts]', 'bind-resizableParts'];
+const mainUnitAttributeNames = [
+  'mainContainerWidthUnit',
+  '[mainContainerWidthUnit]',
+  'bind-mainContainerWidthUnit'
+];
+const detailUnitAttributeNames = ['detailUnit', '[detailUnit]', 'bind-detailUnit'];
+
+export const mainDetailUnitsMigrationRule = (options: { path: string }): Rule => {
+  return async (tree: Tree, context: SchematicContext) => {
+    const processedTemplates = new Set<string>();
+
+    for await (const discoveredSourceFile of discoverSourceFiles(tree, context, options.path)) {
+      const { path: filePath, sourceFile } = discoveredSourceFile;
+      const recorder = tree.beginUpdate(filePath);
+
+      for (const template of getInlineTemplates(sourceFile)) {
+        migrateMainDetailUnitsTemplate(
+          sourceFile.text.substring(template.getStart() + 1, template.getEnd() - 1),
+          template.getStart() + 1,
+          recorder
+        );
+      }
+      tree.commitUpdate(recorder);
+
+      for (const templateUrl of getTemplateUrl(sourceFile)) {
+        const templatePath = join(dirname(filePath), templateUrl);
+        if (processedTemplates.has(templatePath) || !tree.exists(templatePath)) {
+          continue;
+        }
+
+        processedTemplates.add(templatePath);
+        const templateRecorder = tree.beginUpdate(templatePath);
+        migrateMainDetailUnitsTemplate(
+          tree.read(templatePath)!.toString('utf-8'),
+          0,
+          templateRecorder
+        );
+        tree.commitUpdate(templateRecorder);
+      }
+    }
+
+    return tree;
+  };
+};
+
+const migrateMainDetailUnitsTemplate = (
+  template: string,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  findElement(template, element => element.name === 'si-main-detail-container').forEach(element => {
+    migrateMainDetailContainerElement(template, element, offset, recorder);
+  });
+};
+
+const migrateMainDetailContainerElement = (
+  template: string,
+  element: Element,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  const detailUnitAttribute = element.attrs.find(attr =>
+    detailUnitAttributeNames.includes(attr.name)
+  );
+  if (detailUnitAttribute) {
+    removeAttribute(template, detailUnitAttribute, offset, recorder);
+  }
+
+  const resizableAttribute = element.attrs.find(attr =>
+    resizableAttributeNames.includes(attr.name)
+  );
+  if (!resizableAttribute) {
+    return;
+  }
+
+  const isExplicitlyDisabled = getStaticBooleanValue(resizableAttribute) === false;
+  if (isExplicitlyDisabled) {
+    return;
+  }
+
+  const hasMainUnit = element.attrs.some(attr => mainUnitAttributeNames.includes(attr.name));
+  if (hasMainUnit) {
+    return;
+  }
+
+  insertAttribute(template, element, 'mainContainerWidthUnit="fr"', offset, recorder);
+};
+
+const insertAttribute = (
+  template: string,
+  element: Element,
+  attribute: string,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  const selfClosing = element.startSourceSpan.toString().endsWith('/>');
+  const insertOffset = element.startSourceSpan.end.offset - (selfClosing ? 2 : 1);
+  const prefix = /\s/.test(template[insertOffset - 1] ?? '') ? '' : ' ';
+  recorder.insertLeft(insertOffset + offset, `${prefix}${attribute}${selfClosing ? ' ' : ''}`);
+};
+
+const removeAttribute = (
+  template: string,
+  attribute: Attribute,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  const start = attribute.sourceSpan.start.offset;
+  const end = attribute.sourceSpan.end.offset;
+  const lineStart = template.lastIndexOf('\n', start - 1) + 1;
+  const lineEnd = template.indexOf('\n', end);
+  const endOfLine = lineEnd === -1 ? template.length : lineEnd;
+
+  if (
+    template.slice(lineStart, start).trim() === '' &&
+    template.slice(end, endOfLine).trim() === ''
+  ) {
+    const removeEnd = lineEnd === -1 ? endOfLine : lineEnd + 1;
+    recorder.remove(lineStart + offset, removeEnd - lineStart);
+    return;
+  }
+
+  const removeStart = start > 0 && /\s/.test(template[start - 1] ?? '') ? start - 1 : start;
+  recorder.remove(removeStart + offset, end - removeStart);
+};
+
+const getStaticBooleanValue = (attribute: Attribute): boolean | undefined => {
+  if (!attribute.name.startsWith('[')) {
+    if (/^\s*{{[\s\S]*}}\s*$/.test(attribute.value)) {
+      return undefined;
+    }
+    return attribute.value !== 'false';
+  }
+
+  const initializer = getExpression(attribute.value);
+  if (!initializer) {
+    return undefined;
+  }
+
+  if (initializer.kind === ts.SyntaxKind.TrueKeyword) {
+    return true;
+  }
+  if (
+    initializer.kind === ts.SyntaxKind.FalseKeyword ||
+    initializer.kind === ts.SyntaxKind.NullKeyword ||
+    (ts.isIdentifier(initializer) && initializer.text === 'undefined') ||
+    (ts.isStringLiteral(initializer) && initializer.text === 'false')
+  ) {
+    return false;
+  }
+  if (ts.isStringLiteral(initializer) || ts.isNumericLiteral(initializer)) {
+    return true;
+  }
+
+  return undefined;
+};
+
+const getExpression = (value: string): ts.Expression | undefined => {
+  const statement = ts.createSourceFile(
+    'template-expression.ts',
+    `const value = ${value};`,
+    ts.ScriptTarget.Latest,
+    true
+  ).statements[0];
+  if (!statement || !ts.isVariableStatement(statement)) {
+    return undefined;
+  }
+
+  return statement.declarationList.declarations[0]?.initializer;
+};

--- a/projects/element-ng/schematics/ng-update/migrate-main-detail-units.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-main-detail-units.ts
@@ -21,7 +21,6 @@ const mainUnitAttributeNames = [
   '[mainContainerWidthUnit]',
   'bind-mainContainerWidthUnit'
 ];
-const detailUnitAttributeNames = ['detailUnit', '[detailUnit]', 'bind-detailUnit'];
 
 export const mainDetailUnitsMigrationRule = (options: { path: string }): Rule => {
   return async (tree: Tree, context: SchematicContext) => {
@@ -77,13 +76,6 @@ const migrateMainDetailContainerElement = (
   offset: number,
   recorder: UpdateRecorder
 ): void => {
-  const detailUnitAttribute = element.attrs.find(attr =>
-    detailUnitAttributeNames.includes(attr.name)
-  );
-  if (detailUnitAttribute) {
-    removeAttribute(template, detailUnitAttribute, offset, recorder);
-  }
-
   const resizableAttribute = element.attrs.find(attr =>
     resizableAttributeNames.includes(attr.name)
   );
@@ -115,31 +107,6 @@ const insertAttribute = (
   const insertOffset = element.startSourceSpan.end.offset - (selfClosing ? 2 : 1);
   const prefix = /\s/.test(template[insertOffset - 1] ?? '') ? '' : ' ';
   recorder.insertLeft(insertOffset + offset, `${prefix}${attribute}${selfClosing ? ' ' : ''}`);
-};
-
-const removeAttribute = (
-  template: string,
-  attribute: Attribute,
-  offset: number,
-  recorder: UpdateRecorder
-): void => {
-  const start = attribute.sourceSpan.start.offset;
-  const end = attribute.sourceSpan.end.offset;
-  const lineStart = template.lastIndexOf('\n', start - 1) + 1;
-  const lineEnd = template.indexOf('\n', end);
-  const endOfLine = lineEnd === -1 ? template.length : lineEnd;
-
-  if (
-    template.slice(lineStart, start).trim() === '' &&
-    template.slice(end, endOfLine).trim() === ''
-  ) {
-    const removeEnd = lineEnd === -1 ? endOfLine : lineEnd + 1;
-    recorder.remove(lineStart + offset, removeEnd - lineStart);
-    return;
-  }
-
-  const removeStart = start > 0 && /\s/.test(template[start - 1] ?? '') ? start - 1 : start;
-  recorder.remove(removeStart + offset, end - removeStart);
 };
 
 const getStaticBooleanValue = (attribute: Attribute): boolean | undefined => {

--- a/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
@@ -9,6 +9,7 @@ import { ElementMigrationData, getElementMigrationData } from '../migrations/dat
 import { elementMigrationRule } from '../migrations/element-migration/element-migration.js';
 import { missingTranslateMigrationRule } from '../migrations/ngx-translate/index.js';
 import { contentFormatterMigrationRule } from './migrate-content-formatter.js';
+import { mainDetailUnitsMigrationRule } from './migrate-main-detail-units.js';
 import { markdownRendererMigrationRule } from './migrate-markdown-renderer.js';
 import { spacerMigrationRule } from './migrate-spacers.js';
 import { splitCollapseMigrationRule } from './migrate-split-collapse.js';
@@ -26,6 +27,7 @@ export const migrateToV51 = (): Rule => {
       splitScaleMigrationRule(options),
       splitSizesMigrationRule(options),
       splitCollapseMigrationRule(options),
+      mainDetailUnitsMigrationRule(options),
       contentFormatterMigrationRule(options),
       markdownRendererMigrationRule(options),
       spacerMigrationRule(options)

--- a/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.html
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.html
@@ -4,6 +4,7 @@
   detailsHeading="Details"
   resizableParts="true"
   truncateHeading="true"
+  mainContainerWidthUnit="fr"
   [largeLayoutBreakpoint]="largeLayoutBreakpoint"
   [mainContainerWidth]="50"
   [minMainSize]="200"

--- a/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.ts
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container-filtered-search.ts
@@ -88,7 +88,7 @@ export class SampleComponent {
     this.logEvent(this.selectedEntities);
   }
 
-  onSplitChange(containerWidth: number | string): void {
+  onSplitChange(containerWidth: number | 'default'): void {
     this.logEvent(`Main width is ${containerWidth}%.`);
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     this.table().recalculate();

--- a/src/app/examples/si-main-detail-container/si-main-detail-container.html
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container.html
@@ -1,5 +1,6 @@
 <si-main-detail-container
   stateId="si-main-detail-demo"
+  mainContainerWidthUnit="fr"
   [style.maxWidth.px]="containerMaxWidth ? containerMaxWidth : null"
   [largeLayoutBreakpoint]="largeLayoutBreakpoint"
   [heading]="heading"

--- a/src/app/examples/si-main-detail-container/si-main-detail-container.ts
+++ b/src/app/examples/si-main-detail-container/si-main-detail-container.ts
@@ -168,7 +168,7 @@ export class SampleComponent {
     });
   }
 
-  onSplitChange(containerWidth: number | string): void {
+  onSplitChange(containerWidth: number | 'default'): void {
     this.logEvent(`Main width is ${containerWidth}%.`);
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     this.table().recalculate();


### PR DESCRIPTION
Add `mainContainerWidthUnit` input to configure the unit of the underlying main
split part when `resizableParts` is enabled. The detail split part always uses
`unit="fr"`.

BREAKING CHANGE: The default sizing unit of the main split part in
`si-main-detail-container` when `resizableParts` is enabled has changed from `fr`
to `px`.

When `resizableParts` is enabled:
- The main part now defaults to `unit="px"` (initial size of `minMainSize`,
  default 300px), and the detail part takes the remaining space (`1fr`).
- `mainContainerWidth` is now interpreted in `mainContainerWidthUnit`. With the
  default `mainContainerWidthUnit="px"`, numeric values are treated as pixels
  instead of percentages.
- `[(mainContainerWidth)]` and `(mainContainerWidthChange)` now emit and accept
  pixel values instead of percentage values.
- When adopting the new `px` default, main-part sizes saved via `stateId` with
  `fr` are not restored because the persisted unit no longer matches. Keeping
  `mainContainerWidthUnit="fr"` preserves compatible saved splitter positions.

To retain the previous relative percentage-based split behavior, explicitly set
`mainContainerWidthUnit="fr"`.

Static layouts (`resizableParts="false"`) are unaffected and continue to
interpret `mainContainerWidth` as a percentage.

Before:

```html
<!-- Main part was 40% width, detail was 60% -->
<si-main-detail-container
  resizableParts
  [mainContainerWidth]="40"
  [(detailsActive)]="detailsActive"
>
  <div slot="mainData">...</div>
  <div slot="details">...</div>
</si-main-detail-container>
```

After (retaining previous relative behavior):

```html
<!-- Set mainContainerWidthUnit="fr" to retain fractional/percentage sizing -->
<si-main-detail-container
  resizableParts
  mainContainerWidthUnit="fr"
  [mainContainerWidth]="40"
  [(detailsActive)]="detailsActive"
>
  <div slot="mainData">...</div>
  <div slot="details">...</div>
</si-main-detail-container>
```

After (adopting new fixed-width layout):
```html
<!-- Main part is fixed pixel width (e.g. 360px), detail expands with remaining space -->
<si-main-detail-container
  resizableParts
  [mainContainerWidth]="360"
  [(detailsActive)]="detailsActive"
>
  <div slot="mainData">...</div>
  <div slot="details">...</div>
</si-main-detail-container>
```
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2728/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2728/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2728/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2728/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2728/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2728/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2728/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2728/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2728/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2728/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->





