### PR TITLE
feat(list-details)!: support configurable split unit for list pane

### DIFF
--- a/api-goldens/element-ng/list-details/index.api.md
+++ b/api-goldens/element-ng/list-details/index.api.md
@@ -43,6 +43,7 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
     readonly expandBreakpoint: _angular_core.InputSignal<number>;
     // (undocumented)
     readonly hasLargeSize: _angular_core.Signal<boolean>;
+    readonly listUnit: _angular_core.InputSignal<SplitUnit>;
     readonly listWidth: _angular_core.ModelSignal<number>;
     readonly minDetailsSize: _angular_core.InputSignal<number>;
     readonly minListSize: _angular_core.InputSignal<number>;

--- a/api-goldens/element-ng/list-details/index.api.md
+++ b/api-goldens/element-ng/list-details/index.api.md
@@ -43,8 +43,8 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
     readonly expandBreakpoint: _angular_core.InputSignal<number>;
     // (undocumented)
     readonly hasLargeSize: _angular_core.Signal<boolean>;
-    readonly listUnit: _angular_core.InputSignal<SplitUnit>;
     readonly listWidth: _angular_core.ModelSignal<number>;
+    readonly listWidthUnit: _angular_core.InputSignal<SplitUnit>;
     readonly minDetailsSize: _angular_core.InputSignal<number>;
     readonly minListSize: _angular_core.InputSignal<number>;
     readonly stateId: _angular_core.InputSignal<string | undefined>;

--- a/docs/components/layout-navigation/list-details.md
+++ b/docs/components/layout-navigation/list-details.md
@@ -148,6 +148,16 @@ Inside the `<si-details-pane>` the following child components can be used:
 
 It is highly advised to use at least the `<si-details-pane-header>` to show the back button in a responsive (mobile) view.
 
+When resizing is enabled, the underlying list split part uses the `listUnit`
+input, while the details split part always uses `unit="fr"`. The list pane uses
+`unit="px"` by default. Accordingly, `listWidth` defaults to `300` and
+represents pixels with the default configuration.
+
+Use `listUnit="fr"` to retain a relative split, where `listWidth` is the list
+pane's fractional weight. When resizing is disabled, `listWidth` continues to
+control the static layout as a percentage. Values outside the percentage range
+use the standard 32/68 static layout.
+
 If the content may exceed the available space, the `overflow-auto` class should be applied
 to the body components or a child inside them.
 

--- a/docs/components/layout-navigation/list-details.md
+++ b/docs/components/layout-navigation/list-details.md
@@ -148,14 +148,14 @@ Inside the `<si-details-pane>` the following child components can be used:
 
 It is highly advised to use at least the `<si-details-pane-header>` to show the back button in a responsive (mobile) view.
 
-When resizing is enabled, the underlying list split part uses the `listUnit`
+When resizing is enabled, the underlying list split part uses the `listWidthUnit`
 input, while the details split part always uses `unit="fr"`. The list pane uses
 `unit="px"` by default. Accordingly, `listWidth` defaults to `300` and
 represents pixels with the default configuration.
 
-Use `listUnit="fr"` to retain a relative split, where `listWidth` is the list
+Use `listWidthUnit="fr"` to retain a relative split, where `listWidth` is the list
 pane's fractional weight. When resizing is disabled, `listWidth` continues to
-control the static layout as a percentage. For both resizable `listUnit="fr"`
+control the static layout as a percentage. For both resizable `listWidthUnit="fr"`
 and static layouts, values outside the inclusive range 0-100 use the standard
 32/68 list/details split.
 

--- a/docs/components/layout-navigation/list-details.md
+++ b/docs/components/layout-navigation/list-details.md
@@ -167,6 +167,10 @@ though it can also be moved to suite the design needs.
 
 <si-docs-component example="si-list-details/si-list-details" height="500"></si-docs-component>
 
+### Default pixel sizing
+
+<si-docs-component example="si-list-details/si-list-details-pixels" height="500"></si-docs-component>
+
 <si-docs-api component="SiListDetailsComponent"></si-docs-api>
 
 <si-docs-api component="SiListPaneComponent"></si-docs-api>

--- a/docs/components/layout-navigation/list-details.md
+++ b/docs/components/layout-navigation/list-details.md
@@ -155,8 +155,9 @@ represents pixels with the default configuration.
 
 Use `listUnit="fr"` to retain a relative split, where `listWidth` is the list
 pane's fractional weight. When resizing is disabled, `listWidth` continues to
-control the static layout as a percentage. Values outside the percentage range
-use the standard 32/68 static layout.
+control the static layout as a percentage. For both resizable `listUnit="fr"`
+and static layouts, values outside the inclusive range 0-100 use the standard
+32/68 list/details split.
 
 If the content may exceed the available space, the `overflow-auto` class should be applied
 to the body components or a child inside them.

--- a/playwright/e2e/element-examples/si-list-details-pixels.spec.ts
+++ b/playwright/e2e/element-examples/si-list-details-pixels.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { expect, test } from '../../support/test-helpers';
+
+test.describe('si-list-details pixel defaults', () => {
+  const example = 'si-list-details/si-list-details-pixels';
+
+  test('uses a fixed 300px list pane and resizes in pixels', async ({ page, si }) => {
+    await si.visitExample(example);
+    const split = page.locator('si-split');
+    const listPart = split.locator('si-split-part').first();
+    const listWidth = (): Promise<number> =>
+      listPart.evaluate(element => element.getBoundingClientRect().width);
+    await expect(listPart).toBeVisible();
+    await expect.poll(listWidth).toBeCloseTo(300, 0);
+    await si.runVisualAndA11yTests('default');
+
+    const initialSplitWidth = (await split.boundingBox())!.width;
+    await page.setViewportSize({ width: 1200, height: 660 });
+    await expect
+      .poll(async () => (await split.boundingBox())?.width)
+      .toBeGreaterThan(initialSplitWidth);
+    await expect.poll(listWidth).toBeCloseTo(300, 0);
+
+    const splitHandle = split.locator('.si-split-gutter');
+    const handleBox = (await splitHandle.boundingBox())!;
+    const centerX = handleBox.x + handleBox.width / 2;
+    const centerY = handleBox.y + handleBox.height / 2;
+    await page.mouse.move(centerX, centerY);
+    await page.mouse.down();
+    await page.mouse.move(centerX + 100, centerY);
+    await page.mouse.up();
+    await expect.poll(listWidth).toBeCloseTo(400, 0);
+
+    await page.setViewportSize({ width: 1100, height: 660 });
+    await expect.poll(listWidth).toBeCloseTo(400, 0);
+  });
+
+  test('opens equipment details and returns to the list on mobile', async ({ page, si }) => {
+    await page.setViewportSize({ width: 600, height: 800 });
+    await si.visitExample(example);
+    await expect(page.locator('si-split')).toHaveCount(0);
+
+    const equipmentButton = page.getByRole('button', { name: /Room controller/ });
+    await expect(equipmentButton).toBeInViewport();
+    await si.runVisualAndA11yTests('mobile-list');
+
+    await equipmentButton.click();
+    await expect(page.getByText('Room 204, Building A', { exact: true })).toBeInViewport();
+    const backButton = page.getByRole('button', { name: 'Back', exact: true });
+    await expect(backButton).toBeFocused();
+    await si.runVisualAndA11yTests('mobile-details');
+
+    await backButton.click();
+    await expect(equipmentButton).toBeInViewport();
+    await expect(equipmentButton).toBeFocused();
+  });
+});

--- a/playwright/e2e/element-examples/si-list-details.spec.ts
+++ b/playwright/e2e/element-examples/si-list-details.spec.ts
@@ -104,6 +104,36 @@ test.describe('si-list-details', () => {
     });
   });
 
