### PR TITLE
build(semantic-release): stop duplicating and truncating release notes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,7 @@ settings:
 overrides:
   '@microsoft/api-extractor>typescript': 6.0.3
   '@simpl/brand>@siemens/element-theme': workspace:*
+  conventional-commits-parser: ^7.1.1
 
 importers:
 
@@ -1548,7 +1549,7 @@ packages:
     engines: {node: '>=22'}
     peerDependencies:
       conventional-commits-filter: ^6.0.1
-      conventional-commits-parser: ^7.0.1
+      conventional-commits-parser: ^7.1.1
     peerDependenciesMeta:
       conventional-commits-filter:
         optional: true
@@ -4747,11 +4748,6 @@ packages:
   conventional-commits-filter@5.0.0:
     resolution: {integrity: sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==, tarball: https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz}
     engines: {node: '>=18'}
-
-  conventional-commits-parser@6.4.0:
-    resolution: {integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==, tarball: https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz}
-    engines: {node: '>=18'}
-    hasBin: true
 
   conventional-commits-parser@7.1.1:
     resolution: {integrity: sha512-B0f42jI++V5Vb7qK+DDw68r0dNxz5hk+RdKUkx2NOi39emc9hsHa3u2M3doF7QQhRFzCrAj7uM90teG+RBTaYQ==, tarball: https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.1.tgz}
@@ -12057,7 +12053,7 @@ snapshots:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
       conventional-commits-filter: 5.0.0
-      conventional-commits-parser: 6.4.0
+      conventional-commits-parser: 7.1.1
       debug: 4.4.3(supports-color@10.2.2)
       import-from-esm: 2.0.0(supports-color@10.2.2)
       lodash-es: 4.18.1
@@ -12142,7 +12138,7 @@ snapshots:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
       conventional-commits-filter: 5.0.0
-      conventional-commits-parser: 6.4.0
+      conventional-commits-parser: 7.1.1
       debug: 4.4.3(supports-color@10.2.2)
       import-from-esm: 2.0.0(supports-color@10.2.2)
       lodash-es: 4.18.1
@@ -13670,11 +13666,6 @@ snapshots:
       semver: 7.8.5
 
   conventional-commits-filter@5.0.0: {}
-
-  conventional-commits-parser@6.4.0:
-    dependencies:
-      '@simple-libs/stream-utils': 1.2.0
-      meow: 13.2.0
 
   conventional-commits-parser@7.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,11 @@ catalog:
 overrides:
   '@microsoft/api-extractor>typescript': 'catalog:'
   '@simpl/brand>@siemens/element-theme': 'workspace:*'
+  # semantic-release still resolves conventional-commits-parser 6.x, whose reference
+  # regex matches any `#word`. A `#id` inside a code sample in a commit body is
+  # therefore treated as an issue reference, which aborts the note and truncates the
+  # release notes. Fixed in 7.x.
+  conventional-commits-parser: '^7.1.1'
 
 allowBuilds:
   '@parcel/watcher': true

--- a/tools/semantic-release/writer-opts.js
+++ b/tools/semantic-release/writer-opts.js
@@ -3,7 +3,6 @@ import { commitTypes, noteTitleMap, noteTitles } from './commit-config.js';
 const COMMIT_HASH_LENGTH = 7;
 
 const commitGroups = commitTypes.map(t => t.section).filter(Boolean);
-const hiddenTypeCommitNotes = [];
 
 const hiddenTypes = new Set();
 const visibleTypes = {};
@@ -15,6 +14,32 @@ commitTypes.forEach(({ type, section, hidden }) => {
     visibleTypes[type] = section;
   }
 });
+
+/**
+ * Notes of hidden-type commits, collected while `transform` runs over the commits of a
+ * release and consumed by `finalizeContext` once that release is rendered.
+ *
+ * `finalizeContext` must always drain this buffer. semantic-release reuses a single
+ * writerOpts object for every `generateNotes` call - it runs once per release that is added
+ * to a channel plus once for the new release - so anything left behind would be re-emitted
+ * into the notes of the following release.
+ */
+let pendingHiddenTypeNotes = [];
+
+/** Identity of a note, used to drop notes that several commits describe identically. */
+const noteIdentity = note => `${note.title}\u0000${note.text}`;
+
+function commitGroupsSort(a, b) {
+  return commitGroups.indexOf(a.title) - commitGroups.indexOf(b.title);
+}
+
+function noteGroupsSort(a, b) {
+  return noteTitles.indexOf(a.title) - noteTitles.indexOf(b.title);
+}
+
+function notesSort(a, b) {
+  return a.title.localeCompare(b.title);
+}
 
 function transform(commit) {
   const hasNotes = Array.isArray(commit.notes) && commit.notes.length > 0;
@@ -32,9 +57,9 @@ function transform(commit) {
         ...note,
         text: `${commit.scope ? `**${commit.scope}:** ` : ''}${note.text}`
       }));
