### PR TITLE
feat(select): support custom template for selected input values

### DIFF
--- a/api-goldens/element-ng/select/index.api.md
+++ b/api-goldens/element-ng/select/index.api.md
@@ -169,6 +169,10 @@ export class SiSelectSingleValueDirective<T> extends SiSelectSelectionStrategy<T
     allowMultiple: boolean;
 }
 
+// @public
+export class SiSelectValueTemplateDirective {
+}
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/docs/components/forms-inputs/select.md
+++ b/docs/components/forms-inputs/select.md
@@ -153,7 +153,8 @@ Options are provided as an array of `SelectItem<T>` objects:
 />
 ```
 
-Customize option rendering using a template:
+Customize option rendering using a template. This template is used for options in the dropdown and,
+when no input template is provided, for the selected value in the closed input as well:
 
 ```html
 <si-select
@@ -164,6 +165,22 @@ Customize option rendering using a template:
   ]"
 >
   <ng-template let-option siSelectOptionTemplate>{{ option.label | uppercase }}</ng-template>
+</si-select>
+```
+
+To use different templates for the dropdown options and the selected value in the closed input, provide
+an additional `siSelectValueTemplate` template. Both templates receive the `SelectOption<T>` as
+their implicit value:
+
+```html
+<si-select [options]="options">
+  <ng-template let-option siSelectOptionTemplate>
+    <div class="d-flex flex-column">
+      <span>{{ option.label }}</span>
+      <small class="text-secondary">Additional information</small>
+    </div>
+  </ng-template>
+  <ng-template let-option siSelectValueTemplate>{{ option.label }}</ng-template>
 </si-select>
 ```
 

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--custom-template-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--custom-template-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad3ac0ba40577ff6cefe509c6faa56b8883fb1f121323c1459cd709ed088de37
-size 31712
+oid sha256:115dfc70472b0e50f1ff38446ee7be7cd4d87b04d97cca1871bcff257df4f694
+size 30461

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--custom-template-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--custom-template-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56d168c8a31cccd3a1de55668a6cea031694aee0f32eb52ec73af4664b89792e
-size 31231
+oid sha256:f4b611ff15d968ce68f0cb118bef7648050a6d39daf54f90b4c687d6b595d229
+size 29849

--- a/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--custom-template.yaml
+++ b/playwright/snapshots/si-select.spec.ts-snapshots/si-select--si-select--custom-template.yaml
@@ -1,15 +1,15 @@
 - heading "Inline" [level=4]
-- combobox "Inline"
+- combobox "Inline": Fair
 - heading "FormControl" [level=4]
-- combobox "FormControl"
+- combobox "FormControl": Good
 - heading "Multi select" [level=4]
-- combobox "Multi select"
+- combobox "Multi select": Good , Fair
 - heading "Multi-select with groups" [level=4]
-- combobox "Multi-select with groups"
+- combobox "Multi-select with groups": Value 1.1 , Value 2.2
 - heading "Select with custom template" [level=4]
-- combobox "Select with custom template" [expanded]
+- combobox "Select with custom template" [expanded]: Beer 2 (Alc.:7%)
 - heading "Select with actions" [level=4]
-- combobox "Select with actions"
+- combobox "Select with actions": Value 1 , Value 3
 - text: "Control panel Current value: fair"
 - checkbox "Readonly"
 - text: Readonly
@@ -20,9 +20,9 @@
 - listbox "Select with custom template":
   - group "Beer":
     - text: ""
-    - option "Beer 1 (Alc.:5%)"
-    - option "Beer 2 (Alc.:7%)" [selected]
+    - 'option "Beer 1 Alc.: 5%"'
+    - 'option "Beer 2 Alc.: 7%" [selected]'
   - group "Wine":
     - text: ""
-    - option /Red wine \(Alc\.:\d+%\)/
-    - option /White wine \(Alc\.:\d+%\)/
+    - 'option /Red wine Alc\.: \d+%/'
+    - 'option /White wine Alc\.: \d+%/'

--- a/projects/element-ng/select/index.ts
+++ b/projects/element-ng/select/index.ts
@@ -9,6 +9,7 @@ export * from './options/si-select-option.source';
 export * from './selection/si-select-single-value.directive';
 export * from './selection/si-select-multi-value.directive';
 export * from './si-select-option-template.directive';
+export * from './si-select-value-template.directive';
 export * from './si-select-group-template.directive';
 export * from './si-select.module';
 export * from './select-list/si-select-list-has-filter.component';

--- a/projects/element-ng/select/si-select-option-template.directive.ts
+++ b/projects/element-ng/select/si-select-option-template.directive.ts
@@ -7,7 +7,8 @@ import { Directive } from '@angular/core';
 import { SelectOption } from './si-select.types';
 
 /**
- * The directive allows to template/customize the value option rendering.
+ * The directive allows to template/customize the option rendering in the dropdown.
+ * It is also used for rendering selected values in the input if no input template is provided.
  * This requires using the {@link SiSelectSimpleOptionsDirective} to specify options as input.
  *
  * @example

--- a/projects/element-ng/select/si-select-value-template.directive.ts
+++ b/projects/element-ng/select/si-select-value-template.directive.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Siemens 2016 - 2026
+ * SPDX-License-Identifier: MIT
+ */
+import { Directive } from '@angular/core';
+
+import { SelectOption } from './si-select.types';
+
+/**
+ * The directive allows to template/customize the selected value rendering in the select input.
+ * This requires using the {@link SiSelectSimpleOptionsDirective} to specify options as input.
+ *
+ * @example
+ * ```html
+ * <si-select [options]="[
+ *   { type: 'option', value: 'good', label: 'Good' },
+ *   { type: 'option', value: 'fair', label: 'Fair' }
+ * ]">
+ *   <ng-template siSelectValueTemplate let-option>{{ option.label }}</ng-template>
+ * </si-select>
+ * ```
+ */
+@Directive({
+  selector: '[siSelectValueTemplate]'
+})
+export class SiSelectValueTemplateDirective {
+  /** @internal */
+  static ngTemplateContextGuard<T = any>(
+    directive: SiSelectValueTemplateDirective,
+    context: unknown
+  ): context is { $implicit: SelectOption<T> } {
+    return true;
+  }
+}

--- a/projects/element-ng/select/si-select.component.html
+++ b/projects/element-ng/select/si-select.component.html
@@ -3,7 +3,7 @@
   cdkOverlayOrigin
   [baseId]="id()"
   [labelledby]="labelledby()"
-  [optionTemplate]="optionTemplate()"
+  [optionTemplate]="selectedValueTemplate() ?? optionTemplate()"
   [ariaLabel]="ariaLabel()"
   [controls]="id() + '-listbox'"
   [open]="isOpen()"

--- a/projects/element-ng/select/si-select.component.spec.ts
+++ b/projects/element-ng/select/si-select.component.spec.ts
@@ -69,6 +69,54 @@ class TestHostComponent {
 @Component({
   imports: [SiSelectModule],
   template: `