+  test(`${example} – restore split state after resize`, async ({ page, si }) => {
+    await si.visitExample(example);
+    const split = page.locator('si-split');
+    await expect(split).toHaveCount(1);
+
+    const listPart = page.locator('si-split > si-split-part').first();
+    const initialWidth = (await listPart.boundingBox())!.width;
+
+    // Resize the split by dragging gutter
+    const splitHandle = split.locator('.si-split-gutter');
+    const splitHandleBox = (await splitHandle.boundingBox())!;
+    const x = splitHandleBox.x + splitHandleBox.width / 2;
+    const y = splitHandleBox.y + splitHandleBox.height / 2;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + 100, y);
+    await page.mouse.up();
+
+    const resizedWidth = (await listPart.boundingBox())!.width;
+    expect(resizedWidth).toBeGreaterThan(initialWidth + 50);
+
+    // Reload the example to verify state restoration
+    await page.goto(page.url() + '?e=' + encodeURIComponent(example));
+
+    // Verify split state (width) is restored
+    const restoredWidth = (await listPart.boundingBox())!.width;
+    expect(restoredWidth).toBeGreaterThan(initialWidth + 50);
+    expect(Math.abs(restoredWidth - resizedWidth)).toBeLessThan(15);
+  });
+
   test('with router in mobile mode', async ({ page, si }) => {
     await page.setViewportSize({ width: 600, height: 800 }); // mdMinimum is 768px
     await si.visitExample('si-list-details/si-list-details-router');

--- a/playwright/e2e/element-examples/si-list-details.spec.ts
+++ b/playwright/e2e/element-examples/si-list-details.spec.ts
@@ -126,12 +126,14 @@ test.describe('si-list-details', () => {
     expect(resizedWidth).toBeGreaterThan(initialWidth + 50);
 
     // Reload the example to verify state restoration
-    await page.goto(page.url() + '?e=' + encodeURIComponent(example));
+    await page.reload();
+    await si.visitExample(example);
+    await expect(listPart).toBeVisible();
 
     // Verify split state (width) is restored
-    const restoredWidth = (await listPart.boundingBox())!.width;
-    expect(restoredWidth).toBeGreaterThan(initialWidth + 50);
-    expect(Math.abs(restoredWidth - resizedWidth)).toBeLessThan(15);
+    await expect
+      .poll(async () => Math.abs((await listPart.boundingBox())!.width - resizedWidth))
+      .toBeLessThan(15);
   });
 
   test('with router in mobile mode', async ({ page, si }) => {

--- a/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--default-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--default-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99511f64ed12d4ce1179c4e805af589802a6e36d72f798577484ae69d0c1afd9
+size 19524

--- a/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--default-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--default-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebafa358adc188d4512a9919ebe36ee28c0a13505b8b6e42a5646165d086bd9e
+size 18593

--- a/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--default.yaml
+++ b/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--default.yaml
@@ -1,0 +1,11 @@
+- heading "Equipment" [level=2]
+- button /Air handling unit AHU-\d+/
+- button /Room controller RC-\d+/
+- button /Heat pump HP-\d+/
+- text: Air handling unit
+- term: Equipment ID
+- definition: /AHU-\d+/
+- term: Location
+- definition: Roof, Building A
+- term: Status
+- definition: Running

--- a/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-details-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-details-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3d6ca0a9f4261fd63c8283b52294afe76a61ef5882cf250166c657e1950214d
+size 13371

--- a/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-details-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-details-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9a6166774d421b5b77820d15bbdd05d308c2b97e41a89da84f4383cc14aae06
+size 12542

--- a/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-details.yaml
+++ b/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-details.yaml
@@ -1,0 +1,12 @@
+- heading "Equipment" [level=2]
+- button /Air handling unit AHU-\d+/
+- button /Room controller RC-\d+/
+- button /Heat pump HP-\d+/
+- button "Back"
+- text: Room controller
+- term: Equipment ID
+- definition: /RC-\d+/
+- term: Location
+- definition: /Room \d+, Building A/
+- term: Status
+- definition: Connected

--- a/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-list-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-list-element-examples-chromium-dark-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a4277568715ec0e8ec723a523c8add3e205a44ee8e03675805eed3dd2a65c3e
+size 10962

--- a/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-list-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-list-element-examples-chromium-light-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:beaddf4c8392ceedb23032321fcc280e29ca408eea8219997f811a1bf55b7dc2
+size 10550

--- a/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-list.yaml
+++ b/playwright/snapshots/si-list-details-pixels.spec.ts-snapshots/si-list-details--si-list-details-pixels--mobile-list.yaml
@@ -1,0 +1,12 @@
+- heading "Equipment" [level=2]
+- button /Air handling unit AHU-\d+/
+- button /Room controller RC-\d+/
+- button /Heat pump HP-\d+/
+- button "Back"
+- text: Air handling unit
+- term: Equipment ID
+- definition: /AHU-\d+/
+- term: Location
+- definition: Roof, Building A
+- term: Status
+- definition: Running

--- a/projects/element-ng/list-details/si-details-pane/si-details-pane.component.ts
+++ b/projects/element-ng/list-details/si-details-pane/si-details-pane.component.ts
@@ -19,7 +19,7 @@ import { SiListDetailsComponent } from '../si-list-details.component';
     '[class.details-active]': 'parent.detailsActive() && !parent.hasLargeSize()',
     '[attr.inert]': '!parent.hasLargeSize() && !parent.detailsActive() ? "" : null',
     '[style.flex-basis.%]':
-      'parent.hasLargeSize() && parent.disableResizing() ?  100 - parent.listWidth() : undefined'
+      'parent.hasLargeSize() && parent.disableResizing() ? 100 - parent.staticListWidth() : undefined'
   }
 })
 export class SiDetailsPaneComponent {

--- a/projects/element-ng/list-details/si-details-pane/si-details-pane.component.ts
+++ b/projects/element-ng/list-details/si-details-pane/si-details-pane.component.ts
@@ -19,7 +19,7 @@ import { SiListDetailsComponent } from '../si-list-details.component';
     '[class.details-active]': 'parent.detailsActive() && !parent.hasLargeSize()',
     '[attr.inert]': '!parent.hasLargeSize() && !parent.detailsActive() ? "" : null',
     '[style.flex-basis.%]':
-      'parent.hasLargeSize() && parent.disableResizing() ? 100 - parent.staticListWidth() : undefined'
+      'parent.hasLargeSize() && parent.disableResizing() ? 100 - parent.listWidthPercent() : undefined'
   }
 })
 export class SiDetailsPaneComponent {

--- a/projects/element-ng/list-details/si-list-details.component.html
+++ b/projects/element-ng/list-details/si-list-details.component.html
@@ -6,7 +6,7 @@
     (sizesChange)="onSplitSizesChange($event)"
   >
     <si-split-part
-      unit="fr"
+      [unit]="listUnit()"
       [size]="splitSizes()[0]"
       [showHeader]="false"
       [minSize]="minListSize()"

--- a/projects/element-ng/list-details/si-list-details.component.html
+++ b/projects/element-ng/list-details/si-list-details.component.html
@@ -7,7 +7,7 @@
   >
     <si-split-part
       #listSplitPart
-      [unit]="listUnit()"
+      [unit]="listWidthUnit()"
       [size]="splitSizes()[0]"
       [showHeader]="false"
       [minSize]="minListSize()"

--- a/projects/element-ng/list-details/si-list-details.component.html
+++ b/projects/element-ng/list-details/si-list-details.component.html
@@ -6,6 +6,7 @@
     (sizesChange)="onSplitSizesChange($event)"
   >
     <si-split-part
+      #listSplitPart
       [unit]="listUnit()"
       [size]="splitSizes()[0]"
       [showHeader]="false"

--- a/projects/element-ng/list-details/si-list-details.component.spec.ts
+++ b/projects/element-ng/list-details/si-list-details.component.spec.ts
@@ -14,6 +14,7 @@ import {
   ElementDimensions,
   ResizeObserverService
 } from '../resize-observer';
+import { SiSplitPartComponent, SplitUnit } from '../split';
 import { SiDetailsPaneBodyComponent } from './si-details-pane-body/si-details-pane-body.component';
 import { SiDetailsPaneFooterComponent } from './si-details-pane-footer/si-details-pane-footer.component';
 import { SiDetailsPaneHeaderComponent } from './si-details-pane-header/si-details-pane-header.component';
@@ -37,6 +38,8 @@ import { SiListPaneComponent } from './si-list-pane/si-list-pane.component';
       stateId="si-list-details-1"
       [expandBreakpoint]="expandBreakpoint"
       [disableResizing]="disableResizing()"
+      [listUnit]="listUnit()"
+      [listWidth]="listWidth()"
       [(detailsActive)]="detailsActive"
     >
       <si-list-pane>
@@ -62,6 +65,8 @@ class WrapperComponent {
   readonly listDetails = viewChild.required(SiListDetailsComponent);
   readonly hideBackButton = signal(false);
   readonly disableResizing = signal(true);
+  readonly listUnit = signal<SplitUnit>('px');
+  readonly listWidth = signal(300);
   readonly expandBreakpoint = BOOTSTRAP_BREAKPOINTS.mdMinimum;
   readonly detailsActive = signal(false);
 }
@@ -166,6 +171,8 @@ describe('ListDetailsComponent', () => {
     });
 
     it('should change listWidth when split sizes change', async () => {
+      component.listUnit.set('fr');
+      component.listWidth.set(32);
       component.disableResizing.set(false);
       await fixture.whenStable();
 
@@ -181,6 +188,38 @@ describe('ListDetailsComponent', () => {
       fixture.detectChanges();
       await fixture.whenStable();
       expect(component.listDetails().listWidth()).not.toBe(listWidth);
+    });
+
+    it('should use px for the list and fr for details by default', async () => {
+      component.disableResizing.set(false);
+      await fixture.whenStable();
+
+      const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+      expect(parts[0]!.componentInstance.unit()).toBe('px');
+      expect(parts[0]!.componentInstance.size()).toBe(300);
+      expect(parts[1]!.componentInstance.unit()).toBe('fr');
+      expect(parts[1]!.componentInstance.size()).toBe(1);
+    });
+
+    it('should preserve relative sizing when listUnit is fr', async () => {
+      component.listUnit.set('fr');
+      component.listWidth.set(40);
+      component.disableResizing.set(false);
+      await fixture.whenStable();
+
+      const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+      expect(parts[0]!.componentInstance.unit()).toBe('fr');
+      expect(parts[0]!.componentInstance.size()).toBe(40);
+      expect(parts[1]!.componentInstance.unit()).toBe('fr');
+      expect(parts[1]!.componentInstance.size()).toBe(60);
+    });
+
+    it('should keep percentage sizing for the static layout', async () => {
+      component.listWidth.set(300);
+      await fixture.whenStable();
+
+      expect(getListPane().style.flexBasis).toBe('32%');
+      expect(getDetailsPane().style.flexBasis).toBe('68%');
     });
 
     it('should unset detailsActive when back button is clicked', async () => {

--- a/projects/element-ng/list-details/si-list-details.component.spec.ts
+++ b/projects/element-ng/list-details/si-list-details.component.spec.ts
@@ -191,21 +191,41 @@ describe('ListDetailsComponent', () => {
     });
 
     it.each([
-      { measurement: 'list part', listPartWidth: 400, expectedWidth: 400 },
-      { measurement: 'split fallback', listPartWidth: 0, expectedWidth: 360 }
+      {
+        measurement: 'cached fractional size',
+        listPartSize: 399.328125,
+        splitWidth: 900,
+        expectedWidth: 399.328125
+      },
+      { measurement: 'cached zero size', listPartSize: 0, splitWidth: 900, expectedWidth: 0 },
+      {
+        measurement: 'split fallback',
+        listPartSize: undefined,
+        splitWidth: 900.625,
+        expectedWidth: 360.25
+      },
+      {
+        measurement: 'minimum size fallback',
+        listPartSize: undefined,
+        splitWidth: 0,
+        expectedWidth: 300
+      }
     ])(
       'should update listWidth in pixels using the $measurement',
-      async ({ listPartWidth, expectedWidth }) => {
+      async ({ listPartSize, splitWidth, expectedWidth }) => {
+        component.listWidth.set(450);
         component.disableResizing.set(false);
         await fixture.whenStable();
 
-        const listPart = htmlElement.querySelector<HTMLElement>('si-split-part')!;
-        vi.spyOn(listPart, 'getBoundingClientRect').mockReturnValue(
-          new DOMRect(0, 0, listPartWidth, 500)
+        const listPart = debugElement.query(By.directive(SiSplitPartComponent));
+        listPart.injector.get(SiSplitPartComponent).expandedSize.set(listPartSize);
+        const listMeasurement = vi.spyOn(
+          listPart.nativeElement as HTMLElement,
+          'getBoundingClientRect'
         );
-        vi.spyOn(getSiSplit(), 'getBoundingClientRect').mockReturnValue(
-          new DOMRect(0, 0, 900, 500)
-        );
+        const splitMeasurement = vi
+          .spyOn(getSiSplit(), 'getBoundingClientRect')
+          .mockReturnValue(new DOMRect(0, 0, splitWidth, 500));
         const split = debugElement
           .query(By.directive(SiSplitComponent))
           .injector.get(SiSplitComponent);
@@ -213,6 +233,8 @@ describe('ListDetailsComponent', () => {
         component.listDetails().listWidth.subscribe(widthChanged);
 
         split.sizesChange.emit([40, 60]);
+        expect(listMeasurement).not.toHaveBeenCalled();
+        expect(splitMeasurement).toHaveBeenCalledTimes(listPartSize === undefined ? 1 : 0);
         await fixture.whenStable();
 
         expect(component.listDetails().listWidth()).toBe(expectedWidth);

--- a/projects/element-ng/list-details/si-list-details.component.spec.ts
+++ b/projects/element-ng/list-details/si-list-details.component.spec.ts
@@ -251,6 +251,14 @@ describe('ListDetailsComponent', () => {
     );
 
     it('should keep percentage sizing for the static layout', async () => {
+      component.listWidth.set(40);
+      await fixture.whenStable();
+
+      expect(getListPane().style.flexBasis).toBe('40%');
+      expect(getDetailsPane().style.flexBasis).toBe('60%');
+    });
+
+    it('should fall back to 32/68 for an out-of-range static list width', async () => {
       component.listWidth.set(300);
       await fixture.whenStable();
 

--- a/projects/element-ng/list-details/si-list-details.component.spec.ts
+++ b/projects/element-ng/list-details/si-list-details.component.spec.ts
@@ -14,7 +14,7 @@ import {
   ElementDimensions,
   ResizeObserverService
 } from '../resize-observer';
-import { SiSplitPartComponent, SplitUnit } from '../split';
+import { SiSplitComponent, SiSplitPartComponent, SplitUnit } from '../split';
 import { SiDetailsPaneBodyComponent } from './si-details-pane-body/si-details-pane-body.component';
 import { SiDetailsPaneFooterComponent } from './si-details-pane-footer/si-details-pane-footer.component';
 import { SiDetailsPaneHeaderComponent } from './si-details-pane-header/si-details-pane-header.component';
@@ -189,6 +189,36 @@ describe('ListDetailsComponent', () => {
       await fixture.whenStable();
       expect(component.listDetails().listWidth()).not.toBe(listWidth);
     });
+
+    it.each([
+      { measurement: 'list part', listPartWidth: 400, expectedWidth: 400 },
+      { measurement: 'split fallback', listPartWidth: 0, expectedWidth: 360 }
+    ])(
+      'should update listWidth in pixels using the $measurement',
+      async ({ listPartWidth, expectedWidth }) => {
+        component.disableResizing.set(false);
+        await fixture.whenStable();
+
+        const listPart = htmlElement.querySelector<HTMLElement>('si-split-part')!;
+        vi.spyOn(listPart, 'getBoundingClientRect').mockReturnValue(
+          new DOMRect(0, 0, listPartWidth, 500)
+        );
+        vi.spyOn(getSiSplit(), 'getBoundingClientRect').mockReturnValue(
+          new DOMRect(0, 0, 900, 500)
+        );
+        const split = debugElement
+          .query(By.directive(SiSplitComponent))
+          .injector.get(SiSplitComponent);
+        const widthChanged = vi.fn();
+        component.listDetails().listWidth.subscribe(widthChanged);
+
+        split.sizesChange.emit([40, 60]);
+        await fixture.whenStable();
+
+        expect(component.listDetails().listWidth()).toBe(expectedWidth);
+        expect(widthChanged).toHaveBeenCalledWith(expectedWidth);
+      }
+    );
 
     it('should use px for the list and fr for details by default', async () => {
       component.disableResizing.set(false);

--- a/projects/element-ng/list-details/si-list-details.component.spec.ts
+++ b/projects/element-ng/list-details/si-list-details.component.spec.ts
@@ -38,7 +38,7 @@ import { SiListPaneComponent } from './si-list-pane/si-list-pane.component';
       stateId="si-list-details-1"
       [expandBreakpoint]="expandBreakpoint"
       [disableResizing]="disableResizing()"
-      [listUnit]="listUnit()"
+      [listWidthUnit]="listWidthUnit()"
       [listWidth]="listWidth()"
       [(detailsActive)]="detailsActive"
     >
@@ -65,7 +65,7 @@ class WrapperComponent {
   readonly listDetails = viewChild.required(SiListDetailsComponent);
   readonly hideBackButton = signal(false);
   readonly disableResizing = signal(true);
-  readonly listUnit = signal<SplitUnit>('px');
+  readonly listWidthUnit = signal<SplitUnit>('px');
   readonly listWidth = signal(300);
   readonly expandBreakpoint = BOOTSTRAP_BREAKPOINTS.mdMinimum;
   readonly detailsActive = signal(false);
@@ -171,7 +171,7 @@ describe('ListDetailsComponent', () => {
     });
 
     it('should change listWidth when split sizes change', async () => {
-      component.listUnit.set('fr');
+      component.listWidthUnit.set('fr');
       component.listWidth.set(32);
       component.disableResizing.set(false);
       await fixture.whenStable();
@@ -257,9 +257,9 @@ describe('ListDetailsComponent', () => {
       { listWidth: 40, listSize: 40, detailsSize: 60 },
       { listWidth: 300, listSize: 32, detailsSize: 68 }
     ])(
-      'should use $listSize/$detailsSize sizing for listWidth $listWidth when listUnit is fr',
+      'should use $listSize/$detailsSize sizing for listWidth $listWidth when listWidthUnit is fr',
       async ({ listWidth, listSize, detailsSize }) => {
-        component.listUnit.set('fr');
+        component.listWidthUnit.set('fr');
         component.listWidth.set(listWidth);
         component.disableResizing.set(false);
         await fixture.whenStable();

--- a/projects/element-ng/list-details/si-list-details.component.spec.ts
+++ b/projects/element-ng/list-details/si-list-details.component.spec.ts
@@ -231,18 +231,24 @@ describe('ListDetailsComponent', () => {
       expect(parts[1]!.componentInstance.size()).toBe(1);
     });
 
-    it('should preserve relative sizing when listUnit is fr', async () => {
-      component.listUnit.set('fr');
-      component.listWidth.set(40);
-      component.disableResizing.set(false);
-      await fixture.whenStable();
+    it.each([
+      { listWidth: 40, listSize: 40, detailsSize: 60 },
+      { listWidth: 300, listSize: 32, detailsSize: 68 }
+    ])(
+      'should use $listSize/$detailsSize sizing for listWidth $listWidth when listUnit is fr',
+      async ({ listWidth, listSize, detailsSize }) => {
+        component.listUnit.set('fr');
+        component.listWidth.set(listWidth);
+        component.disableResizing.set(false);
+        await fixture.whenStable();
 
-      const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
-      expect(parts[0]!.componentInstance.unit()).toBe('fr');
-      expect(parts[0]!.componentInstance.size()).toBe(40);
-      expect(parts[1]!.componentInstance.unit()).toBe('fr');
-      expect(parts[1]!.componentInstance.size()).toBe(60);
-    });
+        const parts = debugElement.queryAll(By.directive(SiSplitPartComponent));
+        expect(parts[0]!.componentInstance.unit()).toBe('fr');
+        expect(parts[0]!.componentInstance.size()).toBe(listSize);
+        expect(parts[1]!.componentInstance.unit()).toBe('fr');
+        expect(parts[1]!.componentInstance.size()).toBe(detailsSize);
+      }
+    );
 
     it('should keep percentage sizing for the static layout', async () => {
       component.listWidth.set(300);

--- a/projects/element-ng/list-details/si-list-details.component.ts
+++ b/projects/element-ng/list-details/si-list-details.component.ts
@@ -123,15 +123,20 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
    */
   readonly stateId = input<string>();
 
-  /** @internal */
-  readonly staticListWidth = computed(() => {
+  /**
+   * Percentage width shared by static and resizable `fr` layouts.
+   * The migration sets `listUnit="fr"` without setting `listWidth`, so the default
+   * pixel width of 300 must fall back to 32 to preserve the legacy 32/68 split.
+   * @internal
+   */
+  readonly listWidthPercent = computed(() => {
     const listWidth = this.listWidth();
     return listWidth >= 0 && listWidth <= 100 ? listWidth : DEFAULT_LIST_WIDTH_PERCENT;
   });
 
   protected readonly splitSizes = computed<[number, number]>(() => {
     if (this.listUnit() === 'fr') {
-      const relativeListWidth = this.staticListWidth();
+      const relativeListWidth = this.listWidthPercent();
       return [relativeListWidth, 100 - relativeListWidth];
     }
 

--- a/projects/element-ng/list-details/si-list-details.component.ts
+++ b/projects/element-ng/list-details/si-list-details.component.ts
@@ -47,7 +47,7 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   private resizeObserver = inject(ResizeObserverService);
   private readonly listDetailsContainer = viewChild.required<ElementRef>('listDetailsContainer');
   private readonly listPart = viewChild('listSplitPart', {
-    read: ElementRef<HTMLElement>
+    read: SiSplitPartComponent
   });
   private readonly split = viewChild(SiSplitComponent, {
     read: ElementRef<HTMLElement>
@@ -211,13 +211,13 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private getListSizePx(fallbackPercentage: number): number {
-    const listWidth = this.listPart()?.nativeElement.getBoundingClientRect().width;
-    if (listWidth) {
+    const listWidth = this.listPart()?.expandedSize();
+    if (listWidth !== undefined) {
       return listWidth;
     }
 
     const splitWidth = this.split()?.nativeElement.getBoundingClientRect().width;
-    return splitWidth ? (splitWidth * fallbackPercentage) / 100 : fallbackPercentage;
+    return splitWidth ? (splitWidth * fallbackPercentage) / 100 : this.minListSize();
   }
 
   /** @internal */

--- a/projects/element-ng/list-details/si-list-details.component.ts
+++ b/projects/element-ng/list-details/si-list-details.component.ts
@@ -27,6 +27,8 @@ import {
 import { SiSplitComponent, SiSplitPartComponent, SplitUnit } from '@siemens/element-ng/split';
 import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 
+const DEFAULT_LIST_WIDTH_PERCENT = 32;
+
 @Component({
   selector: 'si-list-details',
   imports: [NgTemplateOutlet, SiSplitComponent, SiSplitPartComponent],
@@ -44,6 +46,12 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private resizeObserver = inject(ResizeObserverService);
   private readonly listDetailsContainer = viewChild.required<ElementRef>('listDetailsContainer');
+  private readonly listPart = viewChild(SiSplitPartComponent, {
+    read: ElementRef<HTMLElement>
+  });
+  private readonly split = viewChild(SiSplitComponent, {
+    read: ElementRef<HTMLElement>
+  });
   protected readonly animationsGloballyDisabled = areAnimationsDisabled();
 
   /**
@@ -118,7 +126,7 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   /** @internal */
   readonly staticListWidth = computed(() => {
     const listWidth = this.listWidth();
-    return listWidth >= 0 && listWidth <= 100 ? listWidth : 32;
+    return listWidth >= 0 && listWidth <= 100 ? listWidth : DEFAULT_LIST_WIDTH_PERCENT;
   });
 
   protected readonly splitSizes = computed<[number, number]>(() => {
@@ -196,14 +204,12 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private getListSizePx(fallbackPercentage: number): number {
-    const listPart = this.elementRef.nativeElement.querySelector<HTMLElement>('si-split-part');
-    const listWidth = listPart?.getBoundingClientRect().width;
+    const listWidth = this.listPart()?.nativeElement.getBoundingClientRect().width;
     if (listWidth) {
       return listWidth;
     }
 
-    const split = this.elementRef.nativeElement.querySelector<HTMLElement>('si-split');
-    const splitWidth = split?.getBoundingClientRect().width;
+    const splitWidth = this.split()?.nativeElement.getBoundingClientRect().width;
     return splitWidth ? (splitWidth * fallbackPercentage) / 100 : fallbackPercentage;
   }
 

--- a/projects/element-ng/list-details/si-list-details.component.ts
+++ b/projects/element-ng/list-details/si-list-details.component.ts
@@ -88,7 +88,7 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
 
   /**
    * The list pane size, updated when the split is resized or restored.
-   * With resizing enabled, the value uses {@link listUnit}: pixels for `px`,
+   * With resizing enabled, the value uses {@link listWidthUnit}: pixels for `px`,
    * or a percentage-based fractional weight for `fr`. With resizing disabled,
    * the value is always interpreted as a percentage.
    * Percentage values must be in the inclusive range 0-100; values outside this
@@ -103,7 +103,7 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
    *
    * @defaultValue 'px'
    */
-  readonly listUnit = input<SplitUnit>('px');
+  readonly listWidthUnit = input<SplitUnit>('px');
 
   /**
    * Sets the minimal width of the list component in pixel.
@@ -127,7 +127,7 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
 
   /**
    * Percentage width shared by static and resizable `fr` layouts.
-   * The migration sets `listUnit="fr"` without setting `listWidth`, so the default
+   * The migration sets `listWidthUnit="fr"` without setting `listWidth`, so the default
    * pixel width of 300 must fall back to 32 to preserve the legacy 32/68 split.
    * @internal
    */
@@ -137,7 +137,7 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   });
 
   protected readonly splitSizes = computed<[number, number]>(() => {
-    if (this.listUnit() === 'fr') {
+    if (this.listWidthUnit() === 'fr') {
       const relativeListWidth = this.listWidthPercent();
       return [relativeListWidth, 100 - relativeListWidth];
     }
@@ -203,7 +203,7 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   private readonly resizeDimensions = signal<ElementDimensions | undefined>(undefined);
 
   protected onSplitSizesChange(sizes: number[]): void {
-    if (this.listUnit() === 'px') {
+    if (this.listWidthUnit() === 'px') {
       this.listWidth.set(this.getListSizePx(sizes[0]));
     } else {
       this.listWidth.set(sizes[0]);

--- a/projects/element-ng/list-details/si-list-details.component.ts
+++ b/projects/element-ng/list-details/si-list-details.component.ts
@@ -87,10 +87,12 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   readonly disableResizing = input(false, { transform: booleanAttribute });
 
   /**
-   * The initial size of the list split part when resizing is enabled.
-   * The value uses {@link listUnit}. With `listUnit="fr"`, the value is
-   * treated as a percentage-like fractional weight. In the static layout,
-   * numeric values continue to represent a percentage.
+   * The list pane size, updated when the split is resized or restored.
+   * With resizing enabled, the value uses {@link listUnit}: pixels for `px`,
+   * or a percentage-based fractional weight for `fr`. With resizing disabled,
+   * the value is always interpreted as a percentage.
+   * Percentage values must be in the inclusive range 0-100; values outside this
+   * range fall back to a 32/68 list/details split.
    *
    * @defaultValue 300
    */

--- a/projects/element-ng/list-details/si-list-details.component.ts
+++ b/projects/element-ng/list-details/si-list-details.component.ts
@@ -46,7 +46,7 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private resizeObserver = inject(ResizeObserverService);
   private readonly listDetailsContainer = viewChild.required<ElementRef>('listDetailsContainer');
-  private readonly listPart = viewChild(SiSplitPartComponent, {
+  private readonly listPart = viewChild('listSplitPart', {
     read: ElementRef<HTMLElement>
   });
   private readonly split = viewChild(SiSplitComponent, {

--- a/projects/element-ng/list-details/si-list-details.component.ts
+++ b/projects/element-ng/list-details/si-list-details.component.ts
@@ -24,7 +24,7 @@ import {
   ElementDimensions,
   ResizeObserverService
 } from '@siemens/element-ng/resize-observer';
-import { SiSplitComponent, SiSplitPartComponent } from '@siemens/element-ng/split';
+import { SiSplitComponent, SiSplitPartComponent, SplitUnit } from '@siemens/element-ng/split';
 import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 
 @Component({
@@ -41,7 +41,7 @@ import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 })
 export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   private resizeSubs?: Subscription;
-  private elementRef = inject(ElementRef);
+  private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private resizeObserver = inject(ResizeObserverService);
   private readonly listDetailsContainer = viewChild.required<ElementRef>('listDetailsContainer');
   protected readonly animationsGloballyDisabled = areAnimationsDisabled();
@@ -79,11 +79,21 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   readonly disableResizing = input(false, { transform: booleanAttribute });
 
   /**
-   * The percentage width of the list view of the overall component width.
+   * The initial size of the list split part when resizing is enabled.
+   * The value uses {@link listUnit}. With `listUnit="fr"`, the value is
+   * treated as a percentage-like fractional weight. In the static layout,
+   * numeric values continue to represent a percentage.
    *
-   * @defaultValue 32
+   * @defaultValue 300
    */
-  readonly listWidth = model<number>(32);
+  readonly listWidth = model<number>(300);
+
+  /**
+   * Unit used for the list split part when resizing is enabled.
+   *
+   * @defaultValue 'px'
+   */
+  readonly listUnit = input<SplitUnit>('px');
 
   /**
    * Sets the minimal width of the list component in pixel.
@@ -105,10 +115,20 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
    */
   readonly stateId = input<string>();
 
-  protected readonly splitSizes = computed<[number, number]>(() => [
-    this.listWidth(),
-    100 - this.listWidth()
-  ]);
+  /** @internal */
+  readonly staticListWidth = computed(() => {
+    const listWidth = this.listWidth();
+    return listWidth >= 0 && listWidth <= 100 ? listWidth : 32;
+  });
+
+  protected readonly splitSizes = computed<[number, number]>(() => {
+    if (this.listUnit() === 'fr') {
+      const relativeListWidth = this.staticListWidth();
+      return [relativeListWidth, 100 - relativeListWidth];
+    }
+
+    return [this.listWidth(), 1];
+  });
 
   protected readonly listStateId = computed(() => {
     const stateId = this.stateId();
@@ -168,7 +188,23 @@ export class SiListDetailsComponent implements OnInit, OnChanges, OnDestroy {
   private readonly resizeDimensions = signal<ElementDimensions | undefined>(undefined);
 
   protected onSplitSizesChange(sizes: number[]): void {
-    this.listWidth.set(sizes[0]);
+    if (this.listUnit() === 'px') {
+      this.listWidth.set(this.getListSizePx(sizes[0]));
+    } else {
+      this.listWidth.set(sizes[0]);
+    }
+  }
+
+  private getListSizePx(fallbackPercentage: number): number {
+    const listPart = this.elementRef.nativeElement.querySelector<HTMLElement>('si-split-part');
+    const listWidth = listPart?.getBoundingClientRect().width;
+    if (listWidth) {
+      return listWidth;
+    }
+
+    const split = this.elementRef.nativeElement.querySelector<HTMLElement>('si-split');
+    const splitWidth = split?.getBoundingClientRect().width;
+    return splitWidth ? (splitWidth * fallbackPercentage) / 100 : fallbackPercentage;
   }
 
   /** @internal */

--- a/projects/element-ng/list-details/si-list-pane/si-list-pane.component.ts
+++ b/projects/element-ng/list-details/si-list-pane/si-list-pane.component.ts
@@ -17,7 +17,7 @@ import { SiListDetailsComponent } from '../si-list-details.component';
     '[attr.inert]': '!parent.hasLargeSize() && parent.detailsActive() ? "" : null',
     '[attr.tabindex]': '-1',
     '[style.flex-basis.%]':
-      'parent.hasLargeSize() && parent.disableResizing() ? parent.listWidth() : undefined'
+      'parent.hasLargeSize() && parent.disableResizing() ? parent.staticListWidth() : undefined'
   }
 })
 export class SiListPaneComponent {

--- a/projects/element-ng/list-details/si-list-pane/si-list-pane.component.ts
+++ b/projects/element-ng/list-details/si-list-pane/si-list-pane.component.ts
@@ -17,7 +17,7 @@ import { SiListDetailsComponent } from '../si-list-details.component';
     '[attr.inert]': '!parent.hasLargeSize() && parent.detailsActive() ? "" : null',
     '[attr.tabindex]': '-1',
     '[style.flex-basis.%]':
-      'parent.hasLargeSize() && parent.disableResizing() ? parent.staticListWidth() : undefined'
+      'parent.hasLargeSize() && parent.disableResizing() ? parent.listWidthPercent() : undefined'
   }
 })
 export class SiListPaneComponent {

--- a/projects/element-ng/schematics/ng-update/migrate-list-details-units.spec.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-list-details-units.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+import { callRule, Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+import { addTestFiles, createTestApp } from '../utils/index.js';
+import { listDetailsUnitsMigrationRule } from './migrate-list-details-units.js';
+
+const collectionPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../migration.json');
+
+describe('list details units migration', () => {
+  let runner: SchematicTestRunner;
+  let appTree: Tree;
+
+  beforeEach(async () => {
+    runner = new SchematicTestRunner('migration-v51', collectionPath);
+    appTree = await createTestApp(runner, { style: 'scss' });
+  });
+
+  const runMigration = async (): Promise<Tree> => {
+    const context = runner.engine.createContext(
+      runner.engine.createSchematic('migration-v51', runner.engine.createCollection(collectionPath))
+    );
+    const tree = await callRule(
+      listDetailsUnitsMigrationRule({ path: 'projects/app/src' }),
+      appTree,
+      context
+    ).toPromise();
+
+    if (!tree) {
+      throw new Error('listDetailsUnitsMigrationRule returned undefined');
+    }
+
+    return tree;
+  };
+
+  it('should add listUnit="fr" to resizable list-details in inline templates', async () => {
+    const initialContent = `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  template: \`<si-list-details [listWidth]="40">
+    <si-list-pane>List</si-list-pane>
+    <si-details-pane>Details</si-details-pane>
+  </si-list-details>\`
+})
+export class TestComponent {}`;
+
+    addTestFiles(appTree, {
+      '/projects/app/src/test.component.ts': initialContent
+    });
+
+    const tree = await runMigration();
+
+    expect(tree.readContent('/projects/app/src/test.component.ts')).toBe(
+      `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  template: \`<si-list-details [listWidth]="40" listUnit="fr">
+    <si-list-pane>List</si-list-pane>
+    <si-details-pane>Details</si-details-pane>
+  </si-list-details>\`
+})
+export class TestComponent {}`
+    );
+  });
+
+  it('should add listUnit="fr" to list-details with [disableResizing]="false"', async () => {
+    addTestFiles(appTree, {
+      '/projects/app/src/test.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  templateUrl: './test.component.html'
+})
+export class TestComponent {}`,
+      '/projects/app/src/test.component.html': `<si-list-details [disableResizing]="false" [listWidth]="32">
+  <si-list-pane>List</si-list-pane>
+  <si-details-pane>Details</si-details-pane>
+</si-list-details>`
+    });
+
+    const tree = await runMigration();
+
+    expect(tree.readContent('/projects/app/src/test.component.html')).toBe(
+      `<si-list-details [disableResizing]="false" [listWidth]="32" listUnit="fr">
+  <si-list-pane>List</si-list-pane>
+  <si-details-pane>Details</si-details-pane>
+</si-list-details>`
+    );
+  });
+
+  it('should not modify list-details when disableResizing attribute is present', async () => {
+    const template = `<si-list-details disableResizing [listWidth]="50">
+  <si-list-pane>List</si-list-pane>
+  <si-details-pane>Details</si-details-pane>
+</si-list-details>`;
+
+    addTestFiles(appTree, {
+      '/projects/app/src/test.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  templateUrl: './test.component.html'
+})
+export class TestComponent {}`,
+      '/projects/app/src/test.component.html': template
+    });
+
+    const tree = await runMigration();
+
+    expect(tree.readContent('/projects/app/src/test.component.html')).toBe(template);
+  });
+
+  it('should not modify list-details when disableResizing is explicitly true', async () => {
+    const template = `<si-list-details [disableResizing]="true" [listWidth]="50">
+  <si-list-pane>List</si-list-pane>
+  <si-details-pane>Details</si-details-pane>
+</si-list-details>`;
+
+    addTestFiles(appTree, {
+      '/projects/app/src/test.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  templateUrl: './test.component.html'
+})
+export class TestComponent {}`,
+      '/projects/app/src/test.component.html': template
+    });
+
+    const tree = await runMigration();
+
+    expect(tree.readContent('/projects/app/src/test.component.html')).toBe(template);
+  });
+
+  it('should not overwrite existing listUnit', async () => {
+    const template = `<si-list-details listUnit="px" [listWidth]="300">
+  <si-list-pane>List</si-list-pane>
+  <si-details-pane>Details</si-details-pane>
+</si-list-details>`;
+
+    addTestFiles(appTree, {
+      '/projects/app/src/test.component.ts': `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  templateUrl: './test.component.html'
+})
+export class TestComponent {}`,
+      '/projects/app/src/test.component.html': template
+    });
+
+    const tree = await runMigration();
+
+    expect(tree.readContent('/projects/app/src/test.component.html')).toBe(template);
+  });
+});

--- a/projects/element-ng/schematics/ng-update/migrate-list-details-units.spec.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-list-details-units.spec.ts
@@ -39,7 +39,7 @@ describe('list details units migration', () => {
     return tree;
   };
 
-  it('should add listUnit="fr" to resizable list-details in inline templates', async () => {
+  it('should add listWidthUnit="fr" to resizable list-details in inline templates', async () => {
     const initialContent = `import { Component } from '@angular/core';
 
 @Component({
@@ -62,7 +62,7 @@ export class TestComponent {}`;
 
 @Component({
   selector: 'app-test',
-  template: \`<si-list-details [listWidth]="40" listUnit="fr">
+  template: \`<si-list-details [listWidth]="40" listWidthUnit="fr">
     <si-list-pane>List</si-list-pane>
     <si-details-pane>Details</si-details-pane>
   </si-list-details>\`
@@ -71,7 +71,7 @@ export class TestComponent {}`
     );
   });
 
-  it('should add listUnit="fr" to list-details with [disableResizing]="false"', async () => {
+  it('should add listWidthUnit="fr" to list-details with [disableResizing]="false"', async () => {
     addTestFiles(appTree, {
       '/projects/app/src/test.component.ts': `import { Component } from '@angular/core';
 
@@ -89,7 +89,7 @@ export class TestComponent {}`,
     const tree = await runMigration();
 
     expect(tree.readContent('/projects/app/src/test.component.html')).toBe(
-      `<si-list-details [disableResizing]="false" [listWidth]="32" listUnit="fr">
+      `<si-list-details [disableResizing]="false" [listWidth]="32" listWidthUnit="fr">
   <si-list-pane>List</si-list-pane>
   <si-details-pane>Details</si-details-pane>
 </si-list-details>`
@@ -140,25 +140,28 @@ export class TestComponent {}`,
     expect(tree.readContent('/projects/app/src/test.component.html')).toBe(template);
   });
 
-  it('should not overwrite existing listUnit', async () => {
-    const template = `<si-list-details listUnit="px" [listWidth]="300">
+  it.each(['listWidthUnit="px"', '[listWidthUnit]="unit"', 'bind-listWidthUnit="unit"'])(
+    'should not overwrite existing %s',
+    async unitAttribute => {
+      const template = `<si-list-details ${unitAttribute} [listWidth]="300">
   <si-list-pane>List</si-list-pane>
   <si-details-pane>Details</si-details-pane>
 </si-list-details>`;
 
-    addTestFiles(appTree, {
-      '/projects/app/src/test.component.ts': `import { Component } from '@angular/core';
+      addTestFiles(appTree, {
+        '/projects/app/src/test.component.ts': `import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-test',
   templateUrl: './test.component.html'
 })
 export class TestComponent {}`,
-      '/projects/app/src/test.component.html': template
-    });
+        '/projects/app/src/test.component.html': template
+      });
 
-    const tree = await runMigration();
+      const tree = await runMigration();
 
-    expect(tree.readContent('/projects/app/src/test.component.html')).toBe(template);
-  });
+      expect(tree.readContent('/projects/app/src/test.component.html')).toBe(template);
+    }
+  );
 });

--- a/projects/element-ng/schematics/ng-update/migrate-list-details-units.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-list-details-units.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Rule, SchematicContext, Tree, UpdateRecorder } from '@angular-devkit/schematics';
+import type { Attribute, Element } from '@angular/compiler';
+import { dirname, join } from 'path/posix';
+import ts from 'typescript';
+
+import {
+  discoverSourceFiles,
+  findElement,
+  getInlineTemplates,
+  getTemplateUrl
+} from '../utils/index.js';
+
+const disableResizingAttributeNames = [
+  'disableResizing',
+  '[disableResizing]',
+  'bind-disableResizing'
+];
+const listUnitAttributeNames = ['listUnit', '[listUnit]', 'bind-listUnit'];
+
+export const listDetailsUnitsMigrationRule = (options: { path: string }): Rule => {
+  return async (tree: Tree, context: SchematicContext) => {
+    const processedTemplates = new Set<string>();
+
+    for await (const discoveredSourceFile of discoverSourceFiles(tree, context, options.path)) {
+      const { path: filePath, sourceFile } = discoveredSourceFile;
+      const recorder = tree.beginUpdate(filePath);
+
+      for (const template of getInlineTemplates(sourceFile)) {
+        migrateListDetailsUnitsTemplate(
+          sourceFile.text.substring(template.getStart() + 1, template.getEnd() - 1),
+          template.getStart() + 1,
+          recorder
+        );
+      }
+      tree.commitUpdate(recorder);
+
+      for (const templateUrl of getTemplateUrl(sourceFile)) {
+        const templatePath = join(dirname(filePath), templateUrl);
+        if (processedTemplates.has(templatePath) || !tree.exists(templatePath)) {
+          continue;
+        }
+
+        processedTemplates.add(templatePath);
+        const templateRecorder = tree.beginUpdate(templatePath);
+        migrateListDetailsUnitsTemplate(
+          tree.read(templatePath)!.toString('utf-8'),
+          0,
+          templateRecorder
+        );
+        tree.commitUpdate(templateRecorder);
+      }
+    }
+
+    return tree;
+  };
+};
+
+const migrateListDetailsUnitsTemplate = (
+  template: string,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  findElement(template, element => element.name === 'si-list-details').forEach(element => {
+    migrateListDetailsElement(template, element, offset, recorder);
+  });
+};
+
+const migrateListDetailsElement = (
+  template: string,
+  element: Element,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  const disableResizingAttribute = element.attrs.find(attr =>
+    disableResizingAttributeNames.includes(attr.name)
+  );
+  const isExplicitlyDisabled =
+    disableResizingAttribute && getStaticBooleanValue(disableResizingAttribute) === true;
+  if (isExplicitlyDisabled) {
+    return;
+  }
+
+  const hasListUnit = element.attrs.some(attr => listUnitAttributeNames.includes(attr.name));
+  if (hasListUnit) {
+    return;
+  }
+
+  insertAttribute(template, element, 'listUnit="fr"', offset, recorder);
+};
+
+const insertAttribute = (
+  template: string,
+  element: Element,
+  attribute: string,
+  offset: number,
+  recorder: UpdateRecorder
+): void => {
+  const selfClosing = element.startSourceSpan.toString().endsWith('/>');
+  const insertOffset = element.startSourceSpan.end.offset - (selfClosing ? 2 : 1);
+  const prefix = /\s/.test(template[insertOffset - 1] ?? '') ? '' : ' ';
+  recorder.insertLeft(insertOffset + offset, `${prefix}${attribute}${selfClosing ? ' ' : ''}`);
+};
+
+const getStaticBooleanValue = (attribute: Attribute): boolean | undefined => {
+  if (!attribute.name.startsWith('[')) {
+    if (/^\s*{{[\s\S]*}}\s*$/.test(attribute.value)) {
+      return undefined;
+    }
+    return attribute.value !== 'false';
+  }
+
+  const initializer = getExpression(attribute.value);
+  if (!initializer) {
+    return undefined;
+  }
+
+  if (initializer.kind === ts.SyntaxKind.TrueKeyword) {
+    return true;
+  }
+  if (
+    initializer.kind === ts.SyntaxKind.FalseKeyword ||
+    initializer.kind === ts.SyntaxKind.NullKeyword ||
+    (ts.isIdentifier(initializer) && initializer.text === 'undefined') ||
+    (ts.isStringLiteral(initializer) && initializer.text === 'false')
+  ) {
+    return false;
+  }
+  if (ts.isStringLiteral(initializer) || ts.isNumericLiteral(initializer)) {
+    return true;
+  }
+
+  return undefined;
+};
+
+const getExpression = (value: string): ts.Expression | undefined => {
+  const statement = ts.createSourceFile(
+    'template-expression.ts',
+    `const value = ${value};`,
+    ts.ScriptTarget.Latest,
+    true
+  ).statements[0];
+  if (!statement || !ts.isVariableStatement(statement)) {
+    return undefined;
+  }
+
+  return statement.declarationList.declarations[0]?.initializer;
+};

--- a/projects/element-ng/schematics/ng-update/migrate-list-details-units.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-list-details-units.ts
@@ -12,7 +12,8 @@ import {
   discoverSourceFiles,
   findElement,
   getInlineTemplates,
-  getTemplateUrl
+  getTemplateUrl,
+  insertAttribute
 } from '../utils/index.js';
 
 const disableResizingAttributeNames = [
@@ -91,19 +92,6 @@ const migrateListDetailsElement = (
   }
 
   insertAttribute(template, element, 'listUnit="fr"', offset, recorder);
-};
-
-const insertAttribute = (
-  template: string,
-  element: Element,
-  attribute: string,
-  offset: number,
-  recorder: UpdateRecorder
-): void => {
-  const selfClosing = element.startSourceSpan.toString().endsWith('/>');
-  const insertOffset = element.startSourceSpan.end.offset - (selfClosing ? 2 : 1);
-  const prefix = /\s/.test(template[insertOffset - 1] ?? '') ? '' : ' ';
-  recorder.insertLeft(insertOffset + offset, `${prefix}${attribute}${selfClosing ? ' ' : ''}`);
 };
 
 const getStaticBooleanValue = (attribute: Attribute): boolean | undefined => {

--- a/projects/element-ng/schematics/ng-update/migrate-list-details-units.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-list-details-units.ts
@@ -21,7 +21,7 @@ const disableResizingAttributeNames = [
   '[disableResizing]',
   'bind-disableResizing'
 ];
-const listUnitAttributeNames = ['listUnit', '[listUnit]', 'bind-listUnit'];
+const listWidthUnitAttributeNames = ['listWidthUnit', '[listWidthUnit]', 'bind-listWidthUnit'];
 
 export const listDetailsUnitsMigrationRule = (options: { path: string }): Rule => {
   return async (tree: Tree, context: SchematicContext) => {
@@ -86,12 +86,14 @@ const migrateListDetailsElement = (
     return;
   }
 
-  const hasListUnit = element.attrs.some(attr => listUnitAttributeNames.includes(attr.name));
-  if (hasListUnit) {
+  const hasListWidthUnit = element.attrs.some(attr =>
+    listWidthUnitAttributeNames.includes(attr.name)
+  );
+  if (hasListWidthUnit) {
     return;
   }
 
-  insertAttribute(template, element, 'listUnit="fr"', offset, recorder);
+  insertAttribute(template, element, 'listWidthUnit="fr"', offset, recorder);
 };
 
 const getStaticBooleanValue = (attribute: Attribute): boolean | undefined => {

--- a/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
+++ b/projects/element-ng/schematics/ng-update/migrate-to-v51.ts
@@ -9,6 +9,7 @@ import { ElementMigrationData, getElementMigrationData } from '../migrations/dat
 import { elementMigrationRule } from '../migrations/element-migration/element-migration.js';
 import { missingTranslateMigrationRule } from '../migrations/ngx-translate/index.js';
 import { contentFormatterMigrationRule } from './migrate-content-formatter.js';
+import { listDetailsUnitsMigrationRule } from './migrate-list-details-units.js';
 import { mainDetailUnitsMigrationRule } from './migrate-main-detail-units.js';
 import { markdownRendererMigrationRule } from './migrate-markdown-renderer.js';
 import { spacerMigrationRule } from './migrate-spacers.js';
@@ -28,6 +29,7 @@ export const migrateToV51 = (): Rule => {
       splitSizesMigrationRule(options),
       splitCollapseMigrationRule(options),
       mainDetailUnitsMigrationRule(options),
+      listDetailsUnitsMigrationRule(options),
       contentFormatterMigrationRule(options),
       markdownRendererMigrationRule(options),
       spacerMigrationRule(options)

--- a/src/app/examples/si-list-details/si-list-details-pixels.html
+++ b/src/app/examples/si-list-details/si-list-details-pixels.html
@@ -1,0 +1,40 @@
+<si-list-details
+  stateId="si-list-details-pixels-demo"
+  class="p-6 px-md-9"
+  [(detailsActive)]="detailsActive"
+>
+  <si-list-pane class="card">
+    <si-list-pane-header>
+      <h2 class="si-h5 m-0">Equipment</h2>
+    </si-list-pane-header>
+    <si-list-pane-body class="overflow-auto">
+      <div class="list-group list-group-flush">
+        @for (item of equipment; track item.id) {
+          <button
+            type="button"
+            class="list-group-item list-group-item-action text-start"
+            [class.active]="selectedEquipment().id === item.id"
+            [attr.aria-current]="selectedEquipment().id === item.id ? 'true' : null"
+            (click)="selectEquipment(item)"
+          >
+            <span class="d-block fw-semibold">{{ item.name }}</span>
+            <span class="d-block si-caption">{{ item.id }}</span>
+          </button>
+        }
+      </div>
+    </si-list-pane-body>
+  </si-list-pane>
+  <si-details-pane class="card">
+    <si-details-pane-header [title]="selectedEquipment().name" />
+    <si-details-pane-body class="p-6 overflow-auto">
+      <dl class="m-0">
+        <dt>Equipment ID</dt>
+        <dd>{{ selectedEquipment().id }}</dd>
+        <dt>Location</dt>
+        <dd>{{ selectedEquipment().location }}</dd>
+        <dt>Status</dt>
+        <dd class="mb-0">{{ selectedEquipment().status }}</dd>
+      </dl>
+    </si-details-pane-body>
+  </si-details-pane>
+</si-list-details>

--- a/src/app/examples/si-list-details/si-list-details-pixels.ts
+++ b/src/app/examples/si-list-details/si-list-details-pixels.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Component, signal } from '@angular/core';
+import {
+  SiDetailsPaneBodyComponent,
+  SiDetailsPaneComponent,
+  SiDetailsPaneHeaderComponent,
+  SiListDetailsComponent,
+  SiListPaneBodyComponent,
+  SiListPaneComponent,
+  SiListPaneHeaderComponent
+} from '@siemens/element-ng/list-details';
+
+interface Equipment {
+  id: string;
+  name: string;
+  location: string;
+  status: string;
+}
+
+@Component({
+  selector: 'app-sample',
+  imports: [
+    SiListDetailsComponent,
+    SiListPaneComponent,
+    SiListPaneHeaderComponent,
+    SiListPaneBodyComponent,
+    SiDetailsPaneComponent,
+    SiDetailsPaneHeaderComponent,
+    SiDetailsPaneBodyComponent
+  ],
+  templateUrl: './si-list-details-pixels.html',
+  host: {
+    class: 'si-layout-fixed-height'
+  }
+})
+export class SampleComponent {
+  readonly equipment: Equipment[] = [
+    {
+      id: 'AHU-01',
+      name: 'Air handling unit',
+      location: 'Roof, Building A',
+      status: 'Running'
+    },
+    {
+      id: 'RC-02',
+      name: 'Room controller',
+      location: 'Room 204, Building A',
+      status: 'Connected'
+    },
+    {
+      id: 'HP-03',
+      name: 'Heat pump',
+      location: 'Plant room, Building B',
+      status: 'Standby'
+    }
+  ];
+  readonly selectedEquipment = signal(this.equipment[0]!);
+  readonly detailsActive = signal(false);
+
+  selectEquipment(equipment: Equipment): void {
+    this.selectedEquipment.set(equipment);
+    this.detailsActive.set(true);
+  }
+}

--- a/src/app/examples/si-list-details/si-list-details-router.html
+++ b/src/app/examples/si-list-details/si-list-details-router.html
@@ -2,6 +2,7 @@
   #container
   stateId="si-list-details-demo"
   class="p-6 px-md-9"
+  listUnit="fr"
   [expandBreakpoint]="expandBreakpoint"
   [disableResizing]="disableResizing"
   [listWidth]="50"

--- a/src/app/examples/si-list-details/si-list-details-router.html
+++ b/src/app/examples/si-list-details/si-list-details-router.html
@@ -2,7 +2,7 @@
   #container
   stateId="si-list-details-demo"
   class="p-6 px-md-9"
-  listUnit="fr"
+  listWidthUnit="fr"
   [expandBreakpoint]="expandBreakpoint"
   [disableResizing]="disableResizing"
   [listWidth]="50"

--- a/src/app/examples/si-list-details/si-list-details.html
+++ b/src/app/examples/si-list-details/si-list-details.html
@@ -2,6 +2,7 @@
   #container
   stateId="si-list-details-demo"
   class="p-6 px-md-9"
+  listUnit="fr"
   [expandBreakpoint]="expandBreakpoint"
   [disableResizing]="disableResizing"
   [listWidth]="50"

--- a/src/app/examples/si-list-details/si-list-details.html
+++ b/src/app/examples/si-list-details/si-list-details.html
@@ -2,7 +2,7 @@
   #container
   stateId="si-list-details-demo"
   class="p-6 px-md-9"
-  listUnit="fr"
+  listWidthUnit="fr"
   [expandBreakpoint]="expandBreakpoint"
   [disableResizing]="disableResizing"
   [listWidth]="50"


### PR DESCRIPTION
Add `listWidthUnit` input to configure the unit of the underlying list split part
when resizing is enabled. The details split part always uses `unit="fr"`.

BREAKING CHANGE: The default sizing unit of the list split part in
`si-list-details` when resizing is enabled has changed from `fr` to `px`.

When resizing is enabled:
- The list part now defaults to `unit="px"` (initial size of 300px), and the
  details part takes the remaining space (`1fr`).
- `listWidth` is now interpreted in `listWidthUnit`. With the default
  `listWidthUnit="px"`, numeric values are treated as pixels instead of percentages.
- `[(listWidth)]` now emits and accepts pixel values instead of percentage
  values.

To retain the previous relative percentage-based split behavior, explicitly set
`listUnit="fr"`.

Static layouts (`disableResizing="true"`) continue to interpret `listWidth` as a
percentage. Values in the inclusive range 0-100 and the default 32/68 layout
are unchanged. Out-of-range values now fall back to a 32/68 list/details split
instead of being passed directly to CSS. This fallback also applies when
resizing is enabled with `listUnit="fr"`.

Before:

```html
<si-list-details [listWidth]="50" />
```

After (retaining previous relative behavior):

```html
<si-list-details
  [listWidth]="50"
  listWidthUnit="fr"
/>
```

After (adopting new fixed-width layout):

```html
<si-list-details [listWidth]="300" />
```

<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2729/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2729/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2729/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2729/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2729/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2729/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2729/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2729/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2729/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2729/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->