-      // Add to the hiddenTypeCommitNotes if there are notes and the type is hidden
+      // Add to the pending notes if there are notes and the type is hidden
       // The notes will be added to the context in finalizeContext
-      hiddenTypeCommitNotes.push(...transformedNotes);
+      pendingHiddenTypeNotes.push(...transformedNotes);
     }
     return;
   }
@@ -57,18 +82,47 @@ function transform(commit) {
 }
 
 /**
- *  Append collected notes that have a hidden type to the matching noteGroups
+ * Append the collected notes of hidden-type commits to the matching note groups, drop
+ * duplicates and restore the group and note order.
  */
 function finalizeContext(context) {
-  for (const note of hiddenTypeCommitNotes) {
+  const pending = pendingHiddenTypeNotes;
+  pendingHiddenTypeNotes = [];
+
+  const seen = new Set();
+
+  for (const group of context.noteGroups) {
+    group.notes = group.notes.filter(note => {
+      const identity = noteIdentity(note);
+      if (seen.has(identity)) {
+        return false;
+      }
+      seen.add(identity);
+      return true;
+    });
+  }
+
+  for (const note of pending) {
+    const identity = noteIdentity(note);
+    if (seen.has(identity)) {
+      continue;
+    }
+    seen.add(identity);
+
     let group = context.noteGroups.find(g => g.title === note.title);
     if (!group) {
       group = { title: note.title, notes: [] };
-      const insertIndex = noteTitles.findIndex(t => t === note.title);
-      context.noteGroups.splice(insertIndex, 0, group);
+      context.noteGroups.push(group);
     }
     group.notes.push(note);
   }
+
+  // The writer sorts note groups and notes before finalizeContext runs, so both have to be
+  // sorted again now that the hidden-type notes are merged in.
+  context.noteGroups = context.noteGroups.filter(group => group.notes.length > 0);
+  context.noteGroups.sort(noteGroupsSort);
+  context.noteGroups.forEach(group => group.notes.sort(notesSort));
+
   return context;
 }
 
@@ -81,14 +135,8 @@ export default {
   transform,
   finalizeContext,
   commitPartial,
-  commitGroupsSort(a, b) {
-    return commitGroups.indexOf(a.title) - commitGroups.indexOf(b.title);
-  },
+  commitGroupsSort,
   commitsSort: ['scope', 'subject'],
-  noteGroupsSort(a, b) {
-    return noteTitles.indexOf(a.title) - noteTitles.indexOf(b.title);
-  },
-  notesSort(a, b) {
-    return a.title.localeCompare(b.title);
-  }
+  noteGroupsSort,
+  notesSort
 };

--- a/tools/semantic-release/writer-opts.js
+++ b/tools/semantic-release/writer-opts.js
@@ -29,6 +29,12 @@ let pendingHiddenTypeNotes = [];
 /** Identity of a note, used to drop notes that several commits describe identically. */
 const noteIdentity = note => `${note.title}\u0000${note.text}`;
 
+/** The `**scope:**` prefix that `transform` puts in front of every note text. */
+const noteScope = note => {
+  const match = /^\*\*(.+?):\*\* /.exec(note.text);
+  return match ? match[1] : '';
+};
+
 function commitGroupsSort(a, b) {
   return commitGroups.indexOf(a.title) - commitGroups.indexOf(b.title);
 }
@@ -37,30 +43,31 @@ function noteGroupsSort(a, b) {
   return noteTitles.indexOf(a.title) - noteTitles.indexOf(b.title);
 }
 
+/**
+ * Notes are already grouped by title, so sorting by title would be a no-op. Sort by scope
+ * instead to keep entries about the same scope next to each other.
+ */
 function notesSort(a, b) {
-  return a.title.localeCompare(b.title);
+  return noteScope(a).localeCompare(noteScope(b)) || a.text.localeCompare(b.text);
 }
 
 function transform(commit) {
-  const hasNotes = Array.isArray(commit.notes) && commit.notes.length > 0;
+  // The default footer template renders a bare `* {{text}}`, so the scope has to be part of
+  // the note text. Doing this for every commit type keeps the notes consistently scoped and
+  // lets `notesSort` group them by scope.
+  const prefix = commit.scope ? `**${commit.scope}:** ` : '';
 
-  const normalizedNotes = hasNotes
+  const normalizedNotes = Array.isArray(commit.notes)
     ? commit.notes.map(note => ({
         title: noteTitleMap[note.title] ?? note.title,
-        text: note.text.replace(/\n/g, '\n  ')
+        text: `${prefix}${note.text.replace(/\n/g, '\n  ')}`
       }))
     : [];
 
   if (hiddenTypes.has(commit.type)) {
-    if (normalizedNotes.length > 0) {
-      const transformedNotes = normalizedNotes.map(note => ({
-        ...note,
-        text: `${commit.scope ? `**${commit.scope}:** ` : ''}${note.text}`
-      }));
-      // Add to the pending notes if there are notes and the type is hidden
-      // The notes will be added to the context in finalizeContext
-      pendingHiddenTypeNotes.push(...transformedNotes);
-    }
+    // Hidden commits are dropped from the changelog, but their notes still belong in it.
+    // finalizeContext merges them into the note groups once all commits are transformed.
+    pendingHiddenTypeNotes.push(...normalizedNotes);
     return;
   }
 


### PR DESCRIPTION
Split out of #2755 so the changelog cleanup there can be merged quickly. This part changes the release-notes tooling and deserves a closer look.

## Why

After the v51.0.0 release the GitHub release page was full of duplicated `BREAKING CHANGES` / `DEPRECATIONS` entries, and one note was cut off mid-sentence.

The duplications only ever existed on the **GitHub release page**, never in `CHANGELOG.md`. `semantic-release` calls `generateNotes` once per release step: once for the actual release plus once for every add-to-channel run. `@semantic-release/changelog` and `@semantic-release/git` only implement `prepare`, which never runs for `addChannel`, so the file was written once. `@semantic-release/github` *does* implement `addChannel` and **overwrites the release body** with a freshly generated - and by then duplicated - set of notes.

## Root causes

**1. Shared writer state leaked across generations** (`tools/semantic-release/writer-opts.js`)

Hidden-type commits (`build`, `chore`, ...) are dropped by `conventional-changelog-writer` before their notes are collected, so we buffer them in a module-level array. That array was **never cleared**, and `config.js` hands the *same* `writerOpts` object to every `generateNotes` call - so run #2 emitted run #1's notes again, run #3 emitted both, and so on.

Fixed by draining **and clearing** the buffer as the first thing in `finalizeContext` (which runs exactly once per rendered release), plus de-duplicating identical note texts.

**2. Note ordering was effectively random**

- `notesSort` compared `a.title` vs `b.title`, but notes are *grouped* by title - every title inside a group is identical, so the comparator was a no-op and entries came out in commit order.
- `noteGroupsSort` used `noteTitles.findIndex(...)`, which returns `-1` when a group is missing, and `splice(-1, 0, group)` inserts **second-to-last** - that is why `DEPRECATIONS` sometimes rendered before `BREAKING CHANGES`.

Notes are now sorted by scope and then by text. The scope is read from the `**scope:**` prefix, which `transform()` now adds for every commit type instead of only for hidden ones - the default footer template renders a bare `* {{text}}`, so notes of visible commit types were previously rendered without their scope.

Both sorts are re-applied inside `finalizeContext`, because `conventional-changelog-writer` sorts note groups *before* `finalizeContext` runs and the injected hidden-type notes would otherwise land unsorted.

**3. Notes were silently truncated** (`conventional-commits-parser@6.4.0`)

Its reference regex `([\w-\.\/]*?)??(#)([\w-]+)` has no digit requirement, so a `#container` selector inside a code fence was parsed as an issue reference - and the parser does `if (references.length) break;`, aborting the rest of the note. That is what cut off the Ionic preview note mid-code-block.

`7.x` requires a numeric reference, so this pins it via `pnpm-workspace.yaml` `overrides` (note: `pnpm.overrides` in `package.json` is ignored by pnpm 12). Verified against the real commit - the note now parses with all 3 breaking-change entries, the complete `ts` fence and the trailing paragraph.

## Verification

A regression harness was run against the generator: **6 failures** with the old `writer-opts.js`, **8/8 passing** with the new one, and still 8/8 after the parser bump. It covers the cross-generation leak, note de-duplication, group ordering, scope sorting of all three note groups (`NOTES`, `BREAKING CHANGES`, `DEPRECATIONS`), the hidden-type note merge, and the untouched `commitPartial` rendering.

There is no vitest project covering `tools/`, so the harness is not checked in. Happy to add one if we want this permanently guarded - that felt like a separate discussion.

## Not included

Deliberately left out after review feedback on #2755: no scope alias map in the tooling. `tools/semantic-release/commit-config.js` is untouched; we rely on maintainers picking adequate scopes.<!-- preview-links:start -->

---

[Documentation](https://d33c9dcnqinn2a.cloudfront.net/pr-2761/pages/).
[Examples](https://d33c9dcnqinn2a.cloudfront.net/pr-2761/pages/element-examples/).
[Dashboards Demo](https://d33c9dcnqinn2a.cloudfront.net/pr-2761/pages/dashboards-demo/).
[Playwright report](https://d33c9dcnqinn2a.cloudfront.net/pr-2761/playwright-report/).

**Coverage Reports:**

![Code Coverage](https://img.shields.io/badge/Code%20Coverage-82%25-success?style=flat)

- [charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2761/pages/coverage/charts-ng/)
- [dashboards-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2761/pages/coverage/dashboards-ng/)
- [element-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2761/pages/coverage/element-ng/)
- [element-translate-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2761/pages/coverage/element-translate-ng/)
- [maps-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2761/pages/coverage/maps-ng/)
- [native-charts-ng](https://d33c9dcnqinn2a.cloudfront.net/pr-2761/pages/coverage/native-charts-ng/)

<!-- preview-links:end -->
