### PR TITLE
feat(native-charts): optional marker for nchart-gauge

### DIFF
--- a/api-goldens/native-charts-ng/gauge/index.api.md
+++ b/api-goldens/native-charts-ng/gauge/index.api.md
@@ -30,6 +30,7 @@ export class SiNChartGaugeComponent implements OnInit, OnChanges {
     readonly axisNumberOfDecimals: _angular_core.InputSignal<number>;
     readonly endAngle: _angular_core.InputSignalWithTransform<number, unknown>;
     readonly legendPosition: _angular_core.InputSignal<"row" | "column">;
+    readonly markerValue: _angular_core.InputSignal<number | undefined>;
     readonly max: _angular_core.InputSignalWithTransform<number, unknown>;
     readonly maxNumberOfDecimals: _angular_core.InputSignal<number>;
     readonly min: _angular_core.InputSignalWithTransform<number, unknown>;

--- a/api-goldens/native-charts-ng/index.api.md
+++ b/api-goldens/native-charts-ng/index.api.md
@@ -36,6 +36,7 @@ export class SiNChartGaugeComponent implements OnInit, OnChanges {
     readonly axisNumberOfDecimals: i0.InputSignal<number>;
     readonly endAngle: i0.InputSignalWithTransform<number, unknown>;
     readonly legendPosition: i0.InputSignal<"row" | "column">;
+    readonly markerValue: i0.InputSignal<number | undefined>;
     readonly max: i0.InputSignalWithTransform<number, unknown>;
     readonly maxNumberOfDecimals: i0.InputSignal<number>;
     readonly min: i0.InputSignalWithTransform<number, unknown>;

--- a/projects/native-charts-ng/gauge/si-nchart-gauge.component.html
+++ b/projects/native-charts-ng/gauge/si-nchart-gauge.component.html
@@ -39,6 +39,11 @@
       }
     }
   </g>
+  @if (markerPath) {
+    <g class="marker">
+      <path [attr.d]="markerPath" />
+    </g>
+  }
   <text
     class="text-primary value"
     x="50"

--- a/projects/native-charts-ng/gauge/si-nchart-gauge.component.scss
+++ b/projects/native-charts-ng/gauge/si-nchart-gauge.component.scss
@@ -40,6 +40,11 @@
     stroke-width: 0.5;
   }
 