+    <si-select inputId="test-select" [options]="options" [(value)]="value">
+      <ng-template let-option siSelectOptionTemplate>
+        <span class="dropdown-option">{{ option.label }}</span>
+      </ng-template>
+      <ng-template let-option siSelectValueTemplate>
+        <span class="input-option">{{ option.label }} input</span>
+      </ng-template>
+    </si-select>
+  `
+})
+class TestHostTemplateComponent {
+  value = 'average';
+  readonly options = OPTIONS_LIST;
+}
+
+@Component({
+  imports: [SiSelectModule],
+  template: `
+    <si-select inputId="test-select" [options]="options" [(value)]="value">
+      <ng-template let-option siSelectOptionTemplate>
+        <span class="option-template">{{ option.label }} option</span>
+      </ng-template>
+    </si-select>
+  `
+})
+class TestHostOptionTemplateComponent {
+  readonly value = signal('average');
+  readonly options = OPTIONS_LIST;
+}
+
+@Component({
+  imports: [SiSelectModule],
+  template: `
+    <si-select multi inputId="test-select" [options]="options" [(value)]="values">
+      <ng-template let-option siSelectValueTemplate>
+        <span class="input-option">{{ option.label }} input</span>
+      </ng-template>
+    </si-select>
+  `
+})
+class TestHostMultiTemplateComponent {
+  readonly values = signal(['good', 'average']);
+  readonly options = OPTIONS_LIST;
+}
+
+@Component({
+  imports: [SiSelectModule],
+  template: `
     <si-select
       inputId="test-select"
       [options]="options()"
