### PR TITLE
fix(element-ng): migrate internal list-group usages to element list

### DIFF
--- a/projects/element-ng/about/si-about.component.html
+++ b/projects/element-ng/about/si-about.component.html
@@ -5,26 +5,26 @@
         {{ aboutTitle() }}
       </div>
 
-      <div class="list-group">
-        <div class="list-group-item text-center">
-          @let appIcon = iconName();
-          @if (icon()) {
-            <img
-              class="rounded-circle"
-              height="150"
-              [src]="icon()"
-              [alt]="logoAlt() | translate: { appName: appName() }"
-            />
-          } @else if (appIcon) {
-            <si-icon class="app-icon" [icon]="appIcon" />
-          }
-          <h3>{{ appName() }}</h3>
-          @for (item of subheading(); track $index) {
-            <p>{{ item }}</p>
-          }
-          <si-copyright-notice [copyright]="copyrightDetails()" />
-        </div>
+      <div class="about-branding text-center">
+        @let appIcon = iconName();
+        @if (icon()) {
+          <img
+            class="rounded-circle"
+            height="150"
+            [src]="icon()"
+            [alt]="logoAlt() | translate: { appName: appName() }"
+          />
+        } @else if (appIcon) {
+          <si-icon class="app-icon" [icon]="appIcon" />
+        }
+        <h3>{{ appName() }}</h3>
+        @for (item of subheading(); track $index) {
+          <p>{{ item }}</p>
+        }
+        <si-copyright-notice [copyright]="copyrightDetails()" />
+      </div>
 
+      <ul class="list list-divider">
         @if (imprintLink()) {
           <ng-container
             [ngTemplateOutlet]="linkTemplate"
@@ -61,7 +61,7 @@
             [ngTemplateOutletContext]="{ link: item }"
           />
         }
-      </div>
+      </ul>
     </div>
   </div>
 
@@ -110,11 +110,9 @@
 </div>
 
 <ng-template #linkTemplate let-link="link">
-  <a
-    class="list-group-item si-h5 text-primary focus-inside"
-    siLinkDefaultTarget="_blank"
-    [siLink]="link"
-  >
-    {{ link.title | translate }}
-  </a>
+  <li>
+    <a class="list-item list-item-action text-primary" siLinkDefaultTarget="_blank" [siLink]="link">
+      <span class="list-item-title">{{ link.title | translate }}</span>
+    </a>
+  </li>
 </ng-template>

--- a/projects/element-ng/about/si-about.component.scss
+++ b/projects/element-ng/about/si-about.component.scss
@@ -2,17 +2,10 @@
 
 @use '@siemens/element-theme/src/styles/variables';
 
