### PR TITLE
build(gh-actions): publish release documentation built from the release tag

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -205,45 +205,9 @@ jobs:
           overwrite: true
 
   documentation:
-    runs-on: ubuntu-24.04
     needs:
       - build
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: dist
-          path: dist
-      - name: Install Node.js and pnpm
-        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
-        with:
-          runtime: node@krypton
-          cache: true
-          install: false
-      - name: Set up registry authentication
-        run: pnpm config set "//code.siemens.com/:_authToken" "${SIEMENS_NPM_TOKEN}"
-        env:
-          SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
-      - run: pnpm install
-      - run: cp dist/element-examples/favicon.png docs/_src/favicon.png
-      - run: uv sync
-        env:
-          UV_INDEX_CODE_DOCS_THEME_USERNAME: ${{ secrets.SIEMENS_NPM_USER }}
-          UV_INDEX_CODE_DOCS_THEME_PASSWORD: ${{ secrets.SIEMENS_NPM_TOKEN }}
-      - run: pnpm run icon-viewer:build-docs
-      - run: pnpm run docs:build:generate
-        env:
-          EXAMPLES_BASE: /element-examples/
-        if: ${{ github.ref == 'refs/heads/main' }}
-      - run: pnpm run docs:build:api
-        env:
-          EXAMPLES_BASE: /element-examples/
-        if: ${{ github.ref != 'refs/heads/main' }}
-      - run: mv dist/element-examples/ dist/design/
-      - run: mv dist/dashboards-demo/ dist/design/
-      - run: mv dist/dashboards-demo-esm/ dist/design/
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: pages
-          path: dist/design
+    uses: ./.github/workflows/build-documentation.yaml
+    secrets:
+      SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
+      SIEMENS_NPM_USER: ${{ secrets.SIEMENS_NPM_USER }}

--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -1,0 +1,66 @@
+name: Build Documentation
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref (branch, tag or SHA) to build the documentation from. Defaults to the ref that triggered the calling workflow.
+        type: string
+        required: false
+        default: ''
+      artifact-name:
+        description: Name of the uploaded documentation artifact. Must be unique within a workflow run.
+        type: string
+        required: false
+        default: pages
+    secrets:
+      SIEMENS_NPM_TOKEN:
+        required: true
+      SIEMENS_NPM_USER:
+        required: true
+
+permissions: read-all
+
+jobs:
+  documentation:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist
+          path: dist
+      - name: Install Node.js and pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          runtime: node@krypton
+          cache: true
+          install: false
+      - name: Set up registry authentication
+        run: pnpm config set "//code.siemens.com/:_authToken" "${SIEMENS_NPM_TOKEN}"
+        env:
+          SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
+      - run: pnpm install
+      - run: cp dist/element-examples/favicon.png docs/_src/favicon.png
+      - run: uv sync
+        env:
+          UV_INDEX_CODE_DOCS_THEME_USERNAME: ${{ secrets.SIEMENS_NPM_USER }}
+          UV_INDEX_CODE_DOCS_THEME_PASSWORD: ${{ secrets.SIEMENS_NPM_TOKEN }}
+      - run: pnpm run icon-viewer:build-docs
+      - run: pnpm run docs:build:generate
+        env:
+          EXAMPLES_BASE: /element-examples/
+        if: ${{ github.ref == 'refs/heads/main' }}
+      - run: pnpm run docs:build:api
+        env:
+          EXAMPLES_BASE: /element-examples/
+        if: ${{ github.ref != 'refs/heads/main' }}
+      - run: mv dist/element-examples/ dist/design/
+      - run: mv dist/dashboards-demo/ dist/design/
+      - run: mv dist/dashboards-demo-esm/ dist/design/
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: dist/design

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,6 +71,24 @@ jobs:
             echo "release_tag=" >> $GITHUB_OUTPUT
           fi
 
+  # Rebuilds the documentation from the release tag created by semantic-release.
+  # The "pages" artifact from build-and-test was produced before the release
+  # commit exists, so it still carries the previous CHANGELOG.md and the
+  # pre-bump package.json versions. Building from the tag keeps the published
+  # documentation in sync with the release.
+  build-documentation-release:
+    needs:
+      - publish
+      - build-and-test
+    if: success() && needs.publish.outputs.new_release == 'true' && github.ref_name != 'next'
+    uses: ./.github/workflows/build-documentation.yaml
+    with:
+      ref: ${{ needs.publish.outputs.release_tag }}
+      artifact-name: pages-release
+    secrets:
+      SIEMENS_NPM_TOKEN: ${{ secrets.SIEMENS_NPM_TOKEN }}
+      SIEMENS_NPM_USER: ${{ secrets.SIEMENS_NPM_USER }}
+
   # Generates the versioned documentation and publishes it to S3.
   # This job only runs after a successful release unless the release is on the "next" branch.
   # In general, runs on main push to /latest/, while release branches (e.g., release/48.x) push to /v48/
@@ -84,7 +102,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - publish
-      - build-and-test
+      - build-documentation-release
     if: success() && needs.publish.outputs.new_release == 'true' && github.ref_name != 'next'
     permissions:
       id-token: write
@@ -97,7 +115,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: pages
+          name: pages-release
           path: pages
       - uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:


### PR DESCRIPTION
## Symptom

The versioned documentation published to `element.siemens.io` is always **one release behind** on `CHANGELOG.md`. The changelog page of every released version is missing the entry for that very version.