@@ -413,6 +461,49 @@ describe('SiSelectComponent', () => {
       expect(hostComponent.value()).toBe(2);
       // Ensure placeholder text is not visible when items are selected
       expect(await selectHarness.getPlaceholder()).toBeUndefined();
+    });
+  });
+
+  describe('with custom input and option templates', () => {
+    beforeEach(async () => {
+      fixture = TestBed.createComponent(TestHostTemplateComponent);
+      loader = TestbedHarnessEnvironment.loader(fixture);
+      await fixture.whenStable();
+      selectHarness = await loader.getHarness(SiSelectHarness);
+    });
+
+    it('uses the input template for the selected value', async () => {
+      expect(await selectHarness.getSelectedTexts()).toEqual(['Average input']);
+      expect(fixture.nativeElement.querySelector('.input-option')).toBeInTheDocument();
+      expect(fixture.nativeElement.querySelector('.dropdown-option')).not.toBeInTheDocument();
+    });
+
+    it('uses the option template in the dropdown', async () => {
+      await selectHarness.open();
+      const list = await selectHarness.getList();
+
+      expect(await list?.getAllItemTexts()).toEqual(['Good', 'Average', 'Poor']);
+      expect(document.querySelectorAll('.dropdown-option')).toHaveLength(3);
+    });
+
+    it('uses the option template for the selected value when no input template is provided', async () => {
+      fixture = TestBed.createComponent(TestHostOptionTemplateComponent);
+      loader = TestbedHarnessEnvironment.loader(fixture);
+      await fixture.whenStable();
+      selectHarness = await loader.getHarness(SiSelectHarness);
+
+      expect(await selectHarness.getSelectedTexts()).toEqual(['Average option']);
+      expect(fixture.nativeElement.querySelector('.option-template')).toBeInTheDocument();
+    });
+
+    it('uses the input template for multiple selected values', async () => {
+      fixture = TestBed.createComponent(TestHostMultiTemplateComponent);
+      loader = TestbedHarnessEnvironment.loader(fixture);
+      await fixture.whenStable();
+      selectHarness = await loader.getHarness(SiSelectHarness);
+
+      expect(await selectHarness.getSelectedTexts()).toEqual(['Good input', 'Average input']);
+      expect(fixture.nativeElement.querySelectorAll('.input-option')).toHaveLength(2);
     });
   });
 

--- a/projects/element-ng/select/si-select.component.ts
+++ b/projects/element-ng/select/si-select.component.ts
@@ -27,6 +27,7 @@ import { SiSelectSelectionStrategy } from './selection/si-select-selection-strat
 import { SiSelectActionsDirective } from './si-select-actions.directive';
 import { SiSelectGroupTemplateDirective } from './si-select-group-template.directive';
 import { SiSelectOptionTemplateDirective } from './si-select-option-template.directive';
