### PR TITLE
fix(tooltip): prevent empty tooltips for unlabeled content

### DIFF
--- a/projects/element-ng/application-header/si-application-header.component.spec.ts
+++ b/projects/element-ng/application-header/si-application-header.component.spec.ts
@@ -377,6 +377,51 @@ describe('SiApplicationHeaderComponent', () => {
     });
   });
 
+  describe('with aria-label-only icon action item', () => {
+    @Component({
+      imports: [
+        SiApplicationHeaderComponent,
+        SiHeaderActionItemComponent,
+        SiHeaderActionsDirective,
+        SiHeaderCollapsibleActionsComponent
+      ],
+      template: `
+        <si-application-header expandBreakpoint="never">
+          <si-header-actions>
+            <si-header-collapsible-actions>
+              <button
+                type="button"
+                si-header-action-item
+                icon="fake-icon"
+                aria-label="Action 1"
+              ></button>
+            </si-header-collapsible-actions>
+          </si-header-actions>
+        </si-application-header>
+      `
+    })
+    class TestHostComponent {}
+
+    let fixture: ComponentFixture<TestHostComponent>;
+    let button: HTMLButtonElement;
+
+    beforeEach(async () => {
+      fixture = TestBed.createComponent(TestHostComponent);
+      loader = TestbedHarnessEnvironment.loader(fixture);
+      headerHarness = await loader.getHarness(SiApplicationHeaderHarness);
+      button = fixture.nativeElement.querySelector('button[si-header-action-item]');
+      vi.spyOn(button, 'matches').mockImplementation(selector => selector === ':focus-visible');
+      fixture.detectChanges();
+    });
+
+    it('should not show an empty tooltip', async () => {
+      button.dispatchEvent(new FocusEvent('focus'));
+      await fixture.whenStable();
+
+      await expect.element(page.getByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
   describe('with icon-only action item and custom tooltip', () => {
     @Component({
       imports: [

--- a/projects/element-ng/application-header/si-application-header.component.spec.ts
+++ b/projects/element-ng/application-header/si-application-header.component.spec.ts
@@ -414,7 +414,15 @@ describe('SiApplicationHeaderComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should not show an empty tooltip', async () => {
+    it('should show the aria-label as a tooltip', async () => {
+      button.dispatchEvent(new FocusEvent('focus'));
+      await fixture.whenStable();
+
+      await expect.element(page.getByRole('tooltip', { name: 'Action 1' })).toBeInTheDocument();
+    });
+
+    it('should not show a tooltip without a title or aria-label', async () => {
+      button.removeAttribute('aria-label');
       button.dispatchEvent(new FocusEvent('focus'));
       await fixture.whenStable();
 

--- a/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
+++ b/projects/element-ng/application-header/si-header-action-item-icon-base.directive.ts
@@ -63,9 +63,16 @@ export abstract class SiHeaderActionIconItemBase
       placement: () => 'auto',
       canShow: this.canShowTooltip,
       // Subclass field initializers run after this base constructor. So we cannot directly pass `this.itemTitle`.
-      tooltip: () => this.itemTitle(),
+      tooltip: () => this.getTooltipContent(),
       tooltipContext: () => undefined
     });
+  }
+
+  private getTooltipContent(): string | ElementRef<Element> | null {
+    const itemTitle = this.itemTitle();
+    return itemTitle instanceof ElementRef && !itemTitle.nativeElement.textContent?.trim()
+      ? this.elementRef.nativeElement.getAttribute('aria-label')
+      : itemTitle;
   }
 
   ngOnChanges(changes: SimpleChanges<this>): void {

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -187,11 +187,7 @@ class BrowserTooltipRef {
   }
 
   private show(): void {
-    if (this.config.canShow && !this.config.canShow()) {
-      return;
-    }
-
-    if (!this.hasContent()) {
+    if ((this.config.canShow && !this.config.canShow()) || !this.hasContent()) {
       return;
     }
 

--- a/projects/element-ng/tooltip/si-tooltip.service.ts
+++ b/projects/element-ng/tooltip/si-tooltip.service.ts
@@ -191,6 +191,10 @@ class BrowserTooltipRef {
       return;
     }
 
+    if (!this.hasContent()) {
+      return;
+    }
+
     const overlayRef = this.getOrCreateOverlay();
     if (overlayRef.hasAttached()) {
       return;
@@ -213,6 +217,17 @@ class BrowserTooltipRef {
     this.positionSubscription = positionStrategy?.positionChanges.subscribe(change =>
       tooltipRef.instance.updateTooltipPosition(change, this.config.element)
     );
+  }
+
+  private hasContent(): boolean {
+    const tooltip = this.config.tooltip();
+    if (typeof tooltip === 'string') {
+      return tooltip.trim().length > 0;
+    }
+    if (tooltip instanceof ElementRef) {
+      return !!tooltip.nativeElement.textContent?.trim();
+    }
+    return tooltip !== null && tooltip !== undefined;
   }
 
   private getPlacement(): keyof typeof positions {


### PR DESCRIPTION
Prevent the tooltip service from creating overlays without visible content.

The service now skips empty or whitespace-only string tooltips and `ElementRef` tooltips whose text content is empty.

For icon-only application-header actions without projected title content, the automatic tooltip now uses the action's `aria-label`. When neither a title nor an `aria-label` is available, no tooltip is displayed.

<!-- Describe in detail what your merge request does and why. Add relevant
screenshots and reference related issues via `Closes #XY` or `Related to #XY`.

Please make sure your PR follows the contribution guidelines
https://github.com/siemens/element/blob/main/CONTRIBUTING.md. -->
<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2757/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2757/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2757/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2757/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2757/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2757/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2757/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2757/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2757/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2757/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->