| Route | Newest tag in that line | Newest changelog entry actually deployed |
| --- | --- | --- |
| `https://element.siemens.io/CHANGELOG/` (default = `latest/`) | v51.0.0 | **49.13.0** :x: |
| `https://element.siemens.io/v49/CHANGELOG/` | v49.16.1 | 49.16.0 :x: |
| `https://element.siemens.io/v48/CHANGELOG/` | v48.11.3 | 48.9.0 :x: |
| `https://element.siemens.io/development/CHANGELOG/` | main | 51.0.0 :white_check_mark: |
| `https://siemens.github.io/element/CHANGELOG/` | main | 51.0.0 :white_check_mark: |

`49.13.0` is byte-for-byte the top heading of `CHANGELOG.md` at `0f1c003ad^`, i.e. the commit right before `chore(release): 51.0.0`. So this is systemic across every release, not a v51 one-off.

## Root cause

`release.yaml` job ordering:

```
build-and-test  ─────────►  publish  (pnpm exec semantic-release)
      │                        │
      │                        └─ creates "chore(release): NN.0.0"
      │                           (new CHANGELOG.md section + version bumps)
      │                           and the vNN.0.0 tag
      │
      └─ uploads "pages" artifact  ──►  publish-documentation-release
                                        (aws s3 sync to latest/ and vNN/)
```

- `publish-documentation-release` declared `needs: [publish, build-and-test]` but deployed the `pages` artifact produced by `build-and-test`, which ran **before** `publish`.
- `build-and-test.yaml`'s `documentation` job checks out the dispatch SHA, i.e. the tree *before* semantic-release writes the release commit.
- `publish-documentation-release`'s own `actions/checkout` has no `ref:`, so nothing in that job ever saw the release commit either.
- `docs/CHANGELOG.md` is a MkDocs stub that pulls in the repo-root changelog via a pymdownx snippets include (`--8<-- "CHANGELOG.md"`), so the rendered page is exactly as fresh as the checked-out root `CHANGELOG.md`.

`/development/` and GitHub Pages are unaffected because `publish-documentation.yaml` triggers on `push` to `main`, so it re-runs *after* semantic-release has pushed the release commit.

## The fix

1. **New reusable workflow `.github/workflows/build-documentation.yaml`** containing the steps that previously lived in `build-and-test.yaml`'s `documentation` job, with two optional inputs:
   - `ref` (default `''`) — passed to `actions/checkout`. An empty value makes checkout fall back to the triggering ref, preserving today's behaviour.
   - `artifact-name` (default `pages`) — required because `release.yaml` now uploads a second documentation bundle in the same workflow run, and `actions/upload-artifact` v4+ artifacts are immutable, so a duplicate name would fail the job.

   The `docs:build:generate` vs `docs:build:api` gate on `github.ref == 'refs/heads/main'` is kept verbatim. Inside a reusable workflow `github.ref` still refers to the caller's triggering ref, so behaviour is unchanged for both main and release branches.

2. **`build-and-test.yaml`** now calls that reusable workflow instead of inlining the job. With the default inputs the result is byte-identical, and the artifact is still named `pages`, so `pull-request.yaml` and `publish-documentation.yaml` keep working unchanged.

3. **`release.yaml`** gains a `build-documentation-release` job that runs *after* `publish`, checks out `needs.publish.outputs.release_tag` and uploads `pages-release`. `publish-documentation-release` now depends on that job and deploys `pages-release`.

The two commits are split as refactor-then-fix to keep the review easy.

## Notes

- The `dist` artifact is deliberately still the pre-release build. The compiled output is identical — only version strings differ — and re-downloading it is what keeps the extra job cheap. If we ever want the published examples to carry the exact release version strings too, that would be a separate change.
- The stale artifact also carried the pre-bump `package.json` versions; that is fixed by the same change for the documentation bundle.
- `tools/release/prepare-release.sh`, `publish-docs.sh` and `generate-versions.js` are untouched — the S3 routing logic was always correct, only the artifact it published was stale.
- `publish-documentation-release`'s own `actions/checkout` is also left untouched. It now only provides the release tooling scripts, and using the branch tip there is fine (arguably preferable).
- The `github.ref_name != 'next'` guard is carried over to the new job, so `next` releases behave exactly as before.

### :warning: Operational note

This PR does **not** retroactively repair the already-published site. `https://element.siemens.io/CHANGELOG/` (`latest/`) will stay stale until either:

- the next release runs through the fixed pipeline, or
- someone manually syncs a freshly built docs bundle to `s3://simpl-element-release/latest/`.

## Related

#2755 fixes the *content* of the v51.0.0 changelog entry. This PR fixes the *deployment* of it. They are independent and can be merged in either order.

## Verification

There is no way to exercise a release pipeline locally, so this was validated statically:

- `actionlint` v1.7.7 clean on `build-documentation.yaml`, `build-and-test.yaml`, `release.yaml`, `pull-request.yaml` and `publish-documentation.yaml`. actionlint resolves local `uses: ./.github/workflows/...` calls and type-checks their inputs and secrets — confirmed with a negative control (an intentionally bogus input was correctly rejected).
- `prettier --check` clean on all changed files.
- `commitlint --from=origin/main --to=HEAD` reports 0 problems, 0 warnings.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2760/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2760/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2760/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2760/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2760/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2760/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2760/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2760/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2760/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2760/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
