### PR TITLE
fix(si-chat-input): show primary actions again

### DIFF
--- a/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-input-element-examples-chromium-dark-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-input-element-examples-chromium-dark-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1141c60e46e54a12168c8390520b2a42865ed23feff758c72848ed4ff6cda7e5
-size 14056
+oid sha256:a3942917b65d5849705a14ff4d97317b0d2212fb29fc0bdbaf0c58b20ef4a616
+size 14516

--- a/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-input-element-examples-chromium-light-linux.png
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-input-element-examples-chromium-light-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:169a01857e457301aebbca3da01969fd2bb3d857dc14f9b344aaddfb41dd77c3
-size 13939
+oid sha256:e63c60d00478a7c413482c6289c91ad6170d3ae72c1c43b0ba22bd6b0e3ad02b
+size 14434

--- a/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-input.yaml
+++ b/playwright/snapshots/static.spec.ts-snapshots/si-chat-messages--si-chat-input.yaml
@@ -5,9 +5,10 @@
   - text: mockup.png
   - button "Remove mockup.png"
 - textbox "Chat input":
-  - /placeholder: Enter a command, question or topic...
+  - /placeholder: Enter a command, question or topic…
 - group:
   - button "Additional actions"
-  - button "Insert emoji"
+  - button "Take photo"
+- button "Insert emoji"
 - button "Send Message"
 - text: The content is AI generated. Always verify the information for accuracy.

--- a/projects/element-ng/chat-messages/si-chat-input.component.html
+++ b/projects/element-ng/chat-messages/si-chat-input.component.html
@@ -46,35 +46,68 @@
   </div>
 
   <div class="d-flex align-items-center justify-content-between">
-    <div class="btn-group" role="group">
-      <input
-        #fileInput
-        type="file"
-        class="d-none"
-        siFileUpload
-        [accept]="accept()"
-        [maxFileSize]="maxFileSize()"
-        [multiple]="true"
-        (validFiles)="onFilesAdded($event)"
-        (fileError)="onFileError($event)"
-      />
+    <div class="d-flex align-items-center gap-0">
+      <div class="btn-group" role="group">
+        @if (allowAttachments()) {
+          <input
+            #fileInput
+            type="file"
+            class="d-none"
+            siFileUpload
+            [accept]="accept()"
+            [maxFileSize]="maxFileSize()"
+            [multiple]="true"
+            (validFiles)="onFilesAdded($event)"
+            (fileError)="onFileError($event)"
+          />
+        }
 
-      @if (hasMenuActions()) {
-        <button
-          type="button"
-          class="btn btn-tertiary-ghost btn-icon"
-          [cdkMenuTriggerFor]="allActionsMenu"
-          [attr.aria-label]="secondaryActionsLabel() | translate"
-          [attr.title]="secondaryActionsLabel() | translate"
-        >
-          <si-icon [icon]="icons.elementPlus" />
-        </button>
+        @if (allowAttachments() && !hasSecondaryActions()) {
+          <button
+            type="button"
+            class="btn btn-tertiary-ghost btn-icon"
+            [disabled]="disabled()"
+            [siTooltip]="attachFileLabel() | translate"
+            [attr.aria-label]="attachFileLabel() | translate"
+            (click)="triggerFileInput()"
+          >
+            <si-icon [icon]="icons.elementAttachment" />
+          </button>
+        }
 
-        <ng-template #allActionsMenu>
-          <si-menu-factory [items]="allMenuActions()" [actionParam]="actionParam()" />
-        </ng-template>
-      }
-      <ng-content />
+        @if (hasMenuActions()) {
+          <button
+            type="button"
+            class="btn btn-tertiary-ghost btn-icon"
+            [cdkMenuTriggerFor]="allActionsMenu"
+            [attr.aria-label]="secondaryActionsLabel() | translate"
+            [attr.title]="secondaryActionsLabel() | translate"
+          >
+            <si-icon [icon]="icons.elementPlus" />
+          </button>
+
+          <ng-template #allActionsMenu>
+            <si-menu-factory [items]="combinedMenuActions()" [actionParam]="actionParam()" />
+          </ng-template>
+        }
+        @if (hasActions()) {
+          @for (action of actions(); track $index) {
+            <button
+              type="button"
+              class="btn btn-tertiary-ghost btn-icon"
+              [disabled]="action.disabled"
+              [siTooltip]="action.label | translate"
+              [attr.aria-label]="action.label | translate"
+              (click)="action.action(actionParam(), action)"
+            >
+              <si-icon [icon]="action.icon" />
+            </button>
+          }
+        }
+      </div>
+      <div class="d-flex align-items-center gap-0">
+        <ng-content />
+      </div>
     </div>
 
     <button