+import { SiSelectValueTemplateDirective } from './si-select-value-template.directive';
 import { SelectGroup, SelectItem, SelectOption } from './si-select.types';
 
 @Component({
@@ -115,6 +116,11 @@ export class SiSelectComponent<T> implements SiFormItemControl {
     SiSelectOptionTemplateDirective,
     TemplateRef<{ $implicit: SelectOption<T> }>
   >(SiSelectOptionTemplateDirective, { read: TemplateRef });
+
+  protected readonly selectedValueTemplate = contentChild<
+    SiSelectValueTemplateDirective,
+    TemplateRef<{ $implicit: SelectOption<T> }>
+  >(SiSelectValueTemplateDirective, { read: TemplateRef });
 
   protected readonly groupTemplate = contentChild<
     SiSelectGroupTemplateDirective,

--- a/projects/element-ng/select/si-select.module.ts
+++ b/projects/element-ng/select/si-select.module.ts
@@ -11,6 +11,7 @@ import { SiSelectActionDirective } from './si-select-action.directive';
 import { SiSelectActionsDirective } from './si-select-actions.directive';
 import { SiSelectGroupTemplateDirective } from './si-select-group-template.directive';
 import { SiSelectOptionTemplateDirective } from './si-select-option-template.directive';
+import { SiSelectValueTemplateDirective } from './si-select-value-template.directive';
 import { SiSelectComponent } from './si-select.component';
 
 @NgModule({
@@ -21,6 +22,7 @@ import { SiSelectComponent } from './si-select.component';
     SiSelectGroupTemplateDirective,
     SiSelectMultiValueDirective,
     SiSelectOptionTemplateDirective,
+    SiSelectValueTemplateDirective,
     SiSelectSimpleOptionsDirective,
     SiSelectSingleValueDirective
   ],
@@ -31,6 +33,7 @@ import { SiSelectComponent } from './si-select.component';
     SiSelectGroupTemplateDirective,
     SiSelectMultiValueDirective,
     SiSelectOptionTemplateDirective,
+    SiSelectValueTemplateDirective,
     SiSelectSimpleOptionsDirective,
     SiSelectSingleValueDirective
   ]

--- a/src/app/examples/si-select/si-select.html
+++ b/src/app/examples/si-select/si-select.html
@@ -72,8 +72,14 @@
     [(value)]="drinkValue"
     (valueChange)="logEvent($event)"
   >
-    <ng-template let-option siSelectOptionTemplate
-      >{{ option.label! | translate }} (Alc.:{{ option.value.alcohol | percent }})
+    <ng-template let-option siSelectOptionTemplate>
+      <div class="d-flex flex-column">
+        <span>{{ option.label! | translate }}</span>
+        <span class="si-body-sm text-secondary">Alc.: {{ option.value.alcohol | percent }}</span>
+      </div>
+    </ng-template>
+    <ng-template let-option siSelectValueTemplate>
+      {{ option.label! | translate }} (Alc.:{{ option.value.alcohol | percent }})
     </ng-template>
     <ng-template let-group siSelectGroupTemplate>{{
       group.label! | translate | titlecase

--- a/src/app/examples/si-select/si-select.ts
+++ b/src/app/examples/si-select/si-select.ts
@@ -15,6 +15,7 @@ import {
   SiSelectGroupTemplateDirective,
   SiSelectMultiValueDirective,
   SiSelectOptionTemplateDirective,
+  SiSelectValueTemplateDirective,
   SiSelectSimpleOptionsDirective,
   SiSelectSingleValueDirective
 } from '@siemens/element-ng/select';
@@ -33,6 +34,7 @@ import { LOG_EVENT } from '@siemens/live-preview';
     SiSelectActionsDirective,
     SiSelectActionDirective,
     SiSelectOptionTemplateDirective,
+    SiSelectValueTemplateDirective,
     SiSelectGroupTemplateDirective,
     TitleCasePipe,
     TranslatePipe


### PR DESCRIPTION
Closes #2713

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2733/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2733/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2733/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2733/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2733/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2733/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2733/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2733/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2733/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2733/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