+  .marker {
+    stroke: variables.$si-sys-border-3;
+    stroke-width: 1;
+  }
+
   .segments {
     stroke-width: 0.75;
     fill: none;

--- a/projects/native-charts-ng/gauge/si-nchart-gauge.component.spec.ts
+++ b/projects/native-charts-ng/gauge/si-nchart-gauge.component.spec.ts
@@ -19,6 +19,7 @@ import { GaugeSegment, GaugeSeries, SiNChartGaugeComponent } from './si-nchart-g
       [mode]="mode()"
       [series]="series()"
       [segments]="segments()"
+      [markerValue]="markerValue()"
       [unit]="unit()"
       [showTicks]="showTicks()"
       [showLegend]="showLegend()"
@@ -41,6 +42,7 @@ class TestHostComponent {
   readonly mode = signal<'sum' | 'single'>('sum');
   readonly series = signal<GaugeSeries[]>([]);
   readonly segments = signal<GaugeSegment[]>([]);
+  readonly markerValue = signal<number | undefined>(undefined);
   readonly unit = signal('');
   readonly showTicks = signal(true);
   readonly showLegend = signal(true);
@@ -99,6 +101,19 @@ describe('SiNChartGaugeComponent', () => {
     const bgPath = getBackgroundPath();
     expect(bgPath).toBeTruthy();
     expect(bgPath!.getAttribute('d')).toBeTruthy();
+  });
+
+  it('should render an optional marker on top of the data arc', async () => {
+    host.series.set(defaultSeries);
+    await fixture.whenStable();
+    expect(gaugeEl.querySelector('g.marker')).not.toBeInTheDocument();
+
+    host.markerValue.set(0);
+    await fixture.whenStable();
+
+    const marker = gaugeEl.querySelector('g.marker');
+    expect(marker?.querySelector('path')).toHaveAttribute('d', 'M 50 12.5 L 50 7.5');
+    expect(marker?.previousElementSibling).toHaveClass('data');
   });
 
   describe('sum mode', () => {

--- a/projects/native-charts-ng/gauge/si-nchart-gauge.component.ts
+++ b/projects/native-charts-ng/gauge/si-nchart-gauge.component.ts
@@ -123,6 +123,10 @@ export class SiNChartGaugeComponent implements OnInit, OnChanges {
    */
   readonly segments = input<GaugeSegment[]>([]);
   /**
+   * Optional value displayed as a marker bar across the value arc.
+   */
+  readonly markerValue = input<number>();
+  /**
    * Unit
    *
    * @defaultValue ''
@@ -199,6 +203,7 @@ export class SiNChartGaugeComponent implements OnInit, OnChanges {
   protected totalSumString = '0';
   protected valignMiddle = false;
   protected internalSegments: InternalGaugeSegment[] = [];
+  protected markerPath = '';
 
   private locale = inject(LOCALE_ID).toString();
   private numberFormat = new Intl.NumberFormat(this.locale, { maximumFractionDigits: 2 });
@@ -234,6 +239,7 @@ export class SiNChartGaugeComponent implements OnInit, OnChanges {
       changes.showTicks ||
       changes.showRangeLabelsOutside ||
       changes.segments ||
+      changes.markerValue ||
       changes.axisLabelFormatter ||
       changes.valueFormatter
     ) {
@@ -266,6 +272,29 @@ export class SiNChartGaugeComponent implements OnInit, OnChanges {
     } else {
       this.calcSeriesSingle();
     }
+    this.markerPath = this.makeMarkerPath();
+  }
+
+  private makeMarkerPath(): string {
+    const markerValue = this.markerValue();
+    if (markerValue === undefined) {
+      return '';
+    }
+
+    const angle = this.containAngle(
+      this.startAngle() +
+        valueToRelativeAngle(
+          this.startAngle(),
+          this.endAngle(),
+          this.min(),
+          this.max(),
+          markerValue
+        )
+    );
+    return makeLine(
+      polarToCartesian(this.center, this.radius - 2.5, angle),
+      polarToCartesian(this.center, this.radius + 2.5, angle)
+    );
   }
 
   private reset(): void {

--- a/src/app/examples/si-ncharts/si-nchart-gauge-single.html
+++ b/src/app/examples/si-ncharts/si-nchart-gauge-single.html
@@ -11,6 +11,7 @@
       [endAngle]="90"
       [min]="300"
       [max]="1500"
+      [markerValue]="markerValue"
       [minNumberOfDecimals]="minDecimals"
       [maxNumberOfDecimals]="maxDecimals"
       [axisNumberOfDecimals]="axisDecimals"
@@ -54,6 +55,27 @@
           [step]="1"
           [(ngModel)]="axisDecimals"
         />
+      </si-form-item>
+    </div>
+    <div class="col-sm-4">
+      <si-form-item label="Marker value">
+        <div class="d-flex align-items-center gap-4">
+          <input
+            type="checkbox"
+            class="form-check-input flex-shrink-0"
+            aria-label="Enable marker"
+            [ngModel]="markerValue !== undefined"
+            [ngModelOptions]="{ standalone: true }"
+            (ngModelChange)="setMarkerEnabled($event)"
+          />
+          <si-number-input
+            required
+            class="form-control"
+            [disabled]="markerValue === undefined"
+            [ngModelOptions]="{ standalone: true }"
+            [(ngModel)]="markerValue"
+          />
+        </div>
       </si-form-item>
     </div>
     <div class="col-sm-4">

--- a/src/app/examples/si-ncharts/si-nchart-gauge-single.ts
+++ b/src/app/examples/si-ncharts/si-nchart-gauge-single.ts
@@ -30,8 +30,11 @@ export class SampleComponent {
   minDecimals = 0;
   maxDecimals = 2;
   axisDecimals = 0;
+  markerValue: number | undefined;
   showRangeLabelsOutside = false;
   showSegments = true;
+
+  private lastMarkerValue = 750;
 
   series: GaugeSeries[] = [
     { name: 'Series 1', value: 350, colorToken: 'si-sys-data-categorical-5' }
@@ -40,5 +43,14 @@ export class SampleComponent {
   setValues(val1: number): void {
     this.series[0].value = val1;
     this.series = this.series.slice();
+  }
+
+  setMarkerEnabled(enabled: boolean): void {
+    if (enabled) {
+      this.markerValue = this.lastMarkerValue;
+    } else {
+      this.lastMarkerValue = this.markerValue ?? this.lastMarkerValue;
+      this.markerValue = undefined;
+    }
   }
 }


### PR DESCRIPTION
<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2751/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2751/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2751/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2751/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2751/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2751/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2751/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2751/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2751/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2751/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
