### PR TITLE
fix(chat-messages): display line only between adjacent activity messages or traces

### DIFF
--- a/projects/element-ng/chat-messages/si-activity-message.component.scss
+++ b/projects/element-ng/chat-messages/si-activity-message.component.scss
@@ -18,7 +18,7 @@ $message-spacing: map.get(variables.$spacers-block, 2);
     color: variables.$si-sys-text-danger;
   }
 
-  si-activity-message ~ & {
+  si-activity-message + & {
     margin-block-start: $message-spacing;
 
     &::before {


### PR DESCRIPTION
Otherwise it shows incorrectly.
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2736/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2736/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2736/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2736/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2736/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2736/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2736/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2736/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2736/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2736/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