-.list-group-item {
-  border-width: 0 0 1px;
+.about-branding {
+  padding-block: map.get(variables.$spacers-block, 4);
   padding-inline: map.get(variables.$spacers-inline, 6);
-
-  &.with-border:first-child {
-    border-block-start-width: 1px;
-  }
-
-  &:last-child {
-    border-block-end-width: 0;
-  }
+  border-block-end: 1px solid variables.$si-sys-border-4;
 }
 
 .app-icon {

--- a/projects/element-ng/about/si-about.component.spec.ts
+++ b/projects/element-ng/about/si-about.component.spec.ts
@@ -108,7 +108,7 @@ describe('SiAboutComponent', () => {
     const licenseText = element.querySelector('pre')!.innerHTML;
     const icon = element.querySelector('img')!.getAttribute('src');
     const heading = element.querySelector('img + h3')!.innerHTML;
-    const subheading = element.querySelector('.list-group-item:first-of-type')!.innerHTML;
+    const subheading = element.querySelector('.about-branding')!.innerHTML;
     const links = element.querySelector('.card:first-of-type')!.innerHTML;
 
     expect(title).toContain('About');
@@ -144,7 +144,7 @@ describe('SiAboutComponent', () => {
     const licenseText = element.querySelector('pre')!.innerHTML;
     const icon = element.querySelector('img')!.getAttribute('src');
     const heading = element.querySelector('img + h3')!.innerHTML;
-    const subheading = element.querySelector('.list-group-item:first-of-type')!.innerHTML;
+    const subheading = element.querySelector('.about-branding')!.innerHTML;
     const links = element.querySelector('.card:first-of-type')!.innerHTML;
 
     expect(title).toContain('About');

--- a/projects/element-ng/empty-state/si-empty-state.component.html
+++ b/projects/element-ng/empty-state/si-empty-state.component.html
@@ -1,4 +1,4 @@
-<div class="list-group-item-empty">
+<div class="empty-state-content">
   <si-icon class="state-icon" [icon]="icon()" />
   <span class="si-h3 my-6 text-center">{{ heading() | translate }}</span>
   @if (content()) {

--- a/projects/element-ng/empty-state/si-empty-state.component.scss
+++ b/projects/element-ng/empty-state/si-empty-state.component.scss
@@ -2,7 +2,7 @@
 
 @use '@siemens/element-theme/src/styles/variables';
 
-.list-group-item-empty {
+.empty-state-content {
   min-block-size: 100%;
   display: flex;
   flex-direction: column;

--- a/src/app/examples/drag-drop/drag-drop.html
+++ b/src/app/examples/drag-drop/drag-drop.html
@@ -4,7 +4,7 @@
     <ul
       #cdkListOne="cdkDropList"
       aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown Cmd+X Cmd+V"
-      class="list-group list-group-flush"
+      class="list list-divider"
       cdkListbox
       cdkDropList
       [cdkDropListConnectedTo]="cdkListTwo"
@@ -15,7 +15,7 @@
       @for (item of listOne; track $index) {
         <li
           #listOneItem
-          class="list-group-item list-group-item-action"
+          class="list-item list-item-action"
           cdkDrag
           [cdkOption]="item"
           [cdkDragData]="item"
@@ -26,15 +26,16 @@
           (keydown)="keydown($event, { item: item, list: listOne, index: $index })"
           (keydown.alt.arrowUp)="moveWithinList(listOne, $index, $index - 1)"
           (keydown.alt.arrowDown)="moveWithinList(listOne, $index, $index + 1)"
-          >{{ item }}</li
         >
+          <span class="list-item-title">{{ item }}</span>
+        </li>
       }
     </ul>
 
     <ul
       #cdkListTwo="cdkDropList"
       aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown Cmd+X Cmd+V"
-      class="list-group list-group-flush"
+      class="list list-divider"
       cdkListbox
       cdkDropList
       [cdkDropListData]="listTwo"
@@ -44,7 +45,7 @@
       @for (item of listTwo; track $index) {
         <li
           #listTwoItem
-          class="list-group-item list-group-item-action"
+          class="list-item list-item-action"
           cdkDrag
           [cdkOption]="item"
           [cdkContextMenuTriggerFor]="contextMenu"
@@ -53,8 +54,9 @@
           (keydown)="keydown($event, { item: item, list: listTwo, index: $index })"
           (keydown.alt.arrowUp)="moveWithinList(listTwo, $index, $index - 1)"
           (keydown.alt.arrowDown)="moveWithinList(listTwo, $index, $index + 1)"
-          >{{ item }}</li
         >
+          <span class="list-item-title">{{ item }}</span>
+        </li>
       }
     </ul>
   </div>


### PR DESCRIPTION
## Layer 3 of 3 — migrate remaining internal `list-group` usages

Top layer of the list-group deprecation stack. Base branch is `kaspar-fenner-cards-with-lists` (layer 2), **not** `main`.

- Layer 1: #2742 — `refactor(element-theme): deprecate list group` (docs removed, SCSS deprecated in place, migration guide).
- Layer 2: #2745 — `feat(element-theme): support element list inside cards`.
- **This PR (layer 3)** migrates the internal library-component usages that layers 1 and 2 deliberately left alone.

This is **not** a class rename. `.list-group-item` is `display: block`; `.list-item` is a CSS grid with named slots (`.list-item-title`, `.list-item-action`, …) plus `> * { grid-column: 3 / -1 }`. Each component was restructured into those slots rather than having the class swapped.

## Per-component changes

### `si-about` (`projects/element-ng/about/`)
- The single `.list-group` was doing two unrelated jobs. Split into:
  - a plain branding block `<div class="about-branding">` (icon/image, heading, subheadings, copyright notice), styled directly in SCSS; and
  - a real list `<ul class="list list-divider">` whose rows are the external links.
- Each link row is now `<li><a class="list-item list-item-action text-primary" …><span class="list-item-title">…</span></a></li>`.
- `text-primary` is kept intentionally: it carries a load-bearing `!important` that beats `.list-item-action`'s `color: inherit`, so link colour is unchanged.
- SCSS: `.list-group-item` (and a dead `.with-border`) replaced by `.about-branding` (padding + bottom border).
- Spec: 3 assertions re-targeted from `.list-group-item:first-of-type` to `.about-branding`.

### `si-empty-state` (`projects/element-ng/empty-state/`)
- Pure private-class rename: root `.list-group-item-empty` → `.empty-state-content` in both HTML and SCSS. It was never a real list row (single element, no list semantics). **Zero visual change.**

### `drag-drop` example (`src/app/examples/drag-drop/`)
- Both `<ul class="list-group list-group-flush">` → `<ul class="list list-divider">`; items → `<li class="list-item list-item-action"><span class="list-item-title">…</span></li>`.
- All `cdkDrag` / `cdkListbox` / `cdkOption` / `cdkDropList` / `cdkContextMenu` bindings and template refs preserved.

## Descoped (report only — deliberately left on `list-group`)

The dashboard widget families do not map cleanly and would need a design-system decision, so per the "you're allowed to descope" instruction they are left untouched:

- `si-widget-catalog` (`projects/dashboards-ng/…` — html/scss/spec)
- `si-list-widget-body` / `si-list-widget-item` (`projects/element-ng/dashboard/widgets/si-list-widget/…`)
- `custom-widget-catalog` (`dashboards-demo/…`)

Both gaps below are tracked in **#2748** ("Element list: add selected state and preserve link colour on `.list-item-action` anchors"), framed as what blocks completing the list-group migration for these widgets.

**Headline reason: the Element list has no selected / current-item state.** These widgets rely on a highlighted "selected" row (catalog selection, active list item). `.list-item` only exposes `&:active`; there is no `.active`/selected equivalent, so a faithful migration would need a new design-system affordance rather than a markup change.

Secondary gap: `.list-item-action` on an `<a>` defaults to `color: inherit`, so link-coloured rows need an explicit colour class (as done for `si-about` via `text-primary`, whose load-bearing `!important` beats that inherit). Both are captured in #2748 as prerequisites before these widgets migrate.

## Consumer-visible DOM change

This PR changes the **rendered DOM of shipped components** (`si-about`, `si-empty-state`), so it is typed `fix` (not `refactor` — `refactor` is `hidden` in `commit-config.js` and would produce no release/changelog entry). The commit carries a `NOTE:` footer telling consumers to re-target any custom CSS/tests from `.list-group-item` to the new markup (`ul.list.list-divider > li > a.list-item.list-item-action` for si-about links; `.about-branding` for the branding block; `.empty-state-content` for si-empty-state). Public inputs/outputs are unchanged, so this is **not** typed `BREAKING CHANGE`.

## Accessibility

Layer 2's card focus-ring bug (item background painting over the inset focus ring) was checked here and does **not** occur: in every migrated list the focusable element owns its own background (the `<a>` in si-about, the `<li>` in drag-drop), so its inset outline paints above it. Verified visually — focus ring unbroken at rest and with the first row hovered. No local `z-index` fix needed.

## VRT snapshots

**Docker was unavailable in this environment, so VRT snapshots could not be regenerated.** `si-about` renders differently and its snapshots will need updating:
- `projects/element-ng/…/playwright/snapshots/si-about.spec.ts-snapshots/*` (light + dark)
- static examples `si-about--si-about-api*`, `si-about--si-about-text*`

`si-empty-state` (private class rename) and `drag-drop` are not expected to change visually. Please regenerate `si-about` snapshots with `./e2e-local.sh update si-about` on a Docker-capable machine before merge.

## Verification run (mirrors CI `verification` job)
- `npx prettier --check` on all touched files — clean.
- `pnpm run lint:scss` — pass.
- `ng lint element-ng` + `ng lint element-examples` — pass (full `lint:ng` OOMs on unrelated `dashboards-demo-mfe`, a pre-existing env issue).
- Unit tests: `si-about` + `si-empty-state` specs — 11/11 pass.