--- a/projects/element-ng/chat-messages/si-chat-input.component.spec.ts
+++ b/projects/element-ng/chat-messages/si-chat-input.component.spec.ts
@@ -15,7 +15,6 @@ import { By } from '@angular/platform-browser';
 import { FileUploadError, UploadFile } from '@siemens/element-ng/file-uploader';
 import { MenuItem } from '@siemens/element-ng/menu';
 import { TranslatableString } from '@siemens/element-translate-ng/translate';
-import { page } from 'vitest/browser';
 
 import { MessageAction } from './message-action.model';
 import {
@@ -488,7 +487,7 @@ describe('SiChatInputComponent', () => {
     expect(disclaimerElement.nativeElement).toHaveTextContent('This is a disclaimer');
   });
 
-  it('should render action buttons when actions are provided', async () => {
+  it('should render primary actions inline without an actions menu', async () => {
     actions.set([
       {
         label: 'Attach',
@@ -498,10 +497,36 @@ describe('SiChatInputComponent', () => {
     ]);
     await fixture.whenStable();
 
-    const menuTrigger = page.getByRole('button', { name: 'Additional actions' });
-    await menuTrigger.click();
+    const actionButtons = fixture.nativeElement.querySelectorAll('button');
+    expect(actionButtons).toHaveLength(2);
+    expect(actionButtons[0]).toHaveAttribute('aria-label', 'Attach');
+    expect(actionButtons[0]).toHaveAttribute('aria-describedby');
+    expect(fixture.nativeElement.querySelector('button.cdk-menu-trigger')).toBeFalsy();
+  });
 
-    await expect.element(page.getByRole('menuitem', { name: 'Attach' })).toBeVisible();
+  it('should render the attachment button inline when there are no secondary actions', async () => {
+    allowAttachments.set(true);
+    await fixture.whenStable();
+
+    const actionButtons = fixture.nativeElement.querySelectorAll('button');
+    expect(actionButtons).toHaveLength(2);
+    expect(actionButtons[0]).toHaveAttribute('aria-label', 'Attach file');
+    expect(fixture.nativeElement.querySelector('button.cdk-menu-trigger')).toBeFalsy();
+  });
+
+  it('should render the attachment button in the menu when secondary actions exist', async () => {
+    allowAttachments.set(true);
+    secondaryActions.set([
+      {
+        type: 'action',
+        label: 'Schedule message',
+        action: () => {}
+      }
+    ]);
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('button.cdk-menu-trigger')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('button[aria-label="Attach file"]')).toBeFalsy();
   });
 
   it('should have focus method', async () => {

--- a/projects/element-ng/chat-messages/si-chat-input.component.ts
+++ b/projects/element-ng/chat-messages/si-chat-input.component.ts
@@ -32,6 +32,7 @@ import {
 } from '@siemens/element-ng/file-uploader';
 import { addIcons, SiIconComponent } from '@siemens/element-ng/icon';
 import { MenuItem, SiMenuFactoryComponent } from '@siemens/element-ng/menu';
+import { SiTooltipDirective } from '@siemens/element-ng/tooltip';
 import { SiTranslatePipe, TranslatableString, t } from '@siemens/element-translate-ng/translate';
 
 import { MessageAction } from './message-action.model';
@@ -89,7 +90,8 @@ export interface ChatInputAttachment extends Attachment {
     SiTranslatePipe,
     SiAttachmentListComponent,
     SiMenuFactoryComponent,
-    SiFileUploadDirective
+    SiFileUploadDirective,
+    SiTooltipDirective
   ],
   templateUrl: './si-chat-input.component.html',
   styleUrl: './si-chat-input.component.scss'
@@ -158,8 +160,7 @@ export class SiChatInputComponent implements AfterViewInit {
   readonly disclaimer = input<TranslatableString>();
 
   /**
-   * Primary actions available in the input (attach files, etc.)
-   * All actions displayed inline
+   * Primary actions available in the input. Provide at most one action.
    * @defaultValue []
    */
   readonly actions = input<MessageAction[]>([]);
@@ -317,7 +318,7 @@ export class SiChatInputComponent implements AfterViewInit {
   protected readonly hasAttachments = computed(() => this.attachments().length > 0);
   protected readonly hasActions = computed(() => this.actions().length > 0);
   protected readonly hasSecondaryActions = computed(() => this.secondaryActions().length > 0);
-  protected readonly allMenuActions = computed<MenuItem[]>(() => [
+  protected readonly combinedMenuActions = computed<MenuItem[]>(() => [
     ...(this.allowAttachments()
       ? [
           {
@@ -329,19 +330,10 @@ export class SiChatInputComponent implements AfterViewInit {
           } satisfies MenuItem
         ]
       : []),
-    ...this.actions().map((a): MenuItem => ({
-      type: 'action' as const,
-      label: a.label,
-      icon: a.icon,
-      disabled: a.disabled,
-      action: (param: unknown) => a.action(param, a)
-    })),
     ...this.secondaryActions()
   ]);
 
-  protected readonly hasMenuActions = computed(
-    () => this.allowAttachments() || this.hasActions() || this.hasSecondaryActions()
-  );
+  protected readonly hasMenuActions = computed(() => this.hasSecondaryActions());
 
   protected triggerFileInput(): void {
     this.fileInput()?.nativeElement.click();

--- a/src/app/examples/si-chat-messages/si-chat-container.html
+++ b/src/app/examples/si-chat-messages/si-chat-container.html
@@ -125,7 +125,7 @@
       [maxFileSize]="5242880"
       [sending]="sending()"
       [interruptible]="loading() && !sending()"
-      [followUpPrompts]="followUpPrompts()"
+      [followUpPrompts]="messages().length ? followUpPrompts() : []"
       [(value)]="inputValue"
       (send)="onMessageSent($event)"
       (followUpPromptSelected)="onFollowUpPromptSelected($event)"

--- a/src/app/examples/si-chat-messages/si-chat-input.ts
+++ b/src/app/examples/si-chat-messages/si-chat-input.ts
@@ -33,15 +33,16 @@ export class SampleComponent {
       label: 'Take photo',
       icon: 'element-camera',
       action: () => this.logEvent('Camera clicked')
-    },
-    {
-      label: 'Text formatting',
-      icon: 'element-brush',
-      action: () => this.logEvent('Text formatting clicked')
     }
   ];
 
   secondaryActions: MenuItemAction[] = [
+    {
+      type: 'action',
+      label: 'Text formatting',
+      icon: 'element-brush',
+      action: () => this.logEvent('Text formatting clicked')
+    },
     {
       type: 'action',
       label: 'Schedule message',


### PR DESCRIPTION
Fixes a regression: https://github.com/siemens/element/pull/2027#issuecomment-4742255775

<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2743/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2743/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2743/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2743/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2743/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2743/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2743/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2743/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2743/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2743/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->


